### PR TITLE
Add AutoComplete property to the TextField component

### DIFF
--- a/examples/Demo/Shared/Microsoft.Fast.Components.FluentUI.xml
+++ b/examples/Demo/Shared/Microsoft.Fast.Components.FluentUI.xml
@@ -4633,6 +4633,12 @@
             Gets or sets the content to be rendered inside the component.
             </summary>
         </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentTextField.JSRuntime">
+            <summary />
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentTextField.Module">
+            <summary />
+        </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentTextField.TextFieldType">
             <summary>
             Gets or sets the text filed type. See <see cref="T:Microsoft.Fast.Components.FluentUI.TextFieldType"/>
@@ -4676,6 +4682,12 @@
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentTextField.ChildContent">
             <summary>
             Gets or sets the content to be rendered inside the component.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentTextField.AutoComplete">
+            <summary>
+            Specifies whether a form or an input field should have autocomplete on or off.
+            An Id value must be set to use this property.
             </summary>
         </member>
         <member name="M:Microsoft.Fast.Components.FluentUI.CommunicationToast.Close">

--- a/src/Core/Components/TextField/FluentTextField.razor.js
+++ b/src/Core/Components/TextField/FluentTextField.razor.js
@@ -1,0 +1,7 @@
+export function setAutocomplete(id, value) {
+    const fieldElement = document.querySelector("#" + id)?.shadowRoot?.querySelector("#control");
+
+    if (!!fieldElement) {
+        fieldElement?.setAttribute("autocomplete", value);
+    }
+}


### PR DESCRIPTION
Following on from discussion #637:

Added a new property [AutoComplete](https://www.w3schools.com/TAgs/att_autocomplete.asp) (bool?) assigned to the input control.
This code is only applied when the **AutoComplete** and **Id** properties are set.

```javascript
export function setAutocomplete(id, value) {
    const fieldElement = document.querySelector("#" + id)?.shadowRoot?.querySelector("#control");

    if (!!fieldElement) {
        fieldElement?.setAttribute("autocomplete", value);
    }
}
```