### PR TITLE
Add `EmptyContent` parameter to the DataGrid

### DIFF
--- a/examples/Demo/Shared/Microsoft.Fast.Components.FluentUI.xml
+++ b/examples/Demo/Shared/Microsoft.Fast.Components.FluentUI.xml
@@ -1155,6 +1155,11 @@
             Optionally defines a class to be applied to a rendered row. 
             </summary>
         </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDataGrid`1.EmptyContent">
+            <summary>
+            If specified, grids render this fragment when there is no content.
+            </summary>
+        </member>
         <member name="M:Microsoft.Fast.Components.FluentUI.FluentDataGrid`1.#ctor">
             <summary>
             Constructs an instance of <see cref="T:Microsoft.Fast.Components.FluentUI.FluentDataGrid`1"/>.
@@ -3220,7 +3225,14 @@
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentAutocomplete`1.MaximumSelectedOptions">
             <summary>
-            Gets or sets the maximum number of options (items) selected. Exceeding this value, the user must delete some elements in order to select new ones.
+            Gets or sets the maximum number of options (items) selected.
+            Exceeding this value, the user must delete some elements in order to select new ones.
+            See the <see cref="P:Microsoft.Fast.Components.FluentUI.FluentAutocomplete`1.MaximumSelectedOptionsMessage"/>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentAutocomplete`1.MaximumSelectedOptionsMessage">
+            <summary>
+            Gets or sets the message displayed when the <see cref="P:Microsoft.Fast.Components.FluentUI.FluentAutocomplete`1.MaximumSelectedOptions"/> is reached.
             </summary>
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentAutocomplete`1.OptionTemplate">
@@ -3255,6 +3267,9 @@
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentAutocomplete`1.IsMultiSelectOpened">
             <summary />
         </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentAutocomplete`1.IsReachedMaxItems">
+            <summary />
+        </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentAutocomplete`1.SelectableItem">
             <summary />
         </member>
@@ -3268,6 +3283,9 @@
             <summary />
         </member>
         <member name="M:Microsoft.Fast.Components.FluentUI.FluentAutocomplete`1.OnDropDownExpandedAsync">
