### PR TITLE
Extend FluentButton sample a bit

### DIFF
--- a/examples/Demo/Shared/Pages/Button/Examples/ButtonIcon.razor
+++ b/examples/Demo/Shared/Pages/Button/Examples/ButtonIcon.razor
@@ -13,8 +13,8 @@
               Title="Globe"
               OnClick="@(() => DemoLogger.WriteLine("Button clicked"))" />
 
-<p>With icon in the content</p>
+<p>With icon in the content. By doing it this way, it is possible to specify a <code>Color</code> for the icon.</p>
 <FluentButton>
-    <FluentIcon Value="@(new Icons.Regular.Size16.Globe())" Slot="start" />
+    <FluentIcon Value="@(new Icons.Regular.Size16.Globe())" Color="Color.Error" Slot="start" />
     Button
 </FluentButton>


### PR DESCRIPTION
Clarification of what you can do when using 'old' way of using icon in a button