### PR TITLE
Tooltip Provider

### DIFF
--- a/examples/Demo/Shared/FluentUI.Demo.Shared.csproj
+++ b/examples/Demo/Shared/FluentUI.Demo.Shared.csproj
@@ -49,7 +49,7 @@
 		<ProjectReference Include="..\DocGenerator\FluentUI.Demo.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 		<PackageReference Include="Markdig" Version="0.31.0" />
 		<PackageReference Include="Microsoft.Fast.Components.FluentUI.Emojis" Version="3.*-*" />
-		<PackageReference Include="Microsoft.Fast.Components.FluentUI.Icons" version="3.*-*" />
+		<PackageReference Include="Microsoft.Fast.Components.FluentUI.Icons" version="3.0.0-preview.5" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 		<TrimmerRootAssembly Include="Microsoft.Fast.Components.FluentUI" />
 	</ItemGroup>

--- a/examples/Demo/Shared/Microsoft.Fast.Components.FluentUI.xml
+++ b/examples/Demo/Shared/Microsoft.Fast.Components.FluentUI.xml
@@ -4841,6 +4841,30 @@
             Gets or sets the content to be rendered inside the component.
             </summary>
         </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentTooltip.ServiceProvider">
+            <summary>
+            Gets or sets a reference to the list of registered services.
+            </summary>
+            <remarks>
+            https://github.com/dotnet/aspnetcore/issues/24193
+            </remarks>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentTooltip.TooltipService">
+            <summary>
+            Gets a reference to the tooltip service (if registered).
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentTooltip.GlobalOptions">
+            <summary>
+            Gets the default tooltip options.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentTooltip.UseTooltipService">
+            <summary>
+            Use ITooltipService to create the tooltip, if this service was injected.
+            Default, true.
+            </summary>
+        </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentTooltip.Visible">
             <summary>
             Gets or sets if the tooltip is visible
@@ -4848,17 +4872,23 @@
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentTooltip.Anchor">
             <summary>
-            Gets or sets the anchor
+            Required. Gets or sets the control identifier associated with the tooltip.
             </summary>
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentTooltip.Delay">
             <summary>
-            Gets or sets the delay (in miliseconds)
+            Gets or sets the delay (in milliseconds). Default is 300.
             </summary>
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentTooltip.Position">
             <summary>
-            Gets or sets the tooltip's position. See <see cref="T:Microsoft.Fast.Components.FluentUI.TooltipPosition"/>
+            Gets or sets the tooltip's position. See <see cref="T:Microsoft.Fast.Components.FluentUI.TooltipPosition"/>.
+            Don't set this if you want the tooltip to use the best position.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentTooltip.MaxWidth">
+            <summary>
+            Gets or sets the maximum width of tooltip panel.
             </summary>
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentTooltip.AutoUpdateMode">
@@ -4870,12 +4900,12 @@
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentTooltip.HorizontalViewportLock">
             <summary>
-            Gets or sets wether the horizontal viewport is locked
+            Gets or sets whether the horizontal viewport is locked
             </summary>
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentTooltip.VerticalViewportLock">
             <summary>
-            Gets or sets wether the vertical viewport is locked
+            Gets or sets whether the vertical viewport is locked
             </summary>
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentTooltip.ChildContent">
@@ -4883,10 +4913,187 @@
             Gets or sets the content to be rendered inside the component.
             </summary>
         </member>
