### PR TITLE
[FluentInputFile] Fix the manual upload on iOS

### DIFF
--- a/examples/Demo/Shared/Pages/InputFile/Examples/InputFileBufferMode.razor
+++ b/examples/Demo/Shared/Pages/InputFile/Examples/InputFileBufferMode.razor
@@ -1,4 +1,5 @@
 ﻿<FluentInputFile @ref="@myFileByBuffer"
+                 AnchorId="MyUploadBuffer"
                  DragDropZoneVisible="false"
                  Mode="InputFileMode.Buffer"
                  Multiple="true"
@@ -12,8 +13,7 @@
     @progressTitle
 </FluentLabel>
 
-<FluentButton Appearance="Appearance.Accent"
-@onclick="@(async e => { IsCanceled = false; await myFileByBuffer!.ShowFilesDialogAsync(); })">
+<FluentButton Appearance="Appearance.Accent" Id="MyUploadBuffer">
     Upload files
 </FluentButton>
 

--- a/examples/Demo/Shared/Pages/InputFile/Examples/InputFileByCode.razor
+++ b/examples/Demo/Shared/Pages/InputFile/Examples/InputFileByCode.razor
@@ -1,22 +1,22 @@
-﻿<FluentInputFile @ref="@myFileUploader"
-                DragDropZoneVisible="false"
-                Multiple=true
-                MaximumFileSize="@(100 * 1024 * 1024)"
-                Accept=".mp4, .mov, .avi"
-                OnProgressChange="@(e =>
-                    {
-                        progressPercent = e.ProgressPercent; 
-                        progressTitle = e.ProgressTitle;
-                    })"
-                OnCompleted="@OnCompleted" />
+﻿<FluentInputFile @ref="@myFileUploader" 
+                 DragDropZoneVisible="false"
+                 Multiple="true"
+                 AnchorId="MyUploadButton"
+                 MaximumFileSize="@(100 * 1024 * 1024)"
+                 Accept=".mp4, .mov, .avi"
+                 OnProgressChange="@(e =>
+                     {
+                         progressPercent = e.ProgressPercent; 
+                         progressTitle = e.ProgressTitle;
+                     })"
+                 OnCompleted="@OnCompleted" />
 
 <FluentProgress Min="0" Max="100" Visible="@(progressPercent > 0)" Value="@progressPercent" />
 <FluentLabel Alignment="HorizontalAlignment.Center">
     @progressTitle
 </FluentLabel>
 
-<FluentButton Appearance="Appearance.Accent"
-             @onclick="@(async e => await myFileUploader!.ShowFilesDialogAsync())">
+<FluentButton Id="MyUploadButton" Appearance="Appearance.Accent">
     Upload files
 </FluentButton>
 

--- a/examples/Demo/Shared/Pages/InputFile/Examples/InputFileStream.razor
+++ b/examples/Demo/Shared/Pages/InputFile/Examples/InputFileStream.razor
@@ -1,19 +1,19 @@
 ﻿<FluentInputFile @ref="@myFileByStream"
-                DragDropZoneVisible="false"
-                Mode="InputFileMode.Stream"
-                Multiple="true"
-                MaximumFileSize="@(20 * 1024 * 1024)"
-                Accept=".mp4, .mov, .avi"
-                OnFileUploaded="@OnFileUploadedAsync"
-                OnCompleted="@OnCompleted" />
+                 AnchorId="MyUploadStream"
+                 DragDropZoneVisible="false"
+                 Mode="InputFileMode.Stream"
+                 Multiple="true"
+                 MaximumFileSize="@(20 * 1024 * 1024)"
+                 Accept=".mp4, .mov, .avi"
+                 OnFileUploaded="@OnFileUploadedAsync"
+                 OnCompleted="@OnCompleted" />
 
 <FluentProgress Min="0" Max="100" Value="@progressPercent" Visible="@(progressPercent > 0)" />
 <FluentLabel Alignment="HorizontalAlignment.Center">
     @progressTitle
 </FluentLabel>
 
-<FluentButton Appearance="Appearance.Accent"
-             @onclick="@(async e => await myFileByStream!.ShowFilesDialogAsync() )">
+<FluentButton Appearance="Appearance.Accent" Id="MyUploadStream">
     Upload files
 </FluentButton>
 

--- a/src/Core/Components/InputFile/FluentInputFile.razor.cs
+++ b/src/Core/Components/InputFile/FluentInputFile.razor.cs
@@ -144,10 +144,11 @@ public partial class FluentInputFile : FluentComponentBase
     }
 
     /// <summary>
