### PR TITLE
Button and Icon colors

### DIFF
--- a/examples/Demo/Shared/Pages/Button/Examples/ButtonIcon.razor
+++ b/examples/Demo/Shared/Pages/Button/Examples/ButtonIcon.razor
@@ -1,12 +1,20 @@
-﻿<p>With icon at start</p>
-<FluentButton IconStart="@(new Icons.Regular.Size16.Globe())">
-    Button
-</FluentButton>
-
-<p>With icon at end</p>
-<FluentButton IconEnd="@(new Icons.Regular.Size16.Globe())">
-    Button
-</FluentButton>
+﻿<p>With icon at Start or End</p>
+<FluentStack>
+    <FluentButton IconStart="@(new Icons.Regular.Size16.Globe())">
+        Button
+    </FluentButton>
+    <FluentButton IconStart="@(new Icons.Regular.Size16.Globe())"
+                  Appearance="Appearance.Accent">
+        Button
+    </FluentButton>
+    <FluentButton IconEnd="@(new Icons.Regular.Size16.Globe())">
+        Button
+    </FluentButton>
+    <FluentButton IconEnd="@(new Icons.Regular.Size16.Globe())"
+                  Appearance="Appearance.Accent">
+        Button
+    </FluentButton>
+</FluentStack>
 
 <p>With icon in default slot</p>
 <FluentButton IconEnd="@(new Icons.Regular.Size16.Globe())"
@@ -20,9 +28,19 @@
 </FluentButton>
 
 <p>With icon and loading</p>
-<FluentButton IconStart="@(new Icons.Regular.Size16.ArrowClockwise())" Loading="@loading" OnClick="@StartLoadingAsync">
-    Refresh
-</FluentButton>
+<FluentStack>
+    <FluentButton IconStart="@(new Icons.Regular.Size16.ArrowClockwise())"
+                  Loading="@loading"
+                  OnClick="@StartLoadingAsync">
+        Refresh
+    </FluentButton>
+    <FluentButton IconStart="@(new Icons.Regular.Size16.ArrowClockwise())"
+                  Appearance="Appearance.Accent"
+                  Loading="@loading"
+                  OnClick="@StartLoadingAsync">
+        Refresh
+    </FluentButton>
+</FluentStack>
 
 @code {
 

--- a/examples/Demo/Shared/Pages/Icon/Examples/IconColors.razor
+++ b/examples/Demo/Shared/Pages/Icon/Examples/IconColors.razor
@@ -1,34 +1,80 @@
-﻿<dl>
-    <dt><code>Color.Neutral</code> - Uses CSS variable --neutral-forground-rest, adapts to light/dark mode.</dt>
-    <dd><FluentIcon Icon="@Icons.Filled.Size48.Alert" Color="Color.Neutral" /></dd>
+﻿@{
+    const string AdaptedLightDark = "Adapted to Light/Dark theme";
+    const string CustomColor = "#570078"; // like Purple color
+}
+<FluentGrid Style="align-items: center;">
+    <FluentGridItem xs="2" Style="font-weight: 600;" title="Color Enumeration value">Color&nbsp;Enum</FluentGridItem>
+    <FluentGridItem xs="4" Style="font-weight: 600;" title="Equivalent CSS variable">CSS variable</FluentGridItem>
+    <FluentGridItem xs="1" Style="font-weight: 600;" title="@AdaptedLightDark">Theme</FluentGridItem>
+    <FluentGridItem xs="5" Style="font-weight: 600;" title="Examples">Examples</FluentGridItem>
 
-    <dt><code>Color.Accent</code> - Uses CSS variable --accent-fill-rest.</dt>
-    <dd><FluentIcon Icon="@Icons.Filled.Size48.Alert" Color="Color.Accent" /></dd>
+    @foreach (var color in Enum.GetValues(typeof(Color)).Cast<Color>())
+    {
+        var name = Enum.GetName<Color>(color);
+        var css = color == Color.Custom ? CustomColor : color.ToAttributeValue();
 
-    <dt><code>Color.Warning</code> - Uses CSS variable --warning<sup>*</sup>.</dt>
-    <dd><FluentIcon Icon="@Icons.Filled.Size48.Alert" Color="Color.Warning" /></dd>
+        <FluentGridItem xs="2" Style="font-weight: 600;">
+            @name
+        </FluentGridItem>
+        <FluentGridItem xs="4">
+            <code>@css</code>
+        </FluentGridItem>
+        <FluentGridItem xs="1" title="@AdaptedLightDark">
+            @switch (color)
+            {
+                case Color.Neutral:
+                case Color.Fill:
+                case Color.FillInverse:
+                case Color.Lightweight:
+                    <FluentIcon Value="@(new Icons.Regular.Size24.CheckboxChecked())"
+                                Color="@Color.Success" />
+                    break;
 
-    <dt><code>Color.Info</code> - Uses CSS variable --info<sup>*</sup>.</dt>
-    <dd><FluentIcon Icon="@Icons.Filled.Size48.Alert" Color="Color.Info" /></dd>
+                default:
+                    <FluentIcon Value="@(new Icons.Regular.Size24.CheckboxUnchecked())"
+                                Color="@Color.Info" />
+                    break;
+            }
+        </FluentGridItem>
+        <FluentGridItem xs="1" Style="background-color: var(--neutral-layer-3);">
+            @if (color == Color.Custom)
+            {
+                <FluentIcon Icon="@Icons.Filled.Size24.Alert"
+                            Color="Color.Custom"
+                            CustomColor="@CustomColor"
+                            Title="@($"Icon with Color=\"Color.Custom\"")" />
+            }
+            else
+            {
+                <FluentIcon Icon="@Icons.Filled.Size24.Alert"
+                            Color="@color"
+                            Title="@($"Icon with Color=\"Color.{name}\"")" />
+            }
+        </FluentGridItem>
+        <FluentGridItem xs="2" Style="background-color: var(--neutral-layer-3);">
+            <FluentButton IconStart="@(new Icons.Filled.Size24.Alert().WithColor(css))"
+                          Title="@($"Button with an IconStart colorized using .WithColor(\"{css}\")")"
+                          Style="font-weight: 600;">
+                OK
+            </FluentButton>
+        </FluentGridItem>
+        <FluentGridItem xs="2" Style="background-color: var(--neutral-layer-3);">
+            <FluentButton IconStart="@(new Icons.Filled.Size24.Alert().WithColor(css))"
+                          Title="@($"Button with an IconStart colorized using .WithColor(\"{css}\")")"
+                          Appearance="Appearance.Accent"
+                          Style="font-weight: 600;">
+                OK
+            </FluentButton>
+        </FluentGridItem>
+    }
 
