### PR TITLE
Demo typos

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -3959,7 +3959,7 @@
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentMainLayout.NavMenuTitle">
             <summary>
-            Gets or set the tite of the navigation menu
+            Gets or sets the tite of the navigation menu
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentMainLayout.NavMenuContent">
@@ -5599,7 +5599,7 @@
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentStack.Orientation">
             <summary>
-            Gets or set the orientation of the stacked components. 
+            Gets or sets the orientation of the stacked components. 
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentStack.Width">

--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -633,7 +633,7 @@
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentButton.Name">
             <summary>
-            The name of the element.Allows access by name from the associated form.
+            The name of the element. Allows access by name from the associated form.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentButton.Required">
@@ -1707,7 +1707,7 @@
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDatePicker.Name">
             <summary>
-            The name of the element.Allows access by name from the associated form.
+            The name of the element. Allows access by name from the associated form.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDatePicker.Required">
@@ -2122,7 +2122,7 @@
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.DialogParameters.DialogBodyStyle">
             <summary>
-            Gets or sets the extra styles appied to the Body content.
+            Gets or sets the extra styles applied to the Body content.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.DialogParameters.AriaLabelledby">

--- a/examples/Demo/Shared/Pages/Card/CardPage.razor
+++ b/examples/Demo/Shared/Pages/Card/CardPage.razor
@@ -16,7 +16,7 @@
 <DemoSection Title="Area restricted examples" Component="@typeof(CardAreaRestricted)">
     <Description>
         <p>
-            By default a card restricts it's content to the card area. This means, for exmple, that if you have a select list with a lot of items, the list will be cut off at the bottom of the card.
+            By default a card restricts its content to the card area. This means, for exmple, that if you have a select list with a lot of items, the list will be cut off at the bottom of the card.
             You can override this behavior by setting the <code>AreaRestricted</code> property to <code>false</code>.
         </p>
     </Description>

--- a/examples/Demo/Shared/Pages/Card/Examples/CardAreaRestricted.razor
+++ b/examples/Demo/Shared/Pages/Card/Examples/CardAreaRestricted.razor
@@ -2,7 +2,7 @@
 
 <FluentStack>
     <FluentCard Width="300px" Height="300px">
-        <p>This card's content is restricted to it's area. Open the select list below to see the result</p>
+        <p>This card's content is restricted to its area. Open the select list below to see the result</p>
         <label for="people-listbox">Select a person</label>
         <FluentSelect TOption="Person"
                       Items="@Data.People.WithVeryLongName()"
@@ -15,7 +15,7 @@
 
     </FluentCard>
     <FluentCard Width="300px" Height="300px" AreaRestricted="false">
-        <p>This card's content is not restricted to it's area. Open the select list below to see the result</p>
+        <p>This card's content is not restricted to its area. Open the select list below to see the result</p>
         <label for="people-listbox">Select a person</label>
         <FluentSelect TOption="Person"
                       Items="@Data.People.WithVeryLongName()"

--- a/examples/Demo/Shared/Pages/DataGrid/DataGridPage.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/DataGridPage.razor
@@ -60,7 +60,7 @@
             All columns, except 'Bronze', have a <code>Tooltip</code> parameter value of <code>true</code>.<br />
             When using this for a <code>TemplateColumn</code> (like 'Rank' here), you need to also supply a value for the <code>TooltipText</code> parameter. <b>No value given equals no tooltip shown</b>.<br />
             When using this for a <code>PropertyColumn</code>, a value for the <code>TooltipText</code> is <b>not</b> required. By default, the value given for <code>Property</code>
-            will be re-used for the tooltip. If you do supply a value for <code>TooltipText</code> it's outcome will be used instead.
+            will be re-used for the tooltip. If you do supply a value for <code>TooltipText</code> its outcome will be used instead.
             <br />
             <br />
             <code>TooltipText</code> is a lambda function that takes the current item as input and returns the text to show in the tooltip (and <code>aria-label</code>).
@@ -95,7 +95,7 @@
             In this example they don't relly do anything more than writting a message in the console log'
         </p>
         <p>
-            The second column has a custom <code>Style</code> parameter set and applied to it. The 4th column has it's <code>Tooltip</code> 
+            The second column has a custom <code>Style</code> parameter set and applied to it. The 4th column has its <code>Tooltip</code> 
             parameter set to true. This will show the full content of the cell when hovering over it. See the 'Razor' tab for how these 
             parameters have been applied.
         </p>

--- a/examples/Demo/Shared/Pages/DateTimes/DateTimesPage.razor
+++ b/examples/Demo/Shared/Pages/DateTimes/DateTimesPage.razor
@@ -8,8 +8,8 @@
     The <code>&lt;FluentCalendar&gt;</code> is an implementation of a month calendar display leveraging the Fluent UI design system.
     It allows for setting selected and/or disabled dates and can handle a click on a day event (if not <code>ReadOnly</code>)
 </p>
