### PR TITLE
Add AfterBindValue to FluentInputBase (Fixes #472)

### DIFF
--- a/examples/FluentUI.Demo.Shared/Microsoft.Fast.Components.FluentUI.xml
+++ b/examples/FluentUI.Demo.Shared/Microsoft.Fast.Components.FluentUI.xml
@@ -344,7 +344,8 @@
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentInputBase`1.AfterBindValue">
             <summary>
             An event that is called after the <see cref="P:Microsoft.Fast.Components.FluentUI.FluentInputBase`1.Value"/> property has been changed
-            through data binding.
+            through data binding. This is equivalent to <code>@bind-Value:after</code> which is supported
+            from .Net 7, but not available in .Net 6.
             </summary>
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentInputBase`1.Placeholder">

--- a/examples/FluentUI.Demo.Shared/Microsoft.Fast.Components.FluentUI.xml
+++ b/examples/FluentUI.Demo.Shared/Microsoft.Fast.Components.FluentUI.xml
@@ -341,6 +341,12 @@
             Determines if the element should receive document focus on page load.
             </summary>
         </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentInputBase`1.AfterBindValue">
+            <summary>
+            An event that is called after the <see cref="P:Microsoft.Fast.Components.FluentUI.FluentInputBase`1.Value"/> property has been changed
+            through data binding.
+            </summary>
+        </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentInputBase`1.Placeholder">
             <summary>
             The short hint displayed in the input before the user enters a value.
@@ -366,6 +372,12 @@
             <summary>
             Gets or sets the current value of the input, represented as a string.
             </summary>
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.FluentInputBase`1.SetCurrentValueAsString(System.String)">
+            <summary>
+            Attempts to set the current value of the input, represented as a string.
+            </summary>
+            <param name="value"></param>
         </member>
         <member name="M:Microsoft.Fast.Components.FluentUI.FluentInputBase`1.#ctor">
             <summary>

--- a/examples/FluentUI.Demo.Shared/Pages/DataGrid/Examples/DataGridCustomComparer.razor
+++ b/examples/FluentUI.Demo.Shared/Pages/DataGrid/Examples/DataGridCustomComparer.razor
@@ -8,14 +8,14 @@
     @*<PropertyColumn Property="@(c => c.Name)" InitialSortDirection=SortDirection.Descending Sortable="true" Comparer="@StringLengthComparer.Instance">
         <ColumnOptions>
             <div class="search-box">
-                <FluentSearch type="search" Autofocus=true @bind-Value=nameFilter @oninput="HandleCountryFilter" @onchange="HandleClear" Placeholder="Country name..." />
+                <FluentSearch type="search" Autofocus=true @bind-Value=nameFilter @oninput="HandleCountryFilter" AfterBindValue="HandleClear" Placeholder="Country name..." />
             </div>
         </ColumnOptions>
     </PropertyColumn>*@
     <TemplateColumn Title="Name" InitialSortDirection=SortDirection.Descending SortBy="@nameSort" IsDefaultSortColumn=true>
         <ColumnOptions>
             <div class="search-box">
-                <FluentSearch type="search" Autofocus=true @bind-Value=nameFilter @oninput="HandleCountryFilter" @onchange="HandleClear" Placeholder="Country name..." />
+                <FluentSearch type="search" Autofocus=true @bind-Value=nameFilter @oninput="HandleCountryFilter" AfterBindValue="HandleClear" Placeholder="Country name..." />
             </div>
         </ColumnOptions>
         <ChildContent>
@@ -60,12 +60,9 @@
         }
     }
 
-    private void HandleClear(ChangeEventArgs args)
+    private void HandleClear(string? value)
     {
-        if (args is not null && string.IsNullOrWhiteSpace(args.Value?.ToString()))
-        {
-            nameFilter = string.Empty;
-        }
+        nameFilter = value ?? string.Empty;
     }
 
     public class StringLengthComparer : IComparer<string>