-        <member name="P:Microsoft.Fast.Components.FluentUI.FluentTooltip.OnDissmissed">
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentTooltip.OnDismissed">
             <summary>
             Callback for when the tooltip is dismissed
             </summary>  
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentTooltip.DrawTooltip">
+            <summary />
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.FluentTooltip.HandleDismissed">
+            <summary />
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.FluentTooltip.OnInitialized">
+            <summary />
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.FluentTooltip.Dispose">
+            <summary />
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentTooltipProvider.ClassValue">
+            <summary />
+        </member>
+        <member name="T:Microsoft.Fast.Components.FluentUI.Components.Tooltip.ITooltipService">
+            <summary>
+            Service for managing tooltips.
+            </summary>
+        </member>
+        <member name="E:Microsoft.Fast.Components.FluentUI.Components.Tooltip.ITooltipService.OnTooltipUpdated">
+            <summary>
+            Action that is invoked when the tooltip list is updated.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.Components.Tooltip.ITooltipService.Tooltips">
+            <summary>
+            Gets the list of tooltips currently registered with the service.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.Components.Tooltip.ITooltipService.GlobalOptions">
+            <summary>
+            Gets the global options for tooltips.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.Components.Tooltip.ITooltipService.Add(Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipOptions)">
+            <summary>
+            Adds a tooltip to the service.
+            </summary>
+            <param name="options"></param>
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.Components.Tooltip.ITooltipService.Clear">
+            <summary>
+            clears all tooltips from the service.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.Components.Tooltip.ITooltipService.Remove(System.Guid)">
+            <summary>
+            removes a tooltip from the service.
+            </summary>
+            <param name="value">Identifier of the tooltip</param>
+        </member>
+        <member name="T:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipGlobalOptions">
+            <summary>
+            Global options for tooltips.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipGlobalOptions.DefaultDelay">
+            <summary>
+            Default delay (in milliseconds).
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipGlobalOptions.Delay">
+            <summary>
+            Gets or sets the delay (in milliseconds). Default is 300.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipGlobalOptions.Position">
+            <summary>
+            Gets or sets the default tooltip's position.
+            See <see cref="T:Microsoft.Fast.Components.FluentUI.TooltipPosition"/>
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipGlobalOptions.MaxWidth">
+            <summary>
+            Gets or sets the default maximum width of tooltip panel.
+            Default is 500px.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipGlobalOptions.HorizontalViewportLock">
+            <summary>
+            Gets or sets whether the horizontal viewport is locked
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipGlobalOptions.VerticalViewportLock">
+            <summary>
+            Gets or sets whether the vertical viewport is locked
+            </summary>
+        </member>
+        <member name="T:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipOptions">
+            <summary>
+            Options for a tooltip.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipOptions.Id">
+            <summary>
+            Gets or sets the unique identifier of the tooltip.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipOptions.Anchor">
+            <summary>
+            Gets or sets the anchor identifier of the tooltip.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipOptions.ChildContent">
+            <summary>
+            Gets or sets the tooltip content.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipOptions.MaxWidth">
+            <summary>
+            Gets or sets the tooltip panel width.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipOptions.Delay">
+            <summary>
+            Gets or sets the delay (in milliseconds). Default is 300.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipOptions.Position">
+            <summary>
+            Gets or sets the tooltip's position. See <see cref="T:Microsoft.Fast.Components.FluentUI.TooltipPosition"/>
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipOptions.OnDismissed">
+            <summary>
+            Callback for when the tooltip is dismissed
+            </summary>  
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipOptions.Visible">
+            <summary>
+            Gets or sets if the tooltip is visible
+            </summary>
+        </member>
+        <member name="T:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipService">
+            <inheritdoc cref="T:Microsoft.Fast.Components.FluentUI.Components.Tooltip.ITooltipService"/>
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipService.#ctor">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipService"/> class.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipService.#ctor(Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipGlobalOptions)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipService"/> class.
+            </summary>
+            <param name="options">Default global options</param>
+        </member>
+        <member name="E:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipService.OnTooltipUpdated">
+            <inheritdoc cref="E:Microsoft.Fast.Components.FluentUI.Components.Tooltip.ITooltipService.OnTooltipUpdated"/>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipService.GlobalOptions">
+            <inheritdoc cref="P:Microsoft.Fast.Components.FluentUI.Components.Tooltip.ITooltipService.GlobalOptions"/>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipService.Tooltips">
+            <inheritdoc cref="P:Microsoft.Fast.Components.FluentUI.Components.Tooltip.ITooltipService.Tooltips"/>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipService.TooltipList">
+            <summary />
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipService.TooltipLock">
+            <summary />
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipService.Add(Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipOptions)">
+            <inheritdoc cref="M:Microsoft.Fast.Components.FluentUI.Components.Tooltip.ITooltipService.Add(Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipOptions)"/>
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipService.Clear">
+            <inheritdoc cref="M:Microsoft.Fast.Components.FluentUI.Components.Tooltip.ITooltipService.Clear"/>
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipService.Dispose">
+            <summary>
+            Clears all tooltips from the service.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.Components.Tooltip.TooltipService.Remove(System.Guid)">
+            <inheritdoc cref="M:Microsoft.Fast.Components.FluentUI.Components.Tooltip.ITooltipService.Remove(System.Guid)"/>
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentTreeItem.Text">
             <summary>