-<p>e
-The <code>&lt;FluentDatePicker&gt;</code> is an input field that shos a calendar dropdown to select a date.
+<p>
+    The <code>&lt;FluentDatePicker&gt;</code> is an input field that shows a calendar dropdown to select a date.
 </p>
 <p>
     The <code>&lt;FluentTimePicker&gt;</code> allows for picking a specific time of day by selecting hour, minutes and AM/PM

--- a/examples/Demo/Shared/Pages/Dialog/DialogPage.razor
+++ b/examples/Demo/Shared/Pages/Dialog/DialogPage.razor
@@ -104,7 +104,7 @@
 
 <DemoSection Title="Dialog without using DialogService" MaxHeight="500px" Component="@typeof(DialogDefault)" CollocatedFiles="@(new[] {"css"})">
     <Description>
-        This example shows a simple dialog created by specifying it's content manually (see the Razor tab). Because of this, the dialog is not automatically styled.
+        This example shows a simple dialog created by specifying its content manually (see the Razor tab). Because of this, the dialog is not automatically styled.
         A CSS file has been added to set the width, heigth and padding of the dialog.
     </Description>
 </DemoSection>

--- a/examples/Demo/Shared/Pages/Dialog/DialogPage.razor
+++ b/examples/Demo/Shared/Pages/Dialog/DialogPage.razor
@@ -37,7 +37,7 @@
 </p>
 <p>
     Alternatively, the dialog content can be specified manually by setting the <code>ChildContent</code> parameter of <code>&lt;FluentDialog&gt;</code>.
-    This is useful if you want to show a simple dialog without having to create a component for it or if you do not want to use the <code>DialogService</code>for it.
+    This is useful if you want to show a simple dialog without having to create a component for it or if you do not want to use the <code>DialogService</code> for it.
     <br/>
     When using the <code>DialogService</code>, for displaying a regular dialog, the dialog will always be shown centered on the screen.
 </p>
@@ -70,8 +70,8 @@
 
 <h2 id="example">Examples</h2>
 <p>
-    These examples shows how to use the <code>DialogService</code> to show a dialog. The content of the dialog is specified by
-    a component which implements <code>IDialogContentComponent&lt;T&gt;</code>. Here that is done in <code>SimpleDialog.razor</code>. The dialog is automatically styled and centered.
+    These examples show how to use the <code>DialogService</code> to display a dialog. The content of the dialog is specified by
+    a component which implements <code>IDialogContentComponent&lt;T&gt;</code>. Here, that is done in <code>SimpleDialog.razor</code>. The dialog is automatically styled and centered.
 </p>
 <p>
     Interaction with parent dialog can be made by injecting FluentDialog as Cascading Parameter. See <code>SimpleDialog.razor</code> for more details.
@@ -79,7 +79,7 @@
 
 <DemoSection Title="DialogService with IDialogReference" MaxHeight="500px" Component="@typeof(DialogServiceExample)" AdditionalFiles="@(new[] {"SimpleDialog.razor"})">
     <Description>
-        This example shows how to use async methods to show a dialog and get the result back from it. 
+        This example shows how to use async methods to display a dialog and get the result back from it. 
     </Description>
 </DemoSection>
 
@@ -105,13 +105,13 @@
 <DemoSection Title="Dialog without using DialogService" MaxHeight="500px" Component="@typeof(DialogDefault)" CollocatedFiles="@(new[] {"css"})">
     <Description>
         This example shows a simple dialog created by specifying its content manually (see the Razor tab). Because of this, the dialog is not automatically styled.
-        A CSS file has been added to set the width, heigth and padding of the dialog.
+        A CSS file has been added to set the width, height and padding of the dialog.
     </Description>
 </DemoSection>
 
 <DemoSection Title="SimpleDialog as component" MaxHeight="500px" Component="@typeof(DialogSimpleDialog)">
     <Description>
-        For a components to be useable in a dialog, it just needs to inherit from <code>IDialogContentComponent&lt;T&gt;</code>.
+        For a component to be useable in a dialog, it just needs to inherit from <code>IDialogContentComponent&lt;T&gt;</code>.
         They can still be used as a normal component as well. This example shows the <code>SimpleDialog</code> component from the
         previous example being rendered directly in the page.
     </Description>

--- a/examples/Demo/Shared/Pages/Emoji/EmojiExplorer.razor
+++ b/examples/Demo/Shared/Pages/Emoji/EmojiExplorer.razor
@@ -53,7 +53,7 @@
         if (EmojisCount <= 0)
         {
             <div style="width: 100%; line-height: var(--type-ramp-plus-4-line-height);">
-                <strong>No emoji's found</strong>
+                <strong>No emojis found</strong>
             </div>
         }
         else

--- a/examples/Demo/Shared/Pages/Emoji/EmojiPage.razor
+++ b/examples/Demo/Shared/Pages/Emoji/EmojiPage.razor
@@ -29,11 +29,11 @@
 
 <DemoSection Component="typeof(EmojiDifferentSizes)" Title="Different sizes">
     <Description>
-        You can specify a custom size by setting the Width to a value anywhere between 32 - 1024px, though we suggest scaling on sizes of 32 so 32, 64, etc to get the best result..
+        You can specify a custom size by setting the Width to a value anywhere between 32 - 1024px, though we suggest scaling on sizes of 32 so 32, 64, ... to get the best result.
     </Description>
 </DemoSection>
 