--- a/examples/FluentUI.Demo.Shared/Pages/DataGrid/Examples/DataGridTypical.razor
+++ b/examples/FluentUI.Demo.Shared/Pages/DataGrid/Examples/DataGridTypical.razor
@@ -8,7 +8,7 @@
     <PropertyColumn Property="@(c => c.Name)" Sortable="true">
         <ColumnOptions>
             <div class="search-box">
-                <FluentSearch type="search" Autofocus=true @bind-Value=nameFilter @oninput="HandleCountryFilter" @onchange="HandleClear" Placeholder="Country name..." />
+                <FluentSearch type="search" Autofocus=true @bind-Value=nameFilter @oninput="HandleCountryFilter" AfterBindValue="HandleClear" Placeholder="Country name..." />
             </div>
         </ColumnOptions>
     </PropertyColumn>
@@ -47,11 +47,8 @@
         }
     }
 
-    private void HandleClear(ChangeEventArgs args)
+    private void HandleClear(string? value)
     {
-        if (args is not null && string.IsNullOrWhiteSpace(args.Value?.ToString()))
-        {
-            nameFilter = string.Empty;
-        }
+        nameFilter = value ?? string.Empty;
     }
 }

--- a/examples/FluentUI.Demo.Shared/Pages/Icon/IconPage.razor
+++ b/examples/FluentUI.Demo.Shared/Pages/Icon/IconPage.razor
@@ -57,7 +57,7 @@
 <p>
    <div class="form-grid">
         <div id="item-0">
-            <FluentSearch Style="width: 100%" Name="Searchterm" @bind-Value="Form.Searchterm" @onchange=@(x => HandleSearchField(x)) Placeholder="Part of icon name..."></FluentSearch>
+            <FluentSearch Style="width: 100%" Name="Searchterm" @bind-Value="Form.Searchterm" AfterBindValue="HandleSearchField" Placeholder="Part of icon name..."></FluentSearch>
         </div>
         <div id="item-1">
             @if (IconService.Configuration.Variants.Contains(IconVariant.Filled))

--- a/examples/FluentUI.Demo.Shared/Pages/Icon/IconPage.razor.cs
+++ b/examples/FluentUI.Demo.Shared/Pages/Icon/IconPage.razor.cs
@@ -61,9 +61,9 @@ public partial class IconPage : IAsyncDisposable
         HandleSearch();
     }
 
-    public void HandleSearchField(ChangeEventArgs args)
+    public void HandleSearchField(string value)
     {
-        Form.Searchterm = (string?)args.Value;
+        Form.Searchterm = value;
 
         HandleSearch();
     }

--- a/examples/FluentUI.Demo.Shared/Pages/Search/Examples/SearchInteractive.razor
+++ b/examples/FluentUI.Demo.Shared/Pages/Search/Examples/SearchInteractive.razor
@@ -1,7 +1,6 @@
 <FluentSearch @ref=searchTest 
-              @oninput=handleSearchInput 
-              @onchange=handleSearchInput
               @bind-Value="@searchValue"
+              AfterBindValue=HandleSearchInput
               Placeholder="Search for State" />
 <br />
 <FluentListbox Items=@searchResults TOption="string" SelectedOptionChanged="@(e => searchValue = (e != defaultResultsText ? e : string.Empty) )"  />
@@ -76,11 +75,16 @@
         return new() { defaultResultsText };
     }
 
-    void handleSearchInput(ChangeEventArgs args)
+    void HandleSearchInput(string? value)
     {
-        if (args is not null && ! string.IsNullOrWhiteSpace(args.Value?.ToString()))
+        if (string.IsNullOrWhiteSpace(value))
         {
-            string searchTerm = args.Value.ToString()!.ToLower();
+            searchResults = defaultResults();
+            searchValue = string.Empty;
+        }
+        else
+        {
+            string searchTerm = value.ToLower();
 
             if (searchTerm.Length > 0)
             {
@@ -90,11 +94,6 @@
                     searchResults = temp;
                 }
             }
-        }
-        else
-        {
-            searchResults = defaultResults();
-            searchValue = string.Empty;
         }
     }
 }

