### PR TITLE
[Icons Explorer] search icons on all sizes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,11 @@
     <EfCoreVersion>8.0.0</EfCoreVersion>
   </PropertyGroup>
   <ItemGroup>
-    <!-- build dependencies -->
+    <!-- For Sample Apps -->
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.2.0" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="4.2.0" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" version="4.2.0" />
+    <!-- Build dependencies -->
     <PackageVersion Include="Markdig" Version="0.33.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="$(AspNetCoreVersion)" />
@@ -19,13 +23,10 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.1.1" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="4.1.0" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" version="4.1.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="8.0.0" />
     <PackageVersion Include="System.Text.Json" Version="8.0.0" />
-    <!-- test dependencies -->
+    <!-- Test dependencies -->
     <PackageVersion Include="bunit" Version="1.25.3" />
     <PackageVersion Include="FluentAssertions" Version="7.0.0-alpha.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0-preview-23577-04" />

--- a/examples/Demo/AssetExplorer/Components/Controls/PreviewCard.razor
+++ b/examples/Demo/AssetExplorer/Components/Controls/PreviewCard.razor
@@ -6,6 +6,9 @@
                 Title="Copy to clipboard" />
     @if (Icon is not null)
     {
+        <FluentLabel Class="size" title="Size">
+            @TopLeftLabel
+        </FluentLabel>
         <FluentIcon Class="image"
                     Value="@Icons.GetInstance(Icon)"
                     Color="@IconColor"

--- a/examples/Demo/AssetExplorer/Components/Controls/PreviewCard.razor.cs
+++ b/examples/Demo/AssetExplorer/Components/Controls/PreviewCard.razor.cs
@@ -18,6 +18,9 @@ public partial class PreviewCard
     public IToastService ToastService { get; set; } = default!;
 
     [Parameter]
+    public string? TopLeftLabel { get; set; }
+
+    [Parameter]
     public Color? IconColor { get; set; }
 
     [Parameter]

--- a/examples/Demo/AssetExplorer/Components/Controls/PreviewCard.razor.css
+++ b/examples/Demo/AssetExplorer/Components/Controls/PreviewCard.razor.css
@@ -19,6 +19,13 @@
         display: none;
     }
 
+    .card ::deep .size {
+        position: absolute;
+        top: 4px;
+        left: 4px;
+        font-size: 8px;
+    }
+
     .card:hover ::deep .copy {
         display: block;
     }

--- a/examples/Demo/AssetExplorer/Components/Pages/IconExplorer.razor
+++ b/examples/Demo/AssetExplorer/Components/Pages/IconExplorer.razor
@@ -17,12 +17,12 @@
                           Placeholder="Part of icon name..." />
         </FluentGridItem>
         <FluentGridItem Gap="0">
-            <FluentSelect TOption="IconSize"
+            <FluentSelect TOption="int"
                           @bind-SelectedOption="@Criteria.Size"
                           @bind-SelectedOption:after="@StartNewSearchAsync"
                           Style="min-width: 100px;"
-                          Items="@(Enum.GetValues<IconSize>())"
-                          OptionText="@(i => Convert.ToString(i))" />
+                          Items="@AllAvailableSizes"
+                          OptionText="@(i => i > 0 ? $"Size{i}" : "[All]")" />
         </FluentGridItem>
         <FluentGridItem>
             <FluentSelect TOption="IconVariant"
@@ -62,7 +62,7 @@
             <div class="result-list">
                 @foreach (var item in IconsForCurrentPage)
                 {
-                    <PreviewCard Icon="@item" IconColor="@Criteria.Color" />
+                    <PreviewCard Icon="@item" IconColor="@Criteria.Color" TopLeftLabel="@(Criteria.Size > 0 ? string.Empty : $"{(int)item.Size}")" />
                 }
             </div>
 

--- a/examples/Demo/AssetExplorer/Components/Pages/IconExplorer.razor.cs
+++ b/examples/Demo/AssetExplorer/Components/Pages/IconExplorer.razor.cs
@@ -50,10 +50,10 @@ public partial class IconExplorer
         IconsFound =
         [
             .. Icons.AllIcons
-                                      .Where(i => i.Variant == Criteria.Variant
-                                               && i.Size == Criteria.Size
-                                               && (string.IsNullOrWhiteSpace(Criteria.SearchTerm) ? true : i.Name.Contains(Criteria.SearchTerm, StringComparison.InvariantCultureIgnoreCase)))
-                                      .OrderBy(i => i.Name)
+                    .Where(i => i.Variant == Criteria.Variant
+                             && (Criteria.Size > 0 ? (int)i.Size == Criteria.Size : true)
+                             && (string.IsNullOrWhiteSpace(Criteria.SearchTerm) ? true : i.Name.Contains(Criteria.SearchTerm, StringComparison.InvariantCultureIgnoreCase)))
+                    .OrderBy(i => i.Name)
 ,
         ];
 
@@ -65,5 +65,15 @@ public partial class IconExplorer
     private void HandleCurrentPageIndexChanged()
     {
         StateHasChanged();
+    }
+
+    private IEnumerable<int> AllAvailableSizes
+    {
+        get
+        {
+            var sizes = Enum.GetValues<IconSize>().Select(i => (int)i).ToList();
+            var empty = new int[] { 0 };
+            return empty.Concat(sizes);
+        }
     }
 }

--- a/examples/Demo/AssetExplorer/Models/IconSearchCriteria.cs
+++ b/examples/Demo/AssetExplorer/Models/IconSearchCriteria.cs
@@ -6,6 +6,6 @@ internal class IconSearchCriteria
 {
     public string SearchTerm { get; set; } = string.Empty;
     public IconVariant Variant { get; set; } = IconVariant.Regular;
-    public IconSize Size { get; set; } = IconSize.Size24;
+    public int Size { get; set; } = 20;
     public Color Color { get; set; } = Color.Accent;
 }


### PR DESCRIPTION
# [Icons Explorer] search icons on all size

Updated the list of icon sizes to include an `[All]` item. This allows the user to search for all icons. In this case, a small "size" label is displayed at the top of the card.

![peek](https://github.com/microsoft/fluentui-blazor/assets/8350694/87c54650-2b22-4157-98a8-6a2eae00ae3b)