-<h2>Explore Emoji's</h2>
+<h2>Explore Emojis</h2>
 
 <EmojiExplorer />
 <br />

--- a/examples/Demo/Shared/Pages/FluentInputBasePage.razor
+++ b/examples/Demo/Shared/Pages/FluentInputBasePage.razor
@@ -86,12 +86,12 @@
         new paramDef("ReadOnly","bool","false","When true, the control will be immutable by user interaction. <a href=\"https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly\">readonly</a> HTML attribute for more information."),
         new paramDef("Id","string?","","The id attribute of the element.Used for label association."),
         new paramDef("Disabled","bool","false","Disables the form control, ensuring it doesn't participate in form submission."),
-        new paramDef("Name","string?","null","The name of t_he element.Allows access by name from_ the associated form."),
+        new paramDef("Name","string?","null","The name of the element. Allows access by name from_ the associated form."),
         new paramDef("Required","bool","false","Whether the element needs to have a value"),
         new paramDef("Value","TValue?","null","Gets or sets the value of the input. This should be used with two-way binding."),
-        new paramDef("DisplayName","string?","null","Gets or sets the display name for _this field."),
+        new paramDef("DisplayName","string?","null","Gets or sets the display name for this field."),
         new paramDef("ValueExpression","Expression<Func<TValue>>?","null","Gets or sets an expression that identifies the bound value."),
-        new paramDef("Placeholder","string","null","he short hint displayed in the input before the user enters a value.")
+        new paramDef("Placeholder","string","null","The short hint displayed in the input before the user enters a value.")
     };
 
     private List<eventDef> Callbacks = new List<eventDef>

--- a/examples/Demo/Shared/Pages/Footer/FooterPage.razor
+++ b/examples/Demo/Shared/Pages/Footer/FooterPage.razor
@@ -5,7 +5,7 @@
 <h1>Footer</h1>
 
 <p>
-    The <code>FluentFooter</code> component is used display a colored bar (with text and possibly other components) at the bottom of a site or application. It can be styled with regular CSS.
+    The <code>FluentFooter</code> component is used to display a colored bar (with text and possibly other components) at the bottom of a site or application. It can be styled with regular CSS.
 </p>
 
 <h2 id="example">Example</h2>

--- a/examples/Demo/Shared/Pages/Header/HeaderPage.razor
+++ b/examples/Demo/Shared/Pages/Header/HeaderPage.razor
@@ -5,7 +5,7 @@
 <h1>Header</h1>
 
 <p>
-    The <code>FluentHeader</code> component is used display a title (and possibly other components) in a colored bar at the top of a site or application. For the background color it uses the currently selected accent color.
+    The <code>FluentHeader</code> component is used to display a title (and possibly other components) in a colored bar at the top of a site or application. For the background color it uses the currently selected accent color.
 </p>
 
 <h2 id="example">Example</h2>

--- a/examples/Demo/Shared/Pages/Lab/MarkdownSectionPage.razor
+++ b/examples/Demo/Shared/Pages/Lab/MarkdownSectionPage.razor
@@ -3,7 +3,7 @@
 <h1>MarkdownSection</h1>
 
 <p>
-    The <code>MarkdownSection</code> component allows for rendering a blockof Markdown as HTML.
+    The <code>MarkdownSection</code> component allows for rendering a block of Markdown as HTML.
 </p>
 
 <h2 id="example">Examples</h2>

--- a/examples/Demo/Shared/Pages/Label/LabelPage.razor
+++ b/examples/Demo/Shared/Pages/Label/LabelPage.razor
@@ -9,7 +9,7 @@
     from the <code>Typography</code> enum and the necessary styling will be applied automatically 
 </p>
 <p>
-    The component exposes th following parameters:
+    The component exposes the following parameters:
 </p>
 
 <h2 id="example">Example</h2>

--- a/examples/Demo/Shared/Pages/NavMenu/NavMenuPage.razor
+++ b/examples/Demo/Shared/Pages/NavMenu/NavMenuPage.razor
@@ -52,7 +52,7 @@
 
 <DemoSection Component="typeof(NavMenuCollapsible)" Title="Collapsible navigation">
     <Description>
-        More complete example which show how menu works with together with a text section when it collapses. 
+        More complete example which shows how menu works together with a text section when it collapses. 
     </Description>
 </DemoSection>
 

--- a/examples/Demo/Shared/Pages/NavMenuTree/NavMenuTreePage.razor
+++ b/examples/Demo/Shared/Pages/NavMenuTree/NavMenuTreePage.razor
@@ -52,7 +52,7 @@
 
 <DemoSection Component="typeof(NavMenuTreeCollapsible)" Title="Collapsible navigation">
     <Description>
-        More complete example which show how menu works with together with a text section when it collapses. 
+        More complete example which shows how menu works together with a text section when it collapses. 
     </Description>
 </DemoSection>
 