--- a/examples/FluentUI.Demo.Shared/Pages/Search/Examples/SearchInteractiveWithDebounce.razor
+++ b/examples/FluentUI.Demo.Shared/Pages/Search/Examples/SearchInteractiveWithDebounce.razor
@@ -1,9 +1,9 @@
 @using System.Timers;
 
 <FluentSearch @ref=searchTest
-              @bind-Value="SearchValue"
-              @oninput="@(e => SearchValue = e.Value?.ToString())"
-              @onchange="HandleClear"
+@bind-Value="SearchValue"
+@oninput="@(e => SearchValue = e.Value?.ToString())"
+              AfterBindValue="HandleClear"
               Placeholder="Search for name" />
 <br />
 <FluentListbox Items=@searchResults TOption="string" SelectedOptionChanged="@(e => SearchValue = (e != defaultResultsText ? e : string.Empty))" />
@@ -64,7 +64,7 @@
 
     private async Task OnSearchAsync()
     {
-       if (!string.IsNullOrWhiteSpace(SearchValue))
+        if (!string.IsNullOrWhiteSpace(SearchValue))
         {
             string searchTerm = SearchValue.ToLower();
 
@@ -83,21 +83,21 @@
         else
         {
             searchResults = defaultResults();
-            await InvokeAsync(StateHasChanged); 
+            await InvokeAsync(StateHasChanged);
         }
     }
 
-    private void HandleClear(ChangeEventArgs args)
+    private void HandleClear(string value)
     {
-        if (args is not null && string.IsNullOrWhiteSpace(args.Value?.ToString()))
-        {
-            DisposeTimer();
-            searchResults = defaultResults();
-            SearchValue = string.Empty;
-            StateHasChanged();
-        }
+        if (string.IsNullOrWhiteSpace(value))
+            return;
+
+        DisposeTimer();
+        searchResults = defaultResults();
+        SearchValue = string.Empty;
+        StateHasChanged();
     }
-    
+
     //This component is made for a lot of data. You can copy and paste a list with 6000 entries here https://sharetext.me/vfknowohwl"
     private List<string> searchData = new()
     {

--- a/examples/FluentUI.Demo.Shared/Shared/DemoMainLayout.razor
+++ b/examples/FluentUI.Demo.Shared/Shared/DemoMainLayout.razor
@@ -45,16 +45,16 @@
                           TOption="OfficeColor"
                           Position="SelectPosition.Below"
                           @bind-SelectedOption="@_selectedColorOption"
-                          @onchange="@(x => HandleColorChange(x))" 
+                          @onchange="@(x => HandleColorChange((OfficeColor?)x.Value))" 
                           aria-label="Accent color selector"/>
         </div>
         <div class="switches">
-            <FluentSwitch @bind-Value="@_inDarkMode" @onchange=SwitchTheme title="Switch theme">
+            <FluentSwitch @bind-Value="@_inDarkMode" AfterBindValue="UpdateTheme" title="Switch theme">
                 <span class="label">Theme</span>
                 <span slot="unchecked-message">light</span>
                 <span slot="checked-message">dark</span>
             </FluentSwitch>
-            <FluentSwitch @bind-Value="@_ltr" @onchange="SwitchDirection" title="Switch direction">
+            <FluentSwitch @bind-Value="@_ltr" AfterBindValue="UpdateDirection" title="Switch direction">
                 <span>Direction</span>
                 <span slot="unchecked-message">LTR</span>
                 <span slot="checked-message">RTL</span>

--- a/examples/FluentUI.Demo.Shared/Shared/DemoMainLayout.razor.cs
+++ b/examples/FluentUI.Demo.Shared/Shared/DemoMainLayout.razor.cs
@@ -75,6 +75,9 @@ public partial class DemoMainLayout : IAsyncDisposable
                  "./_content/FluentUI.Demo.Shared/Shared/DemoMainLayout.razor.js");
 
             _inDarkMode = await _jsModule!.InvokeAsync<bool>("isDarkMode");
+            if (_inDarkMode)
+                UpdateTheme();
+
             _mobile = await _jsModule!.InvokeAsync<bool>("isDevice");
 
             if (_selectedColorOption != OfficeColor.Default)
@@ -91,9 +94,9 @@ public partial class DemoMainLayout : IAsyncDisposable
         await _toc!.Refresh();
     }
 
