### PR TITLE
Template updates

### DIFF
--- a/templates/Projects/FluentUIBlazorServerApp/FluentUIBlazorServerApp.csproj
+++ b/templates/Projects/FluentUIBlazorServerApp/FluentUIBlazorServerApp.csproj
@@ -79,7 +79,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Fast.Components.FluentUI" Version="2.1.*" />
+		<PackageReference Include="Microsoft.Fast.Components.FluentUI" Version="2.3.*" />
 	</ItemGroup>
 
 </Project>

--- a/templates/Projects/FluentUIBlazorServerApp/Pages/FetchData.razor
+++ b/templates/Projects/FluentUIBlazorServerApp/Pages/FetchData.razor
@@ -2,7 +2,7 @@
 
 <PageTitle>Weather forecast</PageTitle>
 
-@using FluentUIBlazorServerApp.Data
+@using fluentserver.Data
 @inject WeatherForecastService ForecastService
 
 <h1>Weather forecast</h1>
@@ -16,15 +16,15 @@
 else
 {
     <FluentDataGrid id="manualGrid" RowsData=@forecasts GridTemplateColumns="1fr 1fr 1fr 2fr" TGridItem=WeatherForecast>
-        <PropertyColumn Title="Date" Property="@(c => c.Date)" Sortable="true" Align=Align.Left/>
-        <PropertyColumn Title="Temp. (C)" Property="@(c => c.TemperatureC)" Sortable="true" Align=Align.Center/>
-        <PropertyColumn Title="Temp. (F)" Property="@(c => c.TemperatureF)" Sortable="true" Align=Align.Center/>
-        <PropertyColumn Title="Summary" Property="@(c => c.Summary)" Sortable="true" Align=Align.Right/>
+        <PropertyColumn Title="Date" Property="@(c => c!.Date)" Sortable="true" Align=Align.Left/>
+        <PropertyColumn Title="Temp. (C)" Property="@(c => c!.TemperatureC)" Sortable="true" Align=Align.Center/>
+        <PropertyColumn Title="Temp. (F)" Property="@(c => c!.TemperatureF)" Sortable="true" Align=Align.Center/>
+        <PropertyColumn Title="Summary" Property="@(c => c!.Summary)" Sortable="true" Align=Align.Right/>
     </FluentDataGrid>
 }
 
 @code {
-    private IQueryable<WeatherForecast> forecasts;
+    private IQueryable<WeatherForecast>? forecasts;
 
     protected override async Task OnInitializedAsync()
     {

--- a/templates/Projects/FluentUIBlazorWebAssemblyApp/FluentUIBlazorWebAssemblyApp.csproj
+++ b/templates/Projects/FluentUIBlazorWebAssemblyApp/FluentUIBlazorWebAssemblyApp.csproj
@@ -89,7 +89,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Fast.Components.FluentUI" Version="2.1.*" />
+		<PackageReference Include="Microsoft.Fast.Components.FluentUI" Version="2.3.*" />
 	</ItemGroup>
 
 </Project>

--- a/templates/Projects/FluentUIBlazorWebAssemblyApp/Pages/FetchData.razor
+++ b/templates/Projects/FluentUIBlazorWebAssemblyApp/Pages/FetchData.razor
@@ -1,4 +1,4 @@
-﻿@page "/fetchdata"
+@page "/fetchdata"
 @inject HttpClient Http
 
 <PageTitle>Weather forecast</PageTitle>
@@ -14,15 +14,15 @@
 else
 {
     <FluentDataGrid id="manualGrid" RowsData=@forecasts GridTemplateColumns="1fr 1fr 1fr 2fr" TGridItem=WeatherForecast>
-        <PropertyColumn Title="Date" Property="@(c => c.Date)" Sortable="true" Align=Align.Left/>
-        <PropertyColumn Title="Temp. (C)" Property="@(c => c.TemperatureC)" Sortable="true" Align=Align.Center/>
-        <PropertyColumn Title="Temp. (F)" Property="@(c => c.TemperatureF)" Sortable="true" Align=Align.Center/>
-        <PropertyColumn Title="Summary" Property="@(c => c.Summary)" Sortable="true" Align=Align.Right/>
+        <PropertyColumn Title="Date" Property="@(c => c!.Date)" Sortable="true" Align=Align.Left/>
+        <PropertyColumn Title="Temp. (C)" Property="@(c => c!.TemperatureC)" Sortable="true" Align=Align.Center/>
+        <PropertyColumn Title="Temp. (F)" Property="@(c => c!.TemperatureF)" Sortable="true" Align=Align.Center/>
+        <PropertyColumn Title="Summary" Property="@(c => c!.Summary)" Sortable="true" Align=Align.Right/>
     </FluentDataGrid>
 }
 
 @code {
-    private IQueryable<WeatherForecast> forecasts;
+    private IQueryable<WeatherForecast>? forecasts;
 
     protected override async Task OnInitializedAsync()
     {


### PR DESCRIPTION
# Pull Request

## 📖 Description

When creating a new fluent ui wasm project, _FetchData.razor_ page generates nullable warnings on compile.

### 🎫 Issues

Warnings generated from code created from template.

<!---
* List and link relevant issues here.
-->
``` powershell
Build started...
1>------ Build started: Project: fluentwasm, Configuration: Debug Any CPU ------
1>C:\git\fluentwasm\Pages\FetchData.razor(17,55,17,56): warning CS8602: Dereference of a possibly null reference.
1>C:\git\fluentwasm\Pages\FetchData.razor(18,60,18,61): warning CS8602: Dereference of a possibly null reference.
1>C:\git\fluentwasm\Pages\FetchData.razor(19,60,19,61): warning CS8602: Dereference of a possibly null reference.
1>C:\git\fluentwasm\Pages\FetchData.razor(20,58,20,59): warning CS8602: Dereference of a possibly null reference.
1>C:\git\fluentwasm\Pages\FetchData.razor(25,41,25,50): warning CS8618: Non-nullable field 'forecasts' must contain a non-null value when exiting constructor. Consider declaring the field as nullable.
1>C:\git\fluentwasm\Pages\FetchData.razor(17,55,17,56): warning CS8602: Dereference of a possibly null reference.
1>C:\git\fluentwasm\Pages\FetchData.razor(18,60,18,61): warning CS8602: Dereference of a possibly null reference.
1>C:\git\fluentwasm\Pages\FetchData.razor(19,60,19,61): warning CS8602: Dereference of a possibly null reference.
1>C:\git\fluentwasm\Pages\FetchData.razor(20,58,20,59): warning CS8602: Dereference of a possibly null reference.
1>C:\git\fluentwasm\Pages\FetchData.razor(25,41,25,50): warning CS8618: Non-nullable field 'forecasts' must contain a non-null value when exiting constructor. Consider declaring the field as nullable.
1>fluentwasm -> C:\git\fluentwasm\bin\Debug\net7.0\fluentwasm.dll
1>fluentwasm (Blazor output) -> C:\git\fluentwasm\bin\Debug\net7.0\wwwroot
1>Done building project "fluentwasm.csproj".
1>fluentwasm -> C:\git\fluentwasm\bin\Debug\net6.0\fluentwasm.dll
1>fluentwasm (Blazor output) -> C:\git\fluentwasm\bin\Debug\net6.0\wwwroot
========== Build: 1 succeeded, 0 failed, 0 up-to-date, 0 skipped ==========
========== Build started at 1:58 PM and took 11.658 seconds ==========
```

## 👩‍💻 Reviewer Notes

## 📑 Test Plan

## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [X] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [ ] I have modified an existing component

## ⏭ Next Steps