-    <dt><code>Color.Error</code> - Uses CSS variable --error<sup>*</sup>.</dt>
-    <dd><FluentIcon Icon="@Icons.Filled.Size48.Alert" Color="Color.Error" /></dd>
+</FluentGrid>
 
-    <dt><code>Color.Success</code> - Uses CSS variable --success<sup>*</sup>.</dt>
-    <dd><FluentIcon Icon="@Icons.Filled.Size48.Alert" Color="Color.Success" /></dd>
+<p>
+    With <code>Color.Custom</code>, supply your own color value through the <code>CustomColor</code> parameter. <br/>
+    Needs to be formatted as an HTML hex color string (#rrggbb or #rgb) or a CSS variable (var(--...)).
+</p>
 
-    <dt><code>Color.Fill</code> - Uses CSS variable --neutral-fill-rest, adapts to light/dark mode<sup>**</sup>.</dt>
-    <dd style="background-color: var(--accent-fill-rest); width:48px"><FluentIcon Icon="@Icons.Filled.Size48.Alert" Color="Color.Fill" /></dd>
-
-    <dt><code>Color.FillInverse</code> - Uses CSS variable --neutral-fill-inverse-rest, adapts to light/dark mode<sup>**</sup>.</dt>
-    <dd><FluentIcon Icon="@Icons.Filled.Size48.Alert" Color="Color.FillInverse" /></dd>
-
-    <dt><code>Color.Lightweight</code> - Uses CSS variable --neutral-layer-1, adapts to light/dark mode<sup>**</sup>.</dt>
-    <dd style="background-color: var(--accent-fill-rest); width:48px"><FluentIcon Icon="@Icons.Filled.Size48.Alert" Color="Color.Lightweight" /></dd>
-
-    <dt><code>Color.Custom</code> - Supply your own color value through the <code>CustomColor</code> parameter. Needs to be formatted as an HTML hex color string (#rrggbb or #rgb) or a CSS variable (var(--...)).</dt>
-    <dd><FluentIcon Icon="@Icons.Filled.Size48.Alert" Color="Color.Custom" CustomColor="#570078" /></dd>
-</dl>
 <strong>(*)</strong>: This color is defined in the <code>variables.css</code> file. If your site is using
 <FluentAnchor Href="/Reboot" Appearance="Appearance.Hypertext">Reboot</FluentAnchor> the <code>variables.css</code> file is automatically imported. If you do not
     use Reboot, please add the <code>variables.css</code> file to your <code>index.html</code> or <code>_Layout.cshtml</code> file like this:

--- a/examples/Demo/Shared/Pages/Icon/Examples/IconDefault.razor
+++ b/examples/Demo/Shared/Pages/Icon/Examples/IconDefault.razor
@@ -1,17 +1,28 @@
-﻿<FluentStack>
+﻿<FluentStack VerticalAlignment="VerticalAlignment.Center">
     <FluentIcon Icon="Icons.Regular.Size24.Save" Title="Save" />
     <FluentIcon Icon="Icons.Regular.Size24.Open" Title="Open" Color="Color.Error" />
     <FluentIcon Value="@(new Icons.Regular.Size24.Album())" />
 
-    <FluentIcon Value="@(Icon.FromImageUrl("_content/FluentUI.Demo.Shared/images/BlazorLogo.png"))"
-                      Width="24px"/>
+    <FluentIcon Value="@(Icon.FromImageUrl("_content/FluentUI.Demo.Shared/images/BlazorLogo.png"))" Width="24px"/>
 
     @(new Icons.Regular.Size20.Add().ToMarkup())
     @(new Icons.Regular.Size20.Airplane().ToMarkup("16px", "blue"))
 
-    <FluentButton>
-        <FluentIcon Slot="start" Icon="Icons.Regular.Size24.ArrowCircleLeft" />
+    <FluentButton IconStart="@(new Icons.Regular.Size24.ArrowCircleLeft())">
         Back
+    </FluentButton>
+
+    <FluentButton IconEnd="@(new Icons.Regular.Size24.ArrowCircleRight().WithColor(Color.Success))">
+        Next
+    </FluentButton>
+
+    <FluentButton IconEnd="@(new Icons.Regular.Size24.DismissCircle().WithColor("red"))">
+        Exit
+    </FluentButton>
+
+    <FluentButton Appearance="Appearance.Accent"
+                  IconEnd="@(new Icons.Regular.Size24.Alert().WithColor(Color.Fill))">
+        Next
     </FluentButton>
 
 </FluentStack>

--- a/examples/Demo/Shared/Pages/Icon/Examples/IconPlacement.razor
+++ b/examples/Demo/Shared/Pages/Icon/Examples/IconPlacement.razor
@@ -1,4 +1,0 @@
-﻿<div style="display:flex">
-    <FluentButton Appearance="Appearance.Neutral"><FluentIcon Slot="start" Icon="Icons.Regular.Size20.ArrowCircleLeft" /> Button with icon in 'start' slot</FluentButton>
-    <FluentButton Appearance="Appearance.Neutral"><FluentIcon Slot="end" Icon="Icons.Regular.Size20.ArrowCircleRight" /> Button with icon in 'end' slot</FluentButton>
-</div>

--- a/examples/Demo/Shared/Pages/Icon/IconPage.razor
+++ b/examples/Demo/Shared/Pages/Icon/IconPage.razor
@@ -35,6 +35,11 @@
     There is also a search capability available on this page wich allows you to browse to all the different icons.
 </p>
 
+<h2 id="explorer">Explore Icons</h2>
+<IconExplorer />
+<br />
+<br />
+
 <h2 id="overview">Overview</h2>
 
 <DemoSection Component="typeof(IconDefault)" Title="Icon examples">
@@ -45,16 +50,6 @@
         label in a <code>FluentButton</code> component.
     </Description>
 </DemoSection>
-
-<DemoSection Component="typeof(IconPlacement)" Title="Icon placement">
-    <Description>
-        A lot of the web components have named slots that declare locations in which content can be rendered.
-        FluentIcon leverages this capability through its <code>Slot</code> parameter. With this you can for
-        example render the icon in front (<code>Slot="start"</code>) or after (<code>Slot="end"</code>) a
-        label in a <code>FluentButton</code> component.
-    </Description>
-</DemoSection>
-
 
 <DemoSection Component="typeof(IconColors)" Title="Color options">
     <Description>
@@ -69,10 +64,7 @@
     
 
 
-<h2>Explore Icons</h2>
-<IconExplorer />
-<br />
-<br />
+
 
 <ApiDocumentation Component="typeof(FluentIcon<>)" InstanceTypes="@(new[] {typeof(Icon)})" GenericLabel="Icon">
     <Description>

--- a/src/Core/Components/Button/FluentButton.razor
+++ b/src/Core/Components/Button/FluentButton.razor
@@ -55,7 +55,8 @@ else
         }
         else
         {
-            <FluentIcon Value="@IconStart" Slot="@(ChildContent != null ? "start" : null)" Color="@GetIconColor()" />
+            <FluentIcon Value="@(IconStart.InverseColor(Appearance == FluentUI.Appearance.Accent))"
+                        Slot="@(ChildContent != null ? "start" : null)" />
         }
     }
     @ChildContent
