### PR TITLE
Dialog changes

### DIFF
--- a/examples/Demo/Shared/Components/ApiDocumentation.razor
+++ b/examples/Demo/Shared/Components/ApiDocumentation.razor
@@ -3,7 +3,7 @@
 @using Microsoft.Fast.Components.FluentUI;
 
 <div>
-    <h2 id="@_id">@_displayName</h2>
+    <h3 id="@_id">@_displayName</h3>
 
 
     @if (Component.BaseType != null && Component.BaseType != typeof(FluentComponentBase) && Component.BaseType.Name.StartsWith("Fluent"))
@@ -24,7 +24,7 @@
     @if (this.Properties.Any())
     {
         string header = Properties.Any(x => x.IsParameter) ? "Parameters" : "Properties";
-        <h3 id="@(_id + "_properties")">@header</h3>
+        <h4 id="@(_id + "_properties")">@header</h4>
         <FluentDataGrid Class="docgrid" Items="@this.Properties.AsQueryable()" GridTemplateColumns="1fr 1fr 0.5fr 1.5fr">
             <TemplateColumn Title="Name"><code>@context.Name</code></TemplateColumn>
             <TemplateColumn Title="Type">
@@ -59,7 +59,7 @@
 
     @if (this.Events.Any())
     {
-        <h3 id="@(_id)_callbacks">EventCallbacks</h3>
+        <h4 id="@(_id)_callbacks">EventCallbacks</h4>
         <FluentDataGrid Class="docgrid" Items="@this.Events.AsQueryable()" GridTemplateColumns="1fr 1fr 1fr">
             <TemplateColumn Title="Name"><code>@context.Name</code></TemplateColumn>
             <PropertyColumn Property="@(c => c.Type)" />
@@ -73,7 +73,7 @@
 
     @if (this.Methods.Any())
     {
-         <h3 id="@(_id)_methods">Methods</h3>
+         <h4 id="@(_id)_methods">Methods</h4>
         <FluentDataGrid Class="docgrid" Items="@this.Methods.AsQueryable()" GridTemplateColumns="1fr 1fr 1fr 1fr">
             <TemplateColumn Title="Name"><code>@context.Name</code></TemplateColumn>
             <TemplateColumn Title="Parameters">

--- a/examples/Demo/Shared/Components/DemoSection.razor
+++ b/examples/Demo/Shared/Components/DemoSection.razor
@@ -38,19 +38,20 @@
             @foreach (KeyValuePair<string, string> pair in _tabPanelsContent)
             {
                 string tab = Path.GetExtension(pair.Key);
+                string tabname = GetDisplayName(tab);
 
                 string id = string.Empty;
 
                 if (pair.Key.StartsWith(Component.Name))
                 {
-                    id = "tab-" + @GetDisplayName(tab).Replace("#", "").Replace("/", "").ToLower() + "-" + @ariaid;
+                    id = "tab-" + tabname + "-" + @ariaid;
                 }
                 else
                 {
-                    string tabName = Path.GetFileNameWithoutExtension(pair.Key);
-                    id = "tab-" + tabName.Replace("#", "").Replace("/", "").ToLower() + "-" + @ariaid;
+                    tabname = Path.GetFileNameWithoutExtension(pair.Key);
+                    id = "tab-" + tabname.Replace("#", "").Replace("/", "").ToLower() + "-" + @ariaid;
                 }
-                <FluentTab Id="@id" Label="@GetDisplayName(tab)" fixed>
+                <FluentTab Id="@id" Label="@tabname" fixed>
                     <Content>
                         <CodeSnippet Language="@TabLanguageClass(tab)">@pair.Value</CodeSnippet>
                     </Content>
@@ -63,25 +64,27 @@
 {
     <div class="demo-section-downloads">
         <FluentSpacer />
-        Download:&nbsp;
-        @foreach (KeyValuePair<string, string> pair in _tabPanelsContent)
-        {
-            string source = pair.Key;
-            <FluentAnchor Style="width: 85px; text-overflow: ellipsis" Download="@source" Href="@($"_content/FluentUI.Demo.Shared/sources/{source}.txt")" Appearance="Appearance.Neutral">
-                @if (source.StartsWith(Component.Name))
-                {
-                    @GetDisplayName(source.Substring(source.LastIndexOf('.')))
-                }
-                else
-                {
-                    @source
-                }
-            </FluentAnchor>
-
-            @if (source != _tabPanelsContent.Last().Key)
+        <div style="display: flex; align-items: center;">
+            Download:&nbsp;
+            @foreach (KeyValuePair<string, string> pair in _tabPanelsContent)
             {
-                <span>&nbsp;</span>
+                string source = pair.Key;
+                <FluentAnchor Style="min-width: 85px; text-overflow: ellipsis" Download="@source" Href="@($"_content/FluentUI.Demo.Shared/sources/{source}.txt")" Appearance="Appearance.Neutral">
+                    @if (source.StartsWith(Component.Name))
+                    {
+                        @GetDisplayName(source.Substring(source.LastIndexOf('.')))
+                    }
+                    else
+                    {
+                        @source.Substring(0, source.LastIndexOf('.'))
+                    }
+                </FluentAnchor>
+
+                @if (source != _tabPanelsContent.Last().Key)
+                {
+                    <span>&nbsp;</span>
+                }
             }
-        }
+        </div>
     </div>
 }

--- a/examples/Demo/Shared/Microsoft.Fast.Components.FluentUI.xml
+++ b/examples/Demo/Shared/Microsoft.Fast.Components.FluentUI.xml
@@ -1751,7 +1751,7 @@
             Closes the dialog
             </summary>
         </member>
-        <member name="M:Microsoft.Fast.Components.FluentUI.FluentDialogContainer.#ctor">
+        <member name="M:Microsoft.Fast.Components.FluentUI.FluentDialogProvider.#ctor">
             <summary>
             Constructs an instance of <see cref="T:Microsoft.Fast.Components.FluentUI.FluentToastContainer"/>.
             </summary>

--- a/examples/Demo/Shared/Microsoft.Fast.Components.FluentUI.xml
+++ b/examples/Demo/Shared/Microsoft.Fast.Components.FluentUI.xml
@@ -1951,7 +1951,7 @@
         </member>
         <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowSplashScreen(System.Object,System.Func{Microsoft.Fast.Components.FluentUI.DialogResult,System.Threading.Tasks.Task},Microsoft.Fast.Components.FluentUI.DialogParameters{Microsoft.Fast.Components.FluentUI.SplashScreenContent})">
             <summary>
-            Shows the standard <see cref="T:Microsoft.Fast.Components.FluentUI.FluentSplashScreen"/> with the given parameters."/>
+            Shows the standard <see cref="T:Microsoft.Fast.Components.FluentUI.FluentSplashScreen"/> with the given parameters.
             </summary>
             <param name="receiver">The componente that receives the callback</param>
             <param name="callback">Name of the callback function</param>
@@ -1959,7 +1959,7 @@
         </member>
         <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowSplashScreen``1(System.Object,System.Func{Microsoft.Fast.Components.FluentUI.DialogResult,System.Threading.Tasks.Task},Microsoft.Fast.Components.FluentUI.DialogParameters{Microsoft.Fast.Components.FluentUI.SplashScreenContent})">
             <summary>
-            Shows a custom splash screen dialog with the given parameters."/>
+            Shows a custom splash screen dialog with the given parameters.
             </summary>
             <param name="receiver">The componente that receives the callback</param>
             <param name="callback">Name of the callback function</param>
@@ -1967,7 +1967,7 @@
         </member>
         <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowSplashScreen(System.Type,System.Object,System.Func{Microsoft.Fast.Components.FluentUI.DialogResult,System.Threading.Tasks.Task},Microsoft.Fast.Components.FluentUI.DialogParameters{Microsoft.Fast.Components.FluentUI.SplashScreenContent})">
             <summary>
-            Shows a splash screen of the given type with the given parameters."/>
+            Shows a splash screen of the given type with the given parameters.
             </summary>
             <param name="component">The type of the component to show</param>
             <param name="receiver">The componente that receives the callback</param>
@@ -2023,41 +2023,43 @@
         </member>
         <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowPanel``2(Microsoft.Fast.Components.FluentUI.DialogParameters{``1})">
             <summary>
-            Shows a panel with the dialog component type as the body,
-            passing the specified <paramref name="parameters "/>
+            Shows a panel with the dialog component type as the body
             </summary>
             <param name="parameters">Parameters to pass to component being displayed.</param>
         </member>
         <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowPanel``1(System.Type,Microsoft.Fast.Components.FluentUI.DialogParameters{``0})">
             <summary>
-            Shows a panel with the dialog component type as the body,
-            passing the specified <paramref name="parameters "/>
+            Shows a panel with the dialog component type as the body
             </summary>
             <param name="dialogComponent">Type of component to display.</param>
             <param name="parameters">Parameters to pass to component being displayed.</param>
         </member>
         <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowDialog``2(Microsoft.Fast.Components.FluentUI.DialogParameters{``1})">
             <summary>
-            Shows a dialog with the component type as the body,
-            passing the specified <paramref name="parameters "/>
+            Shows a dialog with the component type as the body
             </summary>
             <param name="parameters">Parameters to pass to component being displayed.</param>
         </member>
-        <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowDialog``1(System.Type,``0,Microsoft.Fast.Components.FluentUI.DialogParameters)">
+        <!-- Badly formed XML comment ignored for member "M:Microsoft.Fast.Components.FluentUI.DialogService.ShowDialog``1(System.Type,``0,Microsoft.Fast.Components.FluentUI.DialogParameters)" -->
+        <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.UpdateDialog``1(System.String,Microsoft.Fast.Components.FluentUI.DialogParameters{``0})">
             <summary>
-            Shows a dialog with the component type as the body,
-            passing the specified <paramref name="content "/> 
+            Updates a dialog 
             </summary>
-            <param name="dialogComponent">Type of component to display.</param>
-            <param name="content">Content to pass to component being displayed.</param>
+            <param name="id">Id of the dialog to update.</param>
             <param name="parameters">Parameters to configure the dialog component.</param>
         </member>
         <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowSplashScreenAsync(System.Object,System.Func{Microsoft.Fast.Components.FluentUI.DialogResult,System.Threading.Tasks.Task},Microsoft.Fast.Components.FluentUI.DialogParameters{Microsoft.Fast.Components.FluentUI.SplashScreenContent})">
             <summary>
-            Shows the standard <see cref="T:Microsoft.Fast.Components.FluentUI.FluentSplashScreen"/> with the given parameters."/>
+            Shows the standard <see cref="T:Microsoft.Fast.Components.FluentUI.FluentSplashScreen"/> with the given parameters.
             </summary>
             <param name="receiver">The componente that receives the callback</param>
             <param name="callback">Name of the callback function</param>
+            <param name="parameters"><see cref="T:Microsoft.Fast.Components.FluentUI.SplashScreenContent"/> that holds the content to display</param>
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowSplashScreenAsync(Microsoft.Fast.Components.FluentUI.DialogParameters{Microsoft.Fast.Components.FluentUI.SplashScreenContent})">
+            <summary>
+            Shows the standard <see cref="T:Microsoft.Fast.Components.FluentUI.FluentSplashScreen"/> with the given parameters.
+            </summary>
             <param name="parameters"><see cref="T:Microsoft.Fast.Components.FluentUI.SplashScreenContent"/> that holds the content to display</param>
         </member>
         <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowSplashScreenAsync``1(System.Object,System.Func{Microsoft.Fast.Components.FluentUI.DialogResult,System.Threading.Tasks.Task},Microsoft.Fast.Components.FluentUI.DialogParameters{Microsoft.Fast.Components.FluentUI.SplashScreenContent})">
@@ -2068,22 +2070,29 @@
             <param name="callback">Name of the callback function</param>
             <param name="parameters"><see cref="T:Microsoft.Fast.Components.FluentUI.SplashScreenContent"/> that holds the content to display</param>
         </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowSplashScreenAsync``1(Microsoft.Fast.Components.FluentUI.DialogParameters{Microsoft.Fast.Components.FluentUI.SplashScreenContent})">
+            <summary>
+            Shows a custom splash screen dialog with the given parameters.
+            </summary>
+            <param name="parameters"><see cref="T:Microsoft.Fast.Components.FluentUI.SplashScreenContent"/> that holds the content to display</param>
+        </member>
         <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowSplashScreenAsync(System.Type,System.Object,System.Func{Microsoft.Fast.Components.FluentUI.DialogResult,System.Threading.Tasks.Task},Microsoft.Fast.Components.FluentUI.DialogParameters{Microsoft.Fast.Components.FluentUI.SplashScreenContent})">
             <summary>
-            Shows a splash screen of the given type with the given parameters."/>
+            Shows a splash screen of the given type with the given parameters.
             </summary>
             <param name="component">The type of the component to show</param>
             <param name="receiver">The componente that receives the callback</param>
             <param name="callback">Name of the callback function</param>
             <param name="parameters"><see cref="T:Microsoft.Fast.Components.FluentUI.SplashScreenContent"/> that holds the content to display</param>
         </member>
-        <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowDialogAsync``2(Microsoft.Fast.Components.FluentUI.DialogParameters{``1})">
+        <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowSplashScreenAsync(System.Type,Microsoft.Fast.Components.FluentUI.DialogParameters{Microsoft.Fast.Components.FluentUI.SplashScreenContent})">
             <summary>
-            Shows a dialog with the component type as the body,
-            passing the specified <paramref name="parameters "/>
+            Shows a splash screen of the given type with the given parameters.
             </summary>
-            <param name="parameters">Parameters to pass to component being displayed.</param>
+            <param name="component">The type of the component to show</param>
+            <param name="parameters"><see cref="T:Microsoft.Fast.Components.FluentUI.SplashScreenContent"/> that holds the content to display</param>
         </member>
+        <!-- Badly formed XML comment ignored for member "M:Microsoft.Fast.Components.FluentUI.DialogService.ShowDialogAsync``2(Microsoft.Fast.Components.FluentUI.DialogParameters{``1})" -->
         <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowSuccessAsync(System.String,System.String)">
             <summary>
             Shows a success message box. Does not have a callback function.
@@ -2141,21 +2150,8 @@
             </summary>
             <param name="parameters">Parameters to pass to component being displayed.</param>
         </member>
-        <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowPanelAsync``2(Microsoft.Fast.Components.FluentUI.DialogParameters{``1})">
-            <summary>
-            Shows a panel with the dialog component type as the body,
-            passing the specified <paramref name="parameters "/>
-            </summary>
-            <param name="parameters">Parameters to pass to component being displayed.</param>
-        </member>
-        <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowPanelAsync``1(System.Type,Microsoft.Fast.Components.FluentUI.DialogParameters{``0})">
-            <summary>
-            Shows a panel with the dialog component type as the body,
-            passing the specified <paramref name="parameters "/>
-            </summary>
-            <param name="dialogComponent">Type of component to display.</param>
-            <param name="parameters">Parameters to pass to component being displayed.</param>
-        </member>
+        <!-- Badly formed XML comment ignored for member "M:Microsoft.Fast.Components.FluentUI.DialogService.ShowPanelAsync``2(Microsoft.Fast.Components.FluentUI.DialogParameters{``1})" -->
+        <!-- Badly formed XML comment ignored for member "M:Microsoft.Fast.Components.FluentUI.DialogService.ShowPanelAsync``1(System.Type,Microsoft.Fast.Components.FluentUI.DialogParameters{``0})" -->
         <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowDialogAsync``1(System.Type,``0,Microsoft.Fast.Components.FluentUI.DialogParameters)">
             <summary>
             Shows a dialog with the component type as the body,
@@ -2163,6 +2159,13 @@
             </summary>
             <param name="dialogComponent">Type of component to display.</param>
             <param name="content">Content to pass to component being displayed.</param>
+            <param name="parameters">Parameters to configure the dialog component.</param>
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.UpdateDialogAsync``1(System.String,Microsoft.Fast.Components.FluentUI.DialogParameters{``0})">
+            <summary>
+            Updates a dialog 
+            </summary>
+            <param name="id">Id of the dialog to update.</param>
             <param name="parameters">Parameters to configure the dialog component.</param>
         </member>
         <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.CreateDialogCallback(System.Object,System.Func{Microsoft.Fast.Components.FluentUI.DialogResult,System.Threading.Tasks.Task})">

--- a/examples/Demo/Shared/Microsoft.Fast.Components.FluentUI.xml
+++ b/examples/Demo/Shared/Microsoft.Fast.Components.FluentUI.xml
@@ -1133,8 +1133,8 @@
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentDataGridCell`1.GridColumn">
             <summary>
-            The column _index of the cell.
-            This will be applied to the css grid-column-_index value
+            The column index of the cell.
+            This will be applied to the css grid-column-index value
             applied to the cell
             </summary>
         </member>
@@ -1150,8 +1150,8 @@
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentDataGridRow`1.RowIndex">
             <summary>
-            Gets or sets the _index of this row.
-            When FluentDataGrid is virtualized, this value is always -1.
+            Gets or sets the index of this row
+            When FluentDataGrid is virtualized, this value is not used
             </summary>
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentDataGridRow`1.GridTemplateColumns">
@@ -1190,7 +1190,7 @@
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.GridItemsProviderRequest`1.StartIndex">
             <summary>
-            The zero-based _index of the first item to be supplied.
+            The zero-based index of the first item to be supplied.
             </summary>
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.GridItemsProviderRequest`1.Count">
@@ -2052,6 +2052,109 @@
             <param name="content">Content to pass to component being displayed.</param>
             <param name="parameters">Parameters to configure the dialog component.</param>
         </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowSplashScreenAsync(System.Object,System.Func{Microsoft.Fast.Components.FluentUI.DialogResult,System.Threading.Tasks.Task},Microsoft.Fast.Components.FluentUI.DialogParameters{Microsoft.Fast.Components.FluentUI.SplashScreenContent})">
+            <summary>
+            Shows the standard <see cref="T:Microsoft.Fast.Components.FluentUI.FluentSplashScreen"/> with the given parameters."/>
+            </summary>
+            <param name="receiver">The componente that receives the callback</param>
+            <param name="callback">Name of the callback function</param>
+            <param name="parameters"><see cref="T:Microsoft.Fast.Components.FluentUI.SplashScreenContent"/> that holds the content to display</param>
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowSplashScreenAsync``1(System.Object,System.Func{Microsoft.Fast.Components.FluentUI.DialogResult,System.Threading.Tasks.Task},Microsoft.Fast.Components.FluentUI.DialogParameters{Microsoft.Fast.Components.FluentUI.SplashScreenContent})">
+            <summary>
+            Shows a custom splash screen dialog with the given parameters."/>
+            </summary>
+            <param name="receiver">The componente that receives the callback</param>
+            <param name="callback">Name of the callback function</param>
+            <param name="parameters"><see cref="T:Microsoft.Fast.Components.FluentUI.SplashScreenContent"/> that holds the content to display</param>
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowSplashScreenAsync(System.Type,System.Object,System.Func{Microsoft.Fast.Components.FluentUI.DialogResult,System.Threading.Tasks.Task},Microsoft.Fast.Components.FluentUI.DialogParameters{Microsoft.Fast.Components.FluentUI.SplashScreenContent})">
+            <summary>
+            Shows a splash screen of the given type with the given parameters."/>
+            </summary>
+            <param name="component">The type of the component to show</param>
+            <param name="receiver">The componente that receives the callback</param>
+            <param name="callback">Name of the callback function</param>
+            <param name="parameters"><see cref="T:Microsoft.Fast.Components.FluentUI.SplashScreenContent"/> that holds the content to display</param>
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowDialogAsync``2(Microsoft.Fast.Components.FluentUI.DialogParameters{``1})">
+            <summary>
+            Shows a dialog with the component type as the body,
+            passing the specified <paramref name="parameters "/>
+            </summary>
+            <param name="parameters">Parameters to pass to component being displayed.</param>
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowSuccessAsync(System.String,System.String)">
+            <summary>
+            Shows a success message box. Does not have a callback function.
+            </summary>
+            <param name="message">The message to display.</param>
+            <param name="title">The title to display on the dialog.</param>
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowWarningAsync(System.String,System.String)">
+            <summary>
+            Shows a warning message box. Does not have a callback function.
+            </summary>
+            <param name="message">The message to display.</param>
+            <param name="title">The title to display on the dialog.</param>
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowErrorAsync(System.String,System.String)">
+            <summary>
+            Shows an error message box. Does not have a callback function.
+            </summary>
+            <param name="message">The message to display.</param>
+            <param name="title">The title to display on the dialog.</param>
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowInfoAsync(System.String,System.String)">
+            <summary>
+            Shows an information message box. Does not have a callback function.
+            </summary>
+            <param name="message">The message to display.</param>
+            <param name="title">The title to display on the dialog.</param>
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowConfirmationAsync(System.Object,System.Func{Microsoft.Fast.Components.FluentUI.DialogResult,System.Threading.Tasks.Task},System.String,System.String,System.String,System.String)">
+            <summary>
+            Shows a confirmation message box. Has a callback function which returns boolean 
+            (true=PrimaryAction clicked, false=SecondaryAction clicked).
+            </summary>
+            <param name="receiver">The component that receives the callback function.</param>
+            <param name="callback">The callback function.</param>
+            <param name="message">The message to display.</param>
+            <param name="primaryText">The text to display on the primary button.</param>
+            <param name="secondaryText">The text to display on the secondary button.</param>
+            <param name="title">The title to display on the dialog.</param>
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowMessageBoxAsync(Microsoft.Fast.Components.FluentUI.DialogParameters{Microsoft.Fast.Components.FluentUI.MessageBoxContent})">
+            <summary>
+            Shows a custom message box. Has a callback function which returns boolean
+            (true=PrimaryAction clicked, false=SecondaryAction clicked).
+            </summary>
+            <param name="parameters">Parameters to pass to component being displayed.</param>
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowPanelAsync``2(Microsoft.Fast.Components.FluentUI.DialogParameters{``1})">
+            <summary>
+            Shows a panel with the dialog component type as the body,
+            passing the specified <paramref name="parameters "/>
+            </summary>
+            <param name="parameters">Parameters to pass to component being displayed.</param>
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowPanelAsync``1(System.Type,Microsoft.Fast.Components.FluentUI.DialogParameters{``0})">
+            <summary>
+            Shows a panel with the dialog component type as the body,
+            passing the specified <paramref name="parameters "/>
+            </summary>
+            <param name="dialogComponent">Type of component to display.</param>
+            <param name="parameters">Parameters to pass to component being displayed.</param>
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowDialogAsync``1(System.Type,``0,Microsoft.Fast.Components.FluentUI.DialogParameters)">
+            <summary>
+            Shows a dialog with the component type as the body,
+            passing the specified <paramref name="content "/> 
+            </summary>
+            <param name="dialogComponent">Type of component to display.</param>
+            <param name="content">Content to pass to component being displayed.</param>
+            <param name="parameters">Parameters to configure the dialog component.</param>
+        </member>
         <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.CreateDialogCallback(System.Object,System.Func{Microsoft.Fast.Components.FluentUI.DialogResult,System.Threading.Tasks.Task})">
             <summary>
             Convenience method to create a <see cref="T:Microsoft.AspNetCore.Components.EventCallback"/> for a dialog result.
@@ -2763,7 +2866,7 @@
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentInputFileEventArgs.Index">
             <summary>
-            Gets the _index of the current file in an upload process.
+            Gets the index of the current file in an upload process.
             </summary>
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentInputFileEventArgs.LocalFile">
@@ -3734,7 +3837,7 @@
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.PaginationState.CurrentPageIndex">
             <summary>
-            Gets the current zero-based page _index. To set it, call <see cref="M:Microsoft.Fast.Components.FluentUI.PaginationState.SetCurrentPageIndexAsync(System.Int32)" />.
+            Gets the current zero-based page index. To set it, call <see cref="M:Microsoft.Fast.Components.FluentUI.PaginationState.SetCurrentPageIndexAsync(System.Int32)" />.
             </summary>
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.PaginationState.TotalItemCount">
@@ -3745,7 +3848,7 @@
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.PaginationState.LastPageIndex">
             <summary>
-            Gets the zero-based _index of the last page, if known. The value will be null until <see cref="P:Microsoft.Fast.Components.FluentUI.PaginationState.TotalItemCount"/> is known.
+            Gets the zero-based index of the last page, if known. The value will be null until <see cref="P:Microsoft.Fast.Components.FluentUI.PaginationState.TotalItemCount"/> is known.
             </summary>
         </member>
         <member name="E:Microsoft.Fast.Components.FluentUI.PaginationState.TotalItemCountChanged">
@@ -3758,10 +3861,10 @@
         </member>
         <member name="M:Microsoft.Fast.Components.FluentUI.PaginationState.SetCurrentPageIndexAsync(System.Int32)">
             <summary>
-            Sets the current page _index, and notifies any associated <see cref="T:Microsoft.Fast.Components.FluentUI.FluentDataGrid`1"/>
+            Sets the current page index, and notifies any associated <see cref="T:Microsoft.Fast.Components.FluentUI.FluentDataGrid`1"/>
             to fetch and render updated data.
             </summary>
-            <param name="pageIndex">The new, zero-based page _index.</param>
+            <param name="pageIndex">The new, zero-based page index.</param>
             <returns>A <see cref="T:System.Threading.Tasks.Task"/> representing the completion of the operation.</returns>
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentPopover.AnchorId">
@@ -4241,7 +4344,7 @@
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentTab.Index">
             <summary>
-            Gets the _index number of this tab.
+            Gets the index number of this tab.
             </summary>
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentTab.LabelEditable">

--- a/examples/Demo/Shared/Microsoft.Fast.Components.FluentUI.xml
+++ b/examples/Demo/Shared/Microsoft.Fast.Components.FluentUI.xml
@@ -2124,6 +2124,16 @@
             <param name="secondaryText">The text to display on the secondary button.</param>
             <param name="title">The title to display on the dialog.</param>
         </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowConfirmationAsync(System.String,System.String,System.String,System.String)">
+            <summary>
+            Shows a confirmation message box. Has no callback function
+            (true=PrimaryAction clicked, false=SecondaryAction clicked).
+            </summary>
+            <param name="message">The message to display.</param>
+            <param name="primaryText">The text to display on the primary button.</param>
+            <param name="secondaryText">The text to display on the secondary button.</param>
+            <param name="title">The title to display on the dialog.</param>
+        </member>
         <member name="M:Microsoft.Fast.Components.FluentUI.DialogService.ShowMessageBoxAsync(Microsoft.Fast.Components.FluentUI.DialogParameters{Microsoft.Fast.Components.FluentUI.MessageBoxContent})">
             <summary>
             Shows a custom message box. Has a callback function which returns boolean

--- a/examples/Demo/Shared/Pages/Dialog/DialogPage.razor
+++ b/examples/Demo/Shared/Pages/Dialog/DialogPage.razor
@@ -23,32 +23,71 @@
     <code>&lt;FluentDialog&gt;</code> wraps the <code>&lt;fluent-dialog&gt;</code> element, a web component implementation of a dialog leveraging
     the Fluent UI design system. <code>&lt;FluentDialog&gt;</code> acts as a shell for the dialog content, which can be specified in a number of ways. 
 </p>
+<h2>DialogService</h2>
 <p>
-    Normally, the dialog content is specified by a component which implements <code>IDialogContentComponent&lt;T&gt;</code>. This component is then
-    passed to the <code>DialogService</code> to be shown. The <code>DialogService</code> will then render a <code>&lt;FluentDialog&gt;</code> with the 
-    component inside of it. Alternatively, the dialog content can be specified manually by setting the <code>ChildContent</code> parameter of <code>&lt;FluentDialog&gt;</code>.
-    This is useful if you want to show a simple dialog without having to create a component for it or if you do not want to use the <code>DialogService</code>for it.
-</p>
-<p>
-    The <code>DialogService</code> is a service which can be used to show different types of dialogs. It is registered as a scoped service, so it can be injected into 
-    pages/components that want to use it. For more information on the <code>DialogService</code>, see the <a href="DialogService">Dialog Service</a> page.
-</p>
-<p>
-        When using the <code>DialogService</code>, for displaying a regular dialog, the dialog will always be shown centered on the screen.
+    The <code>DialogService</code> is a service which is used to show different types of dialogs. It is registered as a scoped service, so it can be injected into 
+    pages/components that use it. For more information on the <code>DialogService</code>, see the <a href="DialogService">Dialog Service</a> page.
 </p>
 
+<h2>Dialog content</h2>
+<p>
+    Normally, the dialog content is specified by a component which implements <code>IDialogContentComponent&lt;T&gt;</code>. This component is then
+    passed to the <code>DialogService</code> to be shown. The <code>DialogService</code> will then render a <code>&lt;FluentDialog&gt;</code> with
+    the component inside of it. 
+</p>
+<p>
+    Alternatively, the dialog content can be specified manually by setting the <code>ChildContent</code> parameter of <code>&lt;FluentDialog&gt;</code>.
+    This is useful if you want to show a simple dialog without having to create a component for it or if you do not want to use the <code>DialogService</code>for it.
+    <br/>
+    When using the <code>DialogService</code>, for displaying a regular dialog, the dialog will always be shown centered on the screen.
+</p>
+<h2>Exchange data between dialog and calling component</h2>
+<p>
+    There are two ways available to exchange data between the dialog and the component which shows it. The first is by capturing the returned 
+    <code>IDialogReference</code> from one of the <code>DialogService.Show...Async</code> methods and then use that reference to get the dialog's 
+    result (of type <code>DialogResult</code>). The second is by using an <code>EventCalback</code> parameter as part of the
+    <code>DialogParameters</code>. Both ways are demonstated in the samples below.
+</p>
+<h2>Dialog provider</h2>
+<strong>IMPORTANT!!</strong>
+<p>
+    Dialogs are rendered by the <code>&lt;FluentDialogProvider /&gt;</code> component. This component needs to be added to the main layout of your application/site.
+    You typically do this in the <code>MainLayout.razor</code> file at the end of the <code>&lt;main&gt;</code> section like this:
+</p>
+<CodeSnippet>
+    &lt;main&gt;
+    &lt;nav&gt;
+    :
+    &lt;/nav&gt;
+    &lt;div class=&quot;content&quot;&gt;
+    &lt;article id=&quot;article&quot;&gt;
+    @@Body
+    &lt;/article&gt;
+    &lt;/div&gt;
+    &lt;FluentDialogProvider /&gt;
+    &lt;/main&gt;
+</CodeSnippet>
+
 <h2>Examples</h2>
-<DemoSection Title="Dialog using DialogService" Component="@typeof(DialogServiceExample)" AdditionalFiles="@(new[] {"SimpleDialog.razor"})">
+<p>
+    These examples shows how to use the <code>DialogService</code> to show a dialog. The content of the dialog is specified by
+    a component which implements <code>IDialogContentComponent&lt;T&gt;</code>. Here that is done in <code>SimpleDialog.razor</code>. The dialog is automatically styled and centered.
+</p>
+<p>
+    Interaction with parent dialog can be made by injecting FluentDialog as Cascading Parameter. See <code>SimpleDialog.razor</code> for more details.
+</p>
+<DemoSection Title="DialogService with IDialogReference" Component="@typeof(DialogServiceExample)" AdditionalFiles="@(new[] {"SimpleDialog.razor"})">
     <Description>
-        <p>
-            This example shows how to use the <code>DialogService</code> to show a dialog. The content of the dialog is specified by
-            a component which implements <code>IDialogContentComponent&lt;T&gt;</code>. Here that is done in <code>SimpleDialog.razor</code>. The dialog is automatically styled and centered.
-        </p>
-        <p>
-            Interaction with parent dialog can be made by injecting FluentDialog as Cascading Parameter.
-        </p>
+        This example shows how to use async methods to show a dialog and get the result back from it. 
     </Description>
 </DemoSection>
+
+<DemoSection Title="DialogService with EventCallback" Component="@typeof(DialogServiceCallbackExample)" AdditionalFiles="@(new[] {"SimpleDialog.razor"})">
+    <Description>
+        This example shows how to use an <code>EventCallback</code> parameter to get data back from the dialog.
+    </Description>
+</DemoSection>
+
 
 <DemoSection Title="Dialog without using DialogService" Component="@typeof(DialogDefault)" CollocatedFiles="@(new[] {"css"})">
     <Description>
@@ -56,8 +95,6 @@
         A CSS file has been added to set the width, heigth and padding of the dialog.
     </Description>
 </DemoSection>
-
-
 
 <DemoSection Title="SimpleDialog as component" Component="@typeof(DialogSimpleDialog)">
     <Description>
@@ -67,28 +104,9 @@
     </Description>
 </DemoSection>
 
+<h2>API Documentation</h2>
 
-<h2>Dialog container</h2>
-<strong>IMPORTANT!!</strong>
-<p>
-    Dialogs are rendered through the <code>&lt;FluentDialogContainer /&gt;</code> component. This component needs to be added to the main layout of your application/site.
-    You typically do this in the <code>MainLayout.razor</code> file at the end of the <code>&lt;main&gt;</code> section like this:
-</p>
-<CodeSnippet>
-    &lt;main&gt;
-        &lt;nav&gt;
-        :
-        &lt;/nav&gt;
-        &lt;div class=&quot;content&quot;&gt;
-            &lt;article id=&quot;article&quot;&gt;
-                @@Body
-            &lt;/article&gt;
-        &lt;/div&gt;
-        &lt;FluentDialogContainer /&gt;
-    &lt;/main&gt;
-</CodeSnippet>
-
-<ApiDocumentation Component="typeof(FluentDialogContainer)" />
+<ApiDocumentation Component="typeof(FluentDialogProvider)" />
 
 <ApiDocumentation Component="typeof(FluentDialog)" />
 

--- a/examples/Demo/Shared/Pages/Dialog/Examples/DialogServiceCallbackExample.razor
+++ b/examples/Demo/Shared/Pages/Dialog/Examples/DialogServiceCallbackExample.razor
@@ -1,0 +1,74 @@
+﻿@inject IDialogService DialogService
+
+<div>
+    <p>
+        When 'Modal' is checked, the dialog can be <em>dismissed</em> by clicking outside of the dialog (anywhere on the overlay). When unchecked,
+        the dialog can be <em>dismissed</em> only by the 'ESC' key.<br />The dialog can always be <em>closed</em> by using the 'Close dialog'
+        button.
+    </p>
+    <p>
+        When 'Trap focus' is checked, only the elements within the dialog will receive focus. When unchecked, focus will also move outside of the
+        dialog.
+    </p>
+    <FluentCheckbox Name="modal" @bind-Value="_modal">
+        Modal
+    </FluentCheckbox>
+    <FluentCheckbox Name="trap" @bind-Value="_trapFocus">
+        Trap focus
+    </FluentCheckbox>
+</div>
+<div style="margin-top: 1rem;">
+    <FluentButton @onclick="@OpenDialog" Appearance="Appearance.Accent">
+        Open Dialog
+    </FluentButton>
+</div>
+
+@code {
+    private bool _trapFocus = true;
+    private bool _modal = true;
+
+    SimplePerson simplePerson = new()
+        {
+            Firstname = "Steve",
+            Lastname = "Roth",
+            Age = 39,
+        };
+
+    private void OpenDialog()
+    {
+        DemoLogger.WriteLine($"Open dialog centered");
+
+        DialogParameters<SimplePerson> parameters = new()
+            {
+                Title = $"Hello {simplePerson.Firstname}",
+                OnDialogResult = DialogService.CreateDialogCallback(this, HandleDialog),
+                PrimaryAction = "Yes",
+                PrimaryActionEnabled = false,
+                SecondaryAction = "No",
+                Width = "500px",
+                Height = "500px",
+                Content = simplePerson,
+                TrapFocus = _trapFocus,
+                Modal = _modal,
+            };
+        DialogService.ShowDialog<SimpleDialog, SimplePerson>(parameters);
+    }
+
+    private async Task HandleDialog(DialogResult result)
+    {
+        if (result.Cancelled)
+        {
+            await Task.Run(() => DemoLogger.WriteLine($"Dialog cancelled"));
+            return;
+        }
+        if (result.Data is not null)
+        {
+            SimplePerson? simplePerson = result.Data as SimplePerson;
+            await Task.Run(() => DemoLogger.WriteLine($"Dialog closed by {simplePerson?.Firstname} {simplePerson?.Lastname} ({simplePerson?.Age})"));
+            return;
+        }
+
+        await Task.Run(() => DemoLogger.WriteLine($"Dialog closed"));
+
+    }
+}

--- a/examples/Demo/Shared/Pages/Dialog/Examples/DialogServiceExample.razor
+++ b/examples/Demo/Shared/Pages/Dialog/Examples/DialogServiceExample.razor
@@ -1,11 +1,32 @@
 ﻿@inject IDialogService DialogService
 
-<FluentButton @onclick="@OpenDialog" Appearance="Appearance.Accent">
-    Open Dialog 
-</FluentButton>
-
+<div>
+    <p>
+        When 'Modal' is checked, the dialog can be <em>dismissed</em> by clicking outside of the dialog (anywhere on the overlay). When unchecked,
+        the dialog can be <em>dismissed</em> only by the 'ESC' key.<br />The dialog can always be <em>closed</em> by using the 'Close dialog'
+        button.
+    </p>
+    <p>
+        When 'Trap focus' is checked, only the elements within the dialog will receive focus. When unchecked, focus will also move outside of the
+        dialog.
+    </p>
+    <FluentCheckbox Name="modal" @bind-Value="_modal">
+        Modal
+    </FluentCheckbox>
+    <FluentCheckbox Name="trap" @bind-Value="_trapFocus">
+        Trap focus
+    </FluentCheckbox>
+</div>
+<div style="margin-top: 1rem;">
+    <FluentButton @onclick="@OpenDialogAsync" Appearance="Appearance.Accent">
+        Open Dialog
+    </FluentButton>
+</div>
 
 @code {
+    private bool _trapFocus = true;
+    private bool _modal = true;
+
     SimplePerson simplePerson = new()
         {
             Firstname = "Dan",
@@ -13,7 +34,7 @@
             Age = 42,
         };
 
-    private void OpenDialog()
+    private async Task OpenDialogAsync()
     {
         DemoLogger.WriteLine($"Open dialog centered");
 
@@ -27,8 +48,22 @@
                 Width = "500px",
                 Height = "500px",
                 Content = simplePerson,
+                TrapFocus = _trapFocus,
+                Modal = _modal,
             };
-        DialogService.ShowDialog<SimpleDialog, SimplePerson>(parameters);
+        IDialogReference dialog = await DialogService.ShowDialogAsync<SimpleDialog, SimplePerson>(parameters);
+        DialogResult? result = await dialog.Result;
+        
+        
+        if (result.Data is not null)
+        {
+            SimplePerson? simplePerson = result.Data as SimplePerson;
+            DemoLogger.WriteLine($"Dialog closed by {simplePerson?.Firstname} {simplePerson?.Lastname} ({simplePerson?.Age}) - Canceled: {result.Cancelled}");
+        }
+        else
+        {
+            DemoLogger.WriteLine($"Dialog closed - Canceled: {result.Cancelled}");
+        }
     }
 
     private async Task HandlePanel(DialogResult result)

--- a/examples/Demo/Shared/Pages/Dialog/Examples/DialogServiceExample.razor
+++ b/examples/Demo/Shared/Pages/Dialog/Examples/DialogServiceExample.razor
@@ -39,18 +39,18 @@
         DemoLogger.WriteLine($"Open dialog centered");
 
         DialogParameters<SimplePerson> parameters = new()
-            {
-                Title = $"Hello {simplePerson.Firstname}",
-                OnDialogResult = DialogService.CreateDialogCallback(this, HandlePanel),
-                PrimaryAction = "Yes",
-                PrimaryActionEnabled = false,
-                SecondaryAction = "No",
-                Width = "500px",
-                Height = "500px",
-                Content = simplePerson,
-                TrapFocus = _trapFocus,
-                Modal = _modal,
-            };
+        {
+            Title = $"Hello {simplePerson.Firstname}",
+            PrimaryAction = "Yes",
+            PrimaryActionEnabled = false,
+            SecondaryAction = "No",
+            Width = "500px",
+            Height = "500px",
+            Content = simplePerson,
+            TrapFocus = _trapFocus,
+            Modal = _modal,
+        };
+
         IDialogReference dialog = await DialogService.ShowDialogAsync<SimpleDialog, SimplePerson>(parameters);
         DialogResult? result = await dialog.Result;
         
@@ -64,23 +64,5 @@
         {
             DemoLogger.WriteLine($"Dialog closed - Canceled: {result.Cancelled}");
         }
-    }
-
-    private async Task HandlePanel(DialogResult result)
-    {
-        if (result.Cancelled)
-        {
-            await Task.Run(() => DemoLogger.WriteLine($"Dialog cancelled"));
-            return;
-        }
-        if (result.Data is not null)
-        {
-            SimplePerson? simplePerson = result.Data as SimplePerson;
-            await Task.Run(() => DemoLogger.WriteLine($"Dialog closed by {simplePerson?.Firstname} {simplePerson?.Lastname} ({simplePerson?.Age})"));
-            return;
-        }
-
-        await Task.Run(() => DemoLogger.WriteLine($"Dialog closed"));
-
     }
 }

--- a/examples/Demo/Shared/Pages/DialogServicePage.razor
+++ b/examples/Demo/Shared/Pages/DialogServicePage.razor
@@ -2,20 +2,20 @@
 <h1>DialogService</h1>
 
 <p>
-    The DialogService is a service that can be used to show dialogs. It can be injected into a page and used to show 
+    The DialogService is a service that can be used to show dialogs. It can be injected into a page or component and is used to show 
     different type of dialogs.
 </p>
 <p>
     For a component to be useable by the DialogService, it needs to implement <code>IDialogContentComponent&lt;T&gt;</code>.
 </p>
 <p>
-    The DialogService is automatically registered in the DI container with the <code>AddFluentUIComponents()</code> call.
+    The DialogService is automatically registered in the DI container with the <code>.AddFluentUIComponents()</code> method call.
 </p>
 
-<h2>Dialog container</h2>
+<h2>Dialog provider</h2>
 <strong>IMPORTANT!!</strong>
 <p>
-    Dialogs are rendered through the <code>&lt;FluentDialogContainer /&gt;</code> component. This component needs to be added to the main layout of your application/site.
+    Dialogs are rendered by the <code>&lt;FluentDialogProvider /&gt;</code>. This component needs to be added to the main layout of your application/site.
     You typically do this in the <code>MainLayout.razor</code> file at the end of the <code>&lt;main&gt;</code> section like this:
 </p>
 <CodeSnippet>
@@ -28,13 +28,13 @@
                 @@Body
             &lt;/article&gt;
         &lt;/div&gt;
-        &lt;FluentDialogContainer /&gt;
+        &lt;FluentDialogProvider /&gt;
     &lt;/main&gt;
 </CodeSnippet>
 
 
 <p>
-    See the following pages for examples on how to use the DialogService.
+    See the following pages for examples on how to use the DialogService with thedifferent types of dialogs.
     <ul>
         <li><a href="/Dialog">Regular dialogs</a></li>
         <li><a href="/MessageBox">Message boxes</a></li>
@@ -42,11 +42,52 @@
         <li><a href="/SplashScreen">Splash screens</a></li>
     </ul>
 </p>
-<ApiDocumentation Component="typeof(DialogService)" />
-<ApiDocumentation Component="typeof(FluentDialogContainer)" />
 
 <h2>Exchange data between dialog and calling component</h2>
+<p>
+    There are two ways to exchange data between the dialog and the component which calls the dialog. The first is by capturing the returned <code>IDialogReference</code> from one of the <code>DialogService.Show...Async</code> methods and then use that
+    reference to get the dialog's result (of type <code>DialogResult</code>). The second is by using an <code>EventCalback</code> parameter as part of the
+    <code>DialogParameters</code>.
+</p>
+<h3>Using async/await with an <code>IDialogReference</code></h3>
+<p>
+    You can use the <code>DialogService.Show...Async()</code> methods to show a dialog. When the type of dialog supports data exchange with the
+    callingcomponent, these methods return an <code>IDialogReference</code> which can be used to get the dialog's result. The 
+    <code>DialogResult</code> contains the data that was passed to and altered in the dialog. It also contains a <code>Cancelled</code> property 
+    which indicates if the dialog was cancelled or not.
+</p>
+<p>
+    A typical implementation could look something like this:
+    <CodeSnippet Language="csharp">
+        DialogParameters&lt;SimplePerson&gt; parameters = new()
+        {
+            Title = $"Hello {simplePerson.Firstname}",
+            PrimaryAction = "Yes",
+            PrimaryActionEnabled = false,
+            SecondaryAction = "No",
+            Width = "500px",
+            Height = "500px",
+            Content = simplePerson,
+            TrapFocus = _trapFocus,
+            Modal = _modal,
+        };
 
+        IDialogReference dialog = await DialogService.ShowDialogAsync&lt;SimpleDialog, SimplePerson&gt;(parameters);
+        DialogResult? result = await dialog.Result;
+        
+        if (result.Data is not null)
+        {
+            SimplePerson? simplePerson = result.Data as SimplePerson;
+            Console.WriteLine($"Dialog closed by {simplePerson?.Firstname} {simplePerson?.Lastname} ({simplePerson?.Age}) - Canceled: {result.Cancelled}");
+        }
+        else
+        {
+            Console.WriteLine($"Dialog closed - Canceled: {result.Cancelled}");
+        }
+    </CodeSnippet>
+</p>
+
+<h3>Using an EventCallback</h3>
 <p>
     You can exchange data between the component that opened the dialog and the dialog component by using the <code>DialogParameters.Content</code> 
     parameter to specify the type of data and providing a callback function to the <code>DialogParameters.OnDialogResult</code> method. <br />
@@ -78,3 +119,6 @@
         }
     </CodeSnippet>
 </p>
+
+<ApiDocumentation Component="typeof(DialogService)" />
+<ApiDocumentation Component="typeof(FluentDialogProvider)" />

--- a/examples/Demo/Shared/Pages/MessageBox/Examples/DialogMessageBoxAsync.razor
+++ b/examples/Demo/Shared/Pages/MessageBox/Examples/DialogMessageBoxAsync.razor
@@ -1,0 +1,13 @@
+﻿@inject IDialogService DialogService
+
+
+<FluentStack>
+    <FluentButton @onclick="@ShowSuccessAsync" Appearance="Appearance.Accent">Success</FluentButton>
+    <FluentButton @onclick="@ShowWarningAsync" Appearance="Appearance.Accent">Warning</FluentButton>
+    <FluentButton @onclick="@ShowErrorAsync" Appearance="Appearance.Accent">Error</FluentButton>
+    <FluentButton @onclick="@ShowInformationAsync" Appearance="Appearance.Accent">Information</FluentButton>
+    <FluentButton @onclick="@ShowConfirmationAsync" Appearance="Appearance.Accent">Confirmation</FluentButton>
+    <FluentButton @onclick="@ShowMessageBoxLongAsync" Appearance="Appearance.Accent">Long message</FluentButton>
+    <FluentButton @onclick="@ShowMessageBoxAsync" Appearance="Appearance.Accent">Custom message</FluentButton>
+</FluentStack>
+

--- a/examples/Demo/Shared/Pages/MessageBox/Examples/DialogMessageBoxAsync.razor.cs
+++ b/examples/Demo/Shared/Pages/MessageBox/Examples/DialogMessageBoxAsync.razor.cs
@@ -1,0 +1,69 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.Fast.Components.FluentUI;
+
+namespace FluentUI.Demo.Shared.Pages.MessageBox.Examples
+{
+    public partial class DialogMessageBoxAsync
+    {
+        private IDialogReference? _dialog;
+        private async Task ShowSuccessAsync()
+        {
+            DemoLogger.WriteLine($"Open Success MessageBox");
+            await DialogService.ShowSuccessAsync("The action was run successfuly", "Success title here");
+        }
+
+        private async Task ShowWarningAsync()
+        {
+            DemoLogger.WriteLine($"Open Warning MessageBox");
+            await DialogService.ShowWarningAsync("This is your final warning!", "Warning title here");
+        }
+
+        private async Task ShowErrorAsync()
+        {
+            DemoLogger.WriteLine($"Open Error MessageBox");
+            await DialogService.ShowErrorAsync("This is an error", "Error title here");
+        }
+
+        private async Task ShowInformationAsync()
+        {
+            DemoLogger.WriteLine($"Open Information MessageBox");
+            await DialogService.ShowInfoAsync("This is a message", "Info title here");
+        }
+
+        private async Task ShowConfirmationAsync()
+        {
+            DemoLogger.WriteLine($"Open Confirmation MessageBox");
+            _dialog = await DialogService.ShowConfirmationAsync("Do you have two eyes?", "Yup", "Nope", "Eyes on you");
+            DialogResult result = await _dialog.Result;
+            MessageBoxContent? data = result.Data as MessageBoxContent;
+            DemoLogger.WriteLine($"{data?.Title} - Confirmed: {!result.Cancelled}");
+        }
+
+        private async Task ShowMessageBoxLongAsync()
+        {
+            DemoLogger.WriteLine($"Open Long MessageBox");
+            await DialogService.ShowInfoAsync("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum");
+        }
+
+        private async Task ShowMessageBoxAsync()
+        {
+            DemoLogger.WriteLine($"Open Customized MessageBox");
+            _dialog = await DialogService.ShowMessageBoxAsync(new DialogParameters<MessageBoxContent>()
+            {
+                Content = new()
+                {
+                    Title = "My title",
+                    MarkupMessage = new MarkupString("My <strong>customized</strong> message"),
+                    Icon = new Icons.Regular.Size24.Games(),
+                    IconColor = Color.Success,
+                },
+                PrimaryAction = "Plus",
+                SecondaryAction = "Minus",
+                Width = "300px",
+            });
+            DialogResult result = await _dialog.Result;
+            MessageBoxContent? data = result.Data as MessageBoxContent;
+            DemoLogger.WriteLine($"{data?.Title} - Action: {(!result.Cancelled ? "Plus" : "Minus")}");
+        }
+    }
+}

--- a/examples/Demo/Shared/Pages/MessageBox/MessageBoxPage.razor
+++ b/examples/Demo/Shared/Pages/MessageBox/MessageBoxPage.razor
@@ -12,39 +12,42 @@
     The <code>DialogService</code> is a singleton service that can be injected into any component. It exposes methods to show a dialog.
     For working with a <code>MessageBox</code>, the following methods are available:
     <ul>
-        <li><code>ShowSuccess</code></li>
-        <li><code>ShowWarning</code></li>
-        <li><code>ShowInfo</code></li>
-        <li><code>ShowError</code></li>
-        <li><code>ShowConfirmation</code></li>
-        <li><code>ShowMessageBox</code></li>
+        <li><code>ShowSuccess</code> / <code>ShowSuccessAsync</code></li>
+        <li><code>ShowWarning</code> / <code>ShowWarningAsync</code></li>
+        <li><code>ShowInfo</code> / <code>ShowInfoAsync</code></li>
+        <li><code>ShowError</code> / <code>ShowErrorAsync</code></li>
+        <li><code>ShowConfirmation</code> / <code>ShowConfirmationAsync</code></li>
+        <li><code>ShowMessageBox</code> / <code>ShowMessageBoxAsync</code></li>
     </ul>
     For more information on how to use the <code>DialogService</code>, see the <a href="/DialogService">DialogService</a> page.
 </p>
 <p>
-    For defining the information to display in the <code>MessageBox</code>, the <code>MessageBoxData</code> class is used. It has the following properties:
+    For defining the information to display in the <code>MessageBox</code>, the <code>MessageBoxData</code> class is used. See the API documentation
+    below for the avialable properties.
 </p>
-
-<ApiDocumentation Component="typeof(MessageBoxContent)" />
-
 <p>
-    The <code>MessageBoxData</code> class is then used as the generic type parameter for the <code>DialogParameters</code> class. 
+    The <code>MessageBoxData</code> class is then used as the generic type parameter for the <code>DialogParameters</code> class.
     The <code>DialogParameters</code> class is used to pass parameters to the <code>DialogService</code> when showing a dialog.
 </p>
 
 <p>
-    When both the <code>PrimaryButton</code> and <code>SecondaryButton</code> properties are set, the <code>MessageBox</code> will be 
+    When both the <code>PrimaryButton</code> and <code>SecondaryButton</code> properties are set, the <code>MessageBox</code> will be
     displayed as a modal. This means that the user has to click one of the buttons to close the dialog. It cannot be closed by clicking
-    outside of the dialog. Clicking <code>PrimaryButton</code> will return <code>true</code> and clicking <code>SecondaryButton</code> will 
+    outside of the dialog. Clicking <code>PrimaryButton</code> will return <code>true</code> and clicking <code>SecondaryButton</code> will
     return <code>false</code> as the dialog result. See the Console log for these return values.
 </p>
 
-
-<ApiDocumentation Component="typeof(DialogParameters<>)" InstanceType="typeof(MessageBoxContent)" GenericLabel="MessageBoxData" />
-
-
 <h2>Examples</h2>
 
-<DemoSection Title="MessageBox" Component="@typeof(DialogMessageBox)">
-    
+<DemoSection Title="MessageBoxAsync" Component="@typeof(DialogMessageBoxAsync)">
+    <p>The buttons below call the <strong>async</strong> MessageBox methods on the DialogService.</p>
 </DemoSection>
+
+<DemoSection Title="MessageBox" Component="@typeof(DialogMessageBox)">
+    <p>The buttons below call the <strong>non-async</strong> MessageBox methods on the DialogService.</p>
+</DemoSection>
+
+<h2>API Documentation</h2>
+<ApiDocumentation Component="typeof(MessageBoxContent)" />
+
+<ApiDocumentation Component="typeof(DialogParameters<>)" InstanceType="typeof(MessageBoxContent)" GenericLabel="MessageBoxData" />

--- a/examples/Demo/Shared/Pages/Panel/Examples/DialogPanelAsync.razor
+++ b/examples/Demo/Shared/Pages/Panel/Examples/DialogPanelAsync.razor
@@ -1,0 +1,11 @@
+﻿@inject IDialogService DialogService
+
+<FluentButton @onclick="@OpenPanelRightAsync" Appearance="Appearance.Accent">
+    Open panel (&gt;&gt;)
+</FluentButton>
+
+<FluentButton @onclick="@OpenPanelLeftAsync" Appearance="Appearance.Accent">
+    Open panel (&lt;&lt;)
+</FluentButton>
+
+

--- a/examples/Demo/Shared/Pages/Panel/Examples/DialogPanelAsync.razor.cs
+++ b/examples/Demo/Shared/Pages/Panel/Examples/DialogPanelAsync.razor.cs
@@ -1,0 +1,71 @@
+using FluentUI.Demo.Shared.SampleData;
+using Microsoft.Fast.Components.FluentUI;
+
+namespace FluentUI.Demo.Shared.Pages.Panel.Examples
+{
+    public partial class DialogPanelAsync
+    {
+        private IDialogReference? _dialog;
+
+        private readonly SimplePerson simplePerson = new()
+        {
+            Firstname = "Steve",
+            Lastname = "Roth",
+            Age = 42,
+        };
+
+        private async Task OpenPanelRightAsync()
+        {
+            DemoLogger.WriteLine($"Open right panel");
+
+            _dialog = await DialogService.ShowPanelAsync<SimplePanel, SimplePerson>(new DialogParameters<SimplePerson>()
+            {
+                Content = simplePerson,
+                Alignment = HorizontalAlignment.Right,
+                Title = $"Hello {simplePerson.Firstname}",
+                PrimaryAction = "Yes",
+                SecondaryAction = "No",
+            });
+            DialogResult result = await _dialog.Result;
+            HandlePanel(result);
+
+
+
+        }
+
+        private async Task OpenPanelLeftAsync()
+        {
+            DemoLogger.WriteLine($"Open left panel");
+            DialogParameters<SimplePerson> parameters = new()
+            {
+                Content = simplePerson,
+                Title = $"Hello {simplePerson.Firstname}",
+                Alignment = HorizontalAlignment.Left,
+                Modal = false,
+                ShowDismiss = false,
+                PrimaryAction = "Maybe",
+                SecondaryAction = "Cancel",
+                Width = "300px",
+            };
+            _dialog = await DialogService.ShowPanelAsync<SimplePanel, SimplePerson>(parameters);
+            DialogResult result = await _dialog.Result;
+            HandlePanel(result);
+        }
+
+        private static void HandlePanel(DialogResult result)
+        {
+            if (result.Cancelled)
+            {
+                DemoLogger.WriteLine($"Panel cancelled");
+                return;
+            }
+
+            if (result.Data is not null)
+            {
+                SimplePerson? simplePerson = result.Data as SimplePerson;
+                DemoLogger.WriteLine($"Panel closed by {simplePerson?.Firstname} {simplePerson?.Lastname} ({simplePerson?.Age})");
+                return;
+            }
+        }
+    }
+}

--- a/examples/Demo/Shared/Pages/Panel/PanelPage.razor
+++ b/examples/Demo/Shared/Pages/Panel/PanelPage.razor
@@ -9,25 +9,42 @@
     a component can be used as the content of a panel. The appearance of the panel can be altered by using the <code>DialogParameters</code> class.
 </p>
 <p>
-    Data can be exchanged between the panel and the component that opened the panel by using the <code>DialogParameters.Data</code> parameter.
-    A complete overview of the <code>DialogParameters</code> class:
+    Data can be exchanged between the panel and the component that opened the panel by by capturing the returned <code>IDialogReference</code> from 
+    one of the <code>DialogService.Show...Async</code> methods and then use that reference to get the dialog's result (of type <code>DialogResult</code>) 
+    or by using an EventCallback. 
 </p>
 
-<ApiDocumentation Component="typeof(DialogParameters<>)" InstanceType="typeof(string)" GenericLabel="TData" />
 
 <p>
-    A panel can be shown by calling one of the two <code>ShowPanel</code> methods on the <code>DialogService</code>.
+    A panel can be shown by calling one of following methods on the <code>DialogService</code>:
+    <ul>
+        <li><code>ShowPanel&lt;TDialogContent,TData&gt;</code> / <code>ShowPanelAsync&lt;TDialogContent,TData&gt;</code></li>
+        <li><code>ShowPanel&lt;TData&gt;</code> / <code>ShowPanelAsync&lt;TData&gt;</code></li>
+    </ul>
+</p>
+<p>
     For more information on how to use the <code>DialogService</code>, see the <a href="DialogService">DialogService</a> page.
 </p>
-
 <h2>Examples</h2>
 
-<DemoSection Title="Simple Panel" Component="@typeof(DialogPanel)" AdditionalFiles="@(new[] {"SimplePanel.razor"})">
+<DemoSection Title="Panels using async" Component="@typeof(DialogPanelAsync)" AdditionalFiles="@(new[] {"SimplePanel.razor"})">
     <Description>
-        This example panel that is anchored to the right side of the screen can be dismissed by clicking the dismiss button (at the top), 
+        The panel that is anchored to the right side of the screen can be dismissed by clicking the dismiss button (at the top), 
         'No' button (at the bottom) or by clicking outside of the panel.<br />
-        The panel shown on the left side of the screen can only be closed by clicking the 'Cancel'' button at the bottom of the panel. It does 
+        The panel shown on the left side of the screen can only be closed by clicking the 'Cancel' button at the bottom of the panel. It does 
+        not show a dissmiss button and is shown in a modal fashion based on the settings provided through the <code>DialogParameters</code>.
+    </Description>
+</DemoSection>
+
+
+<DemoSection Title="Panels using callbacks" Component="@typeof(DialogPanel)" AdditionalFiles="@(new[] {"SimplePanel.razor"})">
+    <Description>
+        The panel that is anchored to the right side of the screen can be dismissed by clicking the dismiss button (at the top),
+        'No' button (at the bottom) or by clicking outside of the panel.<br />
+        The panel shown on the left side of the screen can only be closed by clicking the 'Cancel'' button at the bottom of the panel. It does
         not show a dissmiss button and is shown in a modal fashion based on the settings provided through the <code>DialogParameters</code>
     </Description>
 </DemoSection>
 
+<h2>API Documentation</h2>
+<ApiDocumentation Component="typeof(DialogParameters<>)" InstanceType="typeof(string)" GenericLabel="TData" />

--- a/examples/Demo/Shared/Pages/SplashScreen/Examples/DialogSplashScreenCustom.razor
+++ b/examples/Demo/Shared/Pages/SplashScreen/Examples/DialogSplashScreenCustom.razor
@@ -1,6 +1,9 @@
 ﻿@inject IDialogService DialogService
 
 <FluentButton @onclick="@OpenSplashCustom" Appearance="Appearance.Accent">
-    Open customized splash screen
+    Open splash screen
 </FluentButton>
 
+<FluentButton @onclick="@OpenSplashCustomAsync" Appearance="Appearance.Accent">
+    Open splash screen (async)
+</FluentButton>

--- a/examples/Demo/Shared/Pages/SplashScreen/Examples/DialogSplashScreenCustom.razor.cs
+++ b/examples/Demo/Shared/Pages/SplashScreen/Examples/DialogSplashScreenCustom.razor.cs
@@ -5,6 +5,35 @@ namespace FluentUI.Demo.Shared.Pages.SplashScreen.Examples
 {
     public partial class DialogSplashScreenCustom
     {
+        private IDialogReference? _dialog;
+        private async Task OpenSplashCustomAsync()
+        {
+            DemoLogger.WriteLine($"Open custom splashscreen for 7 seconds");
+            DialogParameters<SplashScreenContent> parameters = new()
+            {
+                Content = new SplashScreenContent()
+                {
+                    Title = "Water drinking 101",
+                    LoadingText = "Filling the re-useable bottles...",
+                    Message = (MarkupString)"Don't drink <strong>too</strong> much water!",
+                    Logo = "_content/FluentUI.Demo.Shared/images/Splash_Corporation_logo.png",
+                },
+                Width = "500px",
+                Height = "300px",
+            };
+            _dialog = await DialogService.ShowSplashScreenAsync<CustomSplashScreen>(parameters);
+
+            for (int i = 0; i < 5; i++)
+            {
+                await Task.Delay(1000);
+                parameters.Content.LoadingText = $"Filling the re-useable bottles... {i + 1}";
+                await DialogService.UpdateDialogAsync(_dialog.Id, parameters);
+            }
+
+
+            DialogResult result = await _dialog.Result;
+            await HandleCustomSplash(result);
+        }
         private void OpenSplashCustom()
         {
             DemoLogger.WriteLine($"Open custom splashscreen for 7 seconds");
@@ -27,5 +56,7 @@ namespace FluentUI.Demo.Shared.Pages.SplashScreen.Examples
         {
             await Task.Run(() => DemoLogger.WriteLine($"Custom splash closed"));
         }
+
+
     }
 }

--- a/examples/Demo/Shared/Pages/SplashScreen/Examples/DialogSplashScreenDefault.razor
+++ b/examples/Demo/Shared/Pages/SplashScreen/Examples/DialogSplashScreenDefault.razor
@@ -1,6 +1,9 @@
 ﻿@inject IDialogService DialogService
 
 <FluentButton @onclick="@OpenSplashDefault" Appearance="Appearance.Accent">
-    Open default splash screen
+    Open splash screen
 </FluentButton>
 
+<FluentButton @onclick="@OpenSplashDefaultAsync" Appearance="Appearance.Accent">
+    Open splash screen (async)
+</FluentButton>

--- a/examples/Demo/Shared/Pages/SplashScreen/Examples/DialogSplashScreenDefault.razor.cs
+++ b/examples/Demo/Shared/Pages/SplashScreen/Examples/DialogSplashScreenDefault.razor.cs
@@ -5,6 +5,30 @@ namespace FluentUI.Demo.Shared.Pages.SplashScreen.Examples
 {
     public partial class DialogSplashScreenDefault
     {
+        private IDialogReference? _dialog;
+
+        private async Task OpenSplashDefaultAsync()
+        {
+            DemoLogger.WriteLine($"Open default splashscreen for 4 seconds");
+            DialogParameters<SplashScreenContent> parameters = new()
+            {
+                Content = new()
+                {
+                    Title = "Core components",
+                    SubTitle = "Microsoft Fluent UI Blazor library",
+                    LoadingText = "Loading...",
+                    Message = (MarkupString)"some <i>extra</i> text <strong>here</strong>",
+                    Logo = FluentSplashScreen.LOGO,
+                },
+                Width = "640px",
+                Height = "480px",
+            };
+            _dialog = await DialogService.ShowSplashScreenAsync(parameters);
+            DialogResult result = await _dialog.Result;
+            await HandleDefaultSplash(result);
+        }
+
+
         private void OpenSplashDefault()
         {
             DemoLogger.WriteLine($"Open default splashscreen for 4 seconds");

--- a/examples/Demo/Shared/Pages/SplashScreen/SplashScreenPage.razor
+++ b/examples/Demo/Shared/Pages/SplashScreen/SplashScreenPage.razor
@@ -4,32 +4,29 @@
 
 <h1>SplashScreen</h1>
 
-<p></p>
 
 <p>
-    For defining the information to display in the <code>SplashScreen</code>, the <code>SplashScreenData</code> class is used.
-    It has the following properties:
+    For defining the information to display in the <code>SplashScreen</code>, the <code>SplashScreenContent</code> class is used. See the API 
+    documentation below for the available properties
 </p>
 
-<ApiDocumentation Component="typeof(SplashScreenContent)"/>
-
 <p>
-    To show a splash screen, the <code>DialogService</code> is used.
-    The <code>DialogService</code> is a singleton service that can be injected into any component. It exposes 2 methods to show a splash screen dialog:
+    To show a splash screen, the <code>DialogService</code> is used. The <code>DialogService</code> is a singleton service that can be injected 
+    into any page/component. It exposes the following methods to show a splash screen dialog:
     <ul>
-        <li><code>SplashScreenParameters</code> (uses the <code>FluentSplashScreen</code> to show the dialog)</li>
-        <li><code>SplashScreenParameters&lt;T&gt;</code> where T is a custom component which inherits the <code>FluentSplashScreen</code> component 
-            and implements <code>IDialogContentComponent&lt;SplashScreenData&gt;</code> .</li>
+        <li><code>ShowSplashScreen</code> / <code>ShowSplashScreenAsync</code> (uses the <code>FluentSplashScreen</code> to show the dialog)</li>
+        <li>
+            <code>ShowSplashScreen&lt;T&gt;</code> / <code>ShowSplashScreenAsync&lt;T&gt;</code> where T is a custom component which inherits the <code>FluentSplashScreen</code> component
+            and implements <code>IDialogContentComponent&lt;SplashScreenContent&gt;</code> .</li>
     </ul>
 </p>
 
-<ApiDocumentation Component="typeof(FluentSplashScreen)" />
 
 <h2>Examples</h2>
 
 <DemoSection Title="Default splash screen" Component="@typeof(DialogSplashScreenDefault)" >
     <Description>
-        The default example shows the standard splash screen. It's content can be alterd by means of the <code>SplashScreenData</code> class.
+        This example shows the standard splash screen. It's content can be alterd by means of the <code>SplashScreenContent</code> class.
         In this example we simulate a startup process that takes 4 seconds. 
     </Description>
 </DemoSection>
@@ -41,3 +38,6 @@
     </Description>
 </DemoSection>
 
+<h2>API Documentation</h2>
+<ApiDocumentation Component="typeof(SplashScreenContent)" />
+<ApiDocumentation Component="typeof(FluentSplashScreen)" />

--- a/examples/Demo/Shared/Shared/DemoMainLayout.razor
+++ b/examples/Demo/Shared/Shared/DemoMainLayout.razor
@@ -96,7 +96,7 @@
             </aside>
         </div>
         <FluentToastContainer MaxToastCount="10"  />
-        <FluentDialogContainer />
+        <FluentDialogProvider />
         <FluentTooltipProvider />
     </main>
     <footer>

--- a/src/Core/Components/Dialog/FluentDialog.razor
+++ b/src/Core/Components/Dialog/FluentDialog.razor
@@ -6,9 +6,9 @@
                    id="@Id"
                    class="@ClassValue"
                    style="@StyleValue"
-                   modal="@((_parameters.Modal ?? Modal).ToString()?.ToLower())"
+                   modal="@((Modal ?? _parameters.Modal).ToString()?.ToLower())"
                    hidden="@Hidden"
-                   trap-focus=@(_parameters.TrapFocus ?? TrapFocus)
+                   trap-focus="@((TrapFocus ?? _parameters.TrapFocus).ToString()?.ToLower())"
                    aria-describedby=@(_parameters.AriaDescribedby ?? AriaDescribedby)
                    aria-labelledby=@(_parameters.AriaLabelledby ?? AriaLabelledby)
                    aria-label=@(_parameters.AriaLabel ?? AriaLabel)

--- a/src/Core/Components/Dialog/FluentDialog.razor.cs
+++ b/src/Core/Components/Dialog/FluentDialog.razor.cs
@@ -4,7 +4,7 @@ using Microsoft.Fast.Components.FluentUI.Utilities;
 
 namespace Microsoft.Fast.Components.FluentUI;
 
-public partial class FluentDialog : FluentComponentBase, IDisposable
+public partial class FluentDialog : FluentComponentBase //, IDisposable
 {
     private const string DEFAULT_WIDTH = "500px";
     private const string DEFAULT_HEIGHT = "unset";
@@ -18,7 +18,7 @@ public partial class FluentDialog : FluentComponentBase, IDisposable
     /// overlay.  Clicks on the overlay will cause the dialog to emit a "dismiss" event.
     /// </summary>
     [Parameter]
-    public bool? Modal { get; set; } = true;
+    public bool? Modal { get; set; }
 
     /// <summary>
     /// Gets or sets if the dialog is hidden
@@ -30,7 +30,7 @@ public partial class FluentDialog : FluentComponentBase, IDisposable
     /// Indicates that the dialog should trap focus.
     /// </summary>
     [Parameter]
-    public bool? TrapFocus { get; set; } = true;
+    public bool? TrapFocus { get; set; }
 
     /// <summary>
     /// The id of the element describing the dialog.
@@ -93,21 +93,22 @@ public partial class FluentDialog : FluentComponentBase, IDisposable
 
     protected override void OnInitialized()
     {
-        if (Instance is not null)
-        {
-            _parameters = Instance.Parameters;
-            DialogContext!.Register(this);
-        }
-        else
+        if (Instance is null)
         {
             _parameters = new()
             {
                 Alignment = HorizontalAlignment.Center,
-                Id = Id ?? Identifier.NewId(),
                 ShowTitle = false,
                 PrimaryAction = string.Empty,
                 SecondaryAction = string.Empty
             };
+            Modal = true;
+            TrapFocus = true;
+        }
+        else
+        {
+            _parameters = Instance.Parameters;
+            //DialogContext!.Register(this);
         }
     }
 
@@ -158,9 +159,12 @@ public partial class FluentDialog : FluentComponentBase, IDisposable
     /// </summary>
     public async Task CloseAsync(DialogResult dialogResult)
     {
-        DialogContext?.DialogContainer.DismissInstance(Id!);
-        await Instance.Parameters.OnDialogResult.InvokeAsync(dialogResult);
+        DialogContext?.DialogContainer.DismissInstance(Id!, dialogResult);
+        if (Instance.Parameters.OnDialogResult.HasDelegate)
+        {
+            await Instance.Parameters.OnDialogResult.InvokeAsync(dialogResult);
+        }
     }
 
-    public void Dispose() => DialogContext?.Unregister(this);
+    //public void Dispose() => DialogContext?.Unregister(this);
 }

--- a/src/Core/Components/Dialog/FluentDialog.razor.cs
+++ b/src/Core/Components/Dialog/FluentDialog.razor.cs
@@ -108,7 +108,6 @@ public partial class FluentDialog : FluentComponentBase //, IDisposable
         else
         {
             _parameters = Instance.Parameters;
-            //DialogContext!.Register(this);
         }
     }
 
@@ -165,6 +164,4 @@ public partial class FluentDialog : FluentComponentBase //, IDisposable
             await Instance.Parameters.OnDialogResult.InvokeAsync(dialogResult);
         }
     }
-
-    //public void Dispose() => DialogContext?.Unregister(this);
 }

--- a/src/Core/Components/Dialog/FluentDialogContainer.razor
+++ b/src/Core/Components/Dialog/FluentDialogContainer.razor
@@ -1,7 +1,7 @@
 ﻿@using Microsoft.AspNetCore.Components.Rendering
 @namespace Microsoft.Fast.Components.FluentUI
 
-@if (_dialogs.Any())
+@if (_internalDialogContext.References.Any())
 {
     <div class="fluent-dialog-container">
         <CascadingValue TValue="InternalDialogContext" IsFixed="true" Value = "@_internalDialogContext" >
@@ -14,9 +14,9 @@
 @code {
     protected void RenderDialogs(RenderTreeBuilder __builder)
     {
-        @foreach (DialogInstance dialog in _dialogs)
+        @foreach (DialogReference dialog in _internalDialogContext.References)
         {
-            <FluentDialog @key="@dialog" Id="@dialog.Id" Settings="@dialog.Parameters" Instance="@dialog" Data="@dialog.Content" @ondialogdismiss=OnDismissAsync />
+            <FluentDialog @key="@dialog" Id="@dialog.Id" Instance="@dialog.Instance" Data="@dialog.Instance.Content" @ondialogdismiss=OnDismissAsync />
         }
     }
 }

--- a/src/Core/Components/Dialog/FluentDialogProvider.razor
+++ b/src/Core/Components/Dialog/FluentDialogProvider.razor
@@ -3,11 +3,9 @@
 
 @if (_internalDialogContext.References.Any())
 {
-    <div class="fluent-dialog-container">
-        <CascadingValue TValue="InternalDialogContext" IsFixed="true" Value = "@_internalDialogContext" >
-            @_renderDialogs
-        </CascadingValue>
-    </div>
+    <CascadingValue TValue="InternalDialogContext" IsFixed="true" Value = "@_internalDialogContext" >
+        @_renderDialogs
+    </CascadingValue>
 }
 
 

--- a/src/Core/Components/Dialog/FluentDialogProvider.razor.cs
+++ b/src/Core/Components/Dialog/FluentDialogProvider.razor.cs
@@ -29,6 +29,8 @@ public partial class FluentDialogProvider : IDisposable
 
         DialogService.OnShow += ShowDialog;
         DialogService.OnShowAsync += ShowDialogAsync;
+        DialogService.OnUpdate += UpdateDialog;
+        DialogService.OnUpdateAsync += UpdateDialogAsync;
         DialogService.OnDialogCloseRequested += DismissInstance;
     }
 
@@ -43,7 +45,7 @@ public partial class FluentDialogProvider : IDisposable
 
     private async Task<IDialogReference> ShowDialogAsync(IDialogReference dialogReference, Type? dialogComponent, DialogParameters parameters, object content)
     {
-        return await Task.Run<IDialogReference>(() =>
+        return await Task.Run(() =>
         {
             DialogInstance dialog = new(dialogComponent, parameters, content);
             dialogReference.Instance = dialog;
@@ -52,6 +54,35 @@ public partial class FluentDialogProvider : IDisposable
             InvokeAsync(StateHasChanged);
 
             return dialogReference;
+        });
+    }
+
+    private void UpdateDialog(string? dialogId, DialogParameters parameters)
+    {
+        IDialogReference reference = _internalDialogContext.References.SingleOrDefault(x => x.Id == dialogId)!;
+        DialogInstance? dialogInstance = reference.Instance;
+
+        if (dialogInstance is not null)
+        {
+            dialogInstance.Parameters = parameters;
+
+            InvokeAsync(StateHasChanged);
+        };
+    }
+
+    private async Task UpdateDialogAsync(string? dialogId, DialogParameters parameters)
+    {
+        await Task.Run(() =>
+        {
+            IDialogReference reference = _internalDialogContext.References.SingleOrDefault(x => x.Id == dialogId)!;
+            DialogInstance? dialogInstance = reference.Instance;
+
+            if (dialogInstance is not null)
+            {
+                dialogInstance.Parameters = parameters;
+
+                InvokeAsync(StateHasChanged);
+            }
         });
     }
 

--- a/src/Core/Components/Dialog/FluentDialogProvider.razor.cs
+++ b/src/Core/Components/Dialog/FluentDialogProvider.razor.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Components.Routing;
 
 namespace Microsoft.Fast.Components.FluentUI;
 
-public partial class FluentDialogContainer : IDisposable
+public partial class FluentDialogProvider : IDisposable
 {
     private readonly InternalDialogContext _internalDialogContext;
     private readonly RenderFragment _renderDialogs;
@@ -17,7 +17,7 @@ public partial class FluentDialogContainer : IDisposable
     /// <summary>
     /// Constructs an instance of <see cref="FluentToastContainer"/>.
     /// </summary>
-    public FluentDialogContainer()
+    public FluentDialogProvider()
     {
         _internalDialogContext = new(this);
         _renderDialogs = RenderDialogs;
@@ -34,14 +34,11 @@ public partial class FluentDialogContainer : IDisposable
 
     private void ShowDialog(IDialogReference dialogReference, Type? dialogComponent, DialogParameters parameters, object content)
     {
-        _ = InvokeAsync(() =>
-        {
-            DialogInstance dialog = new(dialogComponent, parameters, content);
-            dialogReference.Instance = dialog;
+        DialogInstance dialog = new(dialogComponent, parameters, content);
+        dialogReference.Instance = dialog;
 
-            _internalDialogContext.References.Add(dialogReference);
-            StateHasChanged();
-        });
+        _internalDialogContext.References.Add(dialogReference);
+        InvokeAsync(StateHasChanged);
     }
 
     private async Task<IDialogReference> ShowDialogAsync(IDialogReference dialogReference, Type? dialogComponent, DialogParameters parameters, object content)
@@ -77,21 +74,6 @@ public partial class FluentDialogContainer : IDisposable
         _internalDialogContext.References.ToList().ForEach(r => DismissInstance(r, DialogResult.Cancel()));
         StateHasChanged();
     }
-
-    //internal void DismissInstance(string id)
-    //{
-    //    DialogInstance? instance = GetDialogInstance(id);
-    //    if (instance != null)
-    //    {
-    //        DismissInstance(instance);
-    //    }
-    //}
-
-    //private void DismissInstance(DialogInstance dialog)
-    //{
-    //    _dialogs.Remove(dialog);
-    //    StateHasChanged();
-    //}
 
     private void DismissInstance(IDialogReference dialog, DialogResult result)
     {

--- a/src/Core/Components/Dialog/Parameters/DialogParameters.cs
+++ b/src/Core/Components/Dialog/Parameters/DialogParameters.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Fast.Components.FluentUI;
 
 public class DialogParameters : ComponentParameters, IDialogParameters
 {
-    public string? Id { get; set; }
+    public string Id { get; set; } = Identifier.NewId();
     /// <summary>
     /// Gets or sets the dialog position:
     /// left (full height), right (full height)

--- a/src/Core/Components/Dialog/Parameters/IDialogParameters.cs
+++ b/src/Core/Components/Dialog/Parameters/IDialogParameters.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Fast.Components.FluentUI
 {
     public interface IDialogParameters
     {
-        string? Id { get; set; }
+        string Id { get; set; }
         HorizontalAlignment Alignment { get; set; }
         string? Title { get; set; }
         bool? Modal { get; set; }
@@ -13,10 +13,8 @@ namespace Microsoft.Fast.Components.FluentUI
         bool ShowDismiss { get; set; }
         string? PrimaryAction { get; set; }
         bool PrimaryActionEnabled { get; set; }
-        //EventCallback<DialogResult>? OnPrimaryAction { get; set; }
         string? SecondaryAction { get; set; }
         bool SecondaryActionEnabled { get; set; }
-        //EventCallback<DialogResult>? OnSecondaryAction { get; set; }
         string? Width { get; set; }
         string? Height { get; set; }
         string DialogBodyStyle { get; set; }
@@ -25,6 +23,7 @@ namespace Microsoft.Fast.Components.FluentUI
         string? AriaLabelledby { get; set; }
         EventCallback<DialogResult> OnDialogResult { get; set; }
     }
+
     public interface IDialogParameters<TContent> : IDialogParameters
          where TContent : class
     {

--- a/src/Core/Components/Dialog/Services/DialogInstance.cs
+++ b/src/Core/Components/Dialog/Services/DialogInstance.cs
@@ -16,7 +16,7 @@ public sealed class DialogInstance
 
     public object Content { get; set; } = default!;
 
-    public DialogParameters Parameters { get; }
+    public DialogParameters Parameters { get; set; }
 
     public Dictionary<string, object> GetParameterDictionary()
     {

--- a/src/Core/Components/Dialog/Services/DialogReference.cs
+++ b/src/Core/Components/Dialog/Services/DialogReference.cs
@@ -1,0 +1,57 @@
+﻿namespace Microsoft.Fast.Components.FluentUI;
+
+public class DialogReference : IDialogReference
+{
+    private readonly IDialogService _dialogService;
+
+    private readonly TaskCompletionSource<DialogResult> _resultCompletion = new();
+
+    public DialogReference(string dialogInstanceId, IDialogService dialogService)
+    {
+        Id = dialogInstanceId;
+        _dialogService = dialogService;
+    }
+
+    public DialogInstance Instance { get; set; } = default!;
+
+    public string Id { get; }
+
+    public Task<DialogResult> Result => _resultCompletion.Task;
+
+    public async Task CloseAsync()
+    {
+        await _dialogService.CloseAsync(this);
+    }
+
+    public async Task CloseAsync(DialogResult result)
+    {
+        await _dialogService.CloseAsync(this, result);
+    }
+
+    public virtual bool Dismiss(DialogResult result)
+    {
+        _resultCompletion.TrySetResult(result);
+
+        return true;
+    }
+
+    public async Task<T?> GetReturnValueAsync<T>()
+    {
+        DialogResult? result = await Result;
+        try
+        {
+            if (result.Data == null)
+            {
+                return default;
+            }
+            else
+            {
+                return (T)result.Data ?? default;
+            }
+        }
+        catch (InvalidCastException)
+        {
+            return default;
+        }
+    }
+}

--- a/src/Core/Components/Dialog/Services/DialogService.cs
+++ b/src/Core/Components/Dialog/Services/DialogService.cs
@@ -8,13 +8,15 @@ public class DialogService : IDialogService
     /// A event that will be invoked when showing a dialog with a custom component
     /// </summary>
     public event Action<IDialogReference, Type?, DialogParameters, object>? OnShow;
-
     public event Func<IDialogReference, Type?, DialogParameters, object, Task<IDialogReference>>? OnShowAsync;
+
+    public event Action<string, DialogParameters>? OnUpdate;
+    public event Func<string, DialogParameters, Task>? OnUpdateAsync;
 
     public event Action<IDialogReference, DialogResult>? OnDialogCloseRequested;
 
     /// <summary>
-    /// Shows the standard <see cref="FluentSplashScreen"/> with the given parameters."/>
+    /// Shows the standard <see cref="FluentSplashScreen"/> with the given parameters.
     /// </summary>
     /// <param name="receiver">The componente that receives the callback</param>
     /// <param name="callback">Name of the callback function</param>
@@ -23,7 +25,7 @@ public class DialogService : IDialogService
         => ShowSplashScreen<FluentSplashScreen>(receiver, callback, parameters);
 
     /// <summary>
-    /// Shows a custom splash screen dialog with the given parameters."/>
+    /// Shows a custom splash screen dialog with the given parameters.
     /// </summary>
     /// <param name="receiver">The componente that receives the callback</param>
     /// <param name="callback">Name of the callback function</param>
@@ -34,7 +36,7 @@ public class DialogService : IDialogService
 
 
     /// <summary>
-    /// Shows a splash screen of the given type with the given parameters."/>
+    /// Shows a splash screen of the given type with the given parameters.
     /// </summary>
     /// <param name="component">The type of the component to show</param>
     /// <param name="receiver">The componente that receives the callback</param>
@@ -187,8 +189,7 @@ public class DialogService : IDialogService
     }
 
     /// <summary>
-    /// Shows a panel with the dialog component type as the body,
-    /// passing the specified <paramref name="parameters "/>
+    /// Shows a panel with the dialog component type as the body
     /// </summary>
     /// <param name="parameters">Parameters to pass to component being displayed.</param>
     public void ShowPanel<T, TData>(DialogParameters<TData> parameters)
@@ -197,8 +198,7 @@ public class DialogService : IDialogService
         => ShowPanel(typeof(T), parameters);
 
     /// <summary>
-    /// Shows a panel with the dialog component type as the body,
-    /// passing the specified <paramref name="parameters "/>
+    /// Shows a panel with the dialog component type as the body
     /// </summary>
     /// <param name="dialogComponent">Type of component to display.</param>
     /// <param name="parameters">Parameters to pass to component being displayed.</param>
@@ -223,8 +223,7 @@ public class DialogService : IDialogService
     }
 
     /// <summary>
-    /// Shows a dialog with the component type as the body,
-    /// passing the specified <paramref name="parameters "/>
+    /// Shows a dialog with the component type as the body
     /// </summary>
     /// <param name="parameters">Parameters to pass to component being displayed.</param>
     public void ShowDialog<T, TContent>(DialogParameters<TContent> parameters)
@@ -252,8 +251,7 @@ public class DialogService : IDialogService
     }
 
     /// <summary>
-    /// Shows a dialog with the component type as the body,
-    /// passing the specified <paramref name="content "/> 
+    /// Shows a dialog with the component type as the body
     /// </summary>
     /// <param name="dialogComponent">Type of component to display.</param>
     /// <param name="content">Content to pass to component being displayed.</param>
@@ -271,15 +269,34 @@ public class DialogService : IDialogService
         OnShow?.Invoke(dialogReference, dialogComponent, parameters, content);
     }
 
+    /// <summary>
+    /// Updates a dialog 
+    /// </summary>
+    /// <param name="id">Id of the dialog to update.</param>
+    /// <param name="parameters">Parameters to configure the dialog component.</param>
+    public void UpdateDialog<TContent>(string id, DialogParameters<TContent> parameters)
+        where TContent : class
+    {
+        OnUpdate?.Invoke(id, parameters);
+    }
+
+    //Async methods
 
     /// <summary>
-    /// Shows the standard <see cref="FluentSplashScreen"/> with the given parameters."/>
+    /// Shows the standard <see cref="FluentSplashScreen"/> with the given parameters.
     /// </summary>
     /// <param name="receiver">The componente that receives the callback</param>
     /// <param name="callback">Name of the callback function</param>
     /// <param name="parameters"><see cref="SplashScreenContent"/> that holds the content to display</param>
     public async Task<IDialogReference> ShowSplashScreenAsync(object receiver, Func<DialogResult, Task> callback, DialogParameters<SplashScreenContent> parameters)
         => await ShowSplashScreenAsync<FluentSplashScreen>(receiver, callback, parameters);
+
+    /// <summary>
+    /// Shows the standard <see cref="FluentSplashScreen"/> with the given parameters.
+    /// </summary>
+    /// <param name="parameters"><see cref="SplashScreenContent"/> that holds the content to display</param>
+    public async Task<IDialogReference> ShowSplashScreenAsync(DialogParameters<SplashScreenContent> parameters)
+        => await ShowSplashScreenAsync<FluentSplashScreen>(parameters);
 
     /// <summary>
     /// Shows a custom splash screen dialog with the given parameters."/>
@@ -291,9 +308,17 @@ public class DialogService : IDialogService
         where T : IDialogContentComponent<SplashScreenContent>
         => await ShowSplashScreenAsync(typeof(T), receiver, callback, parameters);
 
+    /// <summary>
+    /// Shows a custom splash screen dialog with the given parameters.
+    /// </summary>
+    /// <param name="parameters"><see cref="SplashScreenContent"/> that holds the content to display</param>
+    public async Task<IDialogReference> ShowSplashScreenAsync<T>(DialogParameters<SplashScreenContent> parameters)
+        where T : IDialogContentComponent<SplashScreenContent>
+        => await ShowSplashScreenAsync(typeof(T), parameters);
+
 
     /// <summary>
-    /// Shows a splash screen of the given type with the given parameters."/>
+    /// Shows a splash screen of the given type with the given parameters.
     /// </summary>
     /// <param name="component">The type of the component to show</param>
     /// <param name="receiver">The componente that receives the callback</param>
@@ -320,8 +345,31 @@ public class DialogService : IDialogService
     }
 
     /// <summary>
-    /// Shows a dialog with the component type as the body,
-    /// passing the specified <paramref name="parameters "/>
+    /// Shows a splash screen of the given type with the given parameters.
+    /// </summary>
+    /// <param name="component">The type of the component to show</param>
+    /// <param name="parameters"><see cref="SplashScreenContent"/> that holds the content to display</param>
+    public async Task<IDialogReference> ShowSplashScreenAsync(Type component, DialogParameters<SplashScreenContent> parameters)
+    {
+        DialogParameters dialogParameters = new()
+        {
+            Alignment = HorizontalAlignment.Center,
+            Modal = false,
+            ShowDismiss = false,
+            ShowTitle = false,
+            PrimaryAction = null,
+            SecondaryAction = null,
+            Width = parameters.Width ?? "600px",
+            Height = parameters.Height ?? "370px",
+            DialogBodyStyle = "width: 100%; height: 100%; margin: 0px;",
+            AriaLabel = $"{parameters.Content.Title} splashscreen",
+        };
+
+        return await ShowDialogAsync(component, parameters.Content, dialogParameters);
+    }
+
+    /// <summary>
+    /// Shows a dialog with the component type as the body
     /// </summary>
     /// <param name="parameters">Parameters to pass to component being displayed.</param>
     public async Task<IDialogReference> ShowDialogAsync<T, TContent>(DialogParameters<TContent> parameters)
@@ -500,8 +548,7 @@ public class DialogService : IDialogService
     }
 
     /// <summary>
-    /// Shows a panel with the dialog component type as the body,
-    /// passing the specified <paramref name="parameters "/>
+    /// Shows a panel with the dialog component type as the body
     /// </summary>
     /// <param name="parameters">Parameters to pass to component being displayed.</param>
     public async Task<IDialogReference> ShowPanelAsync<T, TData>(DialogParameters<TData> parameters)
@@ -510,8 +557,7 @@ public class DialogService : IDialogService
         => await ShowPanelAsync(typeof(T), parameters);
 
     /// <summary>
-    /// Shows a panel with the dialog component type as the body,
-    /// passing the specified <paramref name="parameters "/>
+    /// Shows a panel with the dialog component type as the body
     /// </summary>
     /// <param name="dialogComponent">Type of component to display.</param>
     /// <param name="parameters">Parameters to pass to component being displayed.</param>
@@ -553,6 +599,17 @@ public class DialogService : IDialogService
         IDialogReference? dialogReference = new DialogReference(parameters.Id, this);
 
         return await OnShowAsync!.Invoke(dialogReference, dialogComponent, parameters, content);
+    }
+
+    /// <summary>
+    /// Updates a dialog 
+    /// </summary>
+    /// <param name="id">Id of the dialog to update.</param>
+    /// <param name="parameters">Parameters to configure the dialog component.</param>
+    public async Task UpdateDialogAsync<TContent>(string id, DialogParameters<TContent> parameters)
+        where TContent : class
+    {
+        await OnUpdateAsync!.Invoke(id, parameters);
     }
 
     /// <summary>

--- a/src/Core/Components/Dialog/Services/DialogService.cs
+++ b/src/Core/Components/Dialog/Services/DialogService.cs
@@ -7,7 +7,11 @@ public class DialogService : IDialogService
     /// <summary>
     /// A event that will be invoked when showing a dialog with a custom component
     /// </summary>
-    public event Action<Type?, DialogParameters, object>? OnShow;
+    public event Action<IDialogReference, Type?, DialogParameters, object>? OnShow;
+
+    public event Func<IDialogReference, Type?, DialogParameters, object, Task<IDialogReference>>? OnShowAsync;
+
+    public event Action<IDialogReference, DialogResult>? OnDialogCloseRequested;
 
     /// <summary>
     /// Shows the standard <see cref="FluentSplashScreen"/> with the given parameters."/>
@@ -247,18 +251,6 @@ public class DialogService : IDialogService
         ShowDialog(typeof(T), parameters.Content, dialogParameters);
     }
 