-    public async Task SwitchDirection()
+    public async Task UpdateDirection()
     {
-        dir = (dir == LocalizationDirection.rtl) ? LocalizationDirection.ltr : LocalizationDirection.rtl;
+        dir = _ltr ? LocalizationDirection.ltr : LocalizationDirection.rtl;
 
         GlobalState.SetDirection(dir);
 
@@ -101,10 +104,8 @@ public partial class DemoMainLayout : IAsyncDisposable
         await Direction.SetValueFor(container, dir.ToAttributeValue());
     }
 
-    public async void SwitchTheme()
+    public async void UpdateTheme()
     {
-        await Task.Delay(50);
-
         if (_inDarkMode)
             baseLayerLuminance = StandardLuminance.DarkMode;
         else
@@ -122,21 +123,22 @@ public partial class DemoMainLayout : IAsyncDisposable
         menuchecked = !menuchecked;
     }
 
-    private async void HandleColorChange(ChangeEventArgs args)
+    private async void HandleColorChange(OfficeColor? value)
     {
-        string? value = args.Value?.ToString();
-        if (!string.IsNullOrEmpty(value))
+        string? textValue = value?.ToString();
+
+        if (string.IsNullOrEmpty(textValue))
+            return;
+
+        if (textValue != "default")
         {
-            if (value != "default")
-            {
-                //_selectValue = value;
-                await AccentBaseColor.SetValueFor(container, value.ToSwatch());
-            }
-            else
-            {
-                //_selectValue = "default";
-                await AccentBaseColor.DeleteValueFor(container);
-            }
+            //_selectValue = value;
+            await AccentBaseColor.SetValueFor(container, textValue.ToSwatch());
+        }
+        else
+        {
+            //_selectValue = "default";
+            await AccentBaseColor.DeleteValueFor(container);
         }
     }
 

--- a/examples/FluentUI.Demo.Shared/wwwroot/sources/DataGridCustomComparer.razor.txt
+++ b/examples/FluentUI.Demo.Shared/wwwroot/sources/DataGridCustomComparer.razor.txt
@@ -8,14 +8,14 @@
     @*<PropertyColumn Property="@(c => c.Name)" InitialSortDirection=SortDirection.Descending Sortable="true" Comparer="@StringLengthComparer.Instance">
         <ColumnOptions>
             <div class="search-box">
-                <FluentSearch type="search" Autofocus=true @bind-Value=nameFilter @oninput="HandleCountryFilter" @onchange="HandleClear" Placeholder="Country name..." />
+                <FluentSearch type="search" Autofocus=true @bind-Value=nameFilter @oninput="HandleCountryFilter" AfterBindValue="HandleClear" Placeholder="Country name..." />
             </div>
         </ColumnOptions>
     </PropertyColumn>*@
     <TemplateColumn Title="Name" InitialSortDirection=SortDirection.Descending SortBy="@nameSort" IsDefaultSortColumn=true>
         <ColumnOptions>
             <div class="search-box">
-                <FluentSearch type="search" Autofocus=true @bind-Value=nameFilter @oninput="HandleCountryFilter" @onchange="HandleClear" Placeholder="Country name..." />
+                <FluentSearch type="search" Autofocus=true @bind-Value=nameFilter @oninput="HandleCountryFilter" AfterBindValue="HandleClear" Placeholder="Country name..." />
             </div>
         </ColumnOptions>
         <ChildContent>
@@ -60,12 +60,9 @@
         }
     }
 
-    private void HandleClear(ChangeEventArgs args)
+    private void HandleClear(string? value)
     {
-        if (args is not null && string.IsNullOrWhiteSpace(args.Value?.ToString()))
-        {
-            nameFilter = string.Empty;
-        }
+        nameFilter = value ?? string.Empty;
     }
 
     public class StringLengthComparer : IComparer<string>

