### PR TITLE
Add NavigationIconContent to FluentNavMenu (Fixes #463)

### DIFF
--- a/examples/FluentUI.Demo.Shared/Microsoft.Fast.Components.FluentUI.xml
+++ b/examples/FluentUI.Demo.Shared/Microsoft.Fast.Components.FluentUI.xml
@@ -2700,6 +2700,13 @@
             Gets or sets the content to be rendered inside the component.
             </summary>
         </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentNavMenu.NavigationIconContent">
+            <summary>
+            Gets or sets the content to be rendered for the navigation icon
+            when the menu is collapsible.  The default icon will be used if
+            this is not specified.
+            </summary>
+        </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentNavMenu.Title">
             <summary>
             Gets or sets the title of the navigation menu
@@ -2734,6 +2741,18 @@
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentNavMenuGroup.ChildContent">
             <summary>
             Gets or sets the content to be rendered inside the component.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentNavMenuGroup.CollapsedIconContent">
+            <summary>
+            Gets or sets the content to be rendered for the icon when
+            the menu is collapsed.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentNavMenuGroup.ExpandedIconContent">
+            <summary>
+            Gets or sets the content to be rendered for the icon when
+            the menu is expanded.
             </summary>
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentNavMenuGroup.Href">
@@ -2787,6 +2806,11 @@
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentNavMenuLink.ChildContent">
             <summary>
             Gets or sets the content to be rendered inside the component.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentNavMenuLink.IconContent">
+            <summary>
+            Gets or sets the content to be rendered for the icon.
             </summary>
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentNavMenuLink.Href">

--- a/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenu.razor
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenu.razor
@@ -12,7 +12,12 @@
                               Class="navmenu-main-button"
                               @onclick="CollapsibleClickAsync"
                               title="@Title">
-                        <FluentIcon Name="@(FluentIcons.Navigation)" Size="IconSize.Size20" />
+                        @if (NavigationIconContent is not null) {
+                            @NavigationIconContent
+                        }
+                        else {
+                            <FluentIcon Name="@(FluentIcons.Navigation)" Size="IconSize.Size20" />
+                        }
                     </FluentButton>
                 }
                 @ChildContent

--- a/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenu.razor.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenu.razor.cs
@@ -35,6 +35,14 @@ public partial class FluentNavMenu : FluentComponentBase
     public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
+    /// Gets or sets the content to be rendered for the navigation icon
+    /// when the menu is collapsible.  The default icon will be used if
+    /// this is not specified.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? NavigationIconContent { get; set; }
+
+    /// <summary>
     /// Gets or sets the title of the navigation menu
     /// Default to "Navigation menu"
     /// </summary>
@@ -78,7 +86,7 @@ public partial class FluentNavMenu : FluentComponentBase
 
     internal bool HasSubMenu => _groups.Any();
 
-    internal bool HasIcons => _links.Any(i => !string.IsNullOrWhiteSpace(i.Icon));
+    internal bool HasIcons => _links.Any(i => i.HasIcon);
 
     internal async Task CollapsibleClickAsync()
     {

--- a/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenuGroup.razor
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenuGroup.razor
@@ -8,11 +8,27 @@
                 Selected="@Selected"
                 Expanded="@(NavMenuExpanded ? Expanded : false)"
                 Text="@(NavMenuExpanded ? Text : string.Empty)">
-    @if (!NavMenuExpanded) {
-        <FluentIcon Name="@IconNavMenuCollapsed" Size="@IconSize.Size20" Slot="start" OnClick="ExpandMenu" />
+    @if (NavMenuExpanded && HasExpandedIcon)
+    {
+        if (ExpandedIconContent is not null)
+        {
+            <div slot="start" @onclick="HandleIconClick">@ExpandedIconContent</div>
+        }
+        else
+        {
+            <FluentIcon Name="@Icon" Size="@IconSize.Size20" Slot="start" OnClick="HandleIconClick" />
+        }
     }
-    @if (HasIcon) {
-        <FluentIcon Name="@Icon" Size="@IconSize.Size20" Slot="start" OnClick="HandleIconClick" />
+    @if(!NavMenuExpanded && HasCollapsedIcon)
+    {
+        if (CollapsedIconContent is not null)
+        {
+            <div slot="start" @onclick="ExpandMenu">@CollapsedIconContent</div>
+        }
+        else
+        {
+            <FluentIcon Name="@IconNavMenuCollapsed" Size="@IconSize.Size20" Slot="start" OnClick="ExpandMenu" />
+        }
     }
     @if (NavMenuExpanded) {
         @ChildContent

--- a/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenuGroup.razor.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenuGroup.razor.cs
@@ -19,6 +19,20 @@ public partial class FluentNavMenuGroup : FluentComponentBase
     public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
+    /// Gets or sets the content to be rendered for the icon when
+    /// the menu is collapsed.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? CollapsedIconContent { get; set; }
+
+    /// <summary>
+    /// Gets or sets the content to be rendered for the icon when
+    /// the menu is expanded.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? ExpandedIconContent { get; set; }
+
+    /// <summary>
     /// Gets or sets the destination of the link.
     /// </summary>
     [Parameter]
@@ -94,7 +108,8 @@ public partial class FluentNavMenuGroup : FluentComponentBase
         .AddStyle(Style)
         .Build();
 
-    private bool HasIcon => !string.IsNullOrWhiteSpace(Icon);
+    private bool HasCollapsedIcon => !string.IsNullOrWhiteSpace(Icon) || CollapsedIconContent is not null;
+    private bool HasExpandedIcon => !string.IsNullOrWhiteSpace(Icon) || ExpandedIconContent is not null;
 
     protected override void OnParametersSet()
     {

--- a/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenuLink.razor
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenuLink.razor
@@ -9,7 +9,12 @@
                 Text="@(NavMenuExpanded ? Text : string.Empty)">
     @if (HasIcon)
     {
-        <FluentIcon Name="@Icon" Size="@IconSize.Size20" Slot="start" OnClick="HandleIconClick"/>
+        if (IconContent is not null) {
+            <div slot="start">@IconContent</div>
+        }
+        else {
+            <FluentIcon Name="@Icon" Size="@IconSize.Size20" Slot="start" OnClick="HandleIconClick"/>
+        }
     } 
     @if (!HasIcon && NavMenu.HasIcons)
     {

--- a/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenuLink.razor.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenuLink.razor.cs
@@ -16,6 +16,12 @@ public partial class FluentNavMenuLink : FluentComponentBase
     public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
+    /// Gets or sets the content to be rendered for the icon.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? IconContent { get; set; }
+
+    /// <summary>
     /// Gets or sets the destination of the link.
     /// </summary>
     [Parameter]
@@ -83,7 +89,7 @@ public partial class FluentNavMenuLink : FluentComponentBase
         .AddStyle(Style)
         .Build();
 
-    private bool HasIcon => !string.IsNullOrWhiteSpace(Icon);
+    internal bool HasIcon => !string.IsNullOrWhiteSpace(Icon) || IconContent is not null;
 
     [CascadingParameter(Name = "NavMenuExpanded")]
     private bool NavMenuExpanded { get; set; }


### PR DESCRIPTION
I'd like to not have to use `<FluentIcon>` in my `FluentNavMenu` but use images instead.

This PR adds
*  FluentNavMenu.NavigationIconContent
*  FluentNavMenuLink.IconContent
*  FluentNavMenuGroup.CollapsedIconContent (NavMenu currently does not support this)
*  FluentNavMenuGroup.ExpandedIconContent