### PR TITLE
Add Drag and Drop components

### DIFF
--- a/examples/FluentUI.Demo.Shared/Microsoft.Fast.Components.FluentUI.xml
+++ b/examples/FluentUI.Demo.Shared/Microsoft.Fast.Components.FluentUI.xml
@@ -1392,6 +1392,147 @@
             Gets or sets the content to be rendered inside the component.
             </summary>
         </member>
+        <member name="T:Microsoft.Fast.Components.FluentUI.FluentDragContainer`1">
+            <summary />
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDragContainer`1.ClassValue">
+            <summary />
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDragContainer`1.StyleValue">
+            <summary />
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDragContainer`1.ChildContent">
+            <summary>
+            Gets or sets the content to be rendered inside the component.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDragContainer`1.OnDragStart">
+            <summary>
+            This event is fired when the user starts dragging an element.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDragContainer`1.OnDragEnter">
+            <summary>
+            This event is fired when a dragged element enters a valid drop target.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDragContainer`1.OnDragOver">
+            <summary>
+            This event is fired when an element is being dragged over a valid drop target.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDragContainer`1.OnDragLeave">
+            <summary>
+            This event is fired when a dragged element leaves a valid drop target.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDragContainer`1.OnDropEnd">
+            <summary>
+            This event is fired when an element is dropped on a valid drop target.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDragContainer`1.StartedZone">
+            <summary>
+            property to keep the zone currently dragged.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.FluentDragContainer`1.SetStartedZone(Microsoft.Fast.Components.FluentUI.FluentDropZone{`0})">
+            <summary />
+        </member>
+        <member name="T:Microsoft.Fast.Components.FluentUI.FluentDragEventArgs`1">
+            <summary />
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.FluentDragEventArgs`1.#ctor">
+            <summary />
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.FluentDragEventArgs`1.#ctor(Microsoft.Fast.Components.FluentUI.FluentDropZone{`0},Microsoft.Fast.Components.FluentUI.FluentDropZone{`0})">
+            <summary />
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDragEventArgs`1.Source">
+            <summary>
+            Gets the zone where the drag started.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDragEventArgs`1.Target">
+            <summary>
+            Gets the zone where the drag ended.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Fast.Components.FluentUI.FluentDropZone`1">
+            <summary />
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDropZone`1.ClassValue">
+            <summary />
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDropZone`1.StyleValue">
+            <summary />
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDropZone`1.Container">
+            <summary />
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDropZone`1.Item">
+            <summary>
+            Item to identify a draggable zone.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDropZone`1.ChildContent">
+            <summary>
+            Gets or sets the content to be rendered inside the component.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDropZone`1.IsDroppable">
+            <summary>
+            Indicates whether the element can receive a dragged item.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDropZone`1.IsDraggable">
+            <summary>
+            Indicates whether the element can be dragged.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDropZone`1.OnDragStart">
+            <summary>
+            This event is fired when the user starts dragging an element.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDropZone`1.OnDragEnter">
+            <summary>
+            This event is fired when a dragged element enters a valid drop target.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDropZone`1.OnDragOver">
+            <summary>
+            This event is fired when an element is being dragged over a valid drop target.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDropZone`1.OnDragLeave">
+            <summary>
+            This event is fired when a dragged element leaves a valid drop target.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDropZone`1.OnDropEnd">
+            <summary>
+            This event is fired when an element is dropped on a valid drop target.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDropZone`1.IsOver">
+            <summary />
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.FluentDropZone`1.OnDragStartHandler(Microsoft.AspNetCore.Components.Web.DragEventArgs)">
+            <summary />
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.FluentDropZone`1.OnDragEnterHandler(Microsoft.AspNetCore.Components.Web.DragEventArgs)">
+            <summary />
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.FluentDropZone`1.OnDragOverHandler(Microsoft.AspNetCore.Components.Web.DragEventArgs)">
+            <summary />
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.FluentDropZone`1.OnDragLeaveHandler(Microsoft.AspNetCore.Components.Web.DragEventArgs)">
+            <summary />
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.FluentDropZone`1.OnDropHandler(Microsoft.AspNetCore.Components.Web.DragEventArgs)">
+            <summary />
+        </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentEmoji.Name">
             <summary>
             Gets or sets the name of the emoji. Can be specified by using const value from <see cref="T:Microsoft.Fast.Components.FluentUI.FluentEmojis" />

--- a/examples/FluentUI.Demo.Shared/Microsoft.Fast.Components.FluentUI.xml
+++ b/examples/FluentUI.Demo.Shared/Microsoft.Fast.Components.FluentUI.xml
@@ -1480,12 +1480,12 @@
             Gets or sets the content to be rendered inside the component.
             </summary>
         </member>
-        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDropZone`1.IsDroppable">
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDropZone`1.Droppable">
             <summary>
             Indicates whether the element can receive a dragged item.
             </summary>
         </member>
-        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDropZone`1.IsDraggable">
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDropZone`1.Draggable">
             <summary>
             Indicates whether the element can be dragged.
             </summary>

--- a/examples/FluentUI.Demo.Shared/Pages/Drag/DragDropPage.razor
+++ b/examples/FluentUI.Demo.Shared/Pages/Drag/DragDropPage.razor
@@ -1,0 +1,23 @@
+@page "/Drag"
+@using FluentUI.Demo.Shared.Pages.Drag.Examples;
+
+<h1>Drag and Drop</h1>
+
+
+<p>A web component implementation of a <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API" target="_blank" rel="noopener noreferrer">HTML Drag and Drop API</a>.</p>
+
+<p>
+    The user may select draggable elements with a mouse, drag those elements to a droppable element,
+    and drop them by releasing the mouse button. A translucent representation of the draggable elements
+    follows the pointer during the drag operation.
+</p>
+
+<h2>Examples</h2>
+
+<DemoSection Title="Usage examples" Component="@typeof(DragDropBasic)"></DemoSection>
+
+<h2>Documentation</h2>
+
+<ApiDocumentation Component="typeof(FluentDragContainer<>)" InstanceType="typeof(object)" GenericLabel="TItem" />
+<ApiDocumentation Component="typeof(FluentDropZone<>)" InstanceType="typeof(object)" GenericLabel="TItem" />
+<ApiDocumentation Component="typeof(FluentDragEventArgs<>)" InstanceType="typeof(object)" GenericLabel="TItem" />

--- a/examples/FluentUI.Demo.Shared/Pages/Drag/Examples/DragDropBasic.razor
+++ b/examples/FluentUI.Demo.Shared/Pages/Drag/Examples/DragDropBasic.razor
@@ -3,12 +3,12 @@
                      OnDragLeave="@(e => DemoLogger.WriteLine($"{e.Source.Id} has left {e.Target.Id}"))"
                      OnDropEnd="@(e => DemoLogger.WriteLine($"{e.Source.Id} dropped in {e.Target.Id}"))">
     <FluentStack>
-        <FluentDropZone Id="Item1" IsDraggable="true" IsDroppable="true">
+        <FluentDropZone Id="Item1" Draggable="true" Droppable="true">
             <div style="width: 50px; height: 50px; background-color: pink;">
                 Item 1
             </div>
         </FluentDropZone>
-        <FluentDropZone Id="Item2" IsDraggable="true" IsDroppable="true">
+        <FluentDropZone Id="Item2" Draggable="true" Droppable="true">
             <div style="width: 50px; height: 50px; background-color: lightgreen;">
                 Item 2
             </div>

--- a/examples/FluentUI.Demo.Shared/Pages/Drag/Examples/DragDropBasic.razor
+++ b/examples/FluentUI.Demo.Shared/Pages/Drag/Examples/DragDropBasic.razor
@@ -1,0 +1,17 @@
+<FluentDragContainer TItem="string"
+                     OnDragEnter="@(e => DemoLogger.WriteLine($"{e.Source.Id} is entered in  {e.Target.Id}"))"
+                     OnDragLeave="@(e => DemoLogger.WriteLine($"{e.Source.Id} has left {e.Target.Id}"))"
+                     OnDropEnd="@(e => DemoLogger.WriteLine($"{e.Source.Id} dropped in {e.Target.Id}"))">
+    <FluentStack>
+        <FluentDropZone Id="Item1" IsDraggable="true" IsDroppable="true">
+            <div style="width: 50px; height: 50px; background-color: pink;">
+                Item 1
+            </div>
+        </FluentDropZone>
+        <FluentDropZone Id="Item2" IsDraggable="true" IsDroppable="true">
+            <div style="width: 50px; height: 50px; background-color: lightgreen;">
+                Item 2
+            </div>
+        </FluentDropZone>
+    </FluentStack>
+</FluentDragContainer>

--- a/examples/FluentUI.Demo.Shared/Shared/DemoNavMenuList.razor
+++ b/examples/FluentUI.Demo.Shared/Shared/DemoNavMenuList.razor
@@ -112,6 +112,9 @@
         <FluentAnchor Href="Divider" Appearance=Appearance.Neutral>Divider</FluentAnchor>
     </li>
     <li>
+        <FluentAnchor Href="Drag" Appearance=Appearance.Neutral>Drag</FluentAnchor>
+    </li>
+    <li>
         <FluentAnchor Href="Emoji" Appearance=Appearance.Neutral>Emoji</FluentAnchor>
     </li>
     <li>

--- a/examples/FluentUI.Demo.Shared/Shared/DemoNavMenuTree.razor
+++ b/examples/FluentUI.Demo.Shared/Shared/DemoNavMenuTree.razor
@@ -53,6 +53,7 @@
             <FluentNavMenuLink Href="/DataGrid" Icon="@FluentIcons.Grid" Text="Data grid" />
             <FluentNavMenuLink Href="/Dialog" Icon="@FluentIcons.AppGeneric" Text="Dialog" />
             <FluentNavMenuLink Href="/Divider" Icon="@FluentIcons.DividerShort" Text="Divider" />
+            <FluentNavMenuLink Href="/Drag" Icon="@FluentIcons.Drag" Text="Drag and Drop" />
             <FluentNavMenuLink Href="/Emoji" Icon="@FluentIcons.EmojiSmileSlight" Text="Emoji" />
             <FluentNavMenuLink Href="/Flipper" Icon="@FluentIcons.NavigationPlay" Text="Flipper" />
             <FluentNavMenuLink Href="/Highlighter" Icon="@FluentIcons.Highlight" Text="Highlighter" />

--- a/examples/FluentUI.Demo.Shared/wwwroot/sources/DragDropBasic.razor.txt
+++ b/examples/FluentUI.Demo.Shared/wwwroot/sources/DragDropBasic.razor.txt
@@ -3,12 +3,12 @@
                      OnDragLeave="@(e => DemoLogger.WriteLine($"{e.Source.Id} has left {e.Target.Id}"))"
                      OnDropEnd="@(e => DemoLogger.WriteLine($"{e.Source.Id} dropped in {e.Target.Id}"))">
     <FluentStack>
-        <FluentDropZone Id="Item1" IsDraggable="true" IsDroppable="true">
+        <FluentDropZone Id="Item1" Draggable="true" Droppable="true">
             <div style="width: 50px; height: 50px; background-color: pink;">
                 Item 1
             </div>
         </FluentDropZone>
-        <FluentDropZone Id="Item2" IsDraggable="true" IsDroppable="true">
+        <FluentDropZone Id="Item2" Draggable="true" Droppable="true">
             <div style="width: 50px; height: 50px; background-color: lightgreen;">
                 Item 2
             </div>

--- a/examples/FluentUI.Demo.Shared/wwwroot/sources/DragDropBasic.razor.txt
+++ b/examples/FluentUI.Demo.Shared/wwwroot/sources/DragDropBasic.razor.txt
@@ -1,0 +1,17 @@
+<FluentDragContainer TItem="string"
+                     OnDragEnter="@(e => DemoLogger.WriteLine($"{e.Source.Id} is entered in  {e.Target.Id}"))"
+                     OnDragLeave="@(e => DemoLogger.WriteLine($"{e.Source.Id} has left {e.Target.Id}"))"
+                     OnDropEnd="@(e => DemoLogger.WriteLine($"{e.Source.Id} dropped in {e.Target.Id}"))">
+    <FluentStack>
+        <FluentDropZone Id="Item1" IsDraggable="true" IsDroppable="true">
+            <div style="width: 50px; height: 50px; background-color: pink;">
+                Item 1
+            </div>
+        </FluentDropZone>
+        <FluentDropZone Id="Item2" IsDraggable="true" IsDroppable="true">
+            <div style="width: 50px; height: 50px; background-color: lightgreen;">
+                Item 2
+            </div>
+        </FluentDropZone>
+    </FluentStack>
+</FluentDragContainer>

--- a/src/Microsoft.Fast.Components.FluentUI.Tests/Drag/FluentDragTests.FluentDrag_SimpleTest.verified.html
+++ b/src/Microsoft.Fast.Components.FluentUI.Tests/Drag/FluentDragTests.FluentDrag_SimpleTest.verified.html
@@ -1,0 +1,5 @@
+
+<div>
+  <div draggable="true" blazor:ondragstart="1" blazor:ondragover="2" blazor:ondragenter="3" blazor:ondragleave="4" blazor:ondrop="5" blazor:ondrop:preventdefault="" b-9aejvkglh2="">Item 1</div>
+  <div blazor:ondragstart="6" blazor:ondragover="7" blazor:ondragover:preventdefault="" blazor:ondragenter="8" blazor:ondragenter:preventdefault="" blazor:ondragleave="9" blazor:ondragleave:preventdefault="" blazor:ondrop="10" blazor:ondrop:preventdefault="" b-9aejvkglh2="">Item 2</div>
+</div>

--- a/src/Microsoft.Fast.Components.FluentUI.Tests/Drag/FluentDragTests.cs
+++ b/src/Microsoft.Fast.Components.FluentUI.Tests/Drag/FluentDragTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Fast.Components.FluentUI.Tests.Drag
 
                 parameters.AddChildContent<FluentDropZone<int>>(zone =>
                 {
-                    zone.Add(p => p.IsDraggable, true);
+                    zone.Add(p => p.Draggable, true);
                     zone.Add(p => p.Item, 1);
                     zone.AddChildContent("Item 1");
 
@@ -35,7 +35,7 @@ namespace Microsoft.Fast.Components.FluentUI.Tests.Drag
 
                 parameters.AddChildContent<FluentDropZone<int>>(zone =>
                 {
-                    zone.Add(p => p.IsDroppable, true);
+                    zone.Add(p => p.Droppable, true);
                     zone.Add(p => p.Item, 2);
                     zone.AddChildContent("Item 2");
 

--- a/src/Microsoft.Fast.Components.FluentUI.Tests/Drag/FluentDragTests.cs
+++ b/src/Microsoft.Fast.Components.FluentUI.Tests/Drag/FluentDragTests.cs
@@ -1,0 +1,54 @@
+﻿using Bunit;
+using Xunit;
+
+namespace Microsoft.Fast.Components.FluentUI.Tests.Drag
+{
+    public class FluentDragTests : TestBase
+    {
+        [Fact]
+        public void FluentDrag_SimpleTest()
+        {
+            // Arrange
+            using var ctx = new TestContext();
+
+            // Act
+            var cut = ctx.RenderComponent<FluentDragContainer<int>>(parameters =>
+            {
+                parameters.Add(p => p.OnDragStart, (e) => { });
+                parameters.Add(p => p.OnDragEnter, (e) => { });
+                parameters.Add(p => p.OnDragOver, (e) => { });
+                parameters.Add(p => p.OnDragLeave, (e) => { });
+                parameters.Add(p => p.OnDropEnd, (e) => { });
+
+                parameters.AddChildContent<FluentDropZone<int>>(zone =>
+                {
+                    zone.Add(p => p.IsDraggable, true);
+                    zone.Add(p => p.Item, 1);
+                    zone.AddChildContent("Item 1");
+
+                    zone.Add(p => p.OnDragStart, (e) => { });
+                    zone.Add(p => p.OnDragEnter, (e) => { });
+                    zone.Add(p => p.OnDragOver, (e) => { });
+                    zone.Add(p => p.OnDragLeave, (e) => { });
+                    zone.Add(p => p.OnDropEnd, (e) => { });
+                });
+
+                parameters.AddChildContent<FluentDropZone<int>>(zone =>
+                {
+                    zone.Add(p => p.IsDroppable, true);
+                    zone.Add(p => p.Item, 2);
+                    zone.AddChildContent("Item 2");
+
+                    zone.Add(p => p.OnDragStart, (e) => { });
+                    zone.Add(p => p.OnDragEnter, (e) => { });
+                    zone.Add(p => p.OnDragOver, (e) => { });
+                    zone.Add(p => p.OnDragLeave, (e) => { });
+                    zone.Add(p => p.OnDropEnd, (e) => { });
+                });
+            });
+
+            // Assert
+            cut.Verify();
+        }
+    }
+}

--- a/src/Microsoft.Fast.Components.FluentUI/Components/Drag/FluentDragContainer.razor
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/Drag/FluentDragContainer.razor
@@ -1,0 +1,12 @@
+@namespace Microsoft.Fast.Components.FluentUI
+@inherits FluentComponentBase
+
+@typeparam TItem
+@attribute [CascadingTypeParameter(nameof(TItem))]
+<div id=@Id
+     class=@ClassValue
+     style=@StyleValue>
+    <CascadingValue Value="this">
+        @ChildContent
+    </CascadingValue>
+</div>

--- a/src/Microsoft.Fast.Components.FluentUI/Components/Drag/FluentDragContainer.razor.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/Drag/FluentDragContainer.razor.cs
@@ -1,0 +1,66 @@
+﻿// --------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// --------------------------------------------------------------
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.Fast.Components.FluentUI.Utilities;
+
+namespace Microsoft.Fast.Components.FluentUI;
+
+/// <summary />
+public partial class FluentDragContainer<TItem> : FluentComponentBase
+{
+    /// <summary />
+    protected virtual string? ClassValue => new CssBuilder(Class).Build();
+
+    /// <summary />
+    protected virtual string? StyleValue => new StyleBuilder().AddStyle(Style).Build();
+
+    /// <summary>
+    /// Gets or sets the content to be rendered inside the component.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>
+    /// This event is fired when the user starts dragging an element.
+    /// </summary>
+    [Parameter]
+    public Action<FluentDragEventArgs<TItem>>? OnDragStart { get; set; }
+
+    /// <summary>
+    /// This event is fired when a dragged element enters a valid drop target.
+    /// </summary>
+    [Parameter]
+    public Action<FluentDragEventArgs<TItem>>? OnDragEnter { get; set; }
+
+    /// <summary>
+    /// This event is fired when an element is being dragged over a valid drop target.
+    /// </summary>
+    [Parameter]
+    public Action<FluentDragEventArgs<TItem>>? OnDragOver { get; set; }
+
+    /// <summary>
+    /// This event is fired when a dragged element leaves a valid drop target.
+    /// </summary>
+    [Parameter]
+    public Action<FluentDragEventArgs<TItem>>? OnDragLeave { get; set; }
+
+    /// <summary>
+    /// This event is fired when an element is dropped on a valid drop target.
+    /// </summary>
+    [Parameter]
+    public Action<FluentDragEventArgs<TItem>>? OnDropEnd { get; set; }
+
+    /// <summary>
+    /// property to keep the zone currently dragged.
+    /// </summary>
+    internal FluentDropZone<TItem>? StartedZone { get; private set; }
+
+    /// <summary />
+    internal void SetStartedZone(FluentDropZone<TItem>? value)
+    {
+        StartedZone = value;
+        StateHasChanged();
+    }
+}

--- a/src/Microsoft.Fast.Components.FluentUI/Components/Drag/FluentDragEventArgs.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/Drag/FluentDragEventArgs.cs
@@ -1,0 +1,27 @@
+﻿namespace Microsoft.Fast.Components.FluentUI;
+
+/// <summary />
+public class FluentDragEventArgs<TItem> : EventArgs
+{
+    /// <summary />
+    public FluentDragEventArgs()
+    {
+    }
+
+    /// <summary />
+    internal FluentDragEventArgs(FluentDropZone<TItem> source, FluentDropZone<TItem> target)
+    {
+        Source = source;
+        Target = target;
+    }
+
+    /// <summary>
+    /// Gets the zone where the drag started.
+    /// </summary>
+    public FluentDropZone<TItem> Source { get; } = null!;
+
+    /// <summary>
+    /// Gets the zone where the drag ended.
+    /// </summary>
+    public FluentDropZone<TItem> Target { get; } = null!;
+}

--- a/src/Microsoft.Fast.Components.FluentUI/Components/Drag/FluentDropZone.razor
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/Drag/FluentDropZone.razor
@@ -1,0 +1,19 @@
+@namespace Microsoft.Fast.Components.FluentUI
+@inherits FluentComponentBase
+
+@typeparam TItem
+<div draggable=@(IsDraggable ? "true" : null)
+     id=@Id
+     class=@ClassValue
+     style=@StyleValue
+     dragged-over=@IsOver
+     @ondragstart=@OnDragStartHandler
+     @ondragover=@OnDragOverHandler
+     @ondragover:preventDefault="@IsDroppable"
+     @ondragenter=@OnDragEnterHandler
+     @ondragenter:preventDefault="@IsDroppable"
+     @ondragleave=@OnDragLeaveHandler
+     @ondragleave:preventDefault="@IsDroppable"
+     @ondrop=@OnDropHandler @ondrop:preventDefault>
+    @ChildContent
+</div>

--- a/src/Microsoft.Fast.Components.FluentUI/Components/Drag/FluentDropZone.razor
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/Drag/FluentDropZone.razor
@@ -2,18 +2,18 @@
 @inherits FluentComponentBase
 
 @typeparam TItem
-<div draggable=@(IsDraggable ? "true" : null)
+<div draggable=@(Draggable ? "true" : null)
      id=@Id
      class=@ClassValue
      style=@StyleValue
      dragged-over=@IsOver
      @ondragstart=@OnDragStartHandler
      @ondragover=@OnDragOverHandler
-     @ondragover:preventDefault="@IsDroppable"
+     @ondragover:preventDefault="@Droppable"
      @ondragenter=@OnDragEnterHandler
-     @ondragenter:preventDefault="@IsDroppable"
+     @ondragenter:preventDefault="@Droppable"
      @ondragleave=@OnDragLeaveHandler
-     @ondragleave:preventDefault="@IsDroppable"
+     @ondragleave:preventDefault="@Droppable"
      @ondrop=@OnDropHandler @ondrop:preventDefault>
     @ChildContent
 </div>

--- a/src/Microsoft.Fast.Components.FluentUI/Components/Drag/FluentDropZone.razor.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/Drag/FluentDropZone.razor.cs
@@ -38,13 +38,13 @@ public partial class FluentDropZone<TItem> : FluentComponentBase
     /// Indicates whether the element can receive a dragged item.
     /// </summary>
     [Parameter]
-    public bool IsDroppable { get; set; }
+    public bool Droppable { get; set; }
 
     /// <summary>
     /// Indicates whether the element can be dragged.
     /// </summary>
     [Parameter]
-    public bool IsDraggable { get; set; }
+    public bool Draggable { get; set; }
 
     /// <summary>
     /// This event is fired when the user starts dragging an element.
@@ -82,7 +82,7 @@ public partial class FluentDropZone<TItem> : FluentComponentBase
     /// <summary />
     private void OnDragStartHandler(DragEventArgs e)
     {
-        if (!IsDraggable)
+        if (!Draggable)
         {
             return;
         }
@@ -103,7 +103,7 @@ public partial class FluentDropZone<TItem> : FluentComponentBase
     /// <summary />
     private void OnDragEnterHandler(DragEventArgs e)
     {
-        if (!IsDroppable)
+        if (!Droppable)
         {
             return;
         }
@@ -129,7 +129,7 @@ public partial class FluentDropZone<TItem> : FluentComponentBase
     /// <summary />
     private void OnDragOverHandler(DragEventArgs e)
     {
-        if (!IsDroppable)
+        if (!Droppable)
         {
             return;
         }
@@ -155,7 +155,7 @@ public partial class FluentDropZone<TItem> : FluentComponentBase
     /// <summary />
     private void OnDragLeaveHandler(DragEventArgs e)
     {
-        if (!IsDroppable)
+        if (!Droppable)
         {
             return;
         }
@@ -181,7 +181,7 @@ public partial class FluentDropZone<TItem> : FluentComponentBase
     /// <summary />
     private void OnDropHandler(DragEventArgs e)
     {
-        if (!IsDroppable)
+        if (!Droppable)
         {
             return;
         }

--- a/src/Microsoft.Fast.Components.FluentUI/Components/Drag/FluentDropZone.razor.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/Drag/FluentDropZone.razor.cs
@@ -1,0 +1,208 @@
+﻿// --------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// --------------------------------------------------------------
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Fast.Components.FluentUI.Utilities;
+
+namespace Microsoft.Fast.Components.FluentUI;
+
+/// <summary />
+public partial class FluentDropZone<TItem> : FluentComponentBase
+
+{
+    /// <summary />
+    protected virtual string? ClassValue => new CssBuilder(Class).Build();
+
+    /// <summary />
+    protected virtual string? StyleValue => new StyleBuilder().AddStyle(Style).Build();
+
+    /// <summary />
+    [CascadingParameter]
+    private FluentDragContainer<TItem> Container { get; set; } = default!;
+
+    /// <summary>
+    /// Item to identify a draggable zone.
+    /// </summary>
+    [Parameter]
+    public TItem Item { get; set; } = default!;
+
+    /// <summary>
+    /// Gets or sets the content to be rendered inside the component.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>
+    /// Indicates whether the element can receive a dragged item.
+    /// </summary>
+    [Parameter]
+    public bool IsDroppable { get; set; }
+
+    /// <summary>
+    /// Indicates whether the element can be dragged.
+    /// </summary>
+    [Parameter]
+    public bool IsDraggable { get; set; }
+
+    /// <summary>
+    /// This event is fired when the user starts dragging an element.
+    /// </summary>
+    [Parameter]
+    public Action<FluentDragEventArgs<TItem>>? OnDragStart { get; set; }
+
+    /// <summary>
+    /// This event is fired when a dragged element enters a valid drop target.
+    /// </summary>
+    [Parameter]
+    public Action<FluentDragEventArgs<TItem>>? OnDragEnter { get; set; }
+
+    /// <summary>
+    /// This event is fired when an element is being dragged over a valid drop target.
+    /// </summary>
+    [Parameter]
+    public Action<FluentDragEventArgs<TItem>>? OnDragOver { get; set; }
+
+    /// <summary>
+    /// This event is fired when a dragged element leaves a valid drop target.
+    /// </summary>
+    [Parameter]
+    public Action<FluentDragEventArgs<TItem>>? OnDragLeave { get; set; }
+
+    /// <summary>
+    /// This event is fired when an element is dropped on a valid drop target.
+    /// </summary>
+    [Parameter]
+    public Action<FluentDragEventArgs<TItem>>? OnDropEnd { get; set; }
+
+    /// <summary />
+    private bool IsOver { get; set; } = false;
+
+    /// <summary />
+    private void OnDragStartHandler(DragEventArgs e)
+    {
+        if (!IsDraggable)
+        {
+            return;
+        }
+
+        Container.SetStartedZone(this);
+
+        if (OnDragStart != null)
+        {
+            OnDragStart(new FluentDragEventArgs<TItem>(this, this));
+        }
+
+        if (Container.OnDragStart != null)
+        {
+            Container.OnDragStart(new FluentDragEventArgs<TItem>(this, this));
+        }
+    }
+
+    /// <summary />
+    private void OnDragEnterHandler(DragEventArgs e)
+    {
+        if (!IsDroppable)
+        {
+            return;
+        }
+
+        IsOver = true;
+
+        if (Container.StartedZone == null)
+        {
+            return;
+        }
+
+        if (OnDragEnter != null)
+        {
+            OnDragEnter(new FluentDragEventArgs<TItem>(Container.StartedZone, this));
+        }
+
+        if (Container.OnDragEnter != null)
+        {
+            Container.OnDragEnter(new FluentDragEventArgs<TItem>(Container.StartedZone, this));
+        }
+    }
+
+    /// <summary />
+    private void OnDragOverHandler(DragEventArgs e)
+    {
+        if (!IsDroppable)
+        {
+            return;
+        }
+
+        if (Container.StartedZone == null)
+        {
+            return;
+        }
+
+        IsOver = true;
+
+        if (OnDragOver != null)
+        {
+            OnDragOver(new FluentDragEventArgs<TItem>(Container.StartedZone, this));
+        }
+
+        if (Container.OnDragOver != null)
+        {
+            Container.OnDragOver(new FluentDragEventArgs<TItem>(Container.StartedZone, this));
+        }
+    }
+
+    /// <summary />
+    private void OnDragLeaveHandler(DragEventArgs e)
+    {
+        if (!IsDroppable)
+        {
+            return;
+        }
+
+        IsOver = false;
+
+        if (Container.StartedZone == null)
+        {
+            return;
+        }
+
+        if (OnDragLeave != null)
+        {
+            OnDragLeave(new FluentDragEventArgs<TItem>(Container.StartedZone, this));
+        }
+
+        if (Container.OnDragLeave != null)
+        {
+            Container.OnDragLeave(new FluentDragEventArgs<TItem>(Container.StartedZone, this));
+        }
+    }
+
+    /// <summary />
+    private void OnDropHandler(DragEventArgs e)
+    {
+        if (!IsDroppable)
+        {
+            return;
+        }
+
+        IsOver = false;
+
+        if (Container.StartedZone == null)
+        {
+            return;
+        }
+
+        if (OnDropEnd != null)
+        {
+            OnDropEnd(new FluentDragEventArgs<TItem>(Container.StartedZone, this));
+        }
+
+        if (Container.OnDropEnd != null)
+        {
+            Container.OnDropEnd(new FluentDragEventArgs<TItem>(Container.StartedZone, this));
+        }
+
+        Container.SetStartedZone(null);
+    }
+}

--- a/src/Microsoft.Fast.Components.FluentUI/Components/Drag/FluentDropZone.razor.css
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/Drag/FluentDropZone.razor.css
@@ -1,0 +1,9 @@
+﻿div[draggable='true'] {
+    cursor: move;
+}
+
+div[dragged-over] {
+    background-color: lightgray;
+    opacity: 0.6;
+    animation: blinker 1s linear infinite;
+}


### PR DESCRIPTION
# Drag and Drop components

## 📖 Description

A web component implementation of a [HTML Drag and Drop API](https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API).

The user may select draggable elements with a mouse, drag those elements to a droppable element, and drop them by releasing the mouse button. A translucent representation of the draggable elements follows the pointer during the drag operation.

Add these components `FluentDragContainer` and `FluentDropZone`.

```razor
<FluentDragContainer TItem="string">
  <FluentDropZone Draggable="true" Droppable="true">
    Item 1
  </FluentDropZone>
  <FluentDropZone Draggable="true" Droppable="true">
    Item 2
  </FluentDropZone>
</FluentDragContainer>
```

![DragDrop](https://github.com/microsoft/fluentui-blazor/assets/8350694/0fa99544-32c4-4038-8ec6-185fa226a537)

## ✅ Checklist

### General

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
