### PR TITLE
Add item reference to FluentDataGridRow and FluentDataGridCell (#695)

### DIFF
--- a/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridCustomComparer.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridCustomComparer.razor
@@ -87,6 +87,6 @@
 
     private void HandleRowFocus(FluentDataGridRow<Country> row)
     {
-        Console.WriteLine($"Row focused: {row.RowIndex}");
+        Console.WriteLine($"Row focused: {row.Item?.Name}");
     }
 }

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor
@@ -69,13 +69,13 @@
         {
             _rowsDataSize = $"height: {ItemSize}px";
         }
-        
-        <FluentDataGridRow @key="@(ItemKey(item))" GridTemplateColumns=@GridTemplateColumns aria-rowindex="@rowIndex" Class="@rowClass" Style="@_rowsDataSize" TGridItem="TGridItem">
+
+        <FluentDataGridRow @key="@(ItemKey(item))" GridTemplateColumns=@GridTemplateColumns aria-rowindex="@rowIndex" Class="@rowClass" Style="@_rowsDataSize" TGridItem="TGridItem" Item="@item">
             @for (var colIndex = 0; colIndex < _columns.Count; colIndex++)
             {
                 var col = _columns[colIndex];
             
-                <FluentDataGridCell GridColumn=@(colIndex+1) Class="@ColumnClass(col)" @key="@col" TGridItem="TGridItem">
+                <FluentDataGridCell GridColumn=@(colIndex+1) Class="@ColumnClass(col)" @key="@col" TGridItem="TGridItem" Item="@item">
                     @((RenderFragment)(__builder => col.CellContent(__builder, item)))
                 </FluentDataGridCell>
             }

--- a/src/Core/Components/DataGrid/FluentDataGridCell.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGridCell.razor.cs
@@ -7,6 +7,12 @@ public partial class FluentDataGridCell<TGridItem> : FluentComponentBase
     internal string CellId { get; } = Identifier.NewId();
 
     /// <summary>
+    /// Gets or sets the reference to the item that holds this cell's values
+    /// </summary>
+    [Parameter]
+    public TGridItem? Item { get; set; }
+
+    /// <summary>
     /// Gets or sets the cell type. See <see cref="DataGridCellType"/>
     /// </summary>
     [Parameter]

--- a/src/Core/Components/DataGrid/FluentDataGridRow.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGridRow.razor.cs
@@ -10,6 +10,12 @@ public partial class FluentDataGridRow<TGridItem> : FluentComponentBase, IHandle
     private readonly Dictionary<string, FluentDataGridCell<TGridItem>> cells = new();
 
     /// <summary>
+    /// Gets or sets the reference to the item that holds this row's values
+    /// </summary>
+    [Parameter]
+    public TGridItem? Item { get; set; }
+
+    /// <summary>
     /// Gets or sets the index of this row
     /// When FluentDataGrid is virtualized, this value is not used
     /// </summary>


### PR DESCRIPTION
# Pull Request

## 📖 Description

Solves issue #695 by adding a reference to rows' and cells' items.


## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
