### PR TITLE
[Accessibility] fix FluentDividerFix aria-orientation

### DIFF
--- a/examples/Demo/Shared/Microsoft.Fast.Components.FluentUI.xml
+++ b/examples/Demo/Shared/Microsoft.Fast.Components.FluentUI.xml
@@ -2590,6 +2590,9 @@
             A event that will be invoked when showing a dialog with a custom component
             </summary>
         </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentDivider.Module">
+            <summary />
+        </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentDivider.Role">
             <summary>
             The role of the element.
@@ -2938,10 +2941,24 @@
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentGrid.StyleValue">
             <summary />
         </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentGridItem.Justify">
+            <summary>
+            Defines how the browser distributes space between and around content items.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Fast.Components.FluentUI.FluentGridItem.Gap">
+            <summary>
+            Defines the gaps (gutters) between rows and columns.
+            See https://developer.mozilla.org/en-US/docs/Web/CSS/gap
+            </summary>
+        </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentGridItem.ClassValue">
             <summary />
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentGridItem.StyleValue">
+            <summary />
+        </member>
+        <member name="M:Microsoft.Fast.Components.FluentUI.FluentGridItem.NoBreakpointsDefined">
             <summary />
         </member>
         <member name="P:Microsoft.Fast.Components.FluentUI.FluentHeader.Height">

--- a/src/Core/Components/Divider/FluentDivider.razor.cs
+++ b/src/Core/Components/Divider/FluentDivider.razor.cs
@@ -1,9 +1,18 @@
 using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 
 namespace Microsoft.Fast.Components.FluentUI;
 
 public partial class FluentDivider : FluentComponentBase
 {
+    private const string JAVASCRIPT_FILE = "./_content/Microsoft.Fast.Components.FluentUI/Components/Divider/FluentDivider.razor.js";
+
+    [Inject]
+    private IJSRuntime JSRuntime { get; set; } = default!;
+
+    /// <summary />
+    private IJSObjectReference? Module { get; set; }
+
     /// <summary>
     /// The role of the element.
     /// </summary>
@@ -22,5 +31,12 @@ public partial class FluentDivider : FluentComponentBase
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
 
+    protected async override Task OnInitializedAsync()
+    {
+        Module ??= await JSRuntime.InvokeAsync<IJSObjectReference>("import", JAVASCRIPT_FILE);
+        await Module.InvokeVoidAsync("setDividerAriaOrientation");
+     
+        await base.OnInitializedAsync();
+    }
 }
 

--- a/src/Core/Components/Divider/FluentDivider.razor.js
+++ b/src/Core/Components/Divider/FluentDivider.razor.js
@@ -1,0 +1,12 @@
+﻿export function setDividerAriaOrientation() {
+
+    const elements = document.querySelectorAll("fluent-divider[role='presentation']");
+
+    if (!!elements) {
+        elements.forEach((element, i, array) => {
+            if (!!element && element.hasAttribute("aria-orientation")) {
+                element.removeAttribute("aria-orientation");
+            }
+        });
+    }
+}


### PR DESCRIPTION
# Accessibility - fix FluentDividerFix aria-orientation

Until we have a solution from the FAST team, a `setDividerAriaOrientation` script is run each time a **FluentDivider** is rendered. This script removes any `aria-orientation` when the component has a `role='presentation'`.

```js
export function setDividerAriaOrientation() {

    const elements = document.querySelectorAll("fluent-divider[role='presentation']");

    if (!!elements) {
        elements.forEach((element, i, array) => {
            if (!!element && element.hasAttribute("aria-orientation")) {
                element.removeAttribute("aria-orientation");
            }
        });
    }
}
```
