### PR TITLE
[Namespace update] Remove last traces of Microsoft.Fast.Components

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "dotnet.defaultSolution": "Microsoft.Fast.sln"
+  "dotnet.defaultSolution": "Microsoft.FluentUI.sln"
 }

--- a/src/Assets/FluentUI.Emojis/Emojis.cs
+++ b/src/Assets/FluentUI.Emojis/Emojis.cs
@@ -28,7 +28,7 @@ public static partial class Emojis
             var allEmojis = assembly.GetTypes()
                                     .Where(i => i.BaseType == typeof(Emoji));
 
-            // Ex. Microsoft.Fast.Components.FluentUI.Emojis+Activities+Color+Default+Baseball
+            // Ex. Microsoft.FluentUI.AspNetCore.Components.Emojis+Activities+Color+Default+Baseball
             var group = emoji.Group.ToString().Replace("_", string.Empty);
             var emojiFullName = $"{Namespace}.Emojis+{group}+{emoji.Style}+{emoji.Skintone}+{emoji.Name}";
             var emojiType = allEmojis.FirstOrDefault(i => i.FullName == emojiFullName);

--- a/src/Assets/FluentUI.Icons/Icons.cs
+++ b/src/Assets/FluentUI.Icons/Icons.cs
@@ -30,7 +30,7 @@ public static partial class Icons
             var allIcons = assembly.GetTypes()
                                    .Where(i => i.BaseType == typeof(Icon));
 
-            // Ex. Microsoft.Fast.Components.FluentUI.Icons+Filled+Size10+PresenceAvailable
+            // Ex. Microsoft.FluentUI.AspNetCore.Components.Icons+Filled+Size10+PresenceAvailable
             var iconFullName = $"{Namespace}.Icons+{icon.Variant}+Size{(int)icon.Size}+{icon.Name}";
             var iconType = allIcons.FirstOrDefault(i => i.FullName == iconFullName);
 

--- a/src/Assets/Generator/Properties/launchSettings.json
+++ b/src/Assets/Generator/Properties/launchSettings.json
@@ -5,13 +5,13 @@
 
 {
   "profiles": {
-    "Microsoft.Fast.Components.FluentUI.AssetsGenerator": {
+    "Microsoft.FluentUI.AspNetCore.Components.AssetsGenerator": {
       "commandName": "Project",
       // 1. To generate all icons in Icons Lib
       "commandLineArgs": "--Assets=D:/_Temp/Icons --Target=..\\FluentUI.Icons\\Icons"
 
       // 2. To generate only icons used by Core lib
-      // "commandLineArgs": "--Assets=C:/_Temp/Icons --Target=../../Microsoft.Fast.Components.FluentUI/Components/Icons --Names=ArrowDownload_24_Regular,ArrowSortDown_24_regular,ArrowSortUp_24_regular,ArrowUpload_24_Regular,CalendarLTR_24_Regular,CheckmarkCircle_24_Filled,ChevronDoubleLeft_20_Regular,ChevronDoubleRight_20_Regular,ChevronDown_24_Regular,ChevronLeft_24_Regular,ChevronRight_24_Regular,Dismiss_24_regular,DismissCircle_24_Filled,DismissCircl,_24_Regular,Filter_24_regular,Flash_24_Regular,Info_24_Filled,Info_24_Regular,MoreHorizontal_24_Regular,Navigation_24_Regular,Person_24_Regular,PresenceAvailable_24,Filled,PresenceAvailable_24_Regular,PresenceAway_24_Filled,PresenceBusy_24_Filled,PresenceDND_24_Filled,PresenceDND_24_Regular,PresenceOffline_24_Regular,PresenceOf,line_24_Regular,PresenceOOF_24_Regular,PresenceUnknown_24_Regular,QuestionCircle_24_Regular,Warning_24_Filled"
+      // "commandLineArgs": "--Assets=C:/_Temp/Icons --Target=../../src/Core/Components/Icons --Names=ArrowDownload_24_Regular,ArrowSortDown_24_regular,ArrowSortUp_24_regular,ArrowUpload_24_Regular,CalendarLTR_24_Regular,CheckmarkCircle_24_Filled,ChevronDoubleLeft_20_Regular,ChevronDoubleRight_20_Regular,ChevronDown_24_Regular,ChevronLeft_24_Regular,ChevronRight_24_Regular,Dismiss_24_regular,DismissCircle_24_Filled,DismissCircl,_24_Regular,Filter_24_regular,Flash_24_Regular,Info_24_Filled,Info_24_Regular,MoreHorizontal_24_Regular,Navigation_24_Regular,Person_24_Regular,PresenceAvailable_24,Filled,PresenceAvailable_24_Regular,PresenceAway_24_Filled,PresenceBusy_24_Filled,PresenceDND_24_Filled,PresenceDND_24_Regular,PresenceOffline_24_Regular,PresenceOf,line_24_Regular,PresenceOOF_24_Regular,PresenceUnknown_24_Regular,QuestionCircle_24_Regular,Warning_24_Filled"
 
       // 3. To generate all emojis in Emojis Lib
       //"commandLineArgs": "--Assets=C:/_Temp/fluentui-emoji --Library=Emoji --Target=../FluentUI.Emojis/Emojis"

--- a/src/Extensions/DataGrid.EntityFrameworkAdapter/Properties/launchSettings.json
+++ b/src/Extensions/DataGrid.EntityFrameworkAdapter/Properties/launchSettings.json
@@ -1,6 +1,6 @@
 {
   "profiles": {
-    "Microsoft.Fast.Components.FluentUI.DataGrid.EntityFrameworkAdapter": {
+    "Microsoft.FluentUI.AspNetCore.Components.DataGrid.EntityFrameworkAdapter": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/src/Extensions/DesignToken.Generator/Properties/launchSettings.json
+++ b/src/Extensions/DesignToken.Generator/Properties/launchSettings.json
@@ -1,8 +1,8 @@
 {
   "profiles": {
-    "Microsoft.Fast.Components.FluentUI.Generators": {
+    "Microsoft.FluentUI.AspNetCore.Components.Generators": {
       "commandName": "DebugRoslynComponent",
-      "targetProject": "..\\Microsoft.Fast.Components.FluentUI\\Microsoft.Fast.Components.FluentUI.csproj"
+      "targetProject": "..\\..\\Core\\Microsoft.FluentUI.AspNetCore.Components.csproj"
     }
   }
 }

--- a/src/Templates/Properties/launchSettings.json
+++ b/src/Templates/Properties/launchSettings.json
@@ -1,6 +1,6 @@
 {
   "profiles": {
-    "Microsoft.Fast.Templates.FluentUI": {
+    "Microsoft.FluentUI.AspNetCore.Templates": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/tests/Core/Properties/launchSettings.json
+++ b/tests/Core/Properties/launchSettings.json
@@ -1,6 +1,6 @@
 {
   "profiles": {
-    "Microsoft.Fast.Components.FluentUI.Tests": {
+    "Microsoft.FluentUI.AspNetCore.Components.Tests": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {


### PR DESCRIPTION
# Namespace update

Remove last traces of **Microsoft.Fast.Components**

Replace all `Microsoft.Fast.Components.FluentUI` with `Microsoft.FluentUI.AspNetCore.Components`