### PR TITLE
[FluentDatePicker and FluentTimePicker] Keep existing time/date

### DIFF
--- a/src/Core/Components/DateTime/CalendarExtended.cs
+++ b/src/Core/Components/DateTime/CalendarExtended.cs
@@ -92,7 +92,8 @@ internal struct CalendarExtended
     /// <returns></returns>
     public string GetMonthName(DateTime date)
     {
-        return ToTitleCase(Culture.DateTimeFormat.MonthNames[date.Month - 1]);
+        var monthIndex = date.Month <= 1 ? 0 : date.Month - 1;
+        return ToTitleCase(Culture.DateTimeFormat.MonthNames[monthIndex]);
     }
 
     /// <summary>
@@ -101,7 +102,8 @@ internal struct CalendarExtended
     /// <returns></returns>
     public string GetMonthNameAndYear()
     {
-        return $"{ToTitleCase(Culture.DateTimeFormat.MonthNames[Date.Month - 1])} {Date.Year}";
+        var result = $"{GetMonthName(Date)} {Date.Year}";
+        return result;
     }
 
     /// <summary>

--- a/src/Core/Components/DateTime/FluentCalendar.razor
+++ b/src/Core/Components/DateTime/FluentCalendar.razor
@@ -8,16 +8,32 @@
             @CalendarExtended.GetMonthNameAndYear()
         </span>
         <span part="move" class="change-month">
-            <div class="previous-month"
-                    title="@CalendarExtended.GetMonthName(PickerMonth.AddMonths(-1))"
-                    @onclick="@((e) => this.PickerMonth = PickerMonth.AddMonths(-1))">
-                @((MarkupString)ArrowUp)
-            </div>
-            <div title="@CalendarExtended.GetMonthName(PickerMonth.AddMonths(+1))"
-                    class="next-month"
-                    @onclick="@((e) => this.PickerMonth = PickerMonth.AddMonths(+1))">
-                @((MarkupString)ArrowDown)
-            </div>
+            @if (PickerMonth.Year == DateTime.MinValue.Year && 
+                 PickerMonth.Month == DateTime.MinValue.Month)
+            {
+                <div class="previous-month" />
+            }
+            else
+            {
+                <div class="previous-month"
+                     title="@CalendarExtended.GetMonthName(PickerMonth.AddMonths(-1))"
+                     @onclick="@((e) => this.PickerMonth = PickerMonth.AddMonths(-1))">
+                    @((MarkupString)ArrowUp)
+                </div>
+            }
+            @if (PickerMonth.Year == DateTime.MaxValue.Year &&
+            PickerMonth.Month == DateTime.MaxValue.Month)
+            {
+                <div class="next-month" />
+            }
+            else
+            {
+                <div title="@CalendarExtended.GetMonthName(PickerMonth.AddMonths(+1))"
+                     class="next-month"
+                     @onclick="@((e) => this.PickerMonth = PickerMonth.AddMonths(+1))">
+                    @((MarkupString)ArrowDown)
+                </div>  
+            }
         </span>
     </div>
 

--- a/src/Core/Components/DateTime/FluentDatePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor.cs
@@ -81,7 +81,7 @@ public partial class FluentDatePicker : FluentCalendarBase
 
             if (isValid)
             {
-                Value = newDate;
+                Value = newDate + (Value?.TimeOfDay ?? TimeSpan.Zero);
             }
             else
             {
@@ -108,7 +108,16 @@ public partial class FluentDatePicker : FluentCalendarBase
     protected Task OnSelectedDateAsync(DateTime? value)
     {
         Opened = false;
-        Value = value;
+
+        if (Value != null && Value?.TimeOfDay != TimeSpan.Zero)
+        {
+            DateTime currentValue = value ?? DateTime.MinValue;
+            Value = currentValue.Date + Value?.TimeOfDay;
+        }
+        else
+        {
+            Value = value;
+        }
 
         return Task.CompletedTask;
     }

--- a/src/Core/Components/DateTime/FluentTimePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentTimePicker.razor.cs
@@ -20,13 +20,15 @@ public partial class FluentTimePicker : FluentInputBase<DateTime?>
     /// <summary />
     protected override bool TryParseValueFromString(string? value, out DateTime? result, [NotNullWhen(false)] out string? validationErrorMessage)
     {
+        DateTime currentValue = Value ?? DateTime.MinValue;
+
         if (value != null && DateTime.TryParse(value, out var valueConverted))
         {
-            result = valueConverted;
+            result = currentValue.Date + valueConverted.TimeOfDay;
         }
         else
         {
-            result = null;
+            result = Value?.Date;
         }
 
         validationErrorMessage = null;

--- a/tests/Core/DateTime/FluentTimePickerTests.cs
+++ b/tests/Core/DateTime/FluentTimePickerTests.cs
@@ -40,7 +40,7 @@ public class FluentTimePickerTests : TestBase
         // Assert
         if (resultDate != null)
         {
-            Assert.Equal(System.DateTime.Today.Date, resultDate?.Date);
+            Assert.Equal(System.DateTime.MinValue.Date, resultDate?.Date);
             Assert.Equal(time, resultDate?.ToString("HH:mm:ss"));
         }
         else


### PR DESCRIPTION
Previously, using this code, the time was reset to `00:00` when a date was selected.
Conversely, the date was reset to `0001-01-01` when a time was selected.

```xml
<FluentDatePicker @bind-Value="@SelectedValue" />
<FluentTimePicker @bind-Value="@SelectedValue" />
<p>Selected date:</b> @SelectedValue</p>

@code
{
    DateTime? SelectedValue;
}
```

Now you can link the same variable to both a **FluentDatePicker** and a **FluentTimePicker**.
Of course, when selecting a date, the time will be set to `00:00` the first time, because C# DateTime object doesn't accept a nullable time only value.

If you prefer to have a nullable date and time, you need to link these two components to two separate variables.

![DateTime-fix](https://github.com/microsoft/fluentui-blazor/assets/8350694/664083e5-38f2-463c-8b37-82b7efcf6c8b)
