### PR TITLE
[InlineStyleBuilder] Fix the FluentSelect.Height property

### DIFF
--- a/src/Core/Components/List/FluentSelect.razor
+++ b/src/Core/Components/List/FluentSelect.razor
@@ -1,15 +1,8 @@
 @namespace Microsoft.Fast.Components.FluentUI
 @inherits ListComponentBase<TOption>
 @typeparam TOption
-@if (!String.IsNullOrEmpty(Height))
-{
-    <style>
-        @($"#{Id}::part(listbox) {{ max-height: {Height}; z-index: {ZIndex.SelectPopup} }}")
-        @($"#{Id}::part(selected-value) {{ white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }}")
-        @($"fluent-anchored-region[anchor='{Id}'] div[role='listbox'] {{ height: {Height}; }}")
-    </style>
-}
 <CascadingValue Value="_internalListContext" Name="ListContext" TValue="InternalListContext<TOption>" IsFixed="true">
+    @InlineStyleValue
     <fluent-select @ref=Element
                    id=@Id
                    class="@ClassValue"

--- a/src/Core/Components/List/FluentSelect.razor.cs
+++ b/src/Core/Components/List/FluentSelect.razor.cs
@@ -1,10 +1,21 @@
 using Microsoft.AspNetCore.Components;
+using Microsoft.Fast.Components.FluentUI.Utilities;
 
 namespace Microsoft.Fast.Components.FluentUI;
 
 [CascadingTypeParameter(nameof(TOption))]
 public partial class FluentSelect<TOption> : ListComponentBase<TOption>
 {
+    /// <summary />
+    protected virtual MarkupString? InlineStyleValue => new InlineStyleBuilder()
+        .AddStyle($"#{Id}::part(listbox)", "max-height", Height, !string.IsNullOrWhiteSpace(Height))
+        .AddStyle($"#{Id}::part(listbox)", "height", Height, !string.IsNullOrWhiteSpace(Height))
+        .AddStyle($"#{Id}::part(listbox)", "z-index", ZIndex.SelectPopup.ToString())
+        .AddStyle($"#{Id}::part(selected-value)", "white-space", "nowrap")
+        .AddStyle($"#{Id}::part(selected-value)", "overflow", "hidden")
+        .AddStyle($"#{Id}::part(selected-value)", "text-overflow", "ellipsis")
+        .BuildMarkupString();
+
     /// <summary>
     /// The open attribute.
     /// </summary>
@@ -23,5 +34,4 @@ public partial class FluentSelect<TOption> : ListComponentBase<TOption>
     /// </summary>
     [Parameter]
     public Appearance? Appearance { get; set; }
-
 }