--- a/examples/FluentUI.Demo.Shared/wwwroot/sources/DataGridTypical.razor.txt
+++ b/examples/FluentUI.Demo.Shared/wwwroot/sources/DataGridTypical.razor.txt
@@ -8,7 +8,7 @@
     <PropertyColumn Property="@(c => c.Name)" Sortable="true">
         <ColumnOptions>
             <div class="search-box">
-                <FluentSearch type="search" Autofocus=true @bind-Value=nameFilter @oninput="HandleCountryFilter" @onchange="HandleClear" Placeholder="Country name..." />
+                <FluentSearch type="search" Autofocus=true @bind-Value=nameFilter @oninput="HandleCountryFilter" AfterBindValue="HandleClear" Placeholder="Country name..." />
             </div>
         </ColumnOptions>
     </PropertyColumn>
@@ -47,11 +47,8 @@
         }
     }
 
-    private void HandleClear(ChangeEventArgs args)
+    private void HandleClear(string? value)
     {
-        if (args is not null && string.IsNullOrWhiteSpace(args.Value?.ToString()))
-        {
-            nameFilter = string.Empty;
-        }
+        nameFilter = value ?? string.Empty;
     }
 }

--- a/examples/FluentUI.Demo.Shared/wwwroot/sources/SearchInteractive.razor.txt
+++ b/examples/FluentUI.Demo.Shared/wwwroot/sources/SearchInteractive.razor.txt
@@ -1,7 +1,6 @@
 <FluentSearch @ref=searchTest 
-              @oninput=handleSearchInput 
-              @onchange=handleSearchInput
               @bind-Value="@searchValue"
+              AfterBindValue=HandleSearchInput
               Placeholder="Search for State" />
 <br />
 <FluentListbox Items=@searchResults TOption="string" SelectedOptionChanged="@(e => searchValue = (e != defaultResultsText ? e : string.Empty) )"  />
@@ -76,11 +75,16 @@
         return new() { defaultResultsText };
     }
 
-    void handleSearchInput(ChangeEventArgs args)
+    void HandleSearchInput(string? value)
     {
-        if (args is not null && ! string.IsNullOrWhiteSpace(args.Value?.ToString()))
+        if (string.IsNullOrWhiteSpace(value))
         {
-            string searchTerm = args.Value.ToString()!.ToLower();
+            searchResults = defaultResults();
+            searchValue = string.Empty;
+        }
+        else
+        {
+            string searchTerm = value.ToLower();
 
             if (searchTerm.Length > 0)
             {
@@ -90,11 +94,6 @@
                     searchResults = temp;
                 }
             }
-        }
-        else
-        {
-            searchResults = defaultResults();
-            searchValue = string.Empty;
         }
     }
 }

--- a/examples/FluentUI.Demo.Shared/wwwroot/sources/SearchInteractiveWithDebounce.razor.txt
+++ b/examples/FluentUI.Demo.Shared/wwwroot/sources/SearchInteractiveWithDebounce.razor.txt
@@ -1,9 +1,9 @@
 @using System.Timers;
 
 <FluentSearch @ref=searchTest
-              @bind-Value="SearchValue"
-              @oninput="@(e => SearchValue = e.Value?.ToString())"
-              @onchange="HandleClear"
+@bind-Value="SearchValue"
+@oninput="@(e => SearchValue = e.Value?.ToString())"
+              AfterBindValue="HandleClear"
               Placeholder="Search for name" />
 <br />
 <FluentListbox Items=@searchResults TOption="string" SelectedOptionChanged="@(e => SearchValue = (e != defaultResultsText ? e : string.Empty))" />
