### PR TITLE
Fix missing ColumnOptions button for 'Align.Center'

### DIFF
--- a/src/Microsoft.Fast.Components.FluentUI/Components/DataGrid/Columns/ColumnBase.razor
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/DataGrid/Columns/ColumnBase.razor
@@ -15,7 +15,7 @@
         }
         else
         {
-            @if (ColumnOptions is not null && (Align == Align.Left || Align == Align.Start))
+            @if (ColumnOptions is not null && (Align == Align.Left || Align == Align.Start || Align == Align.Center))
             {
                 <FluentButton Appearance="Appearance.Stealth" class="col-options-button" @onclick="@(() => Grid.ShowColumnOptionsAsync(this))" aria-label="Filter this column">
                     <FluentIcon Name="@FluentIcons.Filter" />


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

Filter icon button in column header is neccesarry for ColumnOptions popup.  
However, when `Align == Align.Center`, the button is missing.  
In such cases, QuickGrid places the button at the left side, so I have implemented the same behavior.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
