### PR TITLE
Create FieldIdentifier when no ValueExpression set

### DIFF
--- a/src/Core/Components/Base/FluentInputBase.cs
+++ b/src/Core/Components/Base/FluentInputBase.cs
@@ -287,7 +287,10 @@ public abstract partial class FluentInputBase<TValue> : FluentComponentBase, IDi
             {
                 FieldIdentifier = FieldIdentifier.Create(ValueExpression);
             }
-
+            else if (ValueChanged.HasDelegate)
+            {
+                FieldIdentifier = FieldIdentifier.Create(() => Value);
+            }
 
             if (CascadedEditContext != null)
             {


### PR DESCRIPTION
See #1103 for the original issue. I don't think pulling in this change has any other consequenses