### PR TITLE
Fix splitter rendering on orientation change

### DIFF
--- a/src/Core/wwwroot/js/SplitPanels.js
+++ b/src/Core/wwwroot/js/SplitPanels.js
@@ -73,10 +73,7 @@ class SplitPanels extends HTMLElement {
         shadow.adoptedStyleSheets.push(styleSheet);
         shadow.innerHTML = template;
 
-        if (this.direction === "row")
-            shadow.querySelector('#median').style.inlineSize = this.barsize +'px';
-        else
-            shadow.querySelector('#median').style.blockSize = this.barsize + 'px';
+        this.updateBarSizeStyle();
     }
     connectedCallback() {
         this.render();
@@ -157,6 +154,20 @@ class SplitPanels extends HTMLElement {
             this.style.gridTemplateRows = `${slot1fraction}fr ${median}px ${slot2fraction}fr`;
         }
     }
+    updateBarSizeStyle() {
+        let median = this.shadowRoot?.querySelector('#median');
+
+        if (median) {
+            if (this.direction === "row") {
+                median.style.inlineSize = this.barsize + 'px';
+                median.style.blockSize = null;
+            }
+            else {
+                median.style.blockSize = this.barsize + 'px';
+                median.style.inlineSize = null;
+            }
+        }
+    }
     attributeChangedCallback(name, oldValue, newValue) {
         if (newValue != oldValue) {
             this[name] = newValue;
@@ -198,6 +209,7 @@ class SplitPanels extends HTMLElement {
         this.setAttribute("direction", value);
         this.style.gridTemplateRows = "";
         this.style.gridTemplateColumns = "";
+        this.updateBarSizeStyle();
     }
     get direction() {
         return this.#direction;
@@ -233,6 +245,7 @@ class SplitPanels extends HTMLElement {
     }
     set barsize(value) {
         this.#barsize = value;
+        this.updateBarSizeStyle();
     }
     get barsize() {
         return this.#barsize;


### PR DESCRIPTION
# Pull Request

## 📖 Description

There is an issue with how the splitter bar is rendered when the orientation of a splitter bar is changed after the the splitter is rendered. You can see this by going to the [Demo Site](https://www.fluentui-blazor.net/Splitter) and on the first example change the orientation of the splitter. The bar/handle basically disappear (technically they're tiny and over to the left).

The issue here is because this:

https://github.com/microsoft/fluentui-blazor/blob/94602b92a8dde550314135481f2c6d0aed388f1c/src/Core/wwwroot/js/SplitPanels.js#L76C1-L79C83

is only called during the constructor and not updated later when either the orientation or bar size change.

This PR attempts to address that by pulling out that code to a function, updating it slightly and calling it from the orientation and barSize setters.

### 🎫 Issues

I didn't file an issue first, but can if you want me to

## 👩‍💻 Reviewer Notes

I ran into this when testing upgrading Aspire to 4.1. We use the FluentSplitter with a button to toggle between Horizontal and Vertical orientation. Whichever one it comes up in first (since we remember the last orientation) works fine. But when you toggle to the other, it doesn't render properly.

## 📑 Test Plan

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [X] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new compontent
- [X] I have modified an existing component
- [ ] I have validate [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component 

## ⏭ Next Steps