### PR TITLE
[FluentNumberField] Fix the readonly attribute #v3

### DIFF
--- a/src/Core/Components/NumberField/FluentNumberField.razor
+++ b/src/Core/Components/NumberField/FluentNumberField.razor
@@ -3,6 +3,11 @@
 @typeparam TValue where TValue : new()
 @using System.Globalization;
 @using System.Reflection;
+
+@{
+    var value = BindConverter.FormatValue(CurrentValue, CultureInfo.InvariantCulture);
+}
+
 <FluentInputLabel ForId="@Id" Label="@Label" AriaLabel="@AriaLabel" ChildContent="@LabelTemplate" />
 <fluent-number-field @ref=Element
                      class="@ClassValue"
@@ -16,11 +21,11 @@
                      minlength="@MinLength"
                      size="@Size"
                      step=@Step
-                     max="@Max"
-                     min="@Min"
+                     max="@(ReadOnly ? value : Max)"
+                     min="@(ReadOnly ? value : Min)"
                      id=@Id
-                     value=@BindConverter.FormatValue(CurrentValue, CultureInfo.InvariantCulture)
-                     current-value="@BindConverter.FormatValue(CurrentValue, CultureInfo.InvariantCulture)"
+                     value="@value"
+                     current-value="@value"
                      disabled="@Disabled"
                      name=@Name
                      required="@Required"

--- a/src/Core/Components/NumberField/FluentNumberField.razor.cs
+++ b/src/Core/Components/NumberField/FluentNumberField.razor.cs
@@ -72,7 +72,6 @@ public partial class FluentNumberField<TValue> : FluentInputBase<TValue>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
 
-
     private static readonly string _stepAttributeValue = GetStepAttributeValue();
 
     private static string GetStepAttributeValue()

--- a/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_ReadOnlyParameter.verified.html
+++ b/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_ReadOnlyParameter.verified.html
@@ -1,2 +1,2 @@
 
-<fluent-number-field appearance="outline" readonly="" maxlength="14" minlength="1" size="20" step="1"  value="100" current-value="100" blazor:onchange="1" blazor:elementreference="0aefd8c7-3fe1-4fac-98c8-ae7c2894f68d">100</fluent-number-field>
+<fluent-number-field readonly="" maxlength="14" minlength="1" size="20" step="1" max="100" min="100" id="xxx" value="100" current-value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>


### PR DESCRIPTION
# [FluentNumberField] Fix the readonly attribute

When the `readonly` attribute is used, the component can still be modified using the keyboard arrows.
This problem is due to a bug in the associated WebComponent.

It has been worked around by forcing the min/max values when the ReadOnly property is applied.