### PR TITLE
[Dialogbox] Example using a Cancel button #v3

### DIFF
--- a/examples/Demo/Shared/Pages/Dialog/Examples/DialogCustomizableExample.razor
+++ b/examples/Demo/Shared/Pages/Dialog/Examples/DialogCustomizableExample.razor
@@ -2,23 +2,38 @@
 
 <FluentButton Appearance="Appearance.Accent" OnClick="@OpenAsync">Open dialog</FluentButton>
 
-<p>Name: @DialogData.Firstname</p>
+<p>Name: @DialogData.Name - Age: @DialogData.Age</p>
 
 @code
 {
-    SimplePerson DialogData { get; set; } = new() { Firstname = "Bill", Age = 42 };
+    public record NameAndAge
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public int Age { get; set; }
+    }
+
+    NameAndAge DialogData { get; set; } = new() { Id = 1, Name = "Bill", Age = 42 };
 
     private async Task OpenAsync()
     {
-        var dialog = await DialogService.ShowDialogAsync<SimpleCustomizedDialog>(DialogData, new DialogParameters()
+        // Create a new instance of DialogData
+        // to allow the user to cancel the update
+        var data = DialogData with { Id = 1 };
+
+        var dialog = await DialogService.ShowDialogAsync<SimpleCustomizedDialog>(data, new DialogParameters()
             {
                 Height = "240px",
-                Title = $"Updating the {DialogData.Firstname} sheet",
+                Title = $"Updating the {DialogData.Name} sheet",
                 PreventDismissOnOverlayClick = true,
                 PreventScroll = true,
             });
 
         var result = await dialog.Result;
-        var data = result.Data as SimplePerson;
+        if (!result.Cancelled && result.Data != null)
+        {
+            DialogData = (NameAndAge)result.Data;
+        }
+
     }
 }

--- a/examples/Demo/Shared/Pages/Dialog/Examples/SimpleCustomizedDialog.razor
+++ b/examples/Demo/Shared/Pages/Dialog/Examples/SimpleCustomizedDialog.razor
@@ -1,4 +1,4 @@
-@implements IDialogContentComponent<SimplePerson>
+@implements IDialogContentComponent<DialogCustomizableExample.NameAndAge>
 
 @* Header *@
 <FluentDialogHeader ShowDismiss="true">
@@ -12,24 +12,30 @@
 
 @* Footer *@
 <FluentDialogFooter>
-    <FluentButton Appearance="Appearance.Accent" OnClick="@SaveAsync">Close</FluentButton>
+    <FluentButton Appearance="Appearance.Accent" OnClick="@SaveAsync">Save</FluentButton>
+    <FluentButton Appearance="Appearance.Neutral" OnClick="@CancelAsync">Cancel</FluentButton>
 </FluentDialogFooter>
 
 @* Body *@
 <FluentDialogBody>
-    <FluentTextField @bind-Value="@Content.Firstname">FirstName:</FluentTextField>
+    <FluentTextField @bind-Value="@Content.Name">Name:</FluentTextField>
     <FluentNumberField @bind-Value="@Content.Age">Age:</FluentNumberField>
 </FluentDialogBody>
 
 @code {
     [Parameter]
-    public SimplePerson Content { get; set; } = default!;
+    public DialogCustomizableExample.NameAndAge Content { get; set; } = default!;
 
     [CascadingParameter]
     public FluentDialog Dialog { get; set; } = default!;
 
     private async Task SaveAsync()
     {
-        await Dialog.CloseAsync();
+        await Dialog.CloseAsync(Content);
+    }
+
+    private async Task CancelAsync()
+    {
+        await Dialog.CancelAsync();
     }
 }


### PR DESCRIPTION
# [Dialogbox] Example using a Cancel button

When a dialog box is opened, the data sent to this dialog is linked to the fields.
This means that the content of the linked properties are automatically modified by Blazor,
and it is very difficult to undo the changes.

This example uses a `record` that creates a new object instance to the dialog box.
This makes it easy to undo or undo not the user's modifications.

This answers question #1074 

![CustomizeDialog](https://github.com/microsoft/fluentui-blazor/assets/8350694/9f0e222f-46c6-4c0d-b006-ce02cb12ff4b)
