### PR TITLE
Fix Icons and Emojis trimmed during the WASM publishing

### DIFF
--- a/src/Core/Components/Emojis/Emoji.cs
+++ b/src/Core/Components/Emojis/Emoji.cs
@@ -3,11 +3,20 @@
 namespace Microsoft.Fast.Components.FluentUI;
 
 /// <summary>
-/// FluentUI Icon content.
+/// FluentUI Emoji content.
 /// </summary>
-public abstract class Emoji : EmojiInfo
+public class Emoji : EmojiInfo
 {
     private string? _content = null;
+
+    /// <summary>
+    /// Please use the constructor including parameters.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"></exception>
+    public Emoji() : this(string.Empty, EmojiSize.Size16, EmojiGroup.Flags, EmojiSkintone.Default, EmojiStyle.Flat, new byte[] { })
+    {
+        throw new ArgumentNullException("Please use the constructor including parameters.");
+    }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Icon"/> class.

--- a/src/Core/Components/Emojis/FluentEmoji.razor.cs
+++ b/src/Core/Components/Emojis/FluentEmoji.razor.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Fast.Components.FluentUI;
 /// FluentEmoji is a component that renders an emoji from the Microsoft FluentUI emoji set.
 /// </summary>
 public partial class FluentEmoji<Emoji> : FluentComponentBase
-    where Emoji : FluentUI.Emoji
+    where Emoji : FluentUI.Emoji, new()
 {
     private Emoji _emoji = default!;
 
@@ -75,14 +75,7 @@ public partial class FluentEmoji<Emoji> : FluentComponentBase
     {
         if (_emoji == null)
         {
-            bool hasParameterlessConstructor = typeof(Emoji).GetConstructor(Type.EmptyTypes) != null;
-
-            if (!hasParameterlessConstructor)
-            {
-                throw new ArgumentException($"The type {typeof(Emoji).FullName} must have a parameterless constructor.");
-            }
-
-            _emoji = Activator.CreateInstance<Emoji>();
+            _emoji = new Emoji();
         }
     }
 

--- a/src/Core/Components/Icons/FluentIcon.razor.cs
+++ b/src/Core/Components/Icons/FluentIcon.razor.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Fast.Components.FluentUI;
 /// FluentIcon is a component that renders an icon from the Fluent System icon set.
 /// </summary>
 public partial class FluentIcon<Icon> : FluentComponentBase
-    where Icon : FluentUI.Icon
+    where Icon : FluentUI.Icon, new()
 {
     private Icon _icon = default!;
 
@@ -90,15 +90,8 @@ public partial class FluentIcon<Icon> : FluentComponentBase
     protected override void OnParametersSet()
     {
         if (_icon == null)
-        {
-            bool hasParameterlessConstructor = typeof(Icon).GetConstructor(Type.EmptyTypes) != null;
-            
-            if (!hasParameterlessConstructor)
-            {
-                throw new ArgumentException($"The type {typeof(Icon).FullName} must have a parameterless constructor.");
-            }
-
-            _icon = Activator.CreateInstance<Icon>();
+        {         
+            _icon = new Icon();
         }
 
         if (!string.IsNullOrEmpty(CustomColor) && Color != FluentUI.Color.Custom)

--- a/src/Core/Components/Icons/Icon.cs
+++ b/src/Core/Components/Icons/Icon.cs
@@ -5,8 +5,17 @@ namespace Microsoft.Fast.Components.FluentUI;
 /// <summary>
 /// FluentUI Icon content.
 /// </summary>
-public abstract class Icon : IconInfo
+public class Icon : IconInfo
 {
+    /// <summary>
+    /// Please use the constructor including parameters.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"></exception>
+    public Icon() : this(string.Empty, IconVariant.Regular, IconSize.Size24, string.Empty)
+    { 
+        throw new ArgumentNullException("Please use the constructor including parameters.");
+    }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="Icon"/> class.
     /// </summary>


### PR DESCRIPTION
During the publishing phase of a WASM project, the Trimming feature is automatically activated by dotnet.

Previously, when using an **FluentIcon** without an object instance, the icon content was removed during the publishing.
With this PR, the `FluentIcon Icon="..." />` works and the icon content will not removed during the publishing phases.