-    ///// <summary>
-    ///// Shows a dialog with the component type as the body,
-    ///// passing the specified <paramref name="parameters "/> and <paramref name="settings "/>
-    ///// </summary>
-    ///// <param name="parameters">Content to pass to component being displayed.</param>
-    //public void ShowDialog<T, TContent>(DialogParameters<TContent> parameters)
-    //    where T : IDialogContentComponent<TContent>
-    //    where TContent : class
-    //{
-    //    ShowDialog(typeof(T), parameters.Content, parameters);
-    //}
-
     /// <summary>
     /// Shows a dialog with the component type as the body,
     /// passing the specified <paramref name="content "/> 
@@ -274,7 +266,270 @@ public class DialogService : IDialogService
             throw new ArgumentException($"{dialogComponent.FullName} must be a Dialog Component");
         }
 
-        OnShow?.Invoke(dialogComponent, parameters, content);
+        IDialogReference? dialogReference = new DialogReference(parameters.Id, this);
+
+        OnShow?.Invoke(dialogReference, dialogComponent, parameters, content);
+    }
+
+
+    /// <summary>
+    /// Shows the standard <see cref="FluentSplashScreen"/> with the given parameters."/>
+    /// </summary>
+    /// <param name="receiver">The componente that receives the callback</param>
+    /// <param name="callback">Name of the callback function</param>
+    /// <param name="parameters"><see cref="SplashScreenContent"/> that holds the content to display</param>
+    public async Task<IDialogReference> ShowSplashScreenAsync(object receiver, Func<DialogResult, Task> callback, DialogParameters<SplashScreenContent> parameters)
+        => await ShowSplashScreenAsync<FluentSplashScreen>(receiver, callback, parameters);
+
+    /// <summary>
+    /// Shows a custom splash screen dialog with the given parameters."/>
+    /// </summary>
+    /// <param name="receiver">The componente that receives the callback</param>
+    /// <param name="callback">Name of the callback function</param>
+    /// <param name="parameters"><see cref="SplashScreenContent"/> that holds the content to display</param>
+    public async Task<IDialogReference> ShowSplashScreenAsync<T>(object receiver, Func<DialogResult, Task> callback, DialogParameters<SplashScreenContent> parameters)
+        where T : IDialogContentComponent<SplashScreenContent>
+        => await ShowSplashScreenAsync(typeof(T), receiver, callback, parameters);
+
+
+    /// <summary>
+    /// Shows a splash screen of the given type with the given parameters."/>
+    /// </summary>
+    /// <param name="component">The type of the component to show</param>
+    /// <param name="receiver">The componente that receives the callback</param>
+    /// <param name="callback">Name of the callback function</param>
+    /// <param name="parameters"><see cref="SplashScreenContent"/> that holds the content to display</param>
+    public async Task<IDialogReference> ShowSplashScreenAsync(Type component, object receiver, Func<DialogResult, Task> callback, DialogParameters<SplashScreenContent> parameters)
+    {
+        DialogParameters dialogParameters = new()
+        {
+            Alignment = HorizontalAlignment.Center,
+            Modal = false,
+            ShowDismiss = false,
+            ShowTitle = false,
+            PrimaryAction = null,
+            SecondaryAction = null,
+            Width = parameters.Width ?? "600px",
+            Height = parameters.Height ?? "370px",
+            DialogBodyStyle = "width: 100%; height: 100%; margin: 0px;",
+            AriaLabel = $"{parameters.Content.Title} splashscreen",
+            OnDialogResult = EventCallback.Factory.Create(receiver, callback),
+        };
+
+        return await ShowDialogAsync(component, parameters.Content, dialogParameters);
+    }
+
+    /// <summary>
+    /// Shows a dialog with the component type as the body,
+    /// passing the specified <paramref name="parameters "/>
+    /// </summary>
+    /// <param name="parameters">Parameters to pass to component being displayed.</param>
+    public async Task<IDialogReference> ShowDialogAsync<T, TContent>(DialogParameters<TContent> parameters)
+        where T : IDialogContentComponent<TContent>
+        where TContent : class
+    {
+        DialogParameters dialogParameters = new()
+        {
+            Id = parameters.Id,
+            Alignment = HorizontalAlignment.Center,
+            Title = parameters.Title,
+            Modal = parameters.Modal,
+            TrapFocus = parameters.TrapFocus,
+            ShowDismiss = parameters.ShowDismiss,
+            ShowTitle = parameters.ShowTitle,
+            PrimaryAction = parameters.PrimaryAction,
+            PrimaryActionEnabled = parameters.PrimaryActionEnabled,
+            SecondaryAction = parameters.SecondaryAction,
+            SecondaryActionEnabled = parameters.SecondaryActionEnabled,
+            Width = parameters.Width,
+            Height = parameters.Height,
+            AriaLabel = $"{parameters.Title}",
+            OnDialogResult = parameters.OnDialogResult,
+        };
+
+        return await ShowDialogAsync(typeof(T), parameters.Content, dialogParameters);
+    }
+
+    /// <summary>
+    /// Shows a success message box. Does not have a callback function.
+    /// </summary>
+    /// <param name="message">The message to display.</param>
+    /// <param name="title">The title to display on the dialog.</param>
+    public async Task ShowSuccessAsync(string message, string? title = null) => await ShowMessageBoxAsync(new DialogParameters<MessageBoxContent>()
+    {
+        Content = new MessageBoxContent()
+        {
+            Title = string.IsNullOrWhiteSpace(title) ? "Success!" /*DialogResources.TitleError*/ : title,
+            Intent = MessageBoxIntent.Success,
+            Icon = new CoreIcons.Filled.Size24.CheckmarkCircle(),
+            IconColor = Color.Success,
+            Message = message,
+        },
+        PrimaryAction = "Ok", /*DialogResources.ButtonOK,*/
+        SecondaryAction = string.Empty,
+    });
+
+    /// <summary>
+    /// Shows a warning message box. Does not have a callback function.
+    /// </summary>
+    /// <param name="message">The message to display.</param>
+    /// <param name="title">The title to display on the dialog.</param>
+    public async Task ShowWarningAsync(string message, string? title = null) => await ShowMessageBoxAsync(new DialogParameters<MessageBoxContent>()
+    {
+        Content = new MessageBoxContent()
+        {
+            Title = string.IsNullOrWhiteSpace(title) ? "Warning!" /*DialogResources.TitleError*/ : title,
+            Intent = MessageBoxIntent.Warning,
+            Icon = new CoreIcons.Filled.Size24.Warning(),
+            IconColor = Color.Warning,
+            Message = message,
+        },
+        PrimaryAction = "Ok", /*DialogResources.ButtonOK,*/
+        SecondaryAction = string.Empty,
+    });
+
+    /// <summary>
+    /// Shows an error message box. Does not have a callback function.
+    /// </summary>
+    /// <param name="message">The message to display.</param>
+    /// <param name="title">The title to display on the dialog.</param>
+    public async Task ShowErrorAsync(string message, string? title = null) => await ShowMessageBoxAsync(new DialogParameters<MessageBoxContent>()
+    {
+        Content = new MessageBoxContent()
+        {
+            Title = string.IsNullOrWhiteSpace(title) ? "Error!" /*DialogResources.TitleError*/ : title,
+            Intent = MessageBoxIntent.Error,
+            Icon = new CoreIcons.Filled.Size24.DismissCircle(),
+            IconColor = Color.Error,
+            Message = message,
+        },
+        PrimaryAction = "Ok", /*DialogResources.ButtonOK,*/
+        SecondaryAction = string.Empty,
+    });
+
+    /// <summary>
+    /// Shows an information message box. Does not have a callback function.
+    /// </summary>
+    /// <param name="message">The message to display.</param>
+    /// <param name="title">The title to display on the dialog.</param>
+    public async Task ShowInfoAsync(string message, string? title = null) => await ShowMessageBoxAsync(new DialogParameters<MessageBoxContent>()
+    {
+        Content = new MessageBoxContent()
+        {
+            Title = string.IsNullOrWhiteSpace(title) ? "Information" /*DialogResources.TitleInformation*/ : title,
+            Intent = MessageBoxIntent.Info,
+            Icon = new CoreIcons.Filled.Size24.Info(),
+            IconColor = Color.Info,
+            Message = message,
+        },
+        PrimaryAction = "Ok", /*DialogResources.ButtonOK,*/
+        SecondaryAction = string.Empty,
+    });
+
+    /// <summary>
+    /// Shows a confirmation message box. Has a callback function which returns boolean 
+    /// (true=PrimaryAction clicked, false=SecondaryAction clicked).
+    /// </summary>
+    /// <param name="receiver">The component that receives the callback function.</param>
+    /// <param name="callback">The callback function.</param>
+    /// <param name="message">The message to display.</param>
+    /// <param name="primaryText">The text to display on the primary button.</param>
+    /// <param name="secondaryText">The text to display on the secondary button.</param>
+    /// <param name="title">The title to display on the dialog.</param>
+    public async Task<IDialogReference> ShowConfirmationAsync(object receiver, Func<DialogResult, Task> callback, string message, string primaryText = "Yes", string secondaryText = "No", string? title = null)
+        => await ShowMessageBoxAsync(new DialogParameters<MessageBoxContent>()
+        {
+            Content = new MessageBoxContent()
+            {
+                Title = string.IsNullOrWhiteSpace(title) ? "Confirm" /*DialogResources.TitleConfirmation*/ : title,
+                Intent = MessageBoxIntent.Confirmation,
+                Icon = new CoreIcons.Regular.Size24.QuestionCircle(),
+                IconColor = Color.Success,
+                Message = message,
+            },
+            PrimaryAction = primaryText, /*DialogResources.ButtonYes,*/
+            SecondaryAction = secondaryText, /*DialogResources.ButtonNo,*/
+            OnDialogResult = EventCallback.Factory.Create(receiver, callback)
+        });
+
+    /// <summary>
+    /// Shows a custom message box. Has a callback function which returns boolean
+    /// (true=PrimaryAction clicked, false=SecondaryAction clicked).
+    /// </summary>
+    /// <param name="parameters">Parameters to pass to component being displayed.</param>
+    public async Task<IDialogReference> ShowMessageBoxAsync(DialogParameters<MessageBoxContent> parameters)
+    {
+        DialogParameters dialogParameters = new()
+        {
+            Alignment = HorizontalAlignment.Center,
+            Title = parameters.Content.Title,
+            Modal = string.IsNullOrEmpty(parameters.SecondaryAction),
+            ShowDismiss = false,
+            PrimaryAction = parameters.PrimaryAction,
+            SecondaryAction = parameters.SecondaryAction,
+            Width = parameters.Width,
+            Height = parameters.Height,
+            AriaLabel = $"{parameters.Content.Title}",
+            OnDialogResult = parameters.OnDialogResult,
+        };
+
+        return await ShowDialogAsync(typeof(MessageBox), parameters.Content, dialogParameters);
+    }
+
+    /// <summary>
+    /// Shows a panel with the dialog component type as the body,
+    /// passing the specified <paramref name="parameters "/>
+    /// </summary>
+    /// <param name="parameters">Parameters to pass to component being displayed.</param>
+    public async Task<IDialogReference> ShowPanelAsync<T, TData>(DialogParameters<TData> parameters)
+        where T : IDialogContentComponent<TData>
+        where TData : class
+        => await ShowPanelAsync(typeof(T), parameters);
+
+    /// <summary>
+    /// Shows a panel with the dialog component type as the body,
+    /// passing the specified <paramref name="parameters "/>
+    /// </summary>
+    /// <param name="dialogComponent">Type of component to display.</param>
+    /// <param name="parameters">Parameters to pass to component being displayed.</param>
+    public async Task<IDialogReference> ShowPanelAsync<TData>(Type dialogComponent, DialogParameters<TData> parameters)
+        where TData : class
+    {
+        DialogParameters dialogParameters = new()
+        {
+            Alignment = parameters.Alignment,
+            Title = parameters.Title,
+            Modal = parameters.Modal,
+            ShowTitle = parameters.ShowTitle,
+            ShowDismiss = parameters.ShowDismiss,
+            PrimaryAction = parameters.PrimaryAction,
+            SecondaryAction = parameters.SecondaryAction,
+            Width = parameters.Width,
+            AriaLabel = $"{parameters.Title}",
+            OnDialogResult = parameters.OnDialogResult,
+        };
+
+        return await ShowDialogAsync(dialogComponent, parameters.Content, dialogParameters);
+    }
+
+    /// <summary>
+    /// Shows a dialog with the component type as the body,
+    /// passing the specified <paramref name="content "/> 
+    /// </summary>
+    /// <param name="dialogComponent">Type of component to display.</param>
+    /// <param name="content">Content to pass to component being displayed.</param>
+    /// <param name="parameters">Parameters to configure the dialog component.</param>
+    public virtual async Task<IDialogReference> ShowDialogAsync<TContent>(Type dialogComponent, TContent content, DialogParameters parameters)
+        where TContent : class
+    {
+        if (!typeof(IDialogContentComponent).IsAssignableFrom(dialogComponent))
+        {
+            throw new ArgumentException($"{dialogComponent.FullName} must be a Dialog Component");
+        }
+
+        IDialogReference? dialogReference = new DialogReference(parameters.Id, this);
+
+        return await OnShowAsync!.Invoke(dialogReference, dialogComponent, parameters, content);
     }
 
     /// <summary>