@@ -9214,6 +9421,12 @@
         <member name="T:Microsoft.Fast.Components.FluentUI.LibraryConfiguration">
             <summary>
             Defines the global Fluent UI Blazor component library services configuration
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.LibraryConfiguration.UseTooltipServiceProvider">
+            <summary>
+            Gets or sets a value indicating whether the library should use the TooltipServiceProvider.
+            If set to true, add the FluentTooltipProvider component at end of the MainLayout.razor page.
             </summary>
         </member>
         <member name="T:Microsoft.Fast.Components.FluentUI.Resources.FluentInputFileResource">

--- a/examples/Demo/Shared/Pages/Tooltip/Examples/TooltipDefault.razor
+++ b/examples/Demo/Shared/Pages/Tooltip/Examples/TooltipDefault.razor
@@ -1,19 +1,11 @@
 ﻿@inject ILogger<TooltipDefault> logger;
 
-<div style="height:100px; display: flex; gap: 10px; margin: 2em; flex-direction: row; align-items: center; justify-content: center;" >
-    <FluentButton id="default1" Appearance=Appearance.Accent>Tooltip at the left</FluentButton>
-    <FluentTooltip Anchor="default1" Position=TooltipPosition.Left>I'm helping!</FluentTooltip>
-    
-    <FluentButton id="default2" Appearance=Appearance.Accent>Tooltip at the bottom</FluentButton>
-    <FluentTooltip Anchor="default2" Position=TooltipPosition.Bottom @ontooltipdismiss=OnDismiss>I'm helping!</FluentTooltip>
+<FluentIcon Id="myFirstButton" Icon="Icons.Regular.Size24.Notepad" />
 