@@ -67,7 +68,8 @@ else
         }
         else
         {
-            <FluentIcon Value="@IconEnd" Slot="@(ChildContent != null ? "end" : null)" Color="@GetIconColor()" />
+            <FluentIcon Value="@(IconEnd.InverseColor(Appearance == FluentUI.Appearance.Accent))"
+                        Slot="@(ChildContent != null ? "end" : null)" />
         }
     }
 </fluent-button>

--- a/src/Core/Components/Button/FluentButton.razor
+++ b/src/Core/Components/Button/FluentButton.razor
@@ -55,7 +55,7 @@ else
         }
         else
         {
-            <FluentIcon Value="@IconStart" Slot="@(ChildContent != null ? "start" : null)" />
+            <FluentIcon Value="@IconStart" Slot="@(ChildContent != null ? "start" : null)" Color="@GetIconColor()" />
         }
     }
     @ChildContent
@@ -67,7 +67,7 @@ else
         }
         else
         {
-            <FluentIcon Value="@IconEnd" Slot="@(ChildContent != null ? "end" : null)" />
+            <FluentIcon Value="@IconEnd" Slot="@(ChildContent != null ? "end" : null)" Color="@GetIconColor()" />
         }
     }
 </fluent-button>

--- a/src/Core/Components/Button/FluentButton.razor.cs
+++ b/src/Core/Components/Button/FluentButton.razor.cs
@@ -192,6 +192,20 @@ public partial class FluentButton : FluentComponentBase
     private string RingStyle(Icon icon)
     {
         int size = Convert.ToInt32(icon.Size);
-        return $"width: {size}px; height: {size}px;";
+        string inverse = Appearance == FluentUI.Appearance.Accent ? " filter: invert(1);" : string.Empty;
+
+        return $"width: {size}px; height: {size}px;{inverse}";
+    }
+
+    private Color? GetIconColor()
+    {
+        switch (Appearance)
+        {
+            case FluentUI.Appearance.Accent:
+                return FluentUI.Color.Lightweight;
+
+            default:
+                return FluentUI.Color.Accent;
+        }
     }
 }