@@ -286,5 +541,19 @@ public class DialogService : IDialogService
     /// <returns></returns>
     public EventCallback<DialogResult> CreateDialogCallback(object receiver, Func<DialogResult, Task> callback) => EventCallback.Factory.Create(receiver, callback);
 
+    public Task CloseAsync(DialogReference dialog)
+    {
+        return CloseAsync(dialog, DialogResult.Ok<object?>(null));
+    }
 
+    public async Task CloseAsync(DialogReference dialog, DialogResult result)
+    {
+        await Task.Run(() => { });  // To avoid warning
+        OnDialogCloseRequested?.Invoke(dialog, result);
+    }
+
+    internal virtual IDialogReference CreateReference(string id)
+    {
+        return new DialogReference(id, this);
+    }
 }

--- a/src/Core/Components/Dialog/Services/DialogService.cs
+++ b/src/Core/Components/Dialog/Services/DialogService.cs
@@ -453,6 +453,29 @@ public class DialogService : IDialogService
         });
 
     /// <summary>
+    /// Shows a confirmation message box. Has no callback function
+    /// (true=PrimaryAction clicked, false=SecondaryAction clicked).
+    /// </summary>
+    /// <param name="message">The message to display.</param>
+    /// <param name="primaryText">The text to display on the primary button.</param>
+    /// <param name="secondaryText">The text to display on the secondary button.</param>
+    /// <param name="title">The title to display on the dialog.</param>
+    public async Task<IDialogReference> ShowConfirmationAsync(string message, string primaryText = "Yes", string secondaryText = "No", string? title = null)
+        => await ShowMessageBoxAsync(new DialogParameters<MessageBoxContent>()
+        {
+            Content = new MessageBoxContent()
+            {
+                Title = string.IsNullOrWhiteSpace(title) ? "Confirm" /*DialogResources.TitleConfirmation*/ : title,
+                Intent = MessageBoxIntent.Confirmation,
+                Icon = new CoreIcons.Regular.Size24.QuestionCircle(),
+                IconColor = Color.Success,
+                Message = message,
+            },
+            PrimaryAction = primaryText, /*DialogResources.ButtonYes,*/
+            SecondaryAction = secondaryText, /*DialogResources.ButtonNo,*/
+        });
+
+    /// <summary>
     /// Shows a custom message box. Has a callback function which returns boolean
     /// (true=PrimaryAction clicked, false=SecondaryAction clicked).
     /// </summary>