+            <summary />
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.FluentAutocomplete`1.OnClearAsync">
             <summary />
         </member>
         <member name="M:Microsoft.Fast.Components.FluentUI.FluentAutocomplete`1.OnSelectedItemChangedHandlerAsync(`0)">
@@ -3366,6 +3384,11 @@
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentOptionPeople.Name">
             <summary>
             Gets or sets the name to display.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentOptionPeople.ChildContent">
+            <summary>
+            Gets or sets the content to display under the <see cref="P:Microsoft.Fast.Components.FluentUI.FluentOptionPeople.Name"/>.
             </summary>
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentOptionPeople.Image">
@@ -3555,6 +3578,9 @@
             <summary />
         </member>
         <member name="M:Microsoft.Fast.Components.FluentUI.ListComponentBase`1.RemoveSelectedItem(`0)">
+            <summary />
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.ListComponentBase`1.RemoveAllSelectedItems">
             <summary />
         </member>
         <member name="M:Microsoft.Fast.Components.FluentUI.ListComponentBase`1.AddSelectedItem(`0)">
@@ -4019,7 +4045,7 @@
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.MessageOptions.Timeout">
             <summary>
-            Timeout in milliseconds after which the message bar is removed. Default is null.
+            Timeout in seconds after which the message bar is removed. Default is null.
             </summary>
         </member>
         <member name="T:Microsoft.Fast.Components.FluentUI.MessageService">

--- a/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridTypical.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridTypical.razor
@@ -1,7 +1,7 @@
 ﻿@inject DataSource Data
 
 
-<FluentDataGrid Items="@FilteredItems" ResizableColumns=true Pagination="@pagination" GridTemplateColumns="0.2fr 1fr 0.2fr 0.2fr 0.2fr 0.2fr" RowClass="@rowClass" style="height: 405px; overflow:auto;">
+<FluentDataGrid Items="@FilteredItems" ResizableColumns=true Pagination="@pagination" GridTemplateColumns="0.2fr 1fr 0.2fr 0.2fr 0.2fr 0.2fr" RowClass="@rowClass" Style="height: 405px; overflow:auto;">
     <TemplateColumn Title="Rank" SortBy="@rankSort" Align="Align.Center" InitialSortDirection="SortDirection.Ascending" IsDefaultSortColumn=true>
         <img class="flag" src="_content/FluentUI.Demo.Shared/flags/@(context.Code).svg" alt="Flag of @(context.Code)" />
     </TemplateColumn>
@@ -21,7 +21,14 @@
 
 <FluentPaginator State="@pagination" />
 
+<FluentSwitch @bind-Value="@_clearItems" 
+              AfterBindValue="ToggleItemsAsync" 
+              UncheckedMessage="Clear all results"
+              CheckedMessage="Restore all results">
+</FluentSwitch>
+
 @code {
+    bool _clearItems = false;
     IQueryable<Country>? items;
     PaginationState pagination = new PaginationState { ItemsPerPage = 10 };
     string nameFilter = string.Empty;
@@ -50,5 +57,17 @@
     private void HandleClear(string? value)
     {
         nameFilter = value ?? string.Empty;
+    }
+
+    private async Task ToggleItemsAsync()
+    {
+        if (_clearItems)
+		{
+			items = null;
+		}
+		else
+		{
+			items = (await Data.GetCountriesAsync()).AsQueryable();
+		}
     }
 }

--- a/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridVirtualize.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridVirtualize.razor
@@ -1,16 +1,25 @@
 <div style="height: 400px; overflow-y: scroll;">
-    <FluentDataGrid Items=@items Virtualize="true" ItemSize="32" GridTemplateColumns="1fr 1fr 1fr 1fr">
-        <PropertyColumn Property="@(c => c.Item1)" Sortable="true">
-        </PropertyColumn>
-        <PropertyColumn Property="@(c => c.Item2)" />
-        <PropertyColumn Property="@(c => c.Item3)" Align="Align.Center" />
-        <PropertyColumn Property="@(c => c.Item4)" Align="Align.End">
-        </PropertyColumn>
+    <FluentDataGrid Style="height: 400px;" Items=@items Virtualize="true" ItemSize="32" GridTemplateColumns="1fr 1fr 1fr 1fr">
+        <ChildContent>
+            <PropertyColumn Property="@(c => c.Item1)" Sortable="true" />
+            <PropertyColumn Property="@(c => c.Item2)" />
+            <PropertyColumn Property="@(c => c.Item3)" Align="Align.Center" />
+            <PropertyColumn Property="@(c => c.Item4)" Align="Align.End" />
+        </ChildContent>
+        <EmptyContent><FluentIcon Icon="Icons.Filled.Size24.Crown" Color="@Color.Accent"/>&nbsp; Nothing to see here. Carry on!</EmptyContent>
     </FluentDataGrid>
 </div>
+<br />
+<FluentSwitch @bind-Value="@_clearItems" 
+              AfterBindValue="ToggleItems" 
+              UncheckedMessage="Clear all results"
+              CheckedMessage="Restore all results">
+</FluentSwitch>
+
 
 @code {
-    public record SampleGridData(string Item1, string Item2, string Item3, string Item4);   
+    bool _clearItems = false;
+    public record SampleGridData(string Item1, string Item2, string Item3, string Item4);
 
     IQueryable<SampleGridData>? items = Enumerable.Empty<SampleGridData>().AsQueryable();
 
@@ -27,5 +36,17 @@
     protected override void OnInitialized()
     {
         items = GenerateSampleGridData(5000);
+    }
+
+    private void ToggleItems()
+    {
+        if (_clearItems)
+		{
+			items = null;
+		}
+		else
+		{
+			items =GenerateSampleGridData(5000);;
+		}
     }
 }

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor
@@ -29,19 +29,34 @@
                     @_renderColumnHeaders
                 </FluentDataGridRow>
             }
-
-            @if (Virtualize)
+            @if (Items?.Count() == 0 || _ariaBodyRowCount == 0)
             {
-                <Virtualize @ref="@_virtualizeComponent"
-                            TItem="(int RowIndex, TGridItem Data)"
-                            ItemSize="@ItemSize"
-                            ItemsProvider="@ProvideVirtualizedItems"
-                            ItemContent="@(item => builder => RenderRow(builder, item.RowIndex, item.Data))"
-                            Placeholder="@(placeholderContext => builder => RenderPlaceholderRow(builder, placeholderContext))" />
+                <div class="empty-content">
+                @if (EmptyContent is null)
+                {
+                     @("No data to show!");
+                }
+                else
+                {
+                    @EmptyContent
+                }
+                </div>
             }
             else
             {
-                @_renderNonVirtualizedRows
+                @if (Virtualize)
+                {
+                    <Virtualize @ref="@_virtualizeComponent"
+                                TItem="(int RowIndex, TGridItem Data)"
+                                ItemSize="@ItemSize"
+                                ItemsProvider="@ProvideVirtualizedItems"
+                                ItemContent="@(item => builder => RenderRow(builder, item.RowIndex, item.Data))"
+                                Placeholder="@(placeholderContext => builder => RenderPlaceholderRow(builder, placeholderContext))" />
+                }
+                else
+                {
+                    @_renderNonVirtualizedRows
+                }
             }
 
         </fluent-data-grid>
@@ -62,9 +77,9 @@
     private void RenderRow(RenderTreeBuilder __builder, int rowIndex, TGridItem item)
     {
         string? _rowsDataSize = null;
-        
+
         var rowClass = RowClass?.Invoke(item) ?? "";
-        
+
         if (Virtualize)
         {
             _rowsDataSize = $"height: {ItemSize}px";
@@ -74,7 +89,7 @@
             @for (var colIndex = 0; colIndex < _columns.Count; colIndex++)
             {
                 var col = _columns[colIndex];
-            
+
                 <FluentDataGridCell GridColumn=@(colIndex+1) Class="@ColumnClass(col)" @key="@col" TGridItem="TGridItem" Item="@item">
                     @((RenderFragment)(__builder => col.CellContent(__builder, item)))
                 </FluentDataGridCell>
@@ -85,7 +100,7 @@
     private void RenderPlaceholderRow(RenderTreeBuilder __builder, PlaceholderContext placeholderContext)
     {
         string? _rowsDataSize = $"height: {ItemSize}px";
-        
+
         <FluentDataGridRow GridTemplateColumns=@GridTemplateColumns aria-rowindex="@(placeholderContext.Index + 1)" Style="@_rowsDataSize" TGridItem="TGridItem">
             @for (var colIndex = 0; colIndex < _columns.Count; colIndex++)
             {
@@ -98,13 +113,14 @@
         </FluentDataGridRow>
     }
 
+
     private void RenderColumnHeaders(RenderTreeBuilder __builder)
     {
-        @for (var colIndex = 0; colIndex < _columns.Count; colIndex++) 
+        @for (var colIndex = 0; colIndex < _columns.Count; colIndex++)
         {
             var col = _columns[colIndex];
             string CellId = Identifier.NewId();
-            if (_sortByColumn == col) 
+            if (_sortByColumn == col)
                 col.ShowSortIcon = true;
             else
                 col.ShowSortIcon = false;

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -122,6 +122,11 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     /// </summary>
     [Parameter] public Func<TGridItem, string>? RowClass { get; set; }
 
+    /// <summary>
+    /// If specified, grids render this fragment when there is no content.
+    /// </summary>
+    [Parameter] public RenderFragment? EmptyContent { get; set; }
+
     [Inject] private IServiceProvider Services { get; set; } = default!;
     [Inject] private IJSRuntime JS { get; set; } = default!;
 

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.css
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.css
@@ -2,6 +2,15 @@ fluent-data-grid {
     --col-gap: 1rem;
 }
 
+::deep .empty-content {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-weight: 600;
+}
+
 .col-options {
     position: absolute;
     top: 2.2rem;

--- a/src/Core/Components/MessageBar/Services/MessageOptions.cs
+++ b/src/Core/Components/MessageBar/Services/MessageOptions.cs
@@ -60,7 +60,7 @@ public class MessageOptions
     public bool ClearAfterNavigation { get; set; }
 
     /// <summary>
-    /// Timeout in milliseconds after which the message bar is removed. Default is null.
+    /// Timeout in seconds after which the message bar is removed. Default is null.
     /// </summary>
     public int? Timeout { get; set; }
 }


### PR DESCRIPTION
Adding a new `EmptyContent` parameter to the DataGrid:

![DataGridEmptyContent](https://github.com/microsoft/fluentui-blazor/assets/1761079/7d3fcd33-ea06-4862-a4f8-37df9a42b26a)

Implemented as follows:
- Add parameter `EmptyContent` (of type `RenderFragment`)  (name chosen to stay in line with new parameter added on standard Blazor `Virtualize` component)
- Add a class to the isolated `FluentDataGrid.razor.css`:
```
::deep .empty-content {
    width: 100%;
    height: 100%;
    display: flex;
    justify-content: center;
    align-items: center;
    font-weight: 600;
}
```
- The `FluentDataGrid` component will render this when Items/ItemsProvider is empty/has a count of 0:
```
 <div class="empty-content">
         @if (EmptyContent is null)
          {
                 @("No data to show!");
          }
          else
          {
                  @EmptyContent
           }
</div>
``` 
This allows you to specify your own text and/or layout for when there is no content or uses a sensible default when none is provided.
- Only caveat is that if you specify your own content for the `EmptyContent` parameter, the `PropertyColumn`/`TemplateColumn` definitions need to be wrapped in a `ChildContent` element, i.e.:
```
<FluentDataGrid Style="height: 400px;" Items=@items Virtualize="true" ItemSize="32" GridTemplateColumns="1fr 1fr 1fr 1fr">
        <ChildContent>
            <PropertyColumn Property="@(c => c.Item1)" Sortable="true" />
            <PropertyColumn Property="@(c => c.Item2)" />
            <PropertyColumn Property="@(c => c.Item3)" Align="Align.Center" />
            <PropertyColumn Property="@(c => c.Item4)" Align="Align.End" />
        </ChildContent>
        <EmptyContent>Nothing to see here!</EmptyContent>
    </FluentDataGrid>
```