--- a/examples/Demo/Shared/Pages/Panel/PanelPage.razor
+++ b/examples/Demo/Shared/Pages/Panel/PanelPage.razor
@@ -32,7 +32,7 @@
         The panel that is anchored to the right side of the screen can be dismissed by clicking the dismiss button (at the top), 
         'No' button (at the bottom) or by clicking outside of the panel.<br />
         The panel shown on the left side of the screen can only be closed by clicking the 'Cancel' button at the bottom of the panel. It does 
-        not show a dissmiss button and is shown in a modal fashion based on the settings provided through the <code>DialogParameters</code>.
+        not show a dismiss button and is shown in a modal fashion based on the settings provided through the <code>DialogParameters</code>.
     </Description>
 </DemoSection>
 
@@ -42,7 +42,7 @@
         The panel that is anchored to the right side of the screen can be dismissed by clicking the dismiss button (at the top),
         'No' button (at the bottom) or by clicking outside of the panel.<br />
         The panel shown on the left side of the screen can only be closed by clicking the 'Cancel'' button at the bottom of the panel. It does
-        not show a dissmiss button and is shown in a modal fashion based on the settings provided through the <code>DialogParameters</code>
+        not show a dismiss button and is shown in a modal fashion based on the settings provided through the <code>DialogParameters</code>
     </Description>
 </DemoSection>
 

--- a/examples/Demo/Shared/Pages/Search/SearchPage.razor
+++ b/examples/Demo/Shared/Pages/Search/SearchPage.razor
@@ -29,7 +29,7 @@
 
 <DemoSection Title="Filled style" Component="@typeof(SearchAppearanceFilled)"></DemoSection>
 
-<DemoSection Title="Miscelaneous" Component="@typeof(SearchMisc)"></DemoSection>
+<DemoSection Title="Miscellaneous" Component="@typeof(SearchMisc)"></DemoSection>
 
 <h2 id="documentation">Documentation</h2>
 

--- a/examples/Demo/Shared/Pages/SplashScreen/SplashScreenPage.razor
+++ b/examples/Demo/Shared/Pages/SplashScreen/SplashScreenPage.razor
@@ -24,8 +24,8 @@
 
 <DemoSection Title="Default splash screen" Component="@typeof(DialogSplashScreenDefault)" CollocatedFiles="@(new[] { "cs" })">
     <Description>
-        This example shows the standard splash screen. It's content can be alterd by means of the <code>SplashScreenContent</code> class.
-        In this example we simulate a startup process that takes 4 seconds. 
+        This example shows the standard splash screen. Its content can be altered by means of the <code>SplashScreenContent</code> class.
+        In this example, we simulate a startup process that takes 4 seconds. 
     </Description>
 </DemoSection>
 

--- a/examples/Demo/Shared/Pages/Splitter/SplitterPage.razor
+++ b/examples/Demo/Shared/Pages/Splitter/SplitterPage.razor
@@ -5,7 +5,7 @@
 <h1>Splitter</h1>
 
 <p>
-    The purpose of this component is to have two panels of arbitraty content in a horizontal or vertical layout. 
+    The purpose of this component is to have two panels of arbitrary content in a horizontal or vertical layout. 
     The user can drag the splitter to resize the panels.
 </p>
 

--- a/examples/Demo/Shared/Pages/Stack/StackPage.razor
+++ b/examples/Demo/Shared/Pages/Stack/StackPage.razor
@@ -43,10 +43,10 @@
 
 <DemoSection Component="typeof(StackExample)" Title="Using the FluentStack component">
     <Description>
-        This example shows two <code>FluentStack</code>s. The first <code>FluentStack</code> has it's <code>Orientation</code> parameter set
-        to <code>Orientation.Vertical</code>. It's height has been set to 200 pixels and the <code>VerticalGap</code> has been set to 20 pixels. The second, 
-        nested, <code>FluentStack</code> has it's <code>Orientation</code> parameter set to <code>Orientation.Horizontal</code>. The <code>HorizontalGap</code>
-        has been set to 4 pixels. It's first element contains a forced break. No height has been set, so the container height adjusts to the height 
+        This example shows two <code>FluentStack</code>s. The first <code>FluentStack</code> has its <code>Orientation</code> parameter set
+        to <code>Orientation.Vertical</code>. Its height has been set to 200 pixels and the <code>VerticalGap</code> has been set to 20 pixels. The second, 
+        nested, <code>FluentStack</code> has its <code>Orientation</code> parameter set to <code>Orientation.Horizontal</code>. The <code>HorizontalGap</code>
+        has been set to 4 pixels. Its first element contains a forced break. No height has been set, so the container height adjusts to the height 
         of the highest element.
         <br />
         The alignment of the contents of <strong>both</strong> <code>FluentStack</code>s can be changed by selecting one the different options from each

--- a/examples/Demo/Shared/Pages/Toast/ToastPage.razor
+++ b/examples/Demo/Shared/Pages/Toast/ToastPage.razor
@@ -8,7 +8,7 @@
 <h1>Toast</h1>
 
 <p>
-    Toasts, referred to as “notifications” in the UI, are pop-up notifications that keeps users informed by briefly:
+    Toasts, referred to as “notifications” in the UI, are pop-up notifications that keep users informed by briefly:
     <ul>
         <li>Confirming an action they took.</li>
         <li>Informing them about a timely event.</li>