--- a/src/Core/Components/Dialog/Services/IDialogReference.cs
+++ b/src/Core/Components/Dialog/Services/IDialogReference.cs
@@ -1,0 +1,18 @@
+﻿namespace Microsoft.Fast.Components.FluentUI;
+
+public interface IDialogReference
+{
+    string Id { get; }
+
+    Task<DialogResult> Result { get; }
+
+    DialogInstance Instance { get; set; }
+
+    Task CloseAsync();
+
+    Task CloseAsync(DialogResult result);
+
+    bool Dismiss(DialogResult result);
+
+    Task<T?> GetReturnValueAsync<T>();
+}

--- a/src/Core/Components/Dialog/Services/IDialogService.cs
+++ b/src/Core/Components/Dialog/Services/IDialogService.cs
@@ -7,7 +7,10 @@ public interface IDialogService
     /// <summary>
     /// A event that will be invoked when showing a dialog with a custom component
     /// </summary>
-    public event Action<Type?, DialogParameters, object>? OnShow;
+    public event Action<IDialogReference, Type?, DialogParameters, object>? OnShow;
+    public event Func<IDialogReference, Type?, DialogParameters, object, Task<IDialogReference>>? OnShowAsync;
+
+    public event Action<IDialogReference, DialogResult>? OnDialogCloseRequested;
 
     void ShowSplashScreen(object receiver, Func<DialogResult, Task> callback, DialogParameters<SplashScreenContent> parameters);
 