-    <FluentButton id="default3" Appearance=Appearance.Accent>Tooltip at the top</FluentButton>
-    <FluentTooltip Anchor="default3" Position=TooltipPosition.Top>I'm helping!</FluentTooltip>
-
-    <FluentButton id="default4" Appearance=Appearance.Accent>Tooltip at the right</FluentButton>
-    <FluentTooltip Anchor="default4" Position=TooltipPosition.Right>I'm helping!</FluentTooltip>
-</div>
-
+<FluentTooltip Anchor="myFirstButton">
+    Hello World <br />
+    It is a <i>small</i> tootip.
+</FluentTooltip>
 
 @code {
     private void OnDismiss()

--- a/examples/Demo/Shared/Pages/Tooltip/Examples/TooltipDelay.razor
+++ b/examples/Demo/Shared/Pages/Tooltip/Examples/TooltipDelay.razor
@@ -1,10 +1,10 @@
-﻿<div style="height:100px; display: flex; gap: 10px; margin: 2em; flex-direction: row; align-items: center; justify-content: center;">
-    <FluentButton id="delay1" Appearance=Appearance.Accent>Tooltip at the start</FluentButton>
+﻿<FluentStack>
+    <FluentButton Id="delay1" Appearance=Appearance.Accent>Tooltip at the start</FluentButton>
     <FluentTooltip Anchor="delay1" Position=TooltipPosition.Start Delay=100>I'm helping (very quick)!</FluentTooltip>
 
-    <FluentButton id="delay2" Appearance=Appearance.Accent>Tooltip at the end</FluentButton>
+    <FluentButton Id="delay2" Appearance=Appearance.Accent>Tooltip at the end</FluentButton>
     <FluentTooltip Anchor="delay2" Position=TooltipPosition.Top Delay=200>I'm helping (quick)!</FluentTooltip>
 
-    <FluentButton id="delay3" Appearance=Appearance.Accent>Tooltip at the end</FluentButton>
+    <FluentButton Id="delay3" Appearance=Appearance.Accent>Tooltip at the end</FluentButton>
     <FluentTooltip Anchor="delay3" Position=TooltipPosition.End Delay=600>I'm helping (slow)!</FluentTooltip>
-</div>
+</FluentStack>

--- a/examples/Demo/Shared/Pages/Tooltip/Examples/TooltipLongExample.razor
+++ b/examples/Demo/Shared/Pages/Tooltip/Examples/TooltipLongExample.razor
@@ -1,0 +1,17 @@
+<FluentIcon Id="myLongText" Icon="Icons.Regular.Size24.Notepad" />
+
+<FluentTooltip Anchor="myLongText"
+               Delay="300"
+               MaxWidth="400px"
+               Position="TooltipPosition.Bottom">@content</FluentTooltip>
+
+@code {
+    string content = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, " +
+                     "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. " +
+                     "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut " +
+                     "aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in " +
+                     "voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint " +
+                     "occaecat cupidatat non proident, sunt in culpa qui officia " +
+                     "deserunt mollit anim id est laborum";
+
+}

--- a/examples/Demo/Shared/Pages/Tooltip/Examples/TooltipVisible.razor
+++ b/examples/Demo/Shared/Pages/Tooltip/Examples/TooltipVisible.razor
@@ -1,23 +1,18 @@
-﻿@inject ILogger<TooltipDefault> logger;
+﻿<FluentStack>
+    <FluentButton Id="visible1"
+                  Appearance="Appearance.Accent"
+                  OnClick="@(e => visible = !visible)">
+        Click me to toggle tooltip visibility
+    </FluentButton>
 
+    <FluentTooltip Anchor="visible1"
+                   Position="TooltipPosition.End"
+                   Delay="200"
+                   UseTooltipService="false"
+                   Visible="@visible">I'm helping!</FluentTooltip>
+</FluentStack>
 
-<div style="height:100px; display: flex; gap: 10px; margin: 2em; flex-direction: row; align-items: center; justify-content: center;" >
-    <FluentButton id="visible1" Appearance=Appearance.Accent @onclick=ToggleVisible>Click me to toggle tooltip visibility</FluentButton>
-    <FluentTooltip Anchor="visible1" Position=TooltipPosition.End Delay=200 Visible=@visible @ontooltipdismiss=OnDismiss>I'm helping!</FluentTooltip>
-    
-</div>
-@code {
+@code
+{
     bool visible = true;
-    
-    private void OnDismiss()
-    {
-        visible = false;
-        logger.LogInformation("Tooltip dismissed!");
-    }
-
-    
-    private void ToggleVisible()
-    {
-        visible = !visible;
-    }
 }

--- a/examples/Demo/Shared/Pages/Tooltip/TooltipPage.razor
+++ b/examples/Demo/Shared/Pages/Tooltip/TooltipPage.razor
@@ -28,7 +28,7 @@ and will be written at the end of the HTML page to support the different z-index
 <br />
 <b>Example</b>
     <FluentStack>
-    <FluentButton Id="btnWithoutService" Appearance=Appearance.Accent>Example of tooltip</FluentButton>
+    <FluentButton Id="btnWithoutService" Appearance=Appearance.Accent>Tooltip without service</FluentButton>
         <FluentTooltip Anchor="btnWithoutService" UseTooltipService="false" Position=TooltipPosition.Start>Example of tooltip</FluentTooltip>
     </FluentStack>
     <br/>

--- a/examples/Demo/Shared/Pages/Tooltip/TooltipPage.razor
+++ b/examples/Demo/Shared/Pages/Tooltip/TooltipPage.razor
@@ -10,19 +10,50 @@
     <code>&lt;FluentTooltip&gt;</code> wraps the <code>&lt;fluent-tooltip&gt;</code> element, a web component implementation of a tooltip composition leveraging the
     Fluent UI design system.
 </p>
-<ApiDocumentation Component="typeof(FluentTooltip)" />
+
+
+<h2>Using Tooltip Service Provider</h2>
+
+In the <b>Program.cs</b>, inject the Tooltip service with global options.
+You can also use the <b>Services.AddFluentUIComponents</b> method to register
+all required FluentUI services, including this one.
+<CodeSnippet>builder.Services.AddScoped&lt;ITooltipService, TooltipService&gt;();</CodeSnippet>
+<br />
+At the end of your <b>MainLayout.razor</b> page, include the provider:
+<CodeSnippet>&lt;FluentTooltipProvider /&gt;</CodeSnippet>
+<br />
+With this provider, all tooltip definitions will be generated with these global options
+and will be written at the end of the HTML page to support the different z-index levels.
+<br />
+<br />
+<b>Example</b>
+    <FluentStack>
+    <FluentButton Id="btnWithoutService" Appearance=Appearance.Accent>Example of tooltip</FluentButton>
+        <FluentTooltip Anchor="btnWithoutService" UseTooltipService="false" Position=TooltipPosition.Start>Example of tooltip</FluentTooltip>
+    </FluentStack>
+    <br/>
+    <FluentStack>
+        <FluentButton Id="btnWithService" Appearance=Appearance.Accent>Tooltip using TooltipService</FluentButton>
+        <FluentTooltip Anchor="btnWithService" Position=TooltipPosition.Start>Example of tooltip</FluentTooltip>
+    </FluentStack>
+<br />
+<br />
 
 <h2>Examples</h2>
 
 <DemoSection Title="Default" Component="@typeof(TooltipDefault)">
-    <Description>Hover one of the buttons to have a tooltip appear on hover at the position mentioned.</Description>
+    <Description>Move your mouse over this icon to display a tooltip.</Description>
 </DemoSection>
 
+<DemoSection Title="Large tooltip" Component="@typeof(TooltipLongExample)">
+    <Description>Move your mouse over this icon to display a very large tooltip.</Description>
+</DemoSection>
 
 <DemoSection Title="Different delays" Component="@typeof(TooltipDelay)">
     <Description>Hover one of the buttons to have a tooltip appear on hover at the position mentioned.</Description>
 </DemoSection>
 
-<DemoSection Title="Always visible" Component="@typeof(TooltipVisible)">
-    
-</DemoSection>
+<DemoSection Title="Always visible" Component="@typeof(TooltipVisible)" />
+
+
+<ApiDocumentation Component="typeof(FluentTooltip)" />

--- a/examples/Demo/Shared/Shared/DemoMainLayout.razor
+++ b/examples/Demo/Shared/Shared/DemoMainLayout.razor
@@ -97,6 +97,7 @@
         </div>
         <FluentToastContainer MaxToastCount="10"  />
         <FluentDialogContainer />
+        <FluentTooltipProvider />
     </main>
     <footer>
         <div class="version">

--- a/src/Core/Components/Tooltip/FluentTooltip.razor
+++ b/src/Core/Components/Tooltip/FluentTooltip.razor
@@ -1,16 +1,27 @@
 @namespace Microsoft.Fast.Components.FluentUI
 @inherits FluentComponentBase
-<fluent-tooltip @ref=Element
-                class="@Class"
-                style="@Style"
-                visible=@Visible
-                anchor=@Anchor
-                delay=@Delay
-                position=@Position.ToAttributeValue()
-                auto-update-mode=@AutoUpdateMode
-                horizontal-viewport-lock=@HorizontalViewportLock
-                vertical-viewport-lock=@VerticalViewportLock
-                @ontooltipdismiss=HandleDismissed
-                @attributes="AdditionalAttributes">
-    @ChildContent
-</fluent-tooltip>
+
+@if (DrawTooltip)
+{
+    <fluent-tooltip @ref=Element
+                    class="@Class"
+                    style="@Style"
+                    visible="@Visible"
+                    anchor="@Anchor"
+                    delay="@Delay"
+                    position="@Position.ToAttributeValue()"
+                    auto-update-mode="@AutoUpdateMode"
+                    horizontal-viewport-lock="@HorizontalViewportLock"
+                    vertical-viewport-lock="@VerticalViewportLock"
+                    @ontooltipdismiss="HandleDismissed"
+                    @attributes="AdditionalAttributes">
+        @if (string.IsNullOrWhiteSpace(MaxWidth ?? GlobalOptions?.MaxWidth))
+        {
+            @ChildContent
+        }
+        else
+        {
+            <div style="max-width: @(MaxWidth ?? GlobalOptions?.MaxWidth); text-wrap: wrap;">@ChildContent</div>
+        }
+    </fluent-tooltip>
+}

--- a/src/Core/Components/Tooltip/FluentTooltipProvider.razor
+++ b/src/Core/Components/Tooltip/FluentTooltipProvider.razor
@@ -1,0 +1,18 @@
+@namespace Microsoft.Fast.Components.FluentUI
+@inherits FluentComponentBase
+
+<div @attributes="AdditionalAttributes" class="@ClassValue" style="@Style">
+    @if (Tooltips != null)
+    {
+        @foreach (var item in Tooltips)
+        {
+            <FluentTooltip Anchor="@item.Anchor"
+                           MaxWidth="@item.MaxWidth"
+                           Visible="@item.Visible"
+                           Delay="@item.Delay"
+                           Position="@item.Position"
+                           OnDismissed="@item.OnDismissed"
+                           UseTooltipService="false">@item.ChildContent</FluentTooltip>
+        }
+    }
+</div>

--- a/src/Core/Components/Tooltip/FluentTooltipProvider.razor.cs
+++ b/src/Core/Components/Tooltip/FluentTooltipProvider.razor.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.AspNetCore.Components;
+using Microsoft.Fast.Components.FluentUI.Components.Tooltip;
+using Microsoft.Fast.Components.FluentUI.Utilities;
+
+namespace Microsoft.Fast.Components.FluentUI;
+
+public partial class FluentTooltipProvider : FluentComponentBase, IDisposable
+{
+    /// <summary />
+    protected string? ClassValue
+        =>  new CssBuilder(Class).AddClass("fluent-tooltip-provider")
+                                 .Build();
+
+    [Inject]
+    private ITooltipService TooltipService { get; set; } = default!;
+
+    protected IEnumerable<TooltipOptions> Tooltips => TooltipService.Tooltips;
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        TooltipService.OnTooltipUpdated += OnTooltipUpdated;
+    }
+
+    private void OnTooltipUpdated()
+    {
+        StateHasChanged();
+    }
+
+    public void Dispose()
+    {
+        TooltipService.OnTooltipUpdated -= OnTooltipUpdated;
+    }
+}

--- a/src/Core/Components/Tooltip/Services/ITooltipService.cs
+++ b/src/Core/Components/Tooltip/Services/ITooltipService.cs
@@ -1,0 +1,39 @@
+﻿namespace Microsoft.Fast.Components.FluentUI.Components.Tooltip;
+
+/// <summary>
+/// Service for managing tooltips.
+/// </summary>
+public interface ITooltipService : IDisposable
+{
+    /// <summary>
+    /// Action that is invoked when the tooltip list is updated.
+    /// </summary>
+    event Action? OnTooltipUpdated;
+
+    /// <summary>
+    /// Gets the list of tooltips currently registered with the service.
+    /// </summary>
+    IEnumerable<TooltipOptions> Tooltips { get; }
+
+    /// <summary>
+    /// Gets the global options for tooltips.
+    /// </summary>
+    TooltipGlobalOptions GlobalOptions { get; }
+
+    /// <summary>
+    /// Adds a tooltip to the service.
+    /// </summary>
+    /// <param name="options"></param>
+    void Add(TooltipOptions options);
+
+    /// <summary>
+    /// clears all tooltips from the service.
+    /// </summary>
+    void Clear();
+
+    /// <summary>
+    /// removes a tooltip from the service.
+    /// </summary>
+    /// <param name="value">Identifier of the tooltip</param>
+    void Remove(Guid value);
+}

--- a/src/Core/Components/Tooltip/Services/TooltipGlobalOptions.cs
+++ b/src/Core/Components/Tooltip/Services/TooltipGlobalOptions.cs
@@ -1,0 +1,39 @@
+﻿namespace Microsoft.Fast.Components.FluentUI.Components.Tooltip;
+
+/// <summary>
+/// Global options for tooltips.
+/// </summary>
+public class TooltipGlobalOptions
+{
+    /// <summary>
+    /// Default delay (in milliseconds).
+    /// </summary>
+    public const int DefaultDelay = 300;
+
+    /// <summary>
+    /// Gets or sets the delay (in milliseconds). Default is 300.
+    /// </summary>
+    public int Delay { get; set; } = DefaultDelay;
+
+    /// <summary>
+    /// Gets or sets the default tooltip's position.
+    /// See <see cref="TooltipPosition"/>
+    /// </summary>
+    public TooltipPosition? Position { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default maximum width of tooltip panel.
+    /// Default is 500px.
+    /// </summary>
+    public string? MaxWidth { get; set; } = "500px";
+
+    /// <summary>
+    /// Gets or sets whether the horizontal viewport is locked
+    /// </summary>
+    public bool HorizontalViewportLock { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets whether the vertical viewport is locked
+    /// </summary>
+    public bool VerticalViewportLock { get; set; } = false;
+}

--- a/src/Core/Components/Tooltip/Services/TooltipOptions.cs
+++ b/src/Core/Components/Tooltip/Services/TooltipOptions.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.AspNetCore.Components;
+
+namespace Microsoft.Fast.Components.FluentUI.Components.Tooltip;
+
+/// <summary>
+/// Options for a tooltip.
+/// </summary>
+public class TooltipOptions
+{
+    /// <summary>
+    /// Gets or sets the unique identifier of the tooltip.
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the anchor identifier of the tooltip.
+    /// </summary>
+    public string Anchor { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the tooltip content.
+    /// </summary>
+    public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tooltip panel width.
+    /// </summary>
+    public string? MaxWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets the delay (in milliseconds). Default is 300.
+    /// </summary>
+    [Parameter]
+    public int? Delay { get; set; } = TooltipGlobalOptions.DefaultDelay;
+
+    /// <summary>
+    /// Gets or sets the tooltip's position. See <see cref="FluentUI.TooltipPosition"/>
+    /// </summary>
+    [Parameter]
+    public TooltipPosition? Position { get; set; }
+
+    /// <summary>
+    /// Callback for when the tooltip is dismissed
+    /// </summary>  
+    [Parameter]
+    public EventCallback<EventArgs> OnDismissed { get; set; }
+
+    /// <summary>
+    /// Gets or sets if the tooltip is visible
+    /// </summary>
+    [Parameter]
+    public bool Visible { get; set; }
+}

--- a/src/Core/Components/Tooltip/Services/TooltipService.cs
+++ b/src/Core/Components/Tooltip/Services/TooltipService.cs
@@ -1,0 +1,111 @@
+﻿namespace Microsoft.Fast.Components.FluentUI.Components.Tooltip;
+
+/// <inheritdoc cref="ITooltipService"/>
+public class TooltipService : ITooltipService, IDisposable
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TooltipService"/> class.
+    /// </summary>
+    public TooltipService()
+        : this(new TooltipGlobalOptions())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TooltipService"/> class.
+    /// </summary>
+    /// <param name="options">Default global options</param>
+    public TooltipService(TooltipGlobalOptions options)
+    {
+        this.GlobalOptions = options;
+    }
+
+    /// <inheritdoc cref="ITooltipService.OnTooltipUpdated"/>
+    public event Action? OnTooltipUpdated;
+
+    /// <inheritdoc cref="ITooltipService.GlobalOptions"/>
+    public TooltipGlobalOptions GlobalOptions { get; }
+
+    /// <inheritdoc cref="ITooltipService.Tooltips"/>
+    public IEnumerable<TooltipOptions> Tooltips
+    {
+        get
+        {
+            TooltipLock.EnterReadLock();
+            try
+            {
+                return TooltipList;
+            }
+            finally
+            {
+                TooltipLock.ExitReadLock();
+            }
+        }
+    }
+
+    /// <summary />
+    private IList<TooltipOptions> TooltipList { get; } = new List<TooltipOptions>();
+
+    /// <summary />
+    private ReaderWriterLockSlim TooltipLock { get; } = new ReaderWriterLockSlim();
+
+    /// <inheritdoc cref="ITooltipService.Add(TooltipOptions)"/>
+    public void Add(TooltipOptions options)
+    {
+        TooltipLock.EnterWriteLock();
+        try
+        {
+            TooltipList.Add(options);
+        }
+        finally
+        {
+            TooltipLock.ExitWriteLock();
+        }
+
+        OnTooltipUpdated?.Invoke();
+    }
+
+    /// <inheritdoc cref="ITooltipService.Clear"/>
+    public void Clear()
+    {
+        TooltipLock.EnterWriteLock();
+        try
+        {
+            TooltipList.Clear();
+        }
+        finally
+        {
+            TooltipLock.ExitWriteLock();
+        }
+
+        OnTooltipUpdated?.Invoke();
+    }
+
+    /// <summary>
+    /// Clears all tooltips from the service.
+    /// </summary>
+    public void Dispose()
+    {
+        this.Clear();
+    }
+
+    /// <inheritdoc cref="ITooltipService.Remove(Guid)"/>
+    public void Remove(Guid value)
+    {
+        TooltipLock.EnterWriteLock();
+        try
+        {
+            var item = TooltipList.FirstOrDefault(i => i.Id == value);
+            if (item != null)
+            {
+                TooltipList.Remove(item);
+            }
+        }
+        finally
+        {
+            TooltipLock.ExitWriteLock();
+        }
+
+        OnTooltipUpdated?.Invoke();
+    }
+}

--- a/src/Core/Infrastructure/LibraryConfiguration.cs
+++ b/src/Core/Infrastructure/LibraryConfiguration.cs
@@ -10,7 +10,13 @@ public class LibraryConfiguration
     public BlazorHostingModel HostingModel { get; set; } = BlazorHostingModel.NotSpecified;
 
     public StaticAssetServiceConfiguration StaticAssetServiceConfiguration { get; set; } = new();
-    
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the library should use the TooltipServiceProvider.
+    /// If set to true, add the FluentTooltipProvider component at end of the MainLayout.razor page.
+    /// </summary>
+    public bool UseTooltipServiceProvider { get; set; } = true;
+
     public LibraryConfiguration()
     {
     }        

--- a/tests/Core/Tooltip/FluentTooltipTests.FluentTooltip_AllAttributes.verified.html
+++ b/tests/Core/Tooltip/FluentTooltipTests.FluentTooltip_AllAttributes.verified.html
@@ -1,0 +1,4 @@
+
+<fluent-tooltip visible="" anchor="button-id" delay="200" position="bottom" auto-update-mode="Auto" horizontal-viewport-lock="" vertical-viewport-lock="" blazor:ontooltipdismiss="1" blazor:elementreference="82c7cfb0-d639-4809-ada8-c06caa67273f">
+  <div style="max-width: 300px; text-wrap: wrap;">My help text</div>
+</fluent-tooltip>

--- a/tests/Core/Tooltip/FluentTooltipTests.FluentTooltip_Default.verified.html
+++ b/tests/Core/Tooltip/FluentTooltipTests.FluentTooltip_Default.verified.html
@@ -1,0 +1,2 @@
+
+<fluent-tooltip anchor="button-id" delay="300" blazor:ontooltipdismiss="1" blazor:elementreference="ab13056b-5757-44df-bc3e-aab0ae2b20b4">My help text</fluent-tooltip>

--- a/tests/Core/Tooltip/FluentTooltipTests.cs
+++ b/tests/Core/Tooltip/FluentTooltipTests.cs
@@ -1,0 +1,43 @@
+﻿using Xunit;
+
+namespace Microsoft.Fast.Components.FluentUI.Tests.Tooltip;
+
+public class FluentTooltipTests : TestBase
+{
+    [Fact]
+    public void FluentTooltip_Default()
+    {
+        // Arrange & Act
+        var cut = TestContext.RenderComponent<FluentTooltip>(parameters =>
+        {
+            parameters.Add(p => p.Anchor, "button-id");
+            parameters.AddChildContent("My help text");
+        });
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentTooltip_AllAttributes()
+    {
+        // Arrange & Act
+        var cut = TestContext.RenderComponent<FluentTooltip>(parameters =>
+        {
+            parameters.Add(p => p.Anchor, "button-id");
+            parameters.Add(p => p.UseTooltipService, false);
+            parameters.Add(p => p.Visible, true);
+            parameters.Add(p => p.Delay, 200);
+            parameters.Add(p => p.Position, TooltipPosition.Bottom);
+            parameters.Add(p => p.MaxWidth, "300px");
+            parameters.Add(p => p.AutoUpdateMode, AutoUpdateMode.Auto);
+            parameters.Add(p => p.HorizontalViewportLock, true);
+            parameters.Add(p => p.VerticalViewportLock, true);
+            parameters.Add(p => p.OnDismissed, (e) => { });
+            parameters.AddChildContent("My help text");
+        });
+
+        // Assert
+        cut.Verify();
+    }
+}


### PR DESCRIPTION
# Using Tooltip Service Provider

With this provider, all Tooltip definitions will be generated with these global options and will be written at the end of the HTML page to support the different z-index levels.

![TooltipProvider](https://github.com/microsoft/fluentui-blazor/assets/8350694/7d3fcf1f-953d-47fe-b369-857e083a083c)


## How to use this Service

In the `Program.cs`, inject the Tooltip service with global options. You can also use the `Services.AddFluentUIComponents` method to register all required FluentUI services, including this one.
```csharp
builder.Services.AddScoped<ITooltipService, TooltipService>();
```

At the end of your MainLayout.razor page, include the provider:
```xml
<FluentTooltipProvider />
```

## Usage

```xml
<FluentIcon Id="myFirstButton" Icon="Icons.Regular.Size24.Notepad" />

<FluentTooltip Anchor="myFirstButton">
    Hello World <br />
    It is a <i>small</i> tootip.
</FluentTooltip>
```

> **note**: **There is NO Breaking Change**: if the `TootipServiceProvider` is not used, the code behaves as before: the tooltip is placed in the current location. The Tooltip component detects the presence or absence of the Service and adapts the code accordingly.

## Unit Tests

- [x] for `FluentTooltip` component: included.
- [ ] for `TooltipService` classes: not yet created.