### PR TITLE
[MessageBox] Fix the MessageBox usage in WASM projects #v3

### DIFF
--- a/examples/Demo/Shared/Pages/Dialog/DialogPage.razor
+++ b/examples/Demo/Shared/Pages/Dialog/DialogPage.razor
@@ -41,6 +41,14 @@
     <br/>
     When using the <code>DialogService</code>, for displaying a regular dialog, the dialog will always be shown centered on the screen.
 </p>
+<blockquote>
+    During the WASM DotNet Publication process, the unused classes are automatically removed from the final library.
+    The Dialog razor file will be removed if no reference are set by your code.
+    For example, if you call <code>var = await DialogService.ShowDialogAsync&lt;SimpleDialog>(simplePerson, parameters);</code> the <b>SimpleDialog</b> will be removed by the WASM Publication process.
+    You can configure this behavior by setting the <a href="https://learn.microsoft.com/aspnet/core/blazor/host-and-deploy/configure-trimmer">PublishTrimmed</a> property in your project file
+    or you can create a temporary instance <code>var temp1 = new SimpleDialog();</code> to force the Publication process to keep this class in the final library.
+</blockquote>
+
 <h2>Exchange data between dialog and calling component</h2>
 <p>
     There are two ways available to exchange data between the dialog and the component which shows it. The first is by capturing the returned 

--- a/src/Core/Components/Dialog/FluentDialogProvider.razor.cs
+++ b/src/Core/Components/Dialog/FluentDialogProvider.razor.cs
@@ -22,7 +22,7 @@ public partial class FluentDialogProvider : IDisposable
         _internalDialogContext = new(this);
         _renderDialogs = RenderDialogs;
 
-        var temp1 = new MessageBox(); // To avoid WASM Trimming, to remove this class.
+        var temp1 = new MessageBox(); // To avoid WASM trimming from removing this class
     }
 
     protected override void OnInitialized()

--- a/src/Core/Components/Dialog/FluentDialogProvider.razor.cs
+++ b/src/Core/Components/Dialog/FluentDialogProvider.razor.cs
@@ -21,6 +21,8 @@ public partial class FluentDialogProvider : IDisposable
     {
         _internalDialogContext = new(this);
         _renderDialogs = RenderDialogs;
+
+        var temp1 = new MessageBox(); // To avoid WASM Trimming, to remove this class.
     }
 
     protected override void OnInitialized()


### PR DESCRIPTION
# [MessageBox] Fix the MessageBox usage in WASM projects

During the WASM DotNet Publication process, the unused classes are automatically removed from the final library. The Dialog razor file will be removed if no reference are set by your code. For example, if you call `var = await DialogService.ShowDialogAsync<SimpleDialog>(simplePerson, parameters);` the **SimpleDialog** will be removed by the WASM Publication process. You can configure this behavior by setting the [PublishTrimmed](https://learn.microsoft.com/aspnet/core/blazor/host-and-deploy/configure-trimmer) property in your project file or you can create a temporary instance `var temp1 = new SimpleDialog();` to force the Publication process to keep this class in the final library.

In this PR, this action has been taken for the **MessageBox** class, to solve #1057.

Another solution could be to use:

```xml
<!-- Don't trim these libs -->
<ItemGroup>
	<TrimmerRootAssembly Include="Microsoft.FluentUI.AspNetCore.Components" />
	<TrimmerRootAssembly Include="FluentUI.Demo.Shared" />
</ItemGroup>
```
Examples:

Before
![image](https://github.com/microsoft/fluentui-blazor/assets/8350694/d61b16b6-92bd-4cb5-86c2-1a90918014df)

After
![image](https://github.com/microsoft/fluentui-blazor/assets/8350694/bef47d9f-b858-4bd3-8e05-1832231e46a8)