--- a/examples/Demo/Shared/Pages/Toolbar/ToolbarPage.razor
+++ b/examples/Demo/Shared/Pages/Toolbar/ToolbarPage.razor
@@ -34,7 +34,7 @@
 
 <DemoSection Title="RTL mode" Component="@typeof(ToolbarRTL)"></DemoSection>
 
-<DemoSection Title="Start and Eend slots" Component="@typeof(ToolbarStartEndSlots)"></DemoSection>
+<DemoSection Title="Start and End slots" Component="@typeof(ToolbarStartEndSlots)"></DemoSection>
 
 <h2 id="documentation">Documentation</h2>
 

--- a/examples/Demo/Shared/wwwroot/docs/DesignTokens.md
+++ b/examples/Demo/Shared/wwwroot/docs/DesignTokens.md
@@ -2,7 +2,7 @@
  
 The Fluent UI Blazor Components are built on FAST's Adaptive UI technology, which enables design customization and personalization, while automatically 
 maintaining accessibility. This is accomplished through setting various "Design Tokens". In earlier versions of this library, the only way to manipulate the 
-design tokens was through using the `<FluentDesignSystemProvider>` component. This Blazor component (and it's underlying Web Component) exposed a little 
+design tokens was through using the `<FluentDesignSystemProvider>` component. This Blazor component (and its underlying Web Component) exposed a little 
 over 60 variables that could be used to change things like typography, color, sizes, UI spacing, etc. FAST has been extended a while ago and now has a much 
 more granular way of working with individual design tokens instead of just through a design system provider model. 
 

--- a/examples/Demo/Shared/wwwroot/docs/UpgradeGuide.md
+++ b/examples/Demo/Shared/wwwroot/docs/UpgradeGuide.md
@@ -33,7 +33,7 @@ Another breaking change is found in the `Align` enumeration. Where we previously
  
 `FluentBadge` now uses a `Color` \ `BackgroundColor` combination to determine the fill values.
  
-`FluentCalendar` no longer wraps the `fluent-calendar` web component. It's functionality was too limited. Not all parameters are supported in the updated version.
+`FluentCalendar` no longer wraps the `fluent-calendar` web component. Its functionality was too limited. Not all parameters are supported in the updated version.
  
 `StackHorizontalAlignment`/`StackVerticalAlignment` have been renamed to just `HorizontalAlignment`/`VerticalAlignment` as there are now more components using these enumarations.
 

--- a/examples/Demo/Shared/wwwroot/docs/WhatsNew-Archive.md
+++ b/examples/Demo/Shared/wwwroot/docs/WhatsNew-Archive.md
@@ -630,8 +630,8 @@ For version 2.2 we started working on adding .NET 8 support. One important new f
 QuickGrid is a high performance grid component for displaying data in tabular form. It is built to be a simple and convenient way to display your data, while 
 still providing powerful features like sorting, filtering, paging, and virtualization. 
 
-QuickGrid was originally introduced as an experimental package based on .NET 7 and we copied it's code over to the Fluent UI library to re-use it's 
-features (and some more) but render it with the Fluent UI Web Components instead of it's orignal rendering based on HTML table, tr and td elements. As part 
+QuickGrid was originally introduced as an experimental package based on .NET 7 and we copied its code over to the Fluent UI library to re-use its 
+features (and some more) but render it with the Fluent UI Web Components instead of its orignal rendering based on HTML table, tr and td elements. As part 
 of bringing QuickGrid into .NET 8 the ASP.NET Core team made some changes and improvements to the API. We brought these changes over to the `<FluentDataGrid>` as well. To update an app that uses `<FluentDataGrid>`, 
 you may need to make the following adjustments:
 

--- a/src/Core/Components/Button/FluentButton.razor.cs
+++ b/src/Core/Components/Button/FluentButton.razor.cs
@@ -76,7 +76,7 @@ public partial class FluentButton : FluentComponentBase
     public bool Disabled { get; set; }
 
     /// <summary>
-    /// The name of the element.Allows access by name from the associated form.
+    /// The name of the element. Allows access by name from the associated form.
     /// </summary>
     [Parameter]
     public string? Name { get; set; }

--- a/src/Core/Components/DateTime/FluentDatePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor.cs
@@ -52,7 +52,7 @@ public partial class FluentDatePicker : FluentCalendarBase
     public bool Disabled { get; set; }
 
     /// <summary>
-    /// The name of the element.Allows access by name from the associated form.
+    /// The name of the element. Allows access by name from the associated form.
     /// </summary>
     [Parameter]
     public string? Name { get; set; }

--- a/src/Core/Components/Dialog/Parameters/DialogParameters.cs
+++ b/src/Core/Components/Dialog/Parameters/DialogParameters.cs
@@ -91,7 +91,7 @@ public class DialogParameters : ComponentParameters, IDialogParameters
     public string? Height { get; set; }
 
     /// <summary>
-    /// Gets or sets the extra styles appied to the Body content.
+    /// Gets or sets the extra styles applied to the Body content.
     /// </summary>
     public string DialogBodyStyle { get; set; } = string.Empty;
 

--- a/src/Core/Components/MainLayout/FluentMainLayout.razor.cs
+++ b/src/Core/Components/MainLayout/FluentMainLayout.razor.cs
@@ -33,7 +33,7 @@ public partial class FluentMainLayout : FluentComponentBase
     public int? HeaderHeight { get; set; } = 50;
 
     /// <summary>
-    /// Gets or set the tite of the navigation menu
+    /// Gets or sets the tite of the navigation menu
     /// </summary>
     [Parameter]
     public string? NavMenuTitle { get; set; }

--- a/src/Core/Components/Overlay/FluentOverlay.razor
+++ b/src/Core/Components/Overlay/FluentOverlay.razor
@@ -7,7 +7,7 @@
          @onclick="@OnCloseHandlerAsync" 
          @oncontextmenu="@OnCloseHandlerAsync" 
          @oncontextmenu:preventDefault>
-        <div style="@( $"display: flex; align-items:{Alignment.ToAttributeValue()}; justify-content: {Justification.ToAttributeValue()}; width: 100%; heigth: 100%")">
+        <div style="@( $"display: flex; align-items:{Alignment.ToAttributeValue()}; justify-content: {Justification.ToAttributeValue()}; width: 100%; height: 100%")">
             @ChildContent
         </div>
     </div>

--- a/src/Core/Components/Stack/FluentStack.razor.cs
+++ b/src/Core/Components/Stack/FluentStack.razor.cs
@@ -38,7 +38,7 @@ public partial class FluentStack : FluentComponentBase
     public VerticalAlignment VerticalAlignment { get; set; } = VerticalAlignment.Top;
 
     /// <summary>
-    /// Gets or set the orientation of the stacked components. 
+    /// Gets or sets the orientation of the stacked components. 
     /// </summary>
     [Parameter]
     public Orientation Orientation { get; set; } = Orientation.Horizontal;

--- a/tests/Core/List/FluentAutocompleteTests.FluentAutocomplete_Keyboard-ArrowDown.verified.html
+++ b/tests/Core/List/FluentAutocompleteTests.FluentAutocomplete_Keyboard-ArrowDown.verified.html
@@ -25,7 +25,7 @@
     </svg>
   </fluent-text-field>
   <div class="fluent-overlay" style="cursor: auto; position: fixed; z-index: 9900;" blazor:onclick="10" blazor:oncontextmenu="11" blazor:oncontextmenu:preventdefault="" b-rbsnh2nzwy="">
-    <div style="display: flex; align-items:center; justify-content: center; width: 100%; heigth: 100%" b-rbsnh2nzwy=""></div>
+    <div style="display: flex; align-items:center; justify-content: center; width: 100%; height: 100%" b-rbsnh2nzwy=""></div>
   </div>
   <fluent-anchored-region id="xxx" anchor="xxx" horizontal-positioning-mode="dynamic" horizontal-default-position="right" horizontal-inset="" horizontal-threshold="0" horizontal-scaling="content" vertical-positioning-mode="dynamic" vertical-default-position="unset" vertical-threshold="0" vertical-scaling="content" auto-update-mode="auto" style="z-index: 9999;" b-z9rtvm3m6a="" blazor:elementreference="">
     <div style="z-index: 9999; background-color: var(--neutral-layer-floating); box-shadow: var(--elevation-shadow-flyout); margin-top: 10px; border-radius: calc(var(--control-corner-radius) * 2px); background-color: var(--neutral-layer-floating);" b-z9rtvm3m6a="">

--- a/tests/Core/List/FluentAutocompleteTests.FluentAutocomplete_Keyboard-ArrowUp.verified.html
+++ b/tests/Core/List/FluentAutocompleteTests.FluentAutocomplete_Keyboard-ArrowUp.verified.html
@@ -23,7 +23,7 @@
     </svg>
   </fluent-text-field>
   <div class="fluent-overlay" style="cursor: auto; position: fixed; z-index: 9900;" blazor:onclick="10" blazor:oncontextmenu="11" blazor:oncontextmenu:preventdefault="" b-rbsnh2nzwy="">
-    <div style="display: flex; align-items:center; justify-content: center; width: 100%; heigth: 100%" b-rbsnh2nzwy=""></div>
+    <div style="display: flex; align-items:center; justify-content: center; width: 100%; height: 100%" b-rbsnh2nzwy=""></div>
   </div>
   <fluent-anchored-region id="xxx" anchor="xxx" horizontal-positioning-mode="dynamic" horizontal-default-position="right" horizontal-inset="" horizontal-threshold="0" horizontal-scaling="content" vertical-positioning-mode="dynamic" vertical-default-position="unset" vertical-threshold="0" vertical-scaling="content" auto-update-mode="auto" style="z-index: 9999;" b-z9rtvm3m6a="" blazor:elementreference="xxx">
     <div style="z-index: 9999; background-color: var(--neutral-layer-floating); box-shadow: var(--elevation-shadow-flyout); margin-top: 10px; border-radius: calc(var(--control-corner-radius) * 2px); background-color: var(--neutral-layer-floating);" b-z9rtvm3m6a="">

--- a/tests/Core/List/FluentAutocompleteTests.FluentAutocomplete_Keyboard-Backspace.verified.html
+++ b/tests/Core/List/FluentAutocompleteTests.FluentAutocomplete_Keyboard-Backspace.verified.html
@@ -23,7 +23,7 @@
     </svg>
   </fluent-text-field>
   <div class="fluent-overlay" style="cursor: auto; position: fixed; z-index: 9900;" blazor:onclick="10" blazor:oncontextmenu="11" blazor:oncontextmenu:preventdefault="" b-rbsnh2nzwy="">
-    <div style="display: flex; align-items:center; justify-content: center; width: 100%; heigth: 100%" b-rbsnh2nzwy=""></div>
+    <div style="display: flex; align-items:center; justify-content: center; width: 100%; height: 100%" b-rbsnh2nzwy=""></div>
   </div>
   <fluent-anchored-region id="xxx" anchor="xxx" horizontal-positioning-mode="dynamic" horizontal-default-position="right" horizontal-inset="" horizontal-threshold="0" horizontal-scaling="content" vertical-positioning-mode="dynamic" vertical-default-position="unset" vertical-threshold="0" vertical-scaling="content" auto-update-mode="auto" style="z-index: 9999;" b-z9rtvm3m6a="" blazor:elementreference="">
     <div style="z-index: 9999; background-color: var(--neutral-layer-floating); box-shadow: var(--elevation-shadow-flyout); margin-top: 10px; border-radius: calc(var(--control-corner-radius) * 2px); background-color: var(--neutral-layer-floating);" b-z9rtvm3m6a="">

--- a/tests/Core/List/FluentAutocompleteTests.FluentAutocomplete_Opened.verified.html
+++ b/tests/Core/List/FluentAutocompleteTests.FluentAutocomplete_Opened.verified.html
@@ -7,7 +7,7 @@
     </svg>
   </fluent-text-field>
   <div class="fluent-overlay" style="cursor: auto; position: fixed; z-index: 9900;" blazor:onclick="6" blazor:oncontextmenu="7" blazor:oncontextmenu:preventdefault="" b-rbsnh2nzwy="">
-    <div style="display: flex; align-items:center; justify-content: center; width: 100%; heigth: 100%" b-rbsnh2nzwy=""></div>
+    <div style="display: flex; align-items:center; justify-content: center; width: 100%; height: 100%" b-rbsnh2nzwy=""></div>
   </div>
   <fluent-anchored-region id="xxx" anchor="xxx" horizontal-positioning-mode="dynamic" horizontal-default-position="right" horizontal-inset="" horizontal-threshold="0" horizontal-scaling="content" vertical-positioning-mode="dynamic" vertical-default-position="unset" vertical-threshold="0" vertical-scaling="content" auto-update-mode="auto" style="z-index: 9999;" b-z9rtvm3m6a="" blazor:elementreference="xxx">
     <div style="z-index: 9999; background-color: var(--neutral-layer-floating); box-shadow: var(--elevation-shadow-flyout); margin-top: 10px; border-radius: calc(var(--control-corner-radius) * 2px); background-color: var(--neutral-layer-floating);" b-z9rtvm3m6a="">

--- a/tests/Core/List/FluentAutocompleteTests.FluentAutocomplete_SelectedOptions.verified.html
+++ b/tests/Core/List/FluentAutocompleteTests.FluentAutocomplete_SelectedOptions.verified.html
@@ -23,7 +23,7 @@
     </svg>
   </fluent-text-field>
   <div class="fluent-overlay" style="cursor: auto; position: fixed; z-index: 9900;" blazor:onclick="10" blazor:oncontextmenu="11" blazor:oncontextmenu:preventdefault="" b-rbsnh2nzwy="">
-    <div style="display: flex; align-items:center; justify-content: center; width: 100%; heigth: 100%" b-rbsnh2nzwy=""></div>
+    <div style="display: flex; align-items:center; justify-content: center; width: 100%; height: 100%" b-rbsnh2nzwy=""></div>
   </div>
   <fluent-anchored-region id="xxx" anchor="xxx" horizontal-positioning-mode="dynamic" horizontal-default-position="right" horizontal-inset="" horizontal-threshold="0" horizontal-scaling="content" vertical-positioning-mode="dynamic" vertical-default-position="unset" vertical-threshold="0" vertical-scaling="content" auto-update-mode="auto" style="z-index: 9999;" b-z9rtvm3m6a="" blazor:elementreference="xxx">
     <div style="z-index: 9999; background-color: var(--neutral-layer-floating); box-shadow: var(--elevation-shadow-flyout); margin-top: 10px; border-radius: calc(var(--control-corner-radius) * 2px); background-color: var(--neutral-layer-floating);" b-z9rtvm3m6a="">

--- a/tests/Core/List/FluentAutocompleteTests.FluentAutocomplete_SelectedOptions_OnDismissClick.verified.html
+++ b/tests/Core/List/FluentAutocompleteTests.FluentAutocomplete_SelectedOptions_OnDismissClick.verified.html
@@ -23,7 +23,7 @@
     </svg>
   </fluent-text-field>
   <div class="fluent-overlay" style="cursor: auto; position: fixed; z-index: 9900;" blazor:onclick="10" blazor:oncontextmenu="11" blazor:oncontextmenu:preventdefault="" b-rbsnh2nzwy="">
-    <div style="display: flex; align-items:center; justify-content: center; width: 100%; heigth: 100%" b-rbsnh2nzwy=""></div>
+    <div style="display: flex; align-items:center; justify-content: center; width: 100%; height: 100%" b-rbsnh2nzwy=""></div>
   </div>
   <fluent-anchored-region id="xxx" anchor="xxx" horizontal-positioning-mode="dynamic" horizontal-default-position="right" horizontal-inset="" horizontal-threshold="0" horizontal-scaling="content" vertical-positioning-mode="dynamic" vertical-default-position="unset" vertical-threshold="0" vertical-scaling="content" auto-update-mode="auto" style="z-index: 9999;" b-z9rtvm3m6a="" blazor:elementreference="xxx">
     <div style="z-index: 9999; background-color: var(--neutral-layer-floating); box-shadow: var(--elevation-shadow-flyout); margin-top: 10px; border-radius: calc(var(--control-corner-radius) * 2px); background-color: var(--neutral-layer-floating);" b-z9rtvm3m6a="">

--- a/tests/Core/List/FluentAutocompleteTests.FluentAutocomplete_SelectedOptions_Template.verified.html
+++ b/tests/Core/List/FluentAutocompleteTests.FluentAutocomplete_SelectedOptions_Template.verified.html
@@ -23,7 +23,7 @@
     </svg>
   </fluent-text-field>
   <div class="fluent-overlay" style="cursor: auto; position: fixed; z-index: 9900;" blazor:onclick="10" blazor:oncontextmenu="11" blazor:oncontextmenu:preventdefault="" b-rbsnh2nzwy="">
-    <div style="display: flex; align-items:center; justify-content: center; width: 100%; heigth: 100%" b-rbsnh2nzwy=""></div>
+    <div style="display: flex; align-items:center; justify-content: center; width: 100%; height: 100%" b-rbsnh2nzwy=""></div>
   </div>
   <fluent-anchored-region id="xxx" anchor="xxx" horizontal-positioning-mode="dynamic" horizontal-default-position="right" horizontal-inset="" horizontal-threshold="0" horizontal-scaling="content" vertical-positioning-mode="dynamic" vertical-default-position="unset" vertical-threshold="0" vertical-scaling="content" auto-update-mode="auto" style="z-index: 9999;" b-z9rtvm3m6a="" blazor:elementreference="xxx">
     <div style="z-index: 9999; background-color: var(--neutral-layer-floating); box-shadow: var(--elevation-shadow-flyout); margin-top: 10px; border-radius: calc(var(--control-corner-radius) * 2px); background-color: var(--neutral-layer-floating);" b-z9rtvm3m6a="">

--- a/tests/Core/List/FluentAutocompleteTests.FluentAutocomplete_Templates.verified.html
+++ b/tests/Core/List/FluentAutocompleteTests.FluentAutocomplete_Templates.verified.html
@@ -7,7 +7,7 @@
     </svg>
   </fluent-text-field>
   <div class="fluent-overlay" style="cursor: auto; position: fixed; z-index: 9900;" blazor:onclick="6" blazor:oncontextmenu="7" blazor:oncontextmenu:preventdefault="" b-rbsnh2nzwy="">
-    <div style="display: flex; align-items:center; justify-content: center; width: 100%; heigth: 100%" b-rbsnh2nzwy=""></div>
+    <div style="display: flex; align-items:center; justify-content: center; width: 100%; height: 100%" b-rbsnh2nzwy=""></div>
   </div>
   <fluent-anchored-region id="xxx" anchor="xxx" horizontal-positioning-mode="dynamic" horizontal-default-position="right" horizontal-inset="" horizontal-threshold="0" horizontal-scaling="content" vertical-positioning-mode="dynamic" vertical-default-position="unset" vertical-threshold="0" vertical-scaling="content" auto-update-mode="auto" style="z-index: 9999;" b-z9rtvm3m6a="" blazor:elementreference="xxx">
     <div style="z-index: 9999; background-color: var(--neutral-layer-floating); box-shadow: var(--elevation-shadow-flyout); margin-top: 10px; border-radius: calc(var(--control-corner-radius) * 2px); background-color: var(--neutral-layer-floating);" b-z9rtvm3m6a="">


### PR DESCRIPTION
Typo `Start and Eend slots` on https://www.fluentui-blazor.net/Toolbar#startandeendslots

Before:

![image](https://github.com/microsoft/fluentui-blazor/assets/703248/90463d1f-1366-4281-80c5-0dc2a16c607d)

After:

![image](https://github.com/microsoft/fluentui-blazor/assets/703248/f9d580ea-5aa4-4597-89ef-d0ff5aebb86e)
