### PR TITLE
Prevent NavMenu group text overlapping its expand button

### DIFF
--- a/examples/FluentUI.Demo.Shared/Microsoft.Fast.Components.FluentUI.xml
+++ b/examples/FluentUI.Demo.Shared/Microsoft.Fast.Components.FluentUI.xml
@@ -3067,21 +3067,6 @@
             Gets or sets the content to be rendered inside the component.
             </summary>
         </member>
-        <member name="P:Microsoft.Fast.Components.FluentUI.FluentNavMenuGroup.NavMenuGutterIconContent">
-            <summary>
-            Gets or sets the content to be displayed for this group
-            in the <see cref="T:Microsoft.Fast.Components.FluentUI.FluentNavMenu"/> gutter when the menu is collapsed.
-            This setting takes priority over <see cref="P:Microsoft.Fast.Components.FluentUI.FluentNavMenuGroup.NavMenuGutterIcon"/>.
-            </summary>
-        </member>
-        <member name="P:Microsoft.Fast.Components.FluentUI.FluentNavMenuGroup.NavMenuGutterIcon">
-            <summary>
-            Gets or sets the icon to display for this group
-            in the <see cref="T:Microsoft.Fast.Components.FluentUI.FluentNavMenu"/> gutter when the nav menu is collapsed.
-            This setting is not used when <see cref="P:Microsoft.Fast.Components.FluentUI.FluentNavMenuGroup.NavMenuGutterIconContent"/>
-            is not null.
-            </summary>
-        </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentNavMenuGroup.IconContent">
             <summary>
             Gets or sets the icon content to be displayed for this group

--- a/examples/FluentUI.Demo.Shared/Pages/NavMenu/Examples/NavMenuCollapsible.razor
+++ b/examples/FluentUI.Demo.Shared/Pages/NavMenu/Examples/NavMenuCollapsible.razor
@@ -7,7 +7,7 @@
         <FluentNavMenu @bind-Expanded="@Expanded" Width="150">
             <FluentNavMenuLink Class="level1" Icon="@(new Icons.Regular.Size24.Home())" Text="Item 1" />
             <FluentNavMenuLink Class="level1" Icon="@(new Icons.Regular.Size24.Cloud())" Text="Item 2" />
-            <FluentNavMenuGroup Text="Item 3">
+            <FluentNavMenuGroup Text="Item 3" Icon="@(new Icons.Regular.Size24.EarthLeaf())">
                 <FluentNavMenuLink Icon="@(new Icons.Regular.Size24.LeafOne())" Text="Item 3.1" />
                 <FluentNavMenuLink Icon="@(new Icons.Regular.Size24.LeafTwo())" Text="Item 3.2" />
             </FluentNavMenuGroup>

--- a/examples/FluentUI.Demo.Shared/Pages/NavMenu/Examples/NavMenuCustomIconContent.razor
+++ b/examples/FluentUI.Demo.Shared/Pages/NavMenu/Examples/NavMenuCustomIconContent.razor
@@ -8,7 +8,7 @@
             <NavigationIconContent>⛚</NavigationIconContent>
             <ChildContent>
                 <FluentNavMenuGroup Text="Weather">
-                    <NavMenuGutterIconContent>☀</NavMenuGutterIconContent>
+                    <IconContent>☀</IconContent>
                     <ChildContent>
                         <FluentNavMenuLink Text="Sunny">
                             <IconContent>☀</IconContent>
@@ -22,7 +22,7 @@
                     </ChildContent>
                 </FluentNavMenuGroup>
                 <FluentNavMenuGroup Text="Notes">
-                    <NavMenuGutterIconContent>♬</NavMenuGutterIconContent>
+                    <IconContent>♬</IconContent>
                     <ChildContent>
                         <FluentNavMenuLink Text="Quarter">
                             <IconContent>♩</IconContent>

--- a/examples/FluentUI.Demo.Shared/wwwroot/sources/NavMenuCollapsible.razor.txt
+++ b/examples/FluentUI.Demo.Shared/wwwroot/sources/NavMenuCollapsible.razor.txt
@@ -7,7 +7,7 @@
         <FluentNavMenu @bind-Expanded="@Expanded" Width="150">
             <FluentNavMenuLink Class="level1" Icon="@(new Icons.Regular.Size24.Home())" Text="Item 1" />
             <FluentNavMenuLink Class="level1" Icon="@(new Icons.Regular.Size24.Cloud())" Text="Item 2" />
-            <FluentNavMenuGroup Text="Item 3">
+            <FluentNavMenuGroup Text="Item 3" Icon="@(new Icons.Regular.Size24.EarthLeaf())">
                 <FluentNavMenuLink Icon="@(new Icons.Regular.Size24.LeafOne())" Text="Item 3.1" />
                 <FluentNavMenuLink Icon="@(new Icons.Regular.Size24.LeafTwo())" Text="Item 3.2" />
             </FluentNavMenuGroup>

