### PR TITLE
Fix the WASM Trimming issue

### DIFF
--- a/examples/Demo/Client/FluentUI.Demo.Client.csproj
+++ b/examples/Demo/Client/FluentUI.Demo.Client.csproj
@@ -12,6 +12,13 @@
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" PrivateAssets="all" />
 	</ItemGroup>
 
+	<!-- For WASM, Trim Icons and Emojis Libs, -->
+	<!-- but not Core and Shared libs -->
+	<ItemGroup>
+		<TrimmerRootAssembly Include="Microsoft.FluentUI.AspNetCore.Components" />
+		<TrimmerRootAssembly Include="FluentUI.Demo.Shared" />
+	</ItemGroup>
+	
 	<ItemGroup>
 		<ProjectReference Include="..\Shared\FluentUI.Demo.Shared.csproj" />
 	</ItemGroup>

--- a/examples/Demo/Shared/Pages/Drag/DragDropPage.razor
+++ b/examples/Demo/Shared/Pages/Drag/DragDropPage.razor
@@ -21,13 +21,3 @@
 <ApiDocumentation Component="typeof(FluentDragContainer<>)" InstanceTypes="@(new[] {typeof(object)})" GenericLabel="TItem" />
 <ApiDocumentation Component="typeof(FluentDropZone<>)" InstanceTypes="@(new[] {typeof(object)})" GenericLabel="TItem" />
 <ApiDocumentation Component="typeof(FluentDragEventArgs<>)" InstanceTypes="@(new[] {typeof(object)})" GenericLabel="TItem" />
-
-@code
-{
-    // Hack to force the compiler to include this class in the final library
-    // (WASM publishing)
-    // TODO: To find a better solution
-    FluentDragContainer<object> temp1 = new FluentDragContainer<object>();
-    FluentDropZone<object> temp2 = new FluentDropZone<object>();
-    FluentDragEventArgs<object> temp3 = new FluentDragEventArgs<object>();
-}

--- a/examples/Demo/Shared/Pages/Emoji/EmojiPage.razor
+++ b/examples/Demo/Shared/Pages/Emoji/EmojiPage.razor
@@ -42,11 +42,3 @@
 <h2 id="documentation">Documentation</h2>
 
 <ApiDocumentation Component="typeof(FluentEmoji<>)" InstanceTypes="@(new[] {typeof(Emoji)})" GenericLabel="Emoji"></ApiDocumentation>
-
-@code
-{
-    // Hack to force the compiler to include this class in the final library
-    // (WASM publishing)
-    // TODO: To find a better solution
-    FluentEmoji<Emoji> temp = new FluentEmoji<Emoji>();
-}

--- a/examples/Demo/Shared/Pages/MessageBar/Examples/MessageBarTimed.razor
+++ b/examples/Demo/Shared/Pages/MessageBar/Examples/MessageBarTimed.razor
@@ -36,7 +36,7 @@
             options.Title = message;
             options.Intent = type;
             options.Section = App.MESSAGES_TOP;
-            options.Timeout = 4;
+            options.Timeout = 4000;
         });
     }
 

--- a/examples/Demo/Shared/Pages/MessageBar/MessageBarPage.razor
+++ b/examples/Demo/Shared/Pages/MessageBar/MessageBarPage.razor
@@ -90,14 +90,3 @@
 <ApiDocumentation Component="typeof(MessageService)" />
 
 <ApiDocumentation Component="typeof(Message)" />
-
-@code
-{
-    // Hack to force the compiler to include this class in the final library
-    // (WASM publishing)
-    // TODO: To find a better solution
-    FluentMessageBarProvider temp1 = new FluentMessageBarProvider();
-    FluentMessageBar temp2 = new FluentMessageBar();
-    MessageService temp3 = new MessageService();
-    Message temp4 = new Message();
-}

--- a/examples/Demo/Shared/Pages/MessageBox/MessageBoxPage.razor
+++ b/examples/Demo/Shared/Pages/MessageBox/MessageBoxPage.razor
@@ -48,22 +48,3 @@
 <ApiDocumentation Component="typeof(MessageBoxContent)" />
 
 <ApiDocumentation Component="typeof(DialogParameters<>)" InstanceTypes="@(new[] {typeof(MessageBoxContent)})" GenericLabel="MessageBoxData" />
-
-@code
-{
-    // Hack to force the compiler to include this class in the final library
-    // (WASM publishing)
-    // TODO: To find a better solution
-    protected override void OnInitialized()
-    {
-        var temp1 = new DialogParameters<MessageBoxContent>();
-        var temp2 = new MessageBoxContent()
-            {
-                Icon = new Icons.Regular.Size24.Check(),
-                IconColor = Color.Accent,
-            };
-        var temp3 = temp2.IconColor;
-        var temp4 = temp2.Intent;
-        var temp5 = temp2.MarkupMessage;
-    }    
-}

--- a/examples/Demo/Shared/Pages/SplashScreen/SplashScreenPage.razor
+++ b/examples/Demo/Shared/Pages/SplashScreen/SplashScreenPage.razor
@@ -41,12 +41,3 @@
 <ApiDocumentation Component="typeof(SplashScreenContent)" />
 
 <ApiDocumentation Component="typeof(FluentSplashScreen)" />
-
-@code
-{
-    // Hack to force the compiler to include this class in the final library
-    // (WASM publishing)
-    // TODO: To find a better solution
-    SplashScreenContent temp1 = new SplashScreenContent();
-    FluentSplashScreen temp2 = new FluentSplashScreen() { Dialog = new FluentDialog() };
-}

--- a/examples/Demo/Shared/Pages/Splitter/SplitterPage.razor
+++ b/examples/Demo/Shared/Pages/Splitter/SplitterPage.razor
@@ -45,12 +45,3 @@
 
 <ApiDocumentation Component="typeof(FluentSplitter)" />
 <ApiDocumentation Component="typeof(SplitterResizedEventArgs)" />
-
-@code
-{
-    // Hack to force the compiler to include this class in the final library
-    // (WASM publishing)
-    // TODO: To find a better solution
-    FluentSplitter temp1 = new FluentSplitter();
-    SplitterResizedEventArgs temp2 = new SplitterResizedEventArgs();
-}


### PR DESCRIPTION
Since we configured the Blazor Trimming option, some demo pages were no longer working properly.
These problems are due to Reflector calls that need to be informed in the Trimming parameters.

This is done with this code, added to the csproj

```xml
<ItemGroup>
	<TrimmerRootAssembly Include="Microsoft.FluentUI.AspNetCore.Components" />
	<TrimmerRootAssembly Include="FluentUI.Demo.Shared" />
</ItemGroup>
```

The part of code to "hack the compiler to include these classes in the final library" are removed.