@@ -64,7 +64,7 @@
 
     private async Task OnSearchAsync()
     {
-       if (!string.IsNullOrWhiteSpace(SearchValue))
+        if (!string.IsNullOrWhiteSpace(SearchValue))
         {
             string searchTerm = SearchValue.ToLower();
 
@@ -83,21 +83,21 @@
         else
         {
             searchResults = defaultResults();
-            await InvokeAsync(StateHasChanged); 
+            await InvokeAsync(StateHasChanged);
         }
     }
 
-    private void HandleClear(ChangeEventArgs args)
+    private void HandleClear(string value)
     {
-        if (args is not null && string.IsNullOrWhiteSpace(args.Value?.ToString()))
-        {
-            DisposeTimer();
-            searchResults = defaultResults();
-            SearchValue = string.Empty;
-            StateHasChanged();
-        }
+        if (string.IsNullOrWhiteSpace(value))
+            return;
+
+        DisposeTimer();
+        searchResults = defaultResults();
+        SearchValue = string.Empty;
+        StateHasChanged();
     }
-    
+
     //This component is made for a lot of data. You can copy and paste a list with 6000 entries here https://sharetext.me/vfknowohwl"
     private List<string> searchData = new()
     {

--- a/src/Microsoft.Fast.Components.FluentUI/Components/Base/FluentInputBase.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/Base/FluentInputBase.cs
@@ -86,7 +86,8 @@ public abstract partial class FluentInputBase<TValue> : FluentComponentBase, IDi
 
     /// <summary>
     /// An event that is called after the <see cref="Value"/> property has been changed
-    /// through data binding.
+    /// through data binding. This is equivalent to <code>@bind-Value:after</code> which is supported
+    /// from .Net 7, but not available in .Net 6.
     /// </summary>
     [Parameter]
     public EventCallback<TValue> AfterBindValue { get; set; }

--- a/src/Microsoft.Fast.Components.FluentUI/Components/Base/FluentInputBase.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/Base/FluentInputBase.cs
@@ -85,6 +85,13 @@ public abstract partial class FluentInputBase<TValue> : FluentComponentBase, IDi
     public virtual bool Autofocus { get; set; } = false;
 
     /// <summary>
+    /// An event that is called after the <see cref="Value"/> property has been changed
+    /// through data binding.
+    /// </summary>
+    [Parameter]
+    public EventCallback<TValue> AfterBindValue { get; set; }
+
+    /// <summary>
     /// The short hint displayed in the input before the user enters a value.
     /// </summary>
     [Parameter]
@@ -101,32 +108,35 @@ public abstract partial class FluentInputBase<TValue> : FluentComponentBase, IDi
     /// </summary>
     protected internal FieldIdentifier FieldIdentifier { get; set; }
 
+    protected async Task SetCurrentValue(TValue? value)
+    {
+        var hasChanged = !EqualityComparer<TValue>.Default.Equals(value, Value);
+        if (!hasChanged)
+            return;
+
+        _parsingFailed = false;
+
+        // If we don't do this, then when the user edits from A to B, we'd:
+        // - Do a render that changes back to A
+        // - Then send the updated value to the parent, which sends the B back to this component
+        // - Do another render that changes it to B again
+        // The unnecessary reversion from B to A can cause selection to be lost while typing
+        // A better solution would be somehow forcing the parent component's render to occur first,
+        // but that would involve a complex change in the renderer to keep the render queue sorted
+        // by component depth or similar.
+        Value = value;
+        await ValueChanged.InvokeAsync(Value);
+        EditContext?.NotifyFieldChanged(FieldIdentifier);
+        await AfterBindValue.InvokeAsync(Value);
+    }
+
     /// <summary>
     /// Gets or sets the current value of the input.
     /// </summary>
     protected TValue? CurrentValue
     {
         get => Value;
-        set
-        {
-            var hasChanged = !EqualityComparer<TValue>.Default.Equals(value, Value);
-            if (hasChanged)
-            {
-                _parsingFailed = false;
-
-                // If we don't do this, then when the user edits from A to B, we'd:
-                // - Do a render that changes back to A
-                // - Then send the updated value to the parent, which sends the B back to this component
-                // - Do another render that changes it to B again
-                // The unnecessary reversion from B to A can cause selection to be lost while typing
-                // A better solution would be somehow forcing the parent component's render to occur first,
-                // but that would involve a complex change in the renderer to keep the render queue sorted
-                // by component depth or similar.
-                Value = value;
-                _ = ValueChanged.InvokeAsync(Value);
-                EditContext?.NotifyFieldChanged(FieldIdentifier);
-            }
-        }
+        set => _ = SetCurrentValue(value);
     }
 
     /// <summary>
@@ -139,45 +149,52 @@ public abstract partial class FluentInputBase<TValue> : FluentComponentBase, IDi
         // match what's on the .NET model. This avoids interfering with typing, but still notifies the EditContext
         // about the validation error message.
         get => _parsingFailed ? _incomingValueBeforeParsing : FormatValueAsString(CurrentValue);
-        set
+        set => SetCurrentValueAsString(value);
+    
+    }
+
+    /// <summary>
+    /// Attempts to set the current value of the input, represented as a string.
+    /// </summary>
+    /// <param name="value"></param>
+    protected async Task SetCurrentValueAsString(string? value)
+    {
+        _incomingValueBeforeParsing = value;
+        _parsingValidationMessages?.Clear();
+
+        if (_nullableUnderlyingType != null && string.IsNullOrEmpty(value))
         {
-            _incomingValueBeforeParsing = value;
-            _parsingValidationMessages?.Clear();
+            // Assume if it's a nullable type, null/empty inputs should correspond to default(T)
+            // Then all subclasses get nullable support almost automatically (they just have to
+            // not reject Nullable<T> based on the type itself).
+            _parsingFailed = false;
+            CurrentValue = default!;
+        }
+        else if (TryParseValueFromString(value, out TValue? parsedValue, out var validationErrorMessage))
+        {
+            _parsingFailed = false;
+            await SetCurrentValue(parsedValue);
+        }
+        else
+        {
+            _parsingFailed = true;
 
-            if (_nullableUnderlyingType != null && string.IsNullOrEmpty(value))
+            // EditContext may be null if the input is not a child component of EditForm.
+            if (EditContext is not null)
             {
-                // Assume if it's a nullable type, null/empty inputs should correspond to default(T)
-                // Then all subclasses get nullable support almost automatically (they just have to
-                // not reject Nullable<T> based on the type itself).
-                _parsingFailed = false;
-                CurrentValue = default!;
-            }
-            else if (TryParseValueFromString(value, out var parsedValue, out var validationErrorMessage))
-            {
-                _parsingFailed = false;
-                CurrentValue = parsedValue!;
-            }
-            else
-            {
-                _parsingFailed = true;
+                _parsingValidationMessages ??= new ValidationMessageStore(EditContext);
+                _parsingValidationMessages.Add(FieldIdentifier, validationErrorMessage);
 
-                // EditContext may be null if the input is not a child component of EditForm.
-                if (EditContext is not null)
-                {
-                    _parsingValidationMessages ??= new ValidationMessageStore(EditContext);
-                    _parsingValidationMessages.Add(FieldIdentifier, validationErrorMessage);
-
-                    // Since we're not writing to CurrentValue, we'll need to notify about modification from here
-                    EditContext.NotifyFieldChanged(FieldIdentifier);
-                }
+                // Since we're not writing to CurrentValue, we'll need to notify about modification from here
+                EditContext.NotifyFieldChanged(FieldIdentifier);
             }
+        }
 
-            // We can skip the validation notification if we were previously valid and still are
-            if (_parsingFailed || _previousParsingAttemptFailed)
-            {
-                EditContext?.NotifyValidationStateChanged();
-                _previousParsingAttemptFailed = _parsingFailed;
-            }
+        // We can skip the validation notification if we were previously valid and still are
+        if (_parsingFailed || _previousParsingAttemptFailed)
+        {
+            EditContext?.NotifyValidationStateChanged();
+            _previousParsingAttemptFailed = _parsingFailed;
         }
     }
 
@@ -394,7 +411,7 @@ public abstract partial class FluentInputBase<TValue> : FluentComponentBase, IDi
         {
             EditContext.OnValidationStateChanged -= _validationStateChangedHandler;
         }
-        
+
         _timerCancellationTokenSource.Dispose();
 
         Dispose(disposing: true);

--- a/src/Microsoft.Fast.Components.FluentUI/Components/Checkbox/FluentCheckbox.razor
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/Checkbox/FluentCheckbox.razor
@@ -11,7 +11,7 @@
                  name=@Name
                  required="@Required"
                  current-checked="@CurrentValue"
-                 @oncheckedchange="@((e) => CurrentValue = e.Checked)"
+                 @oncheckedchange="@((e) => SetCurrentValue(e.Checked))"
                  @attributes="@AdditionalAttributes">
     @ChildContent
 </fluent-checkbox>

--- a/src/Microsoft.Fast.Components.FluentUI/Components/Checkbox/FluentCheckbox.razor.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/Checkbox/FluentCheckbox.razor.cs
@@ -18,4 +18,5 @@ public partial class FluentCheckbox : FluentInputBase<bool>
     }
 
     protected override bool TryParseValueFromString(string? value, out bool result, [NotNullWhen(false)] out string? validationErrorMessage) => throw new NotSupportedException($"This component does not parse string inputs. Bind to the '{nameof(CurrentValue)}' property, not '{nameof(CurrentValueAsString)}'.");
