### PR TITLE
feat: add collapsed state to splitter component

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -5587,6 +5587,12 @@
             See <see href="https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-columns">mdn web docs</see> for more information 
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentSplitter.Collapsed">
+            <summary>
+            Gets or sets a value indicating whether the splitter is collapsed.
+            If set to true, Panel1 will take up all the space and Panel2 as well as the splitter bar will be hidden.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentStack.HorizontalAlignment">
             <summary>
             The horizontal alignment of the components in the stack. 

--- a/examples/Demo/Shared/Pages/Splitter/Examples/SplitterCollapse.razor
+++ b/examples/Demo/Shared/Pages/Splitter/Examples/SplitterCollapse.razor
@@ -1,0 +1,41 @@
+﻿<FluentSwitch CheckedMessage="Collapsed" UncheckedMessage="Split" @bind-Value="_collapse" />
+<br />
+<br />
+
+<FluentSplitter Collapsed="_collapse" @oncollapsedchanged="OnCollapsedChanged">
+    <Panel1>
+        <div class="demopanel">
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+                Eget dolor morbi non arcu risus quis varius. Turpis tincidunt id aliquet risus feugiat in ante. Eros donec ac odio tempor orci 
+                dapibus ultrices in iaculis. Sit amet justo donec enim diam vulputate ut. Morbi blandit cursus risus at ultrices mi tempus. Sed 
+                ullamcorper morbi tincidunt ornare massa eget egestas. Mi eget mauris pharetra et ultrices neque. Sit amet porttitor eget dolor 
+                morbi non arcu risus quis. Tempus egestas sed sed risus pretium quam vulputate dignissim. Diam vel quam elementum pulvinar. Enim 
+                nulla aliquet porttitor lacus luctus accumsan. Convallis tellus id interdum velit laoreet id donec ultrices. Dui faucibus in ornare 
+                quam viverra orci sagittis.
+            </p>
+        </div>
+    </Panel1>
+    <Panel2>
+        <div class="demopanel">
+            <p>
+                Neque laoreet suspendisse interdum consectetur libero id faucibus nisl tincidunt. Suspendisse faucibus interdum posuere lorem ipsum 
+                dolor sit amet. Imperdiet sed euismod nisi porta lorem mollis aliquam. Malesuada proin libero nunc consequat interdum. Amet nisl purus
+                in mollis nunc sed id semper risus. Nunc sed augue lacus viverra vitae congue eu. Fermentum dui faucibus in ornare quam viverra. Ut eu 
+                sem integer vitae. Interdum velit laoreet id donec ultrices tincidunt arcu non. Pellentesque dignissim enim sit amet. Scelerisque purus
+                semper eget duis at.
+            </p>
+        </div>
+    </Panel2>
+</FluentSplitter>
+
+
+@code
+{
+    private bool _collapse = false;
+
+    private void OnCollapsedChanged(CollapsedChangedEventArgs eventArgs)
+    {
+        DemoLogger.WriteLine($"Collapsed Changed: {eventArgs.NewValue}");
+    }
+}

--- a/examples/Demo/Shared/Pages/Splitter/SplitterPage.razor
+++ b/examples/Demo/Shared/Pages/Splitter/SplitterPage.razor
@@ -31,6 +31,16 @@
 
 <DemoSection Component="typeof(SplitterCustomSizes)" Title="Custom sizes for panels" />
 
+<DemoSection Component="typeof(SplitterCollapse)" Title="Collapse Splitter">
+    <Description>
+        <p>
+            The <code>FluentSplitter</code> component has a <code>Collapsed</code> parameter that can be set to hide the splitter bar
+            and the contents of Panel2. This can be useful for things like a Summary/Detail view where you don't always want the splitter
+            to be visible.
+        </p>
+    </Description>
+</DemoSection>
+
 <h2 id="documentation">Documentation</h2>
 
 <ApiDocumentation Component="typeof(FluentSplitter)" />

--- a/src/Core/Components/Splitter/FluentSplitter.razor
+++ b/src/Core/Components/Splitter/FluentSplitter.razor
@@ -19,12 +19,14 @@
     
 }
 
