### PR TITLE
Fix DatePicker min-width for mobile devices

### DIFF
--- a/src/Microsoft.Fast.Components.FluentUI/Components/DateTime/FluentTimePicker.razor.css
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/DateTime/FluentTimePicker.razor.css
@@ -1,3 +1,3 @@
 ﻿.fluent-timepicker {
-
+    min-width: 110px;
 }


### PR DESCRIPTION
# Fix DatePicker min-width for mobile devices

## 📖 Description

On mobile phones the placeholder is sometimes missing (e.g. iPhone). In this case the width of the DatePicker is very small.
This PR sets a min-width value to avoid this issue.

