### PR TITLE
fixes minor typo in FluentNumberField.razor.cs

### DIFF
--- a/src/Core/Components/NumberField/FluentNumberField.razor.cs
+++ b/src/Core/Components/NumberField/FluentNumberField.razor.cs
@@ -19,7 +19,7 @@ public partial class FluentNumberField<TValue> : FluentInputBase<TValue>
     public string? DataList { get; set; }
 
     /// <summary>
-    /// Gets or sets the maximum lenth
+    /// Gets or sets the maximum length
     /// </summary>
     [Parameter]
     public int MaxLength { get; set; } = 14;


### PR DESCRIPTION
# Pull Request

## 📖 Description

The word _length_ is misspelled.

### 🎫 Issues

## 👩‍💻 Reviewer Notes

## 📑 Test Plan

## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

## ⏭ Next Steps