@@ -36,19 +39,52 @@ public interface IDialogService
     void ShowPanel<TData>(Type component, DialogParameters<TData> parameters)
         where TData : class;
 
-    //void ShowDialog<T, TContent>(DialogParameters<TContent> parameters)
-    //    where T : IDialogContentComponent<TContent>
-    //    where TContent : class;
-
     void ShowDialog<T, TData>(DialogParameters<TData> parameters)
         where T : IDialogContentComponent<TData>
         where TData : class;
 
-    //void ShowDialog<TContent>(Type component, IDialogContentParameters<TContent> parameters, Action<DialogSettings> settings)
-    //    where TContent : class;
-
     void ShowDialog<TData>(Type component, TData data, DialogParameters parameters)
         where TData : class;
 
+    // Async methods
+    Task<IDialogReference> ShowSplashScreenAsync(object receiver, Func<DialogResult, Task> callback, DialogParameters<SplashScreenContent> parameters);
+
+    Task<IDialogReference> ShowSplashScreenAsync<T>(object receiver, Func<DialogResult, Task> callback, DialogParameters<SplashScreenContent> parameters)
+        where T : IDialogContentComponent<SplashScreenContent>;
+
+    Task<IDialogReference> ShowSplashScreenAsync(Type component, object receiver, Func<DialogResult, Task> callback, DialogParameters<SplashScreenContent> parameters);
+
+
+    Task ShowSuccessAsync(string message, string? title = null);
+
+    Task ShowWarningAsync(string message, string? title = null);
+
+    Task ShowErrorAsync(string message, string? title = null);
+
+    Task ShowInfoAsync(string message, string? title = null);
+
+    Task<IDialogReference> ShowConfirmationAsync(object receiver, Func<DialogResult, Task> callback, string message, string primaryText = "Yes", string secondaryText = "No", string? title = null);
+
+    Task<IDialogReference> ShowMessageBoxAsync(DialogParameters<MessageBoxContent> parameters);
+
+
+    Task<IDialogReference> ShowPanelAsync<T, TData>(DialogParameters<TData> parameters)
+        where T : IDialogContentComponent<TData>
+        where TData : class;
+
+    Task<IDialogReference> ShowPanelAsync<TData>(Type component, DialogParameters<TData> parameters)
+        where TData : class;
+
+    Task<IDialogReference> ShowDialogAsync<T, TData>(DialogParameters<TData> parameters)
+        where T : IDialogContentComponent<TData>
+        where TData : class;
+
+    Task<IDialogReference> ShowDialogAsync<TData>(Type component, TData data, DialogParameters parameters)
+        where TData : class;
+
     public EventCallback<DialogResult> CreateDialogCallback(object receiver, Func<DialogResult, Task> callback);