+
 }

--- a/src/Microsoft.Fast.Components.FluentUI/Components/NumberField/FluentNumberField.razor
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/NumberField/FluentNumberField.razor
@@ -24,7 +24,7 @@
                      name=@Name
                      required="@Required"
                      appearance="@Appearance.ToAttributeValue()"
-                     @onchange="@(EventCallback.Factory.CreateBinder<string?>(this, __value => CurrentValueAsString = __value, CurrentValueAsString))"
+                     @onchange="@(e => SetCurrentValueAsString((string?)e.Value))"
                      @attributes="AdditionalAttributes">
     @ChildContent
 </fluent-number-field>

--- a/src/Microsoft.Fast.Components.FluentUI/Components/Search/FluentSearch.razor
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/Search/FluentSearch.razor
@@ -19,7 +19,7 @@
                name=@Name
                required="@Required"
                appearance="@Appearance.ToAttributeValue()"
-               @onchange="@(EventCallback.Factory.CreateBinder<string?>(this, __value => CurrentValueAsString = __value, CurrentValueAsString))"
+               @onchange=@(e => SetCurrentValue((string?)e.Value))
                @attributes="AdditionalAttributes">
     @ChildContent
 </fluent-search>

--- a/src/Microsoft.Fast.Components.FluentUI/Components/TextArea/FluentTextArea.razor
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/TextArea/FluentTextArea.razor
@@ -21,7 +21,7 @@
                   name=@Name
                   required="@Required"
                   appearance="@Appearance.ToAttributeValue()"
