### PR TITLE
Fix: Lots of properties are not working in fluent-design-system-provider

### DIFF
--- a/src/Microsoft.Fast.Components.FluentUI/Components/DesignSystemProvider/FluentDesignSystemProvider.razor.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/DesignSystemProvider/FluentDesignSystemProvider.razor.cs
@@ -45,58 +45,58 @@ public partial class FluentDesignSystemProvider : FluentComponentBase
     public float? DisabledOpacity { get; set; }
 
     [Parameter]
-    public float? TypeRampMinus2FontSize { get; set; }
+    public string? TypeRampMinus2FontSize { get; set; }
 
     [Parameter]
-    public float? TypeRampMinus2LineHeight { get; set; }
+    public string? TypeRampMinus2LineHeight { get; set; }
 
     [Parameter]
-    public float? TypeRampMinus1FontSize { get; set; }
+    public string? TypeRampMinus1FontSize { get; set; }
 
     [Parameter]
-    public float? TypeRampMinus1LineHeight { get; set; }
+    public string? TypeRampMinus1LineHeight { get; set; }
 
     [Parameter]
-    public float? TypeRampBaseFontSize { get; set; }
+    public string? TypeRampBaseFontSize { get; set; }
 
     [Parameter]
-    public float? TypeRampBaseLineHeight { get; set; }
+    public string? TypeRampBaseLineHeight { get; set; }
 
     [Parameter]
-    public float? TypeRampPlus1FontSize { get; set; }
+    public string? TypeRampPlus1FontSize { get; set; }
 
     [Parameter]
-    public float? TypeRampPlus1LineHeight { get; set; }
+    public string? TypeRampPlus1LineHeight { get; set; }
 
     [Parameter]
-    public float? TypeRampPlus2FontSize { get; set; }
+    public string? TypeRampPlus2FontSize { get; set; }
 
     [Parameter]
-    public float? TypeRampPlus2LineHeight { get; set; }
+    public string? TypeRampPlus2LineHeight { get; set; }
 
     [Parameter]
-    public float? TypeRampPlus3FontSize { get; set; }
+    public string? TypeRampPlus3FontSize { get; set; }
 
     [Parameter]
-    public float? TypeRampPlus3LineHeight { get; set; }
+    public string? TypeRampPlus3LineHeight { get; set; }
 
     [Parameter]
-    public float? TypeRampPlus4FontSize { get; set; }
+    public string? TypeRampPlus4FontSize { get; set; }
 
     [Parameter]
-    public float? TypeRampPlus4LineHeight { get; set; }
+    public string? TypeRampPlus4LineHeight { get; set; }
 
     [Parameter]
-    public float? TypeRampPlus5FontSize { get; set; }
+    public string? TypeRampPlus5FontSize { get; set; }
 
     [Parameter]
-    public float? TypeRampPlus5LineHeight { get; set; }
+    public string? TypeRampPlus5LineHeight { get; set; }
 
     [Parameter]
-    public float? TypeRampPlus6FontSize { get; set; }
+    public string? TypeRampPlus6FontSize { get; set; }
 
     [Parameter]
-    public float? TypeRampPlus6LineHeight { get; set; }
+    public string? TypeRampPlus6LineHeight { get; set; }
 
     [Parameter]
     public int? AccentFillRestDelta { get; set; }


### PR DESCRIPTION


<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
The units for these properties were incorrect and could not be applied even when values were set, due to the absence of measurement units: `px`. Therefore, it was decided to change their data type to string, allowing users to determine both the value and unit type as needed, while also maintaining consistency with the official FluentUI property types (ref: https://github.com/microsoft/fluentui/blob/57de08c18915440cdc54a1242bbdf948e2b0f562/packages/web-components/src/design-system-provider/index.ts#L426). 

For example, if the TypeRampMinus1FontSize property was assigned a value of float `12`, but did not include a unit such as "px" or "em", the value would not be applied correctly in the user interface. By changing the data type to string, users can now include the appropriate unit of measurement along with the value, providing greater flexibility in how the properties can be used.
<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->