--- a/examples/FluentUI.Demo.Shared/wwwroot/sources/NavMenuCustomIconContent.razor.txt
+++ b/examples/FluentUI.Demo.Shared/wwwroot/sources/NavMenuCustomIconContent.razor.txt
@@ -8,7 +8,7 @@
             <NavigationIconContent>⛚</NavigationIconContent>
             <ChildContent>
                 <FluentNavMenuGroup Text="Weather">
-                    <NavMenuGutterIconContent>☀</NavMenuGutterIconContent>
+                    <IconContent>☀</IconContent>
                     <ChildContent>
                         <FluentNavMenuLink Text="Sunny">
                             <IconContent>☀</IconContent>
@@ -22,7 +22,7 @@
                     </ChildContent>
                 </FluentNavMenuGroup>
                 <FluentNavMenuGroup Text="Notes">
-                    <NavMenuGutterIconContent>♬</NavMenuGutterIconContent>
+                    <IconContent>♬</IconContent>
                     <ChildContent>
                         <FluentNavMenuLink Text="Quarter">
                             <IconContent>♩</IconContent>

--- a/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenu.razor.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenu.razor.cs
@@ -84,7 +84,7 @@ public partial class FluentNavMenu : FluentComponentBase
 
     internal bool HasSubMenu => _groups.Any();
 
-    internal bool HasIcons => _links.Any(i => i.HasIcon) || _groups.Any(g => g.HasNavMenuGutterIcon);
+    internal bool HasIcons => _links.Any(i => i.HasIcon) || _groups.Any(g => g.HasIcon);
 
     internal async Task CollapsibleClickAsync()
     {

--- a/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenu.razor.css
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenu.razor.css
@@ -59,8 +59,13 @@
     margin-inline-end: 8px;
 }
 
+::deep .navmenu-group::part(content-region) {
+    margin-inline-end: var(--expand-collapse-button-size);
+    margin-inline-start: unset;
+}
 
-::deep .navmenu-group.nested::part(expand-collapse-button) {
+::deep .navmenu-group::part(expand-collapse-button) {
     left: unset;
     right: 0;
+    margin-right: calc(var(--expand-collapse-button-size) * -1);
 }

--- a/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenuGroup.razor
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenuGroup.razor
@@ -8,20 +8,7 @@
                 Selected="@Selected"
                 Expanded="@(NavMenuExpanded ? Expanded : false)"
                 Text="@(NavMenuExpanded ? Text : string.Empty)">
-    @if (!NavMenuExpanded && HasNavMenuGutterIcon)
-    {
-        <div slot="start" @onclick="ExpandMenu">
-            @if (NavMenuGutterIconContent is not null)
-            {
-                @NavMenuGutterIconContent
-            }
-            else
-            {
-                <FluentIcon Value="@NavMenuGutterIcon" Width="20px" Slot="start" />
-            }
-        </div>
-    }
-    @if (NavMenuExpanded && HasIcon)
+    @if (HasIcon)
     {
         if (IconContent is not null)
         {
@@ -31,6 +18,10 @@
         {
             <FluentIcon Value="@Icon" Width="20px" Slot="start" OnClick="HandleIconClick" />
         }
+    }
+    else if (NavMenu.HasIcons)
+    {
+        <span style="width:20px;" slot="start"></span>
     }
     @if (NavMenuExpanded) {
         @ChildContent

--- a/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenuGroup.razor.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/NavMenu/FluentNavMenuGroup.razor.cs
@@ -15,23 +15,6 @@ public partial class FluentNavMenuGroup : FluentComponentBase
     public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
-    /// Gets or sets the content to be displayed for this group
-    /// in the <see cref="FluentNavMenu"/> gutter when the menu is collapsed.
-    /// This setting takes priority over <see cref="NavMenuGutterIcon"/>.
-    /// </summary>
-    [Parameter]
-    public RenderFragment? NavMenuGutterIconContent { get; set; }
-
-    /// <summary>
-    /// Gets or sets the icon to display for this group
-    /// in the <see cref="FluentNavMenu"/> gutter when the nav menu is collapsed.
-    /// This setting is not used when <see cref="NavMenuGutterIconContent"/>
-    /// is not null.
-    /// </summary>
-    [Parameter]
-    public Icon NavMenuGutterIcon { get; set; } = new CoreIcons.Regular.Size24.MoreHorizontal();
-
-    /// <summary>
     /// Gets or sets the icon content to be displayed for this group
     /// before its <see cref="Text"/>.
     /// This setting takes priority over <see cref="Icon"/>.
@@ -112,9 +95,7 @@ public partial class FluentNavMenuGroup : FluentComponentBase
         .AddStyle(Style)
         .Build();
 
-    private bool HasIcon => Icon != null || IconContent is not null;
-
-    internal bool HasNavMenuGutterIcon => NavMenuGutterIcon != null || NavMenuGutterIconContent is not null;
+    internal bool HasIcon => Icon != null || IconContent is not null;
 
     public override async Task SetParametersAsync(ParameterView parameters)
     {


### PR DESCRIPTION
Fix #494 