### PR TITLE
[FluentIcon] Use of Value attribute (not Icon)

### DIFF
--- a/examples/Demo/Shared/Pages/Emoji/EmojiExplorer.razor.cs
+++ b/examples/Demo/Shared/Pages/Emoji/EmojiExplorer.razor.cs
@@ -86,7 +86,7 @@ public partial class EmojiExplorer
         //Emojis.SmileysEmotion.Color.Default.RollingOnTheFloorLaughing
 
 
-        string Text = $$"""<FluentEmoji Emoji="Emojis.{{emoji.Group}}.{{emoji.Style}}.{{emoji.Skintone}}.{{emoji.Name}}" Width="{{(int)Criteria.Size!}}px" />""";
+        string Text = $$"""<FluentEmoji Value="@(new Emojis.{{emoji.Group}}.{{emoji.Style}}.{{emoji.Skintone}}.{{emoji.Name}}())" Width="{{(int)Criteria.Size!}}px" />""";
 
         if (_jsModule is not null)
         {

--- a/examples/Demo/Shared/Pages/Icon/IconExplorer.razor.cs
+++ b/examples/Demo/Shared/Pages/Icon/IconExplorer.razor.cs
@@ -64,7 +64,7 @@ public partial class IconExplorer
 
     public async void HandleClick(IconInfo icon)
     {
-        string Text = $$"""<FluentIcon Icon="Icons.{{icon.Variant}}.{{icon.Size}}.{{icon.Name}}" Color="@Color.{{IconColor}}"/>""";
+        string Text = $$"""<FluentIcon Value="@(new Icons.{{icon.Variant}}.{{icon.Size}}.{{icon.Name}}())" Color="@Color.{{IconColor}}"/>""";
 
         if (_jsModule is not null)
         {

--- a/examples/Demo/Shared/Pages/Icon/IconPage.razor
+++ b/examples/Demo/Shared/Pages/Icon/IconPage.razor
@@ -17,16 +17,18 @@
     During the DotNet Publication process, the unused icons are automatically removed from the final library.
     You can configure this behavior by setting the <code>PublishTrimmed</code> property in your project file.
     More details on <a href="https://learn.microsoft.com/aspnet/core/blazor/host-and-deploy/configure-trimmer" target="_blank">this page</a>.
+    <blockquote>
+    ⚠️ We recommend always using the <code>Value</code> property to specify the icon to be rendered (and not the <code>Icon</code> property). This ensures that the icon is not deleted from the final library.
+    <CodeSnippet Language="language-xml">@("<FluentIcon Value=\"@(new Icons.Regular.Size24.Bookmark())\" />")</CodeSnippet>
+    </blockquote>
 </p>
 <p>
     You can create your own icons by adding a class like this one:
 
-    <CodeSnippet Language="language-csharp">
-        public static class MyIcons
-        {
-        public class SettingsEmail : Icon { public SettingsEmail() : base("SettingsEmail", IconVariant.Regular, IconSize.Size20, "&lt;svg width=\"20\" height=\"19\" viewBox=\"0 0 20 19\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">&lt;path d=\"M15.6251 2.5H4.37508L4.2214 2.50428C2.79712 2.58396 1.66675 3.76414 1.66675 5.20833V13.125L1.67103 13.2787C1.75071 14.7029 2.93089 15.8333 4.37508 15.8333H9.76425C9.91725 15.4818 10.1354 15.1606 10.4087 14.8873L10.7126 14.5833H4.37508L4.25547 14.5785C3.50601 14.5177 2.91675 13.8902 2.91675 13.125V6.97833L9.709 10.5531L9.78908 10.5883C9.95267 10.647 10.135 10.6353 10.2912 10.5531L17.0834 6.9775V9.17258C17.5072 9.14483 17.9362 9.21517 18.3334 9.38358V5.20833L18.3292 5.05465C18.2494 3.63038 17.0693 2.5 15.6251 2.5ZM4.37508 3.75H15.6251L15.7447 3.75483C16.4942 3.81568 17.0834 4.44319 17.0834 5.20833V5.565L10.0001 9.29375L2.91675 5.56583V5.20833L2.92158 5.08873C2.98242 4.33926 3.60994 3.75 4.37508 3.75ZM15.9167 10.5579L10.9979 15.4766C10.7112 15.7633 10.5077 16.1227 10.4093 16.5162L10.0279 18.0418C9.86208 18.7052 10.4631 19.3062 11.1265 19.1403L12.6521 18.7588C13.0455 18.6605 13.4048 18.4571 13.6917 18.1703L18.6103 13.2516C19.3542 12.5078 19.3542 11.3018 18.6103 10.5579C17.8665 9.814 16.6605 9.814 15.9167 10.5579Z\" fill=\"#212121\" />&lt;/svg>") { } }
-        }
-    </CodeSnippet>
+    <CodeSnippet Language="language-csharp">public static class MyIcons
+{
+    public class SettingsEmail : Icon { public SettingsEmail() : base("SettingsEmail", IconVariant.Regular, IconSize.Size20, "&lt;svg width=\"20\" height=\"19\" viewBox=\"0 0 20 19\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">&lt;path d=\"M15.6251 2.5H4.37508L4.2214 2.50428C2.79712 2.58396 1.66675 3.76414 1.66675 5.20833V13.125L1.67103 13.2787C1.75071 14.7029 2.93089 15.8333 4.37508 15.8333H9.76425C9.91725 15.4818 10.1354 15.1606 10.4087 14.8873L10.7126 14.5833H4.37508L4.25547 14.5785C3.50601 14.5177 2.91675 13.8902 2.91675 13.125V6.97833L9.709 10.5531L9.78908 10.5883C9.95267 10.647 10.135 10.6353 10.2912 10.5531L17.0834 6.9775V9.17258C17.5072 9.14483 17.9362 9.21517 18.3334 9.38358V5.20833L18.3292 5.05465C18.2494 3.63038 17.0693 2.5 15.6251 2.5ZM4.37508 3.75H15.6251L15.7447 3.75483C16.4942 3.81568 17.0834 4.44319 17.0834 5.20833V5.565L10.0001 9.29375L2.91675 5.56583V5.20833L2.92158 5.08873C2.98242 4.33926 3.60994 3.75 4.37508 3.75ZM15.9167 10.5579L10.9979 15.4766C10.7112 15.7633 10.5077 16.1227 10.4093 16.5162L10.0279 18.0418C9.86208 18.7052 10.4631 19.3062 11.1265 19.1403L12.6521 18.7588C13.0455 18.6605 13.4048 18.4571 13.6917 18.1703L18.6103 13.2516C19.3542 12.5078 19.3542 11.3018 18.6103 10.5579C17.8665 9.814 16.6605 9.814 15.9167 10.5579Z\" fill=\"#212121\" />&lt;/svg>") { } }
+}    </CodeSnippet>
 </p>
 <p>
     You can use any of these icons by levaraging the <code>&lt;FluentIcon&gt;</code>&nbsp;component. See below for the parameters and examples. 

--- a/src/Core/Components/DataGrid/Columns/ColumnBase.razor
+++ b/src/Core/Components/DataGrid/Columns/ColumnBase.razor
@@ -18,7 +18,7 @@
             @if (ColumnOptions is not null && (Align == Align.Start || Align == Align.Center))
             {
                 <FluentButton Appearance="Appearance.Stealth" class="col-options-button" @onclick="@(() => Grid.ShowColumnOptionsAsync(this))" aria-label="Filter this column">
-                    <FluentIcon Icon="CoreIcons.Regular.Size24.Filter" />
+                    <FluentIcon Value="@(new CoreIcons.Regular.Size24.Filter())" />
                 </FluentButton>
             }
             
@@ -31,11 +31,11 @@
                     {
                         if (Grid.SortByAscending == true)
                         {
-                            <FluentIcon Icon="CoreIcons.Regular.Size24.ArrowSortUp" Slot="@(Align == Align.End ? "start" : "end")" />
+                            <FluentIcon Value="@(new CoreIcons.Regular.Size24.ArrowSortUp())" Slot="@(Align == Align.End ? "start" : "end")" />
                         }
                         else
                         {
-                            <FluentIcon Icon="CoreIcons.Regular.Size24.ArrowSortDown" Slot="@(Align == Align.End ? "start" : "end")" />
+                            <FluentIcon Value="@(new CoreIcons.Regular.Size24.ArrowSortDown())" Slot="@(Align == Align.End ? "start" : "end")" />
                         }
                      }
 
@@ -51,7 +51,7 @@
             @if (ColumnOptions is not null && Align == Align.End)
             {
                 <FluentButton Appearance="Appearance.Stealth" class="col-options-button" @onclick="@(() => Grid.ShowColumnOptionsAsync(this))" aria-label="Filter this column">
-                    <FluentIcon Icon="CoreIcons.Regular.Size24.Filter" />
+                    <FluentIcon Value="@(new CoreIcons.Regular.Size24.Filter())" />
                 </FluentButton>
             }
         }

--- a/src/Core/Components/Dialog/FluentDialogHeader.razor
+++ b/src/Core/Components/Dialog/FluentDialogHeader.razor
@@ -22,7 +22,7 @@
         @if (ShowDismiss == true)
         {
             <FluentButton Appearance="Appearance.Stealth" OnClick="@(() => Dialog.CancelAsync())" Title="@Dialog.Instance?.Parameters?.DismissTitle">
-                <FluentIcon Icon="CoreIcons.Regular.Size24.Dismiss" Width="16px" />
+                <FluentIcon Value="@(new CoreIcons.Regular.Size24.Dismiss())" Width="16px" />
             </FluentButton>
         }
     </FluentStack>

--- a/src/Core/Components/MenuButton/FluentMenuButton.razor
+++ b/src/Core/Components/MenuButton/FluentMenuButton.razor
@@ -5,7 +5,7 @@
 <div class="fluent-menubutton-container">
     <FluentButton @ref="Button" Appearance="Appearance.Accent" Style=@ButtonStyle aria-haspopup="true" aria-expanded="@_visible" @onclick=ToggleMenu @onkeydown=OnKeyDown>
         @Text
-        <FluentIcon Icon="CoreIcons.Regular.Size24.ChevronDown" Slot="end" Color="@Color.Fill" />
+        <FluentIcon Value="@(new CoreIcons.Regular.Size24.ChevronDown())" Slot="end" Color="@Color.Fill" />
     </FluentButton>
     <FluentMenu @ref="Menu" aria-labelledby="button" Style="@MenuStyle" @bind-Open=@_visible @onmenuchange=OnMenuChange>
         @foreach (KeyValuePair<string, string> item in Items)

--- a/src/Core/Components/MessageBar/FluentMessageBar.razor
+++ b/src/Core/Components/MessageBar/FluentMessageBar.razor
@@ -54,7 +54,7 @@
                         @SecondaryAction?.Text
                     </FluentButton>
                 }
-                <FluentIcon Icon="CoreIcons.Regular.Size16.Dismiss"
+                <FluentIcon Value="@(new CoreIcons.Regular.Size16.Dismiss())"
                             Color=@Color.Neutral
                             Class="fluent-messagebar-close"
                             OnClick="DismissClicked" />
@@ -83,7 +83,7 @@
             @* Close *@
             
                 <div class="fluent-messagebar-notification-close">
-                <FluentIcon Icon="CoreIcons.Regular.Size16.Dismiss"
+                <FluentIcon Value="@(new CoreIcons.Regular.Size16.Dismiss())"
                             Color=@Color.Neutral
                             Class="fluent-messagebar-notification-close"
                             OnClick="DismissClicked" />

--- a/src/Core/Components/Pagination/FluentPaginator.razor
+++ b/src/Core/Components/Pagination/FluentPaginator.razor
@@ -15,20 +15,20 @@
         </div>
         <nav role="navigation" class="paginator-nav">
             <FluentButton @onclick="GoFirstAsync" Disabled="@(!CanGoBack)" title="Go to first page" aria-label="Go to first page">
-                <FluentIcon Icon="CoreIcons.Regular.Size20.ChevronDoubleLeft" Width="20px" />
+                <FluentIcon Value="@(new CoreIcons.Regular.Size20.ChevronDoubleLeft())" Width="20px" />
             </FluentButton>
             <FluentButton @onclick="GoPreviousAsync" Disabled="@(!CanGoBack)" title="Go to previous page" aria-label="Go to previous page">
-                <FluentIcon Icon="CoreIcons.Regular.Size24.ChevronLeft" Width="20px" />
+                <FluentIcon Value="@(new CoreIcons.Regular.Size24.ChevronLeft())" Width="20px" />
             </FluentButton>
             <div class="pagination-text">
                 Page <strong>@(State.CurrentPageIndex + 1)</strong>
                 of <strong>@(State.LastPageIndex + 1)</strong>
             </div>
             <FluentButton @onclick="GoNextAsync" Disabled="@(!CanGoForwards)" title="Go to next page" aria-label="Go to next page">
-                <FluentIcon Icon="CoreIcons.Regular.Size24.ChevronRight" Width="20px" />
+                <FluentIcon Value="@(new CoreIcons.Regular.Size24.ChevronRight())" Width="20px" />
             </FluentButton>
             <FluentButton @onclick="GoLastAsync" Disabled="@(!CanGoForwards)" title="Go to last page" aria-label="Go to last page">
-                <FluentIcon Icon="CoreIcons.Regular.Size20.ChevronDoubleRight" Width="20px" />
+                <FluentIcon Value="@(new CoreIcons.Regular.Size20.ChevronDoubleRight())" Width="20px" />
             </FluentButton>
         </nav>
     }

