### PR TITLE
Fix the Tooltip used by the FluentOverflow

### DIFF
--- a/examples/Demo/Shared/Pages/Overflow/Examples/OverflowHorizontalExample.razor
+++ b/examples/Demo/Shared/Pages/Overflow/Examples/OverflowHorizontalExample.razor
@@ -11,7 +11,7 @@
         </FluentBadge>
     </MoreButtonTemplate>
     <OverflowTemplate>
-        <FluentTooltip Anchor="@context.IdMoreButton">
+        <FluentTooltip Anchor="@context.IdMoreButton" UseTooltipService="false">
             @foreach (var item in context.ItemsOverflow)
             {
                 <div style="margin: 5px;">@item.Text</div>

--- a/src/Core/Components/Overflow/FluentOverflow.razor
+++ b/src/Core/Components/Overflow/FluentOverflow.razor
@@ -23,7 +23,7 @@
     }
     else
     {
-        <FluentTooltip Anchor="@IdMoreButton">
+        <FluentTooltip UseTooltipService="false" Anchor="@IdMoreButton">            
             @foreach (var item in ItemsOverflow)
             {
                 <div style="margin: 5px;">@item.Text</div>

--- a/src/Core/Components/Tooltip/FluentTooltip.razor.cs
+++ b/src/Core/Components/Tooltip/FluentTooltip.razor.cs
@@ -30,6 +30,7 @@ public partial class FluentTooltip : FluentComponentBase, IDisposable
 
     /// <summary>
     /// Use ITooltipService to create the tooltip, if this service was injected.
+    /// If the <see cref="ChildContent"/> is dynamic, set this to false.
     /// Default, true.
     /// </summary>
     [Parameter]


### PR DESCRIPTION
# Pull Request

## 📖 Description

As described in issue #677, the overflow tooltip remains empty.
This PR update the FluentOverflow component to fix this issue.

![image](https://github.com/microsoft/fluentui-blazor/assets/8350694/5c172c63-5827-49bd-a379-2f87b5354ef3)
