### PR TITLE
[FluentDatePicker] Update the popup position

### DIFF
--- a/src/Core/Components/DateTime/FluentDatePicker.razor
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor
@@ -23,7 +23,7 @@
     <FluentAnchoredRegion Anchor="@Id"
                           HorizontalDefaultPosition="@HorizontalPosition.Right"
                           HorizontalInset="true"
-                          VerticalDefaultPosition="@VerticalPosition.Bottom"
+                          VerticalDefaultPosition="@VerticalPosition.Unset"
                           Shadow="ElevationShadow.Flyout"
                           Class="fluent-datepicker-popup"
                           Style="@($"z-index: {ZIndex.DatePickerPopup}; padding: 10px;")">


### PR DESCRIPTION
# Pull Request

With this fix, the DatePicker popup area will be dynamically positioned **below or above** the component, depending on the available space.

![DatePicker-Popup](https://github.com/microsoft/fluentui-blazor/assets/8350694/c4b335ff-39f6-4ab5-af40-1d69d40e17de)
