### PR TITLE
Add NavigationIconContent to FluentNavMenu (Fixes #463)

### DIFF
--- a/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenu.razor
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenu.razor
@@ -12,7 +12,12 @@
                               Class="navmenu-main-button"
                               @onclick="CollapsibleClickAsync"
                               title="@Title">
-                        <FluentIcon Name="@(FluentIcons.Navigation)" Size="IconSize.Size20" />
+                        @if (NavigationIconContent is not null) {
+                            @NavigationIconContent
+                        }
+                        else {
+                            <FluentIcon Name="@(FluentIcons.Navigation)" Size="IconSize.Size20" />
+                        }
                     </FluentButton>
                 }
                 @ChildContent

--- a/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenu.razor.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenu.razor.cs
@@ -86,7 +86,7 @@ public partial class FluentNavMenu : FluentComponentBase
 
     internal bool HasSubMenu => _groups.Any();
 
-    internal bool HasIcons => _links.Any(i => !string.IsNullOrWhiteSpace(i.Icon));
+    internal bool HasIcons => _links.Any(i => i.HasIcon);
 
     internal async Task CollapsibleClickAsync()
     {

--- a/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenu.razor.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenu.razor.cs
@@ -35,6 +35,14 @@ public partial class FluentNavMenu : FluentComponentBase
     public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
+    /// Gets or sets the content to be rendered for the navigation icon
+    /// when the menu is collapsible.  The default icon will be used if
+    /// this is not specified.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? NavigationIconContent { get; set; }
+
+    /// <summary>
     /// Gets or sets the title of the navigation menu
     /// Default to "Navigation menu"
     /// </summary>

--- a/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenuGroup.razor
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenuGroup.razor
@@ -12,7 +12,14 @@
         <FluentIcon Name="@IconNavMenuCollapsed" Size="@IconSize.Size20" Slot="start" OnClick="ExpandMenu" />
     }
     @if (HasIcon) {
-        <FluentIcon Name="@Icon" Size="@IconSize.Size20" Slot="start" OnClick="HandleIconClick" />
+        if (IconContent is not null) {
+            <div slot="start" @onclick="HandleIconClick">
+                @IconContent
+            </div>
+        }
+        else {
+            <FluentIcon Name="@Icon" Size="@IconSize.Size20" Slot="start" OnClick="HandleIconClick" />
+        }
     }
     @if (NavMenuExpanded) {
         @ChildContent

--- a/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenuGroup.razor.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenuGroup.razor.cs
@@ -19,6 +19,12 @@ public partial class FluentNavMenuGroup : FluentComponentBase
     public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
+    /// Gets or sets the content to be rendered for the icon.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? IconContent { get; set; }
+
+    /// <summary>
     /// Gets or sets the destination of the link.
     /// </summary>
     [Parameter]
@@ -94,7 +100,7 @@ public partial class FluentNavMenuGroup : FluentComponentBase
         .AddStyle(Style)
         .Build();
 
-    private bool HasIcon => !string.IsNullOrWhiteSpace(Icon);
+    private bool HasIcon => !string.IsNullOrWhiteSpace(Icon) || IconContent is not null;
 
     protected override void OnParametersSet()
     {

--- a/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenuLink.razor
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenuLink.razor
@@ -9,7 +9,12 @@
                 Text="@(NavMenuExpanded ? Text : string.Empty)">
     @if (HasIcon)
     {
-        <FluentIcon Name="@Icon" Size="@IconSize.Size20" Slot="start" OnClick="HandleIconClick"/>
+        if (IconContent is not null) {
+            @IconContent
+        }
+        else {
+            <FluentIcon Name="@Icon" Size="@IconSize.Size20" Slot="start" OnClick="HandleIconClick"/>
+        }
     } 
     @if (!HasIcon && NavMenu.HasIcons)
     {

--- a/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenuLink.razor.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenuLink.razor.cs
@@ -89,7 +89,7 @@ public partial class FluentNavMenuLink : FluentComponentBase
         .AddStyle(Style)
         .Build();
 
-    private bool HasIcon => !string.IsNullOrWhiteSpace(Icon) || IconContent is not null;
+    internal bool HasIcon => !string.IsNullOrWhiteSpace(Icon) || IconContent is not null;
 
     [CascadingParameter(Name = "NavMenuExpanded")]
     private bool NavMenuExpanded { get; set; }

--- a/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenuLink.razor.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenuLink.razor.cs
@@ -16,6 +16,12 @@ public partial class FluentNavMenuLink : FluentComponentBase
     public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
+    /// Gets or sets the content to be rendered for the icon.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? IconContent { get; set; }
+
+    /// <summary>
     /// Gets or sets the destination of the link.
     /// </summary>
     [Parameter]
@@ -83,7 +89,7 @@ public partial class FluentNavMenuLink : FluentComponentBase
         .AddStyle(Style)
         .Build();
 
-    private bool HasIcon => !string.IsNullOrWhiteSpace(Icon);
+    private bool HasIcon => !string.IsNullOrWhiteSpace(Icon) || IconContent is not null;
 
     [CascadingParameter(Name = "NavMenuExpanded")]
     private bool NavMenuExpanded { get; set; }


### PR DESCRIPTION
I'd like to not have to use `<FluentIcon>` in my `FluentNavMenu` but use images instead.

This PR adds a `FluentNavMenu.NavigationIconContent` render fragment, and also `IconContent` to `FluentNavMenuLink` and `FluentNavMenuGroup`.