--- a/src/Core/Components/Button/FluentButton.razor.cs
+++ b/src/Core/Components/Button/FluentButton.razor.cs
@@ -196,16 +196,4 @@ public partial class FluentButton : FluentComponentBase
 
         return $"width: {size}px; height: {size}px;{inverse}";
     }
-
-    private Color? GetIconColor()
-    {
-        switch (Appearance)
-        {
-            case FluentUI.Appearance.Accent:
-                return FluentUI.Color.Lightweight;
-
-            default:
-                return FluentUI.Color.Accent;
-        }
-    }
 }

--- a/src/Core/Components/Icons/FluentIcon.razor.cs
+++ b/src/Core/Components/Icons/FluentIcon.razor.cs
@@ -19,7 +19,7 @@ public partial class FluentIcon<Icon> : FluentComponentBase
     /// <summary />
     protected string? StyleValue => new StyleBuilder(Style)
         .AddStyle("width", Width ?? $"{_icon.Width}px")
-        .AddStyle("fill", Color == FluentUI.Color.Custom ? CustomColor : Color.ToAttributeValue())
+        .AddStyle("fill", GetIconColor())
         .AddStyle("cursor", "pointer", OnClick.HasDelegate)
         .AddStyle("display", "inline-block", !ContainsSVG())
         .Build();
@@ -41,7 +41,7 @@ public partial class FluentIcon<Icon> : FluentComponentBase
     /// Value comes from the <see cref="FluentUI.Color"/> enumeration. Defaults to Accent.
     /// </summary>
     [Parameter]
