### PR TITLE
Fix .NET 8 initializers

### DIFF
--- a/src/Core/wwwroot/Microsoft.FluentUI.AspNetCore.Components.lib.module.js
+++ b/src/Core/wwwroot/Microsoft.FluentUI.AspNetCore.Components.lib.module.js
@@ -3,9 +3,9 @@
 var beforeStartCalled = false;
 var afterStartedCalled = false;
 
-export function beforeWebStart() {
+export function beforeWebStart(options, extensions) {
     if (!beforeStartCalled) {
-        beforeStart();
+        beforeStart(options, extensions);
     }
     // Ensure that initializers can be async by "yielding" execution
     return new Promise((resolve, reject) => {
@@ -16,16 +16,16 @@ export function beforeWebStart() {
     });
 }
 
-export function afterWebStarted() {
+export function afterWebStarted(blazor) {
     if (!afterStartedCalled) {
         afterStarted(blazor);
     }
     appendElement('modern-after-web-started', 'Modern "afterWebStarted"');
 }
 
-export function beforeWebAssemblyStart() {
+export function beforeWebAssemblyStart(options, extensions) {
     if (!beforeStartCalled) {
-        beforeStart();
+        beforeStart(options, extensions);
     }
     return new Promise((resolve, reject) => {
         setTimeout(() => {
@@ -35,16 +35,16 @@ export function beforeWebAssemblyStart() {
     });
 }
 
-export function afterWebAssemblyStarted() {
+export function afterWebAssemblyStarted(blazor) {
     if (!afterStartedCalled) {
-        afterStarted();
+        afterStarted(blazor);
     }
     appendElement('modern-after-web-assembly-started', 'Modern "afterWebAssemblyStarted"')
 }
 
-export function beforeServerStart(options) {
+export function beforeServerStart(options, extensions) {
     if (!beforeStartCalled) {
-        beforeStart(options);
+        beforeStart(options, extensions);
     }
     // Ensure that initializers can be async by "yielding" execution
     return new Promise((resolve, reject) => {
@@ -60,9 +60,9 @@ export function beforeServerStart(options) {
     });
 }
 
-export function afterServerStarted() {
+export function afterServerStarted(blazor) {
     if (!afterStartedCalled) {
-        afterStarted();
+        afterStarted(blazor);
     }
     appendElement('modern-after-server-started', 'Modern "afterServerStarted"');
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

The new Blazor initializers for .NET 8 have some errors in them that cause runtime errors to show in the browser console, initialization to not succeed if the new initializers are called and some components that depend on those initializers to not work properly.

### 🎫 Issues

I just created the PR instead of creating an issue, in part because of GH's outage this morning when I was trying to file the issue.

## 👩‍💻 Reviewer Notes

It appears this was introduced in https://github.com/microsoft/fluentui-blazor/pull/909 as the initial set of initializers that were introduced to /dev in https://github.com/microsoft/fluentui-blazor/pull/879 had these in place.

## 📑 Test Plan

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [X] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new compontent
- [ ] I have modified an existing component
- [ ] I have validate [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component 

## ⏭ Next Steps