### PR TITLE
[FluentCheckbox] Fix Three States List

### DIFF
--- a/examples/Demo/Shared/Pages/Checkbox/CheckboxPage.razor
+++ b/examples/Demo/Shared/Pages/Checkbox/CheckboxPage.razor
@@ -15,6 +15,8 @@
 
 <DemoSection Title="Three States" Component="@typeof(CheckboxThreeState)"></DemoSection>
 
+<DemoSection Title="Three States List" Component="@typeof(CheckboxThreeStateList)"></DemoSection>
+
 <h2 id="documentation">Documentation</h2>
 
 <ApiDocumentation Component="typeof(FluentCheckbox)" GenericLabel="bool"/>

--- a/examples/Demo/Shared/Pages/Checkbox/Examples/CheckboxThreeStateList.razor
+++ b/examples/Demo/Shared/Pages/Checkbox/Examples/CheckboxThreeStateList.razor
@@ -1,13 +1,13 @@
 ﻿@using System.Collections.Immutable
 <FluentStack Style="margin: 20px;" Orientation="Orientation.Vertical">
-    <FluentCheckbox Label="All"
+    <FluentCheckbox Label="@($"All ({AreAllTypesVisible?.ToString() ?? "null"})")"
                     ThreeState="true"
                     ShowIndeterminate="false"
                     @bind-CheckState="AreAllTypesVisible" />
     @foreach (string resourceType in _allResourceTypes)
     {
         bool isChecked = _visibleResourceTypes.Contains(resourceType);
-        <FluentCheckbox Label="@resourceType"
+        <FluentCheckbox Label="@($"{resourceType} ({isChecked})")"
                         @bind-Value:get="isChecked"
                         @bind-Value:set="c => OnResourceTypeVisibilityChanged(resourceType, c)" />
     }

--- a/examples/Demo/Shared/Pages/Checkbox/Examples/CheckboxThreeStateList.razor
+++ b/examples/Demo/Shared/Pages/Checkbox/Examples/CheckboxThreeStateList.razor
@@ -1,0 +1,61 @@
+﻿@using System.Collections.Immutable
+<FluentStack Style="margin: 20px;" Orientation="Orientation.Vertical">
+    <FluentCheckbox Label="All"
+                    ThreeState="true"
+                    ShowIndeterminate="false"
+                    @bind-CheckState="AreAllTypesVisible" />
+    @foreach (string resourceType in _allResourceTypes)
+    {
+        bool isChecked = _visibleResourceTypes.Contains(resourceType);
+        <FluentCheckbox Label="@resourceType"
+                        @bind-Value:get="isChecked"
+                        @bind-Value:set="c => OnResourceTypeVisibilityChanged(resourceType, c)" />
+    }
+</FluentStack>
+
+
+@code {
+
+    private readonly ImmutableArray<string> _allResourceTypes = ["Project", "Executable", "Container"];
+    private readonly HashSet<string> _visibleResourceTypes;
+
+    public CheckboxThreeStateList()
+    {
+        _visibleResourceTypes = new HashSet<string>(_allResourceTypes);
+    }
+
+    protected void OnResourceTypeVisibilityChanged(string resourceType, bool isVisible)
+    {
+        if (isVisible)
+        {
+            _visibleResourceTypes.Add(resourceType);
+        }
+        else
+        {
+            _visibleResourceTypes.Remove(resourceType);
+        }
+    }
+
+    private bool? AreAllTypesVisible
+    {
+        get
+        {
+            return _visibleResourceTypes.SetEquals(_allResourceTypes)
+                ? true
+                : _visibleResourceTypes.Count == 0
+                    ? false
+                    : null;
+        }
+        set
+        {
+            if (value is true)
+            {
+                _visibleResourceTypes.UnionWith(_allResourceTypes);
+            }
+            else if (value is false)
+            {
+                _visibleResourceTypes.Clear();
+            }
+        }
+    }
+}

--- a/src/Core/Components/Checkbox/FluentCheckbox.razor.cs
+++ b/src/Core/Components/Checkbox/FluentCheckbox.razor.cs
@@ -79,6 +79,7 @@ public partial class FluentCheckbox : FluentInputBase<bool>
         {
             return new CssBuilder(base.ClassValue)
                 .AddClass("checked", when: Value)
+                .AddClass("indeterminate", when: ThreeState && CheckState is null )
                 .Build();
         }
     }


### PR DESCRIPTION
# [FluentCheckbox] Fix Three States List

Sometimes, when a checkbox is placed in "intermediate" mode, the ThreeState property is indeed null, but the checkbox is not "semi-checked". Apparently, the "intermediate" class is not always applied correctly by the Web component.

This double check should correct this problem:

1. Using the `setFluentCheckBoxIndeterminate` javascript method= `item.indeterminate = indeterminate;`
2. Adding the "indeterminate" class: `.AddClass("indeterminate", when: ThreeState && CheckState is null )`

![Checkbox-3States](https://github.com/microsoft/fluentui-blazor/assets/8350694/6c9ae8c7-dfa9-4299-beca-45345b7eb7f2)

This problem should resolve this discussion:
https://github.com/dotnet/aspire/pull/1221#discussion_r1416804617