### PR TITLE
Fix #370 - FluentIcon performance improvements

### DIFF
--- a/src/Microsoft.Fast.Components.FluentUI.Tests/Extensions/AdditionalAttributesExtensionsShould.cs
+++ b/src/Microsoft.Fast.Components.FluentUI.Tests/Extensions/AdditionalAttributesExtensionsShould.cs
@@ -1,0 +1,98 @@
+﻿using System.Collections;
+using Xunit;
+
+namespace Microsoft.Fast.Components.FluentUI.Tests.Extensions;
+
+public class AdditionalAttributesExtensionsShould
+{
+    public sealed class RenderedAttributesEqualityTestData : IEnumerable<object?[]>
+    {
+        public IEnumerator<object?[]> GetEnumerator()
+        {
+            yield return new object?[]
+            {
+                null,
+                null,
+                true
+            };
+
+            yield return new object?[]
+            {
+                null,
+                new Dictionary<string,object>(0),
+                true
+            };
+
+            yield return new object?[]
+            {
+                new Dictionary<string,object>(0),
+                new Dictionary<string,object>(0),
+                true
+            };
+            yield return new object?[]
+            {
+                null,
+                new Dictionary<string,object?> {["attr"] = null},
+                true
+            };
+            yield return new object?[]
+            {
+                new Dictionary<string,object>(0),
+                new Dictionary<string,object?> {["attr"] = null},
+                true
+            };
+            yield return new object?[]
+            {
+                new Dictionary<string,object> { ["attr"] = "value" },
+                new Dictionary<string,object> { ["attr"] = "value" },
+                true
+            };
+            yield return new object?[]
+            {
+                new Dictionary<string,object> { ["attr"] = "value" },
+                new Dictionary<string,object> { ["attr2"] = "value" },
+                false
+            };
+            yield return new object?[]
+            {
+                new Dictionary<string,object> { ["attr"] = "value", ["attr2"] = "value2" },
+                new Dictionary<string,object> { ["attr2"] = "value2" },
+                false
+            };
+            yield return new object?[]
+            {
+                new Dictionary<string,object> { ["attr"] = "value", ["attr2"] = 15 },
+                new Dictionary<string,object> { ["attr"] = "value", ["attr2"] = 15 },
+                true
+            };
+            yield return new object?[]
+            {
+                new Dictionary<string,object> { ["attr"] = "value", ["attr2"] = 15 },
+                new Dictionary<string,object> { ["attr"] = "value", ["attr2"] = "value2" },
+                false
+            };
+            yield return new object?[]
+            {
+                new Dictionary<string,object> { ["attr"] = "value" },
+                new Dictionary<string,object?> { ["attr"] = "value", ["attr2"] = null },
+                true
+            };
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    [Theory]
+    [ClassData(typeof(RenderedAttributesEqualityTestData))]
+    public void CompareProperly_RenderedAttributes(
+        IReadOnlyDictionary<string, object>? x,
+        IReadOnlyDictionary<string, object>? y,
+        bool expected)
+    {
+        // Arrange && Act
+        var actual = x.RenderedAttributesEqual(y);
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+}

--- a/src/Microsoft.Fast.Components.FluentUI/Components/Icon/FluentIcon.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/Icon/FluentIcon.cs
@@ -100,7 +100,7 @@ public partial class FluentIcon : FluentComponentBase
     [Parameter]
     public EventCallback<MouseEventArgs> OnClick { get; set; }
 
-    protected override async Task OnParametersSetAsync()
+    protected override void OnParametersSet()
     {
         string? nc = NeutralCultureName ?? null;
 
@@ -245,40 +245,13 @@ public partial class FluentIcon : FluentComponentBase
         return _previousIconUrl != _iconUrl;
     }
 
-    private bool GetParametersChanged()
-    {
-        if (_previousId != Id ||
-            _previousColor != _color ||
-            _previousSlot != Slot ||
-            _previousClass != Class ||
-            _previousStyle != Style ||
-            (_previousAdditionalAttributes?.Count ?? 0) != (AdditionalAttributes?.Count ?? 0))
-        {
-            return true;
-        }
-
-        if (_previousAdditionalAttributes != null &&
-            _previousAdditionalAttributes.Count > 0)
-        {
-            foreach (var key in _previousAdditionalAttributes.Keys)
-            {
-                if (!AdditionalAttributes!.TryGetValue(key, out var currentValue))
-                {
-                    return true;
-                }
-
-                var previousValue = _previousAdditionalAttributes[key];
-
-                if ((previousValue is null && currentValue is not null) ||
-                    (previousValue is not null && !previousValue.Equals(currentValue)))
-                {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
+    private bool GetParametersChanged() =>
+        _previousId != Id ||
+        _previousColor != _color ||
+        _previousSlot != Slot ||
+        _previousClass != Class ||
+        _previousStyle != Style ||
+        !_previousAdditionalAttributes.RenderedAttributesEqual(AdditionalAttributes);
 
     private void UpdatePreviousParameters()
     {

--- a/src/Microsoft.Fast.Components.FluentUI/Components/Icon/FluentIcon.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/Icon/FluentIcon.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Fast.Components.FluentUI.Infrastructure;
+using Microsoft.Fast.Components.FluentUI.Utilities;
 
 namespace Microsoft.Fast.Components.FluentUI;
 
@@ -13,15 +14,32 @@ public partial class FluentIcon : FluentComponentBase
     private string? _iconUrl;
     private string? _iconUrlFallback;
     private string? _color;
-    private string? _prevResult;
 
     private int _size;
+
+    private string? _previousId;
+    private string? _previousIconUrl;
+    private string? _previousColor;
+    private string? _previousSlot;
+    private string? _previousIconContent;
+    private string? _previousClass;
+    private string? _previousStyle;
+    private IReadOnlyDictionary<string, object>? _previousAdditionalAttributes;
+
+    private bool _iconChanged;
+    private bool _shouldRender;
 
     [Inject]
     private IStaticAssetService StaticAssetService { get; set; } = default!;
 
     [Inject]
     private IconService IconService { get; set; } = default!;
+
+    protected string? StyleValue => new StyleBuilder()
+        .AddStyle("fill", _color)
+        .AddStyle("cursor", "pointer", OnClick.HasDelegate)
+        .AddStyle(Style)
+        .Build();
 
     /// <summary>
     /// Gets or sets the id.
@@ -82,8 +100,7 @@ public partial class FluentIcon : FluentComponentBase
     [Parameter]
     public EventCallback<MouseEventArgs> OnClick { get; set; }
 
-
-    protected override void OnParametersSet()
+    protected override async Task OnParametersSetAsync()
     {
         string? nc = NeutralCultureName ?? null;
 
@@ -118,46 +135,35 @@ public partial class FluentIcon : FluentComponentBase
 
         _iconUrl = $"{ICON_ROOT}/{Name}{(nc is not null ? "/" + nc : "")}/{ComposedName}.svg";
         _iconUrlFallback = $"{ICON_ROOT}/{Name}/{ComposedName}.svg";
+
+        _iconChanged = GetIconChanged();
+
+        _shouldRender = _iconChanged || GetParametersChanged();
+        UpdatePreviousParameters();
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        string? result;
-
-        if (!string.IsNullOrEmpty(_iconUrl))
+        if (!_iconChanged)
         {
-            result = await StaticAssetService.GetAsync(_iconUrl);
-            if (string.IsNullOrEmpty(result))
-            {
-                _iconUrlFallback = $"{ICON_ROOT}/{Name}/{ComposedName}.svg";
-                result = await StaticAssetService.GetAsync(_iconUrlFallback);
-
-                if (string.IsNullOrEmpty(result))
-                {
-                    return;
-                }
-            }
-
-            result = result.Replace("<path ", $"<path fill=\"{_color}\"");
-
-            string pattern = "<svg (?<attributes>.*?)>(?<path>.*?)</svg>";
-            Regex regex = new(pattern);
-            MatchCollection matches = regex.Matches(result);
-            Match? match = matches.FirstOrDefault();
-
-            if (match is not null)
-                result = match.Groups["path"].Value;
-
-
-            if (_prevResult != result)
-            {
-                _svg = result;
-                _prevResult = result;
-                _size = Convert.ToInt32(Size);
-
-                StateHasChanged();
-            }
+            return;
         }
+
+        _iconChanged = false;
+        var iconContent = await GetIconContentAsync();
+
+        if (_previousIconContent != iconContent)
+        {
+            _svg = iconContent;
+            _previousIconContent = iconContent;
+            _size = Convert.ToInt32(Size);
+            StateHasChanged();
+        }
+    }
+
+    protected override bool ShouldRender()
+    {
+        return _shouldRender;
     }
 
     protected override void BuildRenderTree(RenderTreeBuilder builder)
@@ -168,7 +174,7 @@ public partial class FluentIcon : FluentComponentBase
             builder.AddAttribute(1, "id", Id);
             builder.AddAttribute(2, "slot", Slot);
             builder.AddAttribute(3, "class", Class);
-            builder.AddAttribute(4, "style", Style);
+            builder.AddAttribute(4, "style", StyleValue);
             builder.AddAttribute(5, "width", _size);
             builder.AddAttribute(6, "height", _size);
             builder.AddAttribute(7, "viewBox", $"0 0 {_size} {_size}");
@@ -186,6 +192,39 @@ public partial class FluentIcon : FluentComponentBase
             await OnClick.InvokeAsync(e);
     }
 
+    private async Task<string?> GetIconContentAsync()
+    {
+        _previousIconUrl = _iconUrl;
+
+        string? result = null;
+
+        if (!string.IsNullOrEmpty(_iconUrl))
+        {
+            result = await StaticAssetService.GetAsync(_iconUrl);
+
+            if (string.IsNullOrEmpty(result) &&
+                !string.IsNullOrEmpty(_iconUrlFallback))
+            {
+                result = await StaticAssetService.GetAsync(_iconUrlFallback);
+            }
+        }
+
+        if (string.IsNullOrEmpty(result))
+        {
+            return result;
+        }
+
+        string pattern = "<svg (?<attributes>.*?)>(?<path>.*?)</svg>";
+        Regex regex = new(pattern);
+        MatchCollection matches = regex.Matches(result);
+        Match? match = matches.FirstOrDefault();
+
+        if (match is not null)
+            result = match.Groups["path"].Value;
+
+        return result;
+    }
+
     private string ComposedName
     {
         get
@@ -199,6 +238,56 @@ public partial class FluentIcon : FluentComponentBase
 
             return $"{(int)Size}_{variant}";
         }
+    }
+
+    private bool GetIconChanged()
+    {
+        return _previousIconUrl != _iconUrl;
+    }
+
+    private bool GetParametersChanged()
+    {
+        if (_previousId != Id ||
+            _previousColor != _color ||
+            _previousSlot != Slot ||
+            _previousClass != Class ||
+            _previousStyle != Style ||
+            (_previousAdditionalAttributes?.Count ?? 0) != (AdditionalAttributes?.Count ?? 0))
+        {
+            return true;
+        }
+
+        if (_previousAdditionalAttributes != null &&
+            _previousAdditionalAttributes.Count > 0)
+        {
+            foreach (var key in _previousAdditionalAttributes.Keys)
+            {
+                if (!AdditionalAttributes!.TryGetValue(key, out var currentValue))
+                {
+                    return true;
+                }
+
+                var previousValue = _previousAdditionalAttributes[key];
+
+                if ((previousValue is null && currentValue is not null) ||
+                    (previousValue is not null && !previousValue.Equals(currentValue)))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private void UpdatePreviousParameters()
+    {
+        _previousId = Id;
+        _previousColor = _color;
+        _previousSlot = Slot;
+        _previousClass = Class;
+        _previousStyle = Style;
+        _previousAdditionalAttributes = AdditionalAttributes;
     }
 
 #if NET7_0_OR_GREATER

--- a/src/Microsoft.Fast.Components.FluentUI/Components/Icon/FluentIcons.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/Icon/FluentIcons.cs
@@ -15,6 +15,28 @@ public partial class FluentIcons
         new IconModel("Info", IconSize.Size32, IconVariant.Regular)
     };
 
+    private static readonly ushort SizesCount = (ushort)Enum.GetValues(typeof(IconSize)).Length;
+    public static readonly Dictionary<string, uint> IconsAvailability;
+
+    static FluentIcons()
+    {
+        IconsAvailability =
+            FullIconMap
+                .GroupBy(x => x.Name)
+                .ToDictionary(
+                    g => g.Key,
+                    g =>
+                    {
+                        uint mask = 0;
+                        foreach (var icon in g)
+                        {
+                            mask |= GetAvailabilityBitMask(icon.Size, icon.Variant);
+                        }
+
+                        return mask;
+                    });
+    }
+
     public static IEnumerable<IconModel> GetIconMap(IconSize[] sizes, IconVariant[] variants)
     {
         return FullIconMap.Where(x => sizes.Contains(x.Size) && variants.Contains(x.Variant));
@@ -23,9 +45,35 @@ public partial class FluentIcons
     public static bool IconAvailable(IconConfiguration configuration, FluentIcon icon)
     {
         if (configuration.PublishedAssets)
-            return GetIconMap(configuration.Sizes, configuration.Variants).Any(x => x.Name == icon.Name && x.Size == icon.Size && x.Variant == icon.Variant);
+            return configuration.Variants.Contains(icon.Variant) &&
+                   configuration.Sizes.Contains(icon.Size) &&
+                   IconsAvailability.TryGetValue(icon.Name, out var iconAvailability) &&
+                   (iconAvailability & GetAvailabilityBitMask(icon.Size, icon.Variant)) != 0;
         else
             return LibraryUsedIcons.Any(x => x.Name == icon.Name && x.Size == icon.Size && x.Variant == icon.Variant);
+    }
 
+    private static uint GetAvailabilityBitMask(IconSize size, IconVariant variant)
+    {
+        return 1U << GetAvailabilityBitPosition(size, variant);
+    }
+
+    private static int GetAvailabilityBitPosition(IconSize size, IconVariant variant)
+    {
+        var variantOffset = (int)variant * SizesCount;
+        var sizeOffset = size switch
+        {
+            IconSize.Size10 => 0,
+            IconSize.Size12 => 1,
+            IconSize.Size16 => 2,
+            IconSize.Size20 => 3,
+            IconSize.Size24 => 4,
+            IconSize.Size28 => 5,
+            IconSize.Size32 => 6,
+            IconSize.Size48 => 7,
+            _ => throw new ArgumentOutOfRangeException(nameof(size), size, null)
+        };
+
+        return variantOffset + sizeOffset;
     }
 }

--- a/src/Microsoft.Fast.Components.FluentUI/Extensions/AdditionalAttributesExtensions.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/Extensions/AdditionalAttributesExtensions.cs
@@ -1,0 +1,56 @@
+﻿namespace Microsoft.Fast.Components.FluentUI;
+
+public static class AdditionalAttributesExtensions
+{
+    /// <summary> Determines whether two sets of attributes are equal when rendered. </summary>
+    /// <param name="x">The compared set</param>
+    /// <param name="y">The set to compare with</param>
+    /// <remarks></remarks>
+    /// <returns><c>true</c> if both sets render the same attributes; otherwise, <c>false</c>.</returns>
+    public static bool RenderedAttributesEqual(
+        this IReadOnlyDictionary<string, object>? x,
+        IReadOnlyDictionary<string, object>? y)
+    {
+        if ((x?.Count ?? 0) == 0 && (y?.Count ?? 0) == 0)
+        {
+            return true;
+        }
+
+        if (x is { Count: > 0 } &&
+            !x.AllRenderedAttributesInAndEqual(y))
+        {
+            return false;
+        }
+
+        if (y is { Count: > 0 } &&
+            !y.AllRenderedAttributesInAndEqual(x))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool AllRenderedAttributesInAndEqual(
+        this IReadOnlyDictionary<string, object> x,
+        IReadOnlyDictionary<string, object>? y)
+    {
+        foreach (var xKvp in x)
+        {
+            if (xKvp.Value is null)
+            {
+                continue;
+            }
+
+            if (y is null) return false;
+
+            if (!y.TryGetValue(xKvp.Key, out var yValue) ||
+                !xKvp.Value.Equals(yValue))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

 - reduced number of StaticAssetService.GetAsync calls in FluentIcon
 - suppression of re-render if parameters haven't changed (when icon is in RenderFragment)
 - dedicated dictionary instead of array is used for icon availability check

### 🎫 Issues

#370 

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->