-                  @onchange="@(EventCallback.Factory.CreateBinder<string?>(this, __value => CurrentValueAsString = __value, CurrentValueAsString))"
+                  @onchange=@(e => SetCurrentValue((string?)e.Value))
                   @attributes="AdditionalAttributes">
     @ChildContent
 </fluent-text-area>

--- a/src/Microsoft.Fast.Components.FluentUI/Components/TextField/FluentTextField.razor
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/TextField/FluentTextField.razor
@@ -20,7 +20,7 @@
                    name=@Name
                    required="@Required"
                    appearance="@Appearance.ToAttributeValue()"
-                   @onchange="@(EventCallback.Factory.CreateBinder<string?>(this, __value => CurrentValueAsString = __value, CurrentValueAsString))"
+                   @onchange=@(e => SetCurrentValue((string?)e.Value))
                    @attributes="AdditionalAttributes">
     @ChildContent
 </fluent-text-field>


### PR DESCRIPTION
1. Moved `CurrentValue` setter to `SetCurrentValue` method so event-driven attempts to set `CurrentValue` can await `ValueChanged` etc.
2. Moved `CurrentValueAsString` setter to a method for the same reason.
3. Added `AfterBindValue` event to circumvent a .Net 6 lack of `@bind-Value:after` that was introduced in .Net 7 - this ensures a consumer can execute code after a databound value has been updated.
4. Ensured all demos use `AfterBindValue`.