### PR TITLE
Set current-value for FluentSelect

### DIFF
--- a/src/Core/Components/List/FluentSelect.razor
+++ b/src/Core/Components/List/FluentSelect.razor
@@ -11,6 +11,7 @@
                    multiple="@Multiple"
                    disabled="@Disabled"
                    appearance="@Appearance.ToAttributeValue()"
+                   current-value="@Value"
                    aria-label="@(!string.IsNullOrWhiteSpace(Title) ? Title : "")"
                    @onchange="@OnChangedHandlerAsync"
                    @attributes="AdditionalAttributes">


### PR DESCRIPTION
# Pull Request

My scenario is, that I have a Component with a `FluentSelect`, and I want to reset its value by clicking a button. But it's not updating the value, no matter what I tried. I think the `current-value` in the `FluentSelect` needs to be bound, so the current value is updated in the `FluentSelect`.

I've tried it with the `new-components` branch and it works. I could try to come up with a simplified test case for it.

## 📖 Description

The `FluentSelect` currently does not reset its value, when updating the bound value. I think the `current-value` on the Web Component needs to be set. This fixes the issue, so the currently selected value can be set.

### 🎫 Issues

- #266 

## 👩‍💻 Reviewer Notes

-

## 📑 Test Plan

-

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->