--- a/src/Core/Components/Tabs/FluentTab.razor
+++ b/src/Core/Components/Tabs/FluentTab.razor
@@ -26,7 +26,7 @@
 
     @if (Owner.ShowClose)
     {
-        <FluentIcon Icon="CoreIcons.Regular.Size24.Dismiss" Width="12px" Class="fluent-tab-close" Title="Close" OnClick="CloseClickedAsync" />
+        <FluentIcon Value="@(new CoreIcons.Regular.Size24.Dismiss())" Width="12px" Class="fluent-tab-close" Title="Close" OnClick="CloseClickedAsync" />
     }
 </fluent-tab>
 <fluent-tab-panel style="@StyleValue" class="@ClassValue">

--- a/src/Core/Components/Toast/FluentToast.razor
+++ b/src/Core/Components/Toast/FluentToast.razor
@@ -18,11 +18,11 @@
                 @switch (_parameters.TopCTAType)
                 {
                     case ToastTopCTAType.Dismiss:
-                        <FluentIcon Icon="CoreIcons.Regular.Size24.Dismiss"
-                                          Width="12px"
-                                          Title="Close"
-                                          Color="@Color.FillInverse"
-                                          OnClick="@Close" />
+                        <FluentIcon Value="@(new CoreIcons.Regular.Size24.Dismiss())"
+                                    Width="12px"
+                                    Title="Close"
+                                    Color="@Color.FillInverse"
+                                    OnClick="@Close" />
                         break;
                     case ToastTopCTAType.Timestamp:
                         <span class="fluent-toast-small timestamp ">@_parameters.Timestamp.ToString("HH:mm tt")</span>

--- a/src/Templates/Projects/FluentUIBlazorServerApp/Shared/SurveyPrompt.razor
+++ b/src/Templates/Projects/FluentUIBlazorServerApp/Shared/SurveyPrompt.razor
@@ -1,7 +1,7 @@
 ﻿<div class="prompt">
     <div style="display:flex; align-items:center">
         @* For below code to work, first install the Microsoft.Fast.Components.FluentUI.Icons nuget package *@
-        @* <FluentIcon Icon="Icons.Regular.Size32.Info" Color="@Color.Neutral" /> *@
+        @* <FluentIcon Value="@(new Icons.Regular.Size32.Info())" Color="@Color.Neutral" /> *@
         <strong>@Title</strong>
     </div>
     <p class="text-nowrap">

--- a/src/Templates/Projects/FluentUIBlazorWebAssemblyApp/Shared/SurveyPrompt.razor
+++ b/src/Templates/Projects/FluentUIBlazorWebAssemblyApp/Shared/SurveyPrompt.razor
@@ -1,7 +1,7 @@
 ﻿<div class="prompt">
     <div style="display:flex; align-items:center">
         @* For below code to work, first install the Microsoft.Fast.Components.FluentUI.Icons nuget package *@
-        @* <FluentIcon Icon="Icons.Regular.Size32.Info" Color="@Color.Neutral" /> *@
+        @* <FluentIcon Value="@(new Icons.Regular.Size32.Info())" Color="@Color.Neutral" /> *@
         <strong>@Title</strong>
     </div>
     <p class="text-nowrap">


### PR DESCRIPTION
# [FluentIcon] Use of Value attribute (not Icon)

During the DotNet Publication process, the unused icons are automatically removed from the final library. You can configure this behavior by setting the `PublishTrimmed` property in your project file. More details on [this page](https://learn.microsoft.com/aspnet/core/blazor/host-and-deploy/configure-trimmer).

To avoid this issue, we recommend always using the `Value` property to specify the icon to be rendered (and not the `Icon` property). This ensures that the icon is not deleted from the final library.

With this PR...
1. The "Core/Lib" code has been updated to always use the `Value` attribute (the documentation will be updated in another PR).
2. The documentation has been updated, on the Icon page.

This solves the issue #776