### PR TITLE
[Fix #805] - Fix the InlineStyleBuilder on .NET6

### DIFF
--- a/src/Core/Components/List/FluentSelect.razor.cs
+++ b/src/Core/Components/List/FluentSelect.razor.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Fast.Components.FluentUI;
 public partial class FluentSelect<TOption> : ListComponentBase<TOption>
 {
     /// <summary />
-    protected virtual MarkupString? InlineStyleValue => new InlineStyleBuilder()
+    protected virtual MarkupString InlineStyleValue => new InlineStyleBuilder()
         .AddStyle($"#{Id}::part(listbox)", "max-height", Height, !string.IsNullOrWhiteSpace(Height))
         .AddStyle($"#{Id}::part(listbox)", "height", Height, !string.IsNullOrWhiteSpace(Height))
         .AddStyle($"#{Id}::part(listbox)", "z-index", ZIndex.SelectPopup.ToString())

--- a/src/Core/Utilities/InlineStyleBuilder.cs
+++ b/src/Core/Utilities/InlineStyleBuilder.cs
@@ -80,10 +80,10 @@ public readonly struct InlineStyleBuilder
     /// Finalize the completed Style as a string.
     /// </summary>
     /// <returns>string</returns>
-    public MarkupString? BuildMarkupString()
+    public MarkupString BuildMarkupString()
     {
         var styles = Build();
-        return styles != null ? (MarkupString)styles : null;
+        return styles != null ? (MarkupString)styles : (MarkupString)string.Empty;
     }
 
     /// <summary>

--- a/tests/Core/MessageBar/FluentMessageBarTests.FluentMessageBar_Default.verified.html
+++ b/tests/Core/MessageBar/FluentMessageBarTests.FluentMessageBar_Default.verified.html
@@ -1,18 +1,17 @@
 
 <div class="fluent-messagebar intent-info" blazor:onfocusin="1" blazor:onfocusout="2" b-5ykbiib3u4="">
-  <div class="fluent-messagebar-icon" b-5ykbiib3u4="">
-    <svg style="width: 20px; fill: var(--info);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onclick="3">
-      <title>info</title>
-      <path d="M18 10a8 8 0 1 0-16 0 8 8 0 0 0 16 0ZM9.5 8.91a.5.5 0 0 1 1 0V13.6a.5.5 0 0 1-1 0V8.9Zm-.25-2.16a.75.75 0 1 1 1.5 0 .75.75 0 0 1-1.5 0Z"></path>
-    </svg>
-  </div>
-  <div class="fluent-messagebar-message" b-5ykbiib3u4="">
-    <span class="title" b-5ykbiib3u4="">This is a message</span>
-    <fluent-anchor href="#" target="_blank" appearance="hypertext" blazor:onclick:preventdefault="" blazor:onclick="4" title="Link" blazor:elementreference="a1e5e303-a30a-4f14-9bcc-a9f61e41d1bb"></fluent-anchor>
-  </div>
-  <div class="fluent-messagebar-container-action" b-5ykbiib3u4="">
-    <svg class="fluent-messagebar-close" style="width: 16px; fill: var(--neutral-foreground-rest); cursor: pointer;" focusable="false" viewBox="0 0 16 16" aria-hidden="true" blazor:onclick="5">
-      <path d="m2.59 2.72.06-.07a.5.5 0 0 1 .63-.06l.07.06L8 7.29l4.65-4.64a.5.5 0 0 1 .7.7L8.71 8l4.64 4.65c.18.17.2.44.06.63l-.06.07a.5.5 0 0 1-.63.06l-.07-.06L8 8.71l-4.65 4.64a.5.5 0 0 1-.7-.7L7.29 8 2.65 3.35a.5.5 0 0 1-.06-.63l.06-.07-.06.07Z"></path>
-    </svg>
-  </div>
+    <div class="fluent-messagebar-icon" b-5ykbiib3u4="">
+        <svg style="width: 20px; fill: var(--info);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onclick="3">
+            <title>info</title>
+            <path d="M18 10a8 8 0 1 0-16 0 8 8 0 0 0 16 0ZM9.5 8.91a.5.5 0 0 1 1 0V13.6a.5.5 0 0 1-1 0V8.9Zm-.25-2.16a.75.75 0 1 1 1.5 0 .75.75 0 0 1-1.5 0Z"></path>
+        </svg>
+    </div>
+    <div class="fluent-messagebar-message" b-5ykbiib3u4="">
+        <span class="title" b-5ykbiib3u4="">This is a message</span>
+    </div>
+    <div class="fluent-messagebar-container-action" b-5ykbiib3u4="">
+        <svg class="fluent-messagebar-close" style="width: 16px; fill: var(--neutral-foreground-rest); cursor: pointer;" focusable="false" viewBox="0 0 16 16" aria-hidden="true" blazor:onclick="4">
+            <path d="m2.59 2.72.06-.07a.5.5 0 0 1 .63-.06l.07.06L8 7.29l4.65-4.64a.5.5 0 0 1 .7.7L8.71 8l4.64 4.65c.18.17.2.44.06.63l-.06.07a.5.5 0 0 1-.63.06l-.07-.06L8 8.71l-4.65 4.64a.5.5 0 0 1-.7-.7L7.29 8 2.65 3.35a.5.5 0 0 1-.06-.63l.06-.07-.06.07Z"></path>
+        </svg>
+    </div>
 </div>

--- a/tests/Core/Utilities/InlineStyleBuilderTests.cs
+++ b/tests/Core/Utilities/InlineStyleBuilderTests.cs
@@ -44,5 +44,6 @@ public class InlineStyleBuilderTests : TestBase
 
         // Assert - Values are sorted
         Assert.Null(styleBuilder.Build(newLineSeparator: false));
+        Assert.Equal(string.Empty, styleBuilder.BuildMarkupString().Value);
     }
 }


### PR DESCRIPTION
# Fix the InlineStyleBuilder on .NET6

1. On .NET6, the `InlineStyleBuilder` renders the style tag as a string.

    ![271475899-1cebf83d-ad73-4bb6-8208-0931c1ab5c3b](https://github.com/microsoft/fluentui-blazor/assets/8350694/bab26ce7-2a77-4ee3-935d-dba192d178b5)

2. After this fix, the style is included in the code like a `style` tag.
    ![image](https://github.com/microsoft/fluentui-blazor/assets/8350694/21755698-6ddb-48c9-a26c-9458a90523f5)
    ![image](https://github.com/microsoft/fluentui-blazor/assets/8350694/9f7b204a-bebb-4ef2-a4bc-c9a3630fdd90)

#805 