+
+    Task CloseAsync(DialogReference dialog);
+
+    Task CloseAsync(DialogReference dialog, DialogResult result);
 }

--- a/src/Core/Components/Dialog/Services/IDialogService.cs
+++ b/src/Core/Components/Dialog/Services/IDialogService.cs
@@ -65,6 +65,8 @@ public interface IDialogService
 
     Task<IDialogReference> ShowConfirmationAsync(object receiver, Func<DialogResult, Task> callback, string message, string primaryText = "Yes", string secondaryText = "No", string? title = null);
 
+    Task<IDialogReference> ShowConfirmationAsync(string message, string primaryText = "Yes", string secondaryText = "No", string? title = null);
+
     Task<IDialogReference> ShowMessageBoxAsync(DialogParameters<MessageBoxContent> parameters);
 
 

--- a/src/Core/Components/Dialog/Services/IDialogService.cs
+++ b/src/Core/Components/Dialog/Services/IDialogService.cs
@@ -10,6 +10,9 @@ public interface IDialogService
     public event Action<IDialogReference, Type?, DialogParameters, object>? OnShow;
     public event Func<IDialogReference, Type?, DialogParameters, object, Task<IDialogReference>>? OnShowAsync;
 
+    public event Action<string, DialogParameters>? OnUpdate;
+    public event Func<string, DialogParameters, Task>? OnUpdateAsync;
+
     public event Action<IDialogReference, DialogResult>? OnDialogCloseRequested;
 
     void ShowSplashScreen(object receiver, Func<DialogResult, Task> callback, DialogParameters<SplashScreenContent> parameters);