-<split-panels @attributes="AdditionalAttributes" id="@Id" class="@ClassValue" style="@StyleValue" direction="@_direction">
+<split-panels @attributes="AdditionalAttributes" id="@Id" class="@ClassValue" style="@StyleValue" direction="@_direction" collapsed="@Collapsed">
     <div slot="1">
         @Panel1
     </div>
-
-    <div slot="2">
-        @Panel2
-    </div>
+    @if (!Collapsed)
+    {
+        <div slot="2">
+            @Panel2
+        </div>
+    }
 </split-panels>

--- a/src/Core/Components/Splitter/FluentSplitter.razor.cs
+++ b/src/Core/Components/Splitter/FluentSplitter.razor.cs
@@ -51,6 +51,13 @@ public partial class FluentSplitter : FluentComponentBase
     [Parameter]
     public string? Panel2Size { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether the splitter is collapsed.
+    /// If set to true, Panel1 will take up all the space and Panel2 as well as the splitter bar will be hidden.
+    /// </summary>
+    [Parameter]
+    public bool Collapsed { get; set; }
+
     public FluentSplitter()
     {
         Id = Identifier.NewId();   

--- a/src/Core/Events/CollapsedChangedEventArgs.cs
+++ b/src/Core/Events/CollapsedChangedEventArgs.cs
@@ -1,0 +1,6 @@
+﻿namespace Microsoft.FluentUI.AspNetCore.Components;
+
+public class CollapsedChangedEventArgs : EventArgs
+{
+    public bool NewValue { get; set; }
+}

--- a/src/Core/Events/EventHandlers.cs
+++ b/src/Core/Events/EventHandlers.cs
@@ -19,6 +19,7 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 [EventHandler("onclosecolumnoptions", typeof(EventArgs), enableStopPropagation: true, enablePreventDefault: true)]
 [EventHandler("ontooltipdismiss", typeof(EventArgs), enableStopPropagation: true, enablePreventDefault: true)]
 [EventHandler("onsizechanged", typeof(EventArgs), enableStopPropagation: true, enablePreventDefault: true)]
+[EventHandler("oncollapsedchanged", typeof(CollapsedChangedEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
 public static class EventHandlers
 {
 }

--- a/src/Core/wwwroot/Microsoft.FluentUI.AspNetCore.Components.lib.module.js
+++ b/src/Core/wwwroot/Microsoft.FluentUI.AspNetCore.Components.lib.module.js
@@ -193,6 +193,13 @@ export function afterStarted(blazor) {
             return event;
         }
     });
+    blazor.registerCustomEventType('collapsedchanged', {
+        createEventArgs: event => {
+            return {
+                newValue: event.detail.newValue
+            }
+        }
+    });
 
     afterStartedCalled = true;
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

We have a use case for the FluentSplitter (effectively a Summary/Details view) where it'd be nice if the splitter bar and Panel2 could be hidden under certain conditions. Right now the best you can do is push the splitter bar all the way over to the side or bottom. 

This PR adds a Collapsed parameter (and a collapsed attribute on the underlying custom element) that can be used for this purpose. Setting `Collapsed="true"` on the blazor component (or simply adding the boolean `collapsed` attribute on the custom element) will trigger this mode, hiding the splitter bar and Panel2.

I also tweaked some of the setup of the splitter custom element, by pulling the styling out into a shared constructed stylesheet and adding it to the shadow root's adoptedStyleSheets property. It won't make a noticeable difference in most cases, but on pages like the splitter example page in the demo site, it means there's just one instance of all those styles in the page not one for each splitter.

### 🎫 Issues

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

There were no existing tests for the splitter component and this PR adds none. I did add a new DemoSection to the splitter page in the demo site that uses a FluentSwitch to toggle the Collapsed parameter and logs the oncollapsedchanged event to the demo logger.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [X] I have tested my changes.
- [X] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new compontent
- [X] I have modified an existing component
- [ ] I have validate [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component 

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->