-    /// Open the dialogbox to select files. This method doesn't work on Safari and iOS and will be removed in a future release.
+    /// Open the dialogbox to select files.
+    /// Use <see cref="AnchorId"/> instead to specify the ID of the button (for example) on which the user should click.
+    /// ⚠️ This method doesn't work on Safari and iOS.
     /// </summary>
     /// <returns></returns>
-    [Obsolete("Use AnchorId instead to specify the ID of the button (for example) on which the user should click. This method will be removed in a future release.")]
     public async Task ShowFilesDialogAsync()
     {
         Module ??= await JSRuntime.InvokeAsync<IJSObjectReference>("import", JAVASCRIPT_FILE);

--- a/src/Core/Components/InputFile/FluentInputFile.razor.cs
+++ b/src/Core/Components/InputFile/FluentInputFile.razor.cs
@@ -132,6 +132,11 @@ public partial class FluentInputFile : FluentComponentBase
     [Parameter]
     public EventCallback<IEnumerable<FluentInputFileEventArgs>> OnCompleted { get; set; }
 
+    /// <summary>
+    /// Identifier of the source component clickable by the end user.
+    /// </summary>
+    [Parameter]
+    public string AnchorId { get; set; } = string.Empty;
 
     public FluentInputFile()
     {
@@ -139,14 +144,26 @@ public partial class FluentInputFile : FluentComponentBase
     }
 
     /// <summary>
-    /// Open the dialogbox to select files.
+    /// Open the dialogbox to select files. This method doesn't work on Safari and iOS and will be removed in a future release.
     /// </summary>
     /// <returns></returns>
+    [Obsolete("Use AnchorId instead to specify the ID of the button (for example) on which the user should click. This method will be removed in a future release.")]
     public async Task ShowFilesDialogAsync()
     {
         Module ??= await JSRuntime.InvokeAsync<IJSObjectReference>("import", JAVASCRIPT_FILE);
 
         await Module.InvokeVoidAsync("raiseFluentInputFile", Id);
+    }
+
+    /// <summary />
+    protected override async Task OnInitializedAsync()
+    {
+        if (!string.IsNullOrEmpty(AnchorId))
+        {
+            Module ??= await JSRuntime.InvokeAsync<IJSObjectReference>("import", JAVASCRIPT_FILE);
+
+            await Module.InvokeVoidAsync("attachClickHandler", AnchorId, Id);
+        }
     }
 
     /// <summary />

--- a/src/Core/Components/InputFile/FluentInputFile.razor.js
+++ b/src/Core/Components/InputFile/FluentInputFile.razor.js
@@ -1,7 +1,17 @@
-﻿export function raiseFluentInputFile(id) {
-    var item = document.getElementById(id);
+﻿export function raiseFluentInputFile(fileInputId) {
+    var item = document.getElementById(fileInputId);
     if (!!item) {
         item.click();
+    }
+}
+
+export function attachClickHandler(buttonId, fileInputId) {
+    var button = document.getElementById(buttonId);
+    var fileInput = document.getElementById(fileInputId);
+    if (button && fileInput) {
+        button.addEventListener("click", function (e) {
+            fileInput.click();
+        });
     }
 }
 


### PR DESCRIPTION
# Fix the FluentInputFile.ShowFilesDialogAsync on Safari and iOS

The `ShowFilesDialogAsync` method of the `FluentInputFile` component doesn't work in Safari. Normally, the browser should pop its native file selection dialog. In Safari, this browser dialog doesn't show when the application tries to open it programmatically via C#.

# Causes

The `ShowFilesDialogAsync` method is pretty simple. It uses JSInterop to call the click JavaScript method of the `<input type="file" />` element inside the component HTML output.

Safari requires the file input dialog to open programmatically as a direct result of a user action. If the file input is clicked programmatically, this must happen in JavaScript code, which handles a user event.

JSInterop cannot be directly associated with a user action, due to its nature. A .NET method itself is not directly triggered by user action. For example, an `@onclick` Blazor handler will react to the `click` user event and call a .NET handler. However, the subsequent server-client JSInterop call that executes JavaScript code will no longer have relationship with the user action that started the whole sequence.

# Solution

The `ShowFilesDialogAsync` function has been marked **obsolete** in favor of the new `AnchorId` attribute. When set, the `attachClickHandler` JavaScript method attaches the `Click` event to this **Anchor** (e.g. Button) to simulate the click on the `InputFile`.

**Example**

```html
<FluentInputFile AnchorId="MyUploadButton" />
<FluentButton Id="MyUploadButton">Upload files</FluentButton>

```

![image](https://github.com/microsoft/fluentui-blazor/assets/8350694/fd67367a-e32a-4abd-b81b-6d1caef38579)


![image](https://github.com/microsoft/fluentui-blazor/assets/8350694/0f4cd928-947f-40bd-95aa-bc441aacc94e)

