### PR TITLE
fix typo

### DIFF
--- a/examples/Demo/Shared/Pages/RebootPage.razor
+++ b/examples/Demo/Shared/Pages/RebootPage.razor
@@ -35,7 +35,7 @@
 </ul>
 <h2 id="css-variables">CSS variables <a class="anchor-link" href="#css-variables" aria-label="Link to this section: CSS variables"></a></h2>
 <p>
-    There are a number of extra variables defined (for now only colors). They can be found in the <FluentAnchor Appearance=Appearance.Hypertext Href="_content/Microsoft.Fast.Components.FluentUI/css/variables.css" Download="variables.css" >varables.css</FluentAnchor> 
+    There are a number of extra variables defined (for now only colors). They can be found in the <FluentAnchor Appearance=Appearance.Hypertext Href="_content/Microsoft.Fast.Components.FluentUI/css/variables.css" Download="variables.css" >variables.css</FluentAnchor> 
     file (which Reboot imports). Many more CSS variable are defined are in the Fluent UI Web Components for Blazor library. They are definded 
     through the Fluent UI Web Components scripts and can be used without including or importing any other files besides the 'web-components' script.
 </p>


### PR DESCRIPTION
# Pull Request

## 📖 Description

Fix a minor typo in the name of the variables.css file in the Reboot page in the Demo project.

### 🎫 Issues

N/A

## 👩‍💻 Reviewer Notes

Just a minor typo correction: varables.css -> variables.css

## 📑 Test Plan

N/A

## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

I intend to fix more typos that I've noticed while going through the docs/demo. ;)
Just need to run into them again.