### PR TITLE
fix: Do not render percent sign for indeterminate ProgressToast

### DIFF
--- a/examples/Demo/Shared/Pages/Toast/Examples/ToastProgressToasts.razor
+++ b/examples/Demo/Shared/Pages/Toast/Examples/ToastProgressToasts.razor
@@ -1,10 +1,11 @@
 ﻿@inject IToastService ToastService
 
-<FluentStack>
+<FluentStack Wrap=true>
     <FluentButton Appearance=Appearance.Neutral @onclick="@ShowExample">Progress toast example 1</FluentButton>
     <FluentButton @ref=_button Appearance="Appearance.Neutral" @onclick=UpdateProgress>Update</FluentButton>
     <FluentButton Appearance="Appearance.Neutral" @onclick=Reset>Reset</FluentButton>
     <FluentButton Appearance="Appearance.Neutral" @onclick=Close>Close</FluentButton>
+    <FluentButton Appearance=Appearance.Neutral @onclick="@ShowIndeterminateExample">Indeterminate progress toast</FluentButton>
 </FluentStack>
 
 @code {
@@ -13,6 +14,7 @@
     private CancellationTokenSource _cancel = new();
 
     private ToastParameters<ProgressToastContent> _progressToastData;
+    private ToastParameters<ProgressToastContent> _progressToastDataIndeterminate;
 
     public ToastProgressToasts()
     {
@@ -31,6 +33,17 @@
                 },
             };
 
+        _progressToastDataIndeterminate = new()
+            {
+                Id = $"{_id}Indeterminate",
+                Intent = ToastIntent.Progress,
+                Title = "Creating resource",
+                Content = new ProgressToastContent()
+                {
+                    Details = "This will close after the default timeout of 7000 milliseconds.",
+                },
+            };
+
     }
 
     protected override void OnAfterRender(bool firstRender)
@@ -45,6 +58,11 @@
     {
         _button!.SetDisabled(false);
         ToastService.ShowProgressToast(_progressToastData);
+    }
+
+    private void ShowIndeterminateExample()
+    {
+        ToastService.ShowProgressToast(_progressToastDataIndeterminate);
     }
 
     private static void ClickedCancel()

--- a/src/Core/Components/Toast/ContentComponents/ProgressToast.razor
+++ b/src/Core/Components/Toast/ContentComponents/ProgressToast.razor
@@ -9,5 +9,8 @@
     }
 
     <FluentProgress Class="fluent-toast-progressbar" Min="0" Max="100" Value="@Content.Progress"></FluentProgress>
-    <div class="fluent-toast-progressbar-percentage">@Content.Progress%</div>
+    @if (Content.Progress is not null)
+    {
+        <div class="fluent-toast-progressbar-percentage">@Content.Progress%</div>
+    }
 </div>


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

The current `ProgressToast` component renders a percent sign below the progress bar, regardless of whether the progress has a determinate or indeterminate state. This PR updates the `ProgressToast` component to only render the percent sign if the `ProgressToastContent.Progress` property is **not** null.

Current `ProgressToast` with indeterminate progress bar:
![fluentui-blazor ProgressToast indeterminate with percentage](https://github.com/microsoft/fluentui-blazor/assets/36118918/8c88b604-2667-4c8f-a511-54af255d6393)

Proposed change to `ProgressToast` with indeterminate progress bar:
![fluentui-blazor ProgressToast indeterminate without percentage](https://github.com/microsoft/fluentui-blazor/assets/36118918/764427f6-d785-4caf-a267-e98d7766c5e3)

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

No issue has been opened for this UI bug.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

The changes are viewable in the demo project--the indeterminate progress toast does not have a percent sign while the determinate progress toast still does.

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

Ad-hoc testing through the demo project.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

(Note: there are currently no active tests for Toast components.)

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new compontent
- [x] I have modified an existing component
- [ ] I have validate [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component 

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->