-    public Color? Color { get; set; } = FluentUI.Color.Accent;
+    public Color? Color { get; set; }
 
     /// <summary>
     /// Gets or sets the icon drawing and fill color to a custom value.
@@ -111,5 +111,31 @@ public partial class FluentIcon<Icon> : FluentComponentBase
                 _icon.Content.StartsWith("<g ") ||
                 _icon.Content.StartsWith("<circle ") ||
                 _icon.Content.StartsWith("<mark "));
+    }
+
+    /// <summary>
+    /// Returns FluentIcon.CustomColor, or FluentIcon.Color, or Icon.Color.
+    /// </summary>
+    /// <returns></returns>
+    private string GetIconColor()
+    {
+        string defaultColor = FluentUI.Color.Accent.ToAttributeValue()!;
+
+        if (Color == FluentUI.Color.Custom && !string.IsNullOrEmpty(CustomColor))
+        {
+            return CustomColor;
+        }
+
+        if (Color != null)
+        {
+            return Color.ToAttributeValue() ?? defaultColor;
+        }
+        
+        if (!string.IsNullOrEmpty(_icon.Color))
+        {
+            return _icon.Color;
+        }
+
+        return defaultColor;
     }
 }

--- a/src/Core/Components/Icons/Icon.cs
+++ b/src/Core/Components/Icons/Icon.cs
@@ -64,6 +64,22 @@ public class Icon : IconInfo
     }
 
     /// <summary>
+    /// Inverse the color of the icon, if the <paramref name="accentContainer"/> is true,
+    /// and is not set (<see cref="Color"/> overrides this accent color).
+    /// </summary>
+    /// <param name="accentContainer"></param>
+    /// <returns></returns>
+    internal Icon InverseColor(bool accentContainer)
+    {
+        if (accentContainer && Color == null)
+        {
+            Color = FluentUI.Color.Lightweight.ToAttributeValue();
+        }
+
+        return this;
+    }
+
+    /// <summary>
     /// Gets the HTML markup of the icon.
     /// </summary>
     public virtual MarkupString ToMarkup(string? size = null, string? color = null)

--- a/src/Core/Components/Icons/Icon.cs
+++ b/src/Core/Components/Icons/Icon.cs
@@ -37,12 +37,39 @@ public class Icon : IconInfo
     public virtual string Content { get; }
 
     /// <summary>
+    /// Gets the color of the icon (set.
+    /// </summary>
+    internal virtual string? Color { get; private set; }
+
+    /// <summary>
+    /// Sets the color of the icon.
+    /// </summary>
+    /// <param name="color"></param>
+    /// <returns></returns>
+    public virtual Icon WithColor(string color)
+    { 
+        Color = color;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the color of the icon.
+    /// </summary>
+    /// <param name="color"></param>
+    /// <returns></returns>
+    public virtual Icon WithColor(Color color)
+    {
+        Color = color.ToAttributeValue();
+        return this;
+    }
+
+    /// <summary>
     /// Gets the HTML markup of the icon.
     /// </summary>
     public virtual MarkupString ToMarkup(string? size = null, string? color = null)
     {
         var styleWidth = size ?? $"{(int)Size}px";
-        var styleColor = color ?? "var(--accent-fill-rest)";
+        var styleColor = color ?? Color ?? "var(--accent-fill-rest)";
         return new MarkupString($"<svg viewBox=\"0 0 {(int)Size} {(int)Size}\" fill=\"{styleColor}\" style=\"background-color: var(--neutral-layer-1); width: {styleWidth};\" aria-hidden=\"true\">{Content}</svg>");
     }
 


### PR DESCRIPTION
# Button and Icon colors

At present, when an icon is added to a button whose appearance is **Accent**, the icon color is not correct (and must be changed manually by adding an icon to the button content).

This PR:
1. Add a method `WithColor(color)` on the **Icon** object to customize the color.
2. Detect the appearance of the **FluentButton** and update the icon color to `Color.Lightweight` if the `Appearance=Appearance.Accent`.

![image](https://github.com/microsoft/fluentui-blazor/assets/8350694/95cc1d5f-c943-42f6-a396-ddf02a1a566d)

This PR refactors the **Icon page** / **Color options** section to display a table with a list of color possibilities.

![image](https://github.com/microsoft/fluentui-blazor/assets/8350694/712a37fb-2bbf-4728-9dda-716f8b3f8d29)
