### PR TITLE
[Checkbox] ThreeStateOrderUncheckToIntermediate

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -746,6 +746,13 @@
             Gets or sets a value indicating whether the CheckBox will allow three check states rather than two.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentCheckbox.ThreeStateOrderUncheckToIntermediate">
+            <summary>
+            Gets or sets a value indicating the order of the three states of the CheckBox.
+            False (by default), the order is Unchecked -> Checked -> Intermediate.
+            True: the order is Unchecked -> Intermediate -> Checked.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentCheckbox.ShowIndeterminate">
             <summary>
             Gets or sets a value indicating whether the user can display the indeterminate state by clicking the CheckBox.

--- a/src/Core/Components/Checkbox/FluentCheckbox.razor.cs
+++ b/src/Core/Components/Checkbox/FluentCheckbox.razor.cs
@@ -11,7 +11,6 @@ public partial class FluentCheckbox : FluentInputBase<bool>
     private bool? _checkState = false;
     private const string JAVASCRIPT_FILE = "./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Checkbox/FluentCheckbox.razor.js";
 
-
     [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(CheckboxChangeEventArgs))]
     public FluentCheckbox()
     {
@@ -36,6 +35,14 @@ public partial class FluentCheckbox : FluentInputBase<bool>
     /// </summary>
     [Parameter]
     public bool ThreeState { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets a value indicating the order of the three states of the CheckBox.
+    /// False (by default), the order is Unchecked -> Checked -> Intermediate.
+    /// True: the order is Unchecked -> Intermediate -> Checked.
+    /// </summary>
+    [Parameter]
+    public bool ThreeStateOrderUncheckToIntermediate { get; set; } = false;
 
     /// <summary>
     /// Gets or sets a value indicating whether the user can display the indeterminate state by clicking the CheckBox.
@@ -123,46 +130,64 @@ public partial class FluentCheckbox : FluentInputBase<bool>
     /// <summary />
     private async Task SetCurrentCheckState(bool newChecked)
     {
-        // Value:        False   -> True  -> False         -> False
-        // Intermediate: False   -> False -> True          -> False
-        //               ---------------------------------------------
-        //               Uncheck -> Check -> Indeterminate -> Uncheck
+        bool? newState = null;
 
-        // Uncheck -> Check
-        if (newChecked && !_intermediate)
+        // Uncheck -> Indeterminate -> Check
+        if (ThreeStateOrderUncheckToIntermediate)
         {
-            await SetCurrentAndIntermediate(true);
-            await UpdateAndRaiseCheckStateEvent(true);
-        }
+            // NewChecked  |  Intermediate  |  NewState
+            //   True             False          [-]
+            //   True             True           [x]
+            //   False            False          [ ]
 
-        // Check -> Indeterminate (or Uncheck is ShowIndeterminate is false)
-        else if (!newChecked && !_intermediate)
-        {
-            if (ShowIndeterminate)
+            // Uncheck -> Intermediate (or Check is ShowIndeterminate is false)
+            if (newChecked && !_intermediate)
             {
-                await SetCurrentAndIntermediate(null);
-                await UpdateAndRaiseCheckStateEvent(null);
+                newState = ShowIndeterminate ? null : true;                
             }
+
+            // Indeterminate -> Checked
+            else if (newChecked && _intermediate)
+            {
+                newState = true;
+            }
+
+            // Checked -> Uncheck
             else
             {
-                await SetCurrentAndIntermediate(false);
-                await UpdateAndRaiseCheckStateEvent(false);
+                newState = false;
             }
         }
 
-        // Indeterminate -> Uncheck
-        else if (newChecked && _intermediate)
-        {
-            await SetCurrentAndIntermediate(false);
-            await UpdateAndRaiseCheckStateEvent(false);
-        }
-
-        // 
+        // Uncheck -> Check -> Indeterminate
         else
         {
-            await SetCurrentAndIntermediate(false);
-            await UpdateAndRaiseCheckStateEvent(false);
+            // NewChecked  |  Intermediate  |  NewState
+            //   True             False          [x]
+            //   False            False          [-]
+            //   True             true           [ ]
+
+            // Uncheck -> Check
+            if (newChecked && !_intermediate)
+            {
+                newState = true;
+            }
+
+            // Check -> Indeterminate (or Uncheck is ShowIndeterminate is false)
+            else if (!newChecked && !_intermediate)
+            {
+                newState = ShowIndeterminate ? null : false;
+            }
+
+            // Indeterminate -> Uncheck
+            else
+            {
+                newState = false;
+            }
         }
+
+        await SetCurrentAndIntermediate(newState);
+        await UpdateAndRaiseCheckStateEvent(newState);
     }
 
     /// <summary />

--- a/tests/Core/Checkbox/FluentCheckboxThreeStatesTests.razor
+++ b/tests/Core/Checkbox/FluentCheckboxThreeStatesTests.razor
@@ -27,6 +27,32 @@
         Assert.Equal(assertValue, myValue);
     }
 
+    [Theory]
+    [InlineData(false, null, false)] // Unchecked => Indeterminate
+    [InlineData(null, true, true)] // Indeterminate => Checked
+    [InlineData(true, false, false)] // Checked => Unchecked
+    public void FluentCheckbox_ThreeStates_InverseOrder(bool? initialState, bool? assertState, bool assertValue)
+    {
+        this.JSInterop.Mode = JSRuntimeMode.Loose;
+
+        bool myValue = initialState ?? false;
+        bool? myState = initialState;
+
+        // Arrange && Act
+        var cut = Render(@<FluentCheckbox Id="myCheck"
+                ThreeState="true"
+                ThreeStateOrderUncheckToIntermediate="true"
+                @bind-CheckState="@myState"
+                @bind-Value="@myValue" />);
+
+        var component = cut.Find("fluent-checkbox");
+        component.TriggerEvent("oncheckedchange", new CheckboxChangeEventArgs() { Checked = !myValue });
+
+        // Assert
+        Assert.Equal(assertState, myState);
+        Assert.Equal(assertValue, myValue);
+    }
+
     [Fact]
     public void FluentCheckbox_ThreeStates_ShowIntermediateFalse()
     {


### PR DESCRIPTION
# [Checkbox] ThreeStateOrderUncheckToIntermediate

Add a `ThreeStateOrderUncheckToIntermediate` attribute indicating the order of the three CheckBox states.
- False (default), the order is Unchecked -> Checked -> Intermediate.
- True: the order is Unchecked -> Intermediate -> Checked.

## Example

1. ThreeStateOrderUncheckToIntermediate = False: `[ ] -> [x] -> [-]`
  ![ThreeState-False](https://github.com/microsoft/fluentui-blazor/assets/8350694/94f4f176-78b2-43a2-9c8f-e4c0b6e34643)

2. ThreeStateOrderUncheckToIntermediate = True: `[ ] -> [-] -> [x]`
  ![ThreeState-True](https://github.com/microsoft/fluentui-blazor/assets/8350694/e757945c-a19d-47e1-9718-9f4cb8af606a)


Related to #1096