### PR TITLE
Fix #674

### DIFF
--- a/examples/Demo/Shared/Microsoft.Fast.Components.FluentUI.xml
+++ b/examples/Demo/Shared/Microsoft.Fast.Components.FluentUI.xml
@@ -2394,8 +2394,14 @@
         </member>
         <member name="T:Microsoft.Fast.Components.FluentUI.Emoji">
             <summary>
-            FluentUI Icon content.
+            FluentUI Emoji content.
             </summary>
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.Emoji.#ctor">
+            <summary>
+            Please use the constructor including parameters.
+            </summary>
+            <exception cref="T:System.ArgumentNullException"></exception>
         </member>
         <member name="M:Microsoft.Fast.Components.FluentUI.Emoji.#ctor(System.String,Microsoft.Fast.Components.FluentUI.EmojiSize,Microsoft.Fast.Components.FluentUI.EmojiGroup,Microsoft.Fast.Components.FluentUI.EmojiSkintone,Microsoft.Fast.Components.FluentUI.EmojiStyle,System.Byte[])">
             <summary>
@@ -2715,6 +2721,12 @@
             <summary>
             FluentUI Icon content.
             </summary>
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.Icon.#ctor">
+            <summary>
+            Please use the constructor including parameters.
+            </summary>
+            <exception cref="T:System.ArgumentNullException"></exception>
         </member>
         <member name="M:Microsoft.Fast.Components.FluentUI.Icon.#ctor(System.String,Microsoft.Fast.Components.FluentUI.IconVariant,Microsoft.Fast.Components.FluentUI.IconSize,System.String)">
             <summary>

--- a/examples/Demo/Shared/Pages/NavMenu/Examples/NavMenuCustomActions.razor
+++ b/examples/Demo/Shared/Pages/NavMenu/Examples/NavMenuCustomActions.razor
@@ -40,6 +40,14 @@
             It does have a Href, so it will navigate.
             *@
             <FluentNavMenuLink Href="https://microsoft.com" Text="Default behavior (navigate)" Icon="@(new Icons.Regular.Size24.Earth())" />
+
+            @*
+                This is a group without link or action. Should expand/collapse when text clicked
+            *@
+             <FluentNavMenuGroup Text="Item 3" Icon="@(new Icons.Regular.Size24.EarthLeaf())" >
+                 <FluentNavMenuLink Icon="@(new Icons.Regular.Size24.LeafOne())" Text="Item 3.1" />
+                 <FluentNavMenuLink Icon="@(new Icons.Regular.Size24.LeafTwo())" Text="Item 3.2" />
+             </FluentNavMenuGroup>
         </FluentNavMenu>
     </div>
     <div style="width: 100%;">

--- a/src/Core/Components/NavMenu/FluentNavMenuGroup.razor.cs
+++ b/src/Core/Components/NavMenu/FluentNavMenuGroup.razor.cs
@@ -89,6 +89,7 @@ public partial class FluentNavMenuGroup : FluentNavMenuItemBase, INavMenuItemsOw
 
     protected internal override async ValueTask ExecuteAsync(NavMenuActionArgs args)
     {
+        bool _justExpanded = false;
         await base.ExecuteAsync(args);
 
         if (!args.Handled)
@@ -97,6 +98,12 @@ public partial class FluentNavMenuGroup : FluentNavMenuItemBase, INavMenuItemsOw
             if (shouldExpand)
             {
                 await SetExpandedAsync(true);
+                _justExpanded = true;
+            }
+            bool shouldCollapse = Expanded && !NavMenu.Collapsed;
+            if (shouldCollapse && !_justExpanded)
+            {
+                await SetExpandedAsync(false);
             }
         }
     }


### PR DESCRIPTION
FluentNavMenuGroups only collapsed when the expand/collapse button was clicked. It did however expand when clicked anywhere on the element. With this change it also collapses.