### PR TITLE
fix!: Implement DesignToken.WithDefault and use in Demo site

### DIFF
--- a/examples/Demo/Shared/Components/SiteSettingsPanel.razor.cs
+++ b/examples/Demo/Shared/Components/SiteSettingsPanel.razor.cs
@@ -64,7 +64,7 @@ public partial class SiteSettingsPanel : IDialogContentComponent<GlobalState>, I
         Content.Dir = _dir;
 
         await _jsModule!.InvokeVoidAsync("switchDirection", _dir.ToString());
-        await Direction.SetValueFor(_container, _dir.ToAttributeValue());
+        await Direction.WithDefault(_dir.ToAttributeValue());
 
         StateHasChanged();
     }
@@ -82,7 +82,7 @@ public partial class SiteSettingsPanel : IDialogContentComponent<GlobalState>, I
 
         Content.Luminance = _baseLayerLuminance;
         
-        await BaseLayerLuminance.SetValueFor(_container, _baseLayerLuminance.GetLuminanceValue());
+        await BaseLayerLuminance.WithDefault(_baseLayerLuminance.GetLuminanceValue());
         await _jsModule!.InvokeVoidAsync("switchHighlightStyle", _baseLayerLuminance == StandardLuminance.DarkMode);
     }
 
@@ -93,11 +93,13 @@ public partial class SiteSettingsPanel : IDialogContentComponent<GlobalState>, I
         {
             if (value != "default")
             {
-                await AccentBaseColor.SetValueFor(_container, value.ToSwatch());
+                await AccentBaseColor.WithDefault(value.ToSwatch());
             }
             else
             {
-                await AccentBaseColor.DeleteValueFor(_container);
+                // Default FluentUI value for AccentBaseColor from 
+                // https://github.com/microsoft/fluentui/blob/c0d3065982e1646c54ba00c1d524248b792dbcad/packages/web-components/src/color/utilities/color-constants.ts#L22C32-L22C39
+                await AccentBaseColor.WithDefault("#0078D4".ToSwatch());
             }
 
             Content.Color = value;

--- a/examples/Demo/Shared/Shared/DemoMainLayout.razor.cs
+++ b/examples/Demo/Shared/Shared/DemoMainLayout.razor.cs
@@ -77,7 +77,7 @@ public partial class DemoMainLayout : IAsyncDisposable
             GlobalState.SetLuminance(_dark ? StandardLuminance.DarkMode: StandardLuminance.LightMode);
 
             if (_selectedColorOption != OfficeColor.Default)
-                await AccentBaseColor.SetValueFor(container, _selectedColorOption.ToAttributeValue()!.ToSwatch());            
+                await AccentBaseColor.WithDefault(_selectedColorOption.ToAttributeValue()!.ToSwatch());            
         }
     }
 

--- a/src/Core/DesignTokens/DesignToken.razor.cs
+++ b/src/Core/DesignTokens/DesignToken.razor.cs
@@ -74,9 +74,10 @@ public partial class DesignToken<T> : ComponentBase, IDesignToken<T>, IAsyncDisp
     /// <summary>
     /// Sets the default value of this token
     /// </summary>
-    public DesignToken<T> WithDefault(T value)
+    public async ValueTask<DesignToken<T>> WithDefault(T value)
     {
-        //_defaultValue = value;
+        await InitJSReference();
+        await _jsModule.InvokeVoidAsync(Name + ".withDefault", value);
         return this;
     }
 

--- a/src/Core/DesignTokens/IDesignToken.cs
+++ b/src/Core/DesignTokens/IDesignToken.cs
@@ -10,7 +10,7 @@ public interface IDesignToken<T>
     ValueTask<T> GetValueFor(ElementReference element);
 
     ValueTask SetValueFor(ElementReference element, T value);
-    DesignToken<T> WithDefault(T value);
+    ValueTask<DesignToken<T>> WithDefault(T value);
 
     ValueTask<DesignToken<T>> Create(string name);
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

FAST/FluentUI DesignTokens support setting a default value for a particular token as well as setting a (non-default) value for a particular container element (and its descendants). FluentUI-Blazor supports the latter, with DesignToken.SetValueFor, but WithDefault is currently not implemented.

When you truly want to set the value for a particular design token for all elements on the page (not just a subset), WithDefault is useful. It has the side benefit of not polluting the DOM with a large style attribute on whatever container element is used in SetValueFor.

Using WithDefault doesn't prevent you from using SetValueFor in other places in the page, as evidenced by the example pages for buttons and toolbars, and the design token page itself. 

This is technically a breaking change since it changes the signature of the WithDefault method from `DesignToken<T> WithDefault(T value)` to `ValueTask<DesignToken<T> WithDefault(T value)`, though it is unlikely anyone was using WithDefault previously since it had no effect at all. 

### 🎫 Issues

No issues currently that I'm aware of, but there's this discussion item: https://github.com/microsoft/fluentui-blazor/discussions/427

## 👩‍💻 Reviewer Notes

I'm throwing this up for discussion as I'm not sure what the intent is with WithDefault in this library. The discussion above (and the fact that it was left unimplemented) makes it seem intentional, but it feels like a gap to me. I made the change to the example/demo site so that it uses WithDefault for theme changes and it all works as far as I can tell.

## 📑 Test Plan

I'm not sure (though would be surprised) if this has any impact on unit tests, though they all pass for me locally.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new compontent
- [ ] I have modified an existing component
- [ ] I have validate [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component 

## ⏭ Next Steps

If implemented, we'd probably want to update the design token documentation to reference WithDefault in addition to SetValueFor. But I didn't want to spend the time wordsmithing things yet if this wasn't a direction you wanted to go for the library. 