--- a/src/Core/Utilities/InlineStyleBuilder.cs
+++ b/src/Core/Utilities/InlineStyleBuilder.cs
@@ -1,0 +1,111 @@
+﻿using System.Text;
+using Microsoft.AspNetCore.Components;
+
+namespace Microsoft.Fast.Components.FluentUI.Utilities;
+
+public readonly struct InlineStyleBuilder
+{
+    private readonly Dictionary<string, StyleBuilder> _styles;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InlineStyleBuilder"/> class.
+    /// </summary>
+    public InlineStyleBuilder()
+    {
+        _styles = new Dictionary<string, StyleBuilder>();
+    }
+
+    /// <summary>
+    /// Adds a conditional in-line style to the builder with space separator and closing semicolon..
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="prop"></param>
+    /// <param name="value">Style to add</param>
+    /// <returns>StyleBuilder</returns>
+    public InlineStyleBuilder AddStyle(string name, string prop, string? value)
+        => AddRaw(name, prop, value);
+
+    /// <summary>
+    /// Adds a conditional in-line style to the builder with space separator and closing semicolon..
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="prop"></param>
+    /// <param name="value">Style to conditionally add.</param>
+    /// <param name="when">Condition in which the style is added.</param>
+    /// <returns>StyleBuilder</returns>
+    public InlineStyleBuilder AddStyle(string name, string prop, string? value, bool when = true)
+        => when ? AddStyle(name, prop, value) : this;
+
+    /// <summary>
+    /// Adds a conditional in-line style to the builder with space separator and closing semicolon..
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="prop"></param>
+    /// <param name="value">Style to conditionally add.</param>
+    /// <param name="when">Condition in which the style is added.</param>
+    /// <returns>StyleBuilder</returns>
+    public InlineStyleBuilder AddStyle(string name, string prop, string? value, Func<bool> when)
+         => this.AddStyle(name, prop, value, when != null && when());
+
+    /// <summary>
+    /// Finalize the completed Style as a string.
+    /// </summary>
+    /// <returns>string</returns>
+    public string? Build(bool newLineSeparator = true)
+    {
+        string separator = newLineSeparator ? Environment.NewLine : " ";
+
+        var styles = _styles.Select(item =>
+        {
+            var style = item.Value.Build();
+            if (string.IsNullOrWhiteSpace(style))
+            {
+                return string.Empty;
+            }
+
+            return $"{item.Key} {{ {item.Value.Build()} }}";
+        });
+
+        var result = string.Join(separator, styles.Where(i => !string.IsNullOrEmpty(i)));
+
+        if (string.IsNullOrWhiteSpace(result))
+        {
+            return null;
+        }
+
+        return $"<style>{separator}{result}{separator}</style>";
+    }
+
+    /// <summary>
+    /// Finalize the completed Style as a string.
+    /// </summary>
+    /// <returns>string</returns>
+    public MarkupString? BuildMarkupString()
+    {
+        var styles = Build();
+        return styles != null ? (MarkupString)styles : null;
+    }
+
+    /// <summary>
+    /// Adds a raw string to the builder that will be concatenated with the next style or value added to the builder.
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="prop"></param>
+    /// <param name="value"></param>
+    /// <returns>StyleBuilder</returns>
+    private InlineStyleBuilder AddRaw(string name, string prop, string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            if (!_styles.TryGetValue(name, out var styleBuilder))
+            {
+                styleBuilder = new StyleBuilder();
+                _styles.Add(name, styleBuilder);
+            }
+
+            styleBuilder.AddStyle(prop, value);
+        }
+
+        return this;
+    }
+}

--- a/tests/Core/Utilities/InlineStyleBuilderTests.cs
+++ b/tests/Core/Utilities/InlineStyleBuilderTests.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.Fast.Components.FluentUI.Utilities;
+using Xunit;
+
+namespace Microsoft.Fast.Components.FluentUI.Tests.Utilities;
+
+public class InlineStyleBuilderTests : TestBase
+{
+    [Fact]
+    public void InlineStyleBuilder_Default()
+    {
+        // Assert
+        var styleBuilder = new InlineStyleBuilder();
+
+        // Act
+        styleBuilder.AddStyle("div", "color", "red");
+        styleBuilder.AddStyle("div", "background-color", "blue");
+        styleBuilder.AddStyle("span", "color", "yellow");
+
+        // Assert - Values are sorted
+        Assert.Equal(@"<style> div { color: red; background-color: blue; } span { color: yellow; } </style>", styleBuilder.Build(newLineSeparator: false));
+    }
+
+    [Fact]
+    public void InlineStyleBuilder_SingleStyle()
+    {
+        // Assert
+        var styleBuilder = new InlineStyleBuilder();
+
+        // Act
+        styleBuilder.AddStyle("div", "color", "red");
+
+        // Assert - Values are sorted
+        Assert.Equal(@"<style> div { color: red; } </style>", styleBuilder.Build(newLineSeparator: false));
+    }
+
+    [Fact]
+    public void InlineStyleBuilder_NoStyle()
+    {
+        // Assert
+        var styleBuilder = new InlineStyleBuilder();
+
+        // Act
+        styleBuilder.AddStyle("div", "color", string.Empty);
+
+        // Assert - Values are sorted
+        Assert.Null(styleBuilder.Build(newLineSeparator: false));
+    }
+}


### PR DESCRIPTION
Add `InlineStyleBuilder` and fix the `FluentSelect.Height` property

Example, the code...
```csharp
new InlineStyleBuilder()
    .AddStyle("div", "color", "red")
    .AddStyle("div", "background-color", "blue")
    .AddStyle("span", "color", "yellow")
    .Build()
```

... will generate this **inline** style:
```html
<style>
div { color: red; background-color: blue; }
span { color: yellow; }
</style>
```

This new class is used in the `FluentSelect` component to always define the **z-index** and **height** style (if a Height value has been defined).

> **note** This PR fixes the discussion #771.