@@ -46,13 +49,23 @@ public interface IDialogService
     void ShowDialog<TData>(Type component, TData data, DialogParameters parameters)
         where TData : class;
 
+    void UpdateDialog<TContent>(string id, DialogParameters<TContent> parameters)
+        where TContent : class;
+
     // Async methods
     Task<IDialogReference> ShowSplashScreenAsync(object receiver, Func<DialogResult, Task> callback, DialogParameters<SplashScreenContent> parameters);
+
+    Task<IDialogReference> ShowSplashScreenAsync(DialogParameters<SplashScreenContent> parameters);
 
     Task<IDialogReference> ShowSplashScreenAsync<T>(object receiver, Func<DialogResult, Task> callback, DialogParameters<SplashScreenContent> parameters)
         where T : IDialogContentComponent<SplashScreenContent>;
 
+    Task<IDialogReference> ShowSplashScreenAsync<T>(DialogParameters<SplashScreenContent> parameters)
+        where T : IDialogContentComponent<SplashScreenContent>;
+
     Task<IDialogReference> ShowSplashScreenAsync(Type component, object receiver, Func<DialogResult, Task> callback, DialogParameters<SplashScreenContent> parameters);
+
+    Task<IDialogReference> ShowSplashScreenAsync(Type component, DialogParameters<SplashScreenContent> parameters);
 
 
     Task ShowSuccessAsync(string message, string? title = null);
