### PR TITLE
fix(toast): set FluentIcon width correctly

### DIFF
--- a/src/Core/Components/Toast/FluentToast.razor
+++ b/src/Core/Components/Toast/FluentToast.razor
@@ -10,7 +10,7 @@
             @if (_parameters.Icon is not null)
             {
                 var Icon = _parameters.Icon.Value;
-                <FluentIcon Value="@Icon.Value" Style="min-width: 16px;" Width="16" Color="@Icon.Color"/>
+                <FluentIcon Value="@Icon.Value" Style="min-width: 16px;" Width="16px" Color="@Icon.Color"/>
             }
 
             <div class="fluent-toast-title">@_parameters.Title</div>
@@ -19,7 +19,7 @@
                 {
                     case ToastTopCTAType.Dismiss:
                         <FluentIcon Icon="CoreIcons.Regular.Size24.Dismiss"
-                                          Width="12"
+                                          Width="12px"
                                           Title="Close"
                                           Color="@Color.FillInverse"
                                           OnClick="@Close" />


### PR DESCRIPTION
# Pull Request

## 📖 Description

FluentToast does not pass the width correctly to the FluentIcon. This causes warnings in chrome, but works in chrome, and causes icons to be incorrectly sized on other platforms.

### 🎫 Issues
the PR fixes #593 

## 👩‍💻 Reviewer Notes
I looked into adding at least a default Testcase for the FluentToast, which isn't tested yet, but the ToastContext made it a bit hard and i had no idea how to make that work in a test case.

i did run the storybook/demo and verified it working correctly :)

## 📑 Test Plan
n/a

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [x] I have modified an existing component

## ⏭ Next Steps
n/a