@@ -83,6 +96,9 @@ public interface IDialogService
 
     Task<IDialogReference> ShowDialogAsync<TData>(Type component, TData data, DialogParameters parameters)
         where TData : class;
+
+    Task UpdateDialogAsync<TContent>(string id, DialogParameters<TContent> parameters)
+        where TContent : class;
 
     public EventCallback<DialogResult> CreateDialogCallback(object receiver, Func<DialogResult, Task> callback);
 

--- a/src/Core/Components/Dialog/Services/InternalDialogContext.cs
+++ b/src/Core/Components/Dialog/Services/InternalDialogContext.cs
@@ -8,10 +8,10 @@ internal sealed class InternalDialogContext
 
     public Collection<IDialogReference> References { get; set; } = [];
 
-    public FluentDialogContainer DialogContainer { get; }
+    public FluentDialogProvider DialogContainer { get; }
 
 
-    public InternalDialogContext(FluentDialogContainer container)
+    public InternalDialogContext(FluentDialogProvider container)
     {
         DialogContainer = container;
     }

--- a/src/Core/Components/Dialog/Services/InternalDialogContext.cs
+++ b/src/Core/Components/Dialog/Services/InternalDialogContext.cs
@@ -1,8 +1,12 @@
-﻿namespace Microsoft.Fast.Components.FluentUI;
+﻿using System.Collections.ObjectModel;
+
+namespace Microsoft.Fast.Components.FluentUI;
 
 internal sealed class InternalDialogContext
 {
-    public Dictionary<string, FluentDialog> References { get; set; } = new();
+    //public Dictionary<string, FluentDialog> ComponentReferences { get; set; } = new();
+
+    public Collection<IDialogReference> References { get; set; } = [];
 
     public FluentDialogContainer DialogContainer { get; }
 
@@ -12,13 +16,13 @@ internal sealed class InternalDialogContext
         DialogContainer = container;
     }
 
-    internal void Register(FluentDialog dialog)
-    {
-        References.Add(dialog.Id!, dialog);
-    }
+    //internal void Register(FluentDialog dialog)
+    //{
+    //    ComponentReferences.Add(dialog.Id!, dialog);
+    //}
 
-    internal void Unregister(FluentDialog dialog)
-    {
-        References.Remove(dialog.Id!);
-    }
+    //internal void Unregister(FluentDialog dialog)
+    //{
+    //    ComponentReferences.Remove(dialog.Id!);
+    //}
 }

--- a/src/Core/Components/Dialog/Services/InternalDialogContext.cs
+++ b/src/Core/Components/Dialog/Services/InternalDialogContext.cs
@@ -4,9 +4,7 @@ namespace Microsoft.Fast.Components.FluentUI;
 
 internal sealed class InternalDialogContext
 {
-    //public Dictionary<string, FluentDialog> ComponentReferences { get; set; } = new();
-
-    public Collection<IDialogReference> References { get; set; } = [];
+    public Collection<IDialogReference> References { get; set; } = new();
 
     public FluentDialogProvider DialogContainer { get; }
 
@@ -15,14 +13,4 @@ internal sealed class InternalDialogContext
     {
         DialogContainer = container;
     }
-
-    //internal void Register(FluentDialog dialog)
-    //{
-    //    ComponentReferences.Add(dialog.Id!, dialog);
-    //}
-
-    //internal void Unregister(FluentDialog dialog)
-    //{
-    //    ComponentReferences.Remove(dialog.Id!);
-    //}
 }


### PR DESCRIPTION
- Add `DiaogService.Show...Async` methods
- Add IDialogReference and make dialog handling awaitable:
```
   IDialogReference dialog = await DialogService.ShowDialogAsync<SimpleDialog, SimplePerson>(parameters);
   DialogResult? result = await dialog.Result;
   Console.WriteLine($"Dialog closed by {result?.Data} - Canceled: {result.Cancelled}");
```
- Update docs 


- Prep for doc/example swap
- Fix small DemoSection bug


 

 

 