### PR TITLE
[List components] Each item must be instantiated (cannot be null).

### DIFF
--- a/src/Core/Components/List/FluentAutocomplete.razor.cs
+++ b/src/Core/Components/List/FluentAutocomplete.razor.cs
@@ -7,7 +7,7 @@ using Microsoft.JSInterop;
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 [CascadingTypeParameter(nameof(TOption))]
-public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption>
+public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> where TOption : notnull
 {
     public const string JAVASCRIPT_FILE = "./_content/Microsoft.FluentUI.AspNetCore.Components/Components/List/FluentAutocomplete.razor.js";
     private string _valueText = string.Empty;

--- a/src/Core/Components/List/FluentCombobox.razor.cs
+++ b/src/Core/Components/List/FluentCombobox.razor.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Components;
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 [CascadingTypeParameter(nameof(TOption))]
-public partial class FluentCombobox<TOption> : ListComponentBase<TOption>
+public partial class FluentCombobox<TOption> : ListComponentBase<TOption> where TOption : notnull
 {
     /// <summary>
     /// Gets or sets a value indicating whether the element auto completes. See <seealso cref="AspNetCore.Components.ComboboxAutocomplete"/>

--- a/src/Core/Components/List/FluentListbox.razor.cs
+++ b/src/Core/Components/List/FluentListbox.razor.cs
@@ -4,7 +4,7 @@ using Microsoft.FluentUI.AspNetCore.Components.Utilities;
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 [CascadingTypeParameter(nameof(TOption))]
-public partial class FluentListbox<TOption> : ListComponentBase<TOption>
+public partial class FluentListbox<TOption> : ListComponentBase<TOption> where TOption : notnull
 {
     /// <summary>
     /// Gets or sets the maximum number of options that should be visible in the listbox scroll area.

--- a/src/Core/Components/List/FluentSelect.razor.cs
+++ b/src/Core/Components/List/FluentSelect.razor.cs
@@ -4,7 +4,7 @@ using Microsoft.FluentUI.AspNetCore.Components.Utilities;
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 [CascadingTypeParameter(nameof(TOption))]
-public partial class FluentSelect<TOption> : ListComponentBase<TOption>
+public partial class FluentSelect<TOption> : ListComponentBase<TOption> where TOption : notnull
 {
     /// <summary />
     protected virtual MarkupString InlineStyleValue => new InlineStyleBuilder()

--- a/src/Core/Components/List/ListComponentBase.cs
+++ b/src/Core/Components/List/ListComponentBase.cs
@@ -7,7 +7,7 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// Component that provides a list of options.
 /// </summary>
 /// <typeparam name="TOption"></typeparam>
-public abstract class ListComponentBase<TOption> : FluentComponentBase
+public abstract class ListComponentBase<TOption> : FluentComponentBase where TOption : notnull
 {
     private bool _multiple = false;
     private List<TOption> _selectedOptions = [];
@@ -425,8 +425,13 @@ public abstract class ListComponentBase<TOption> : FluentComponentBase
 
                     builder.AddAttribute(4, "ChildContent", (RenderFragment)(content =>
                     {
+                        if (item is null)
+                        {
+                            throw new NullReferenceException($"You cannot use a null element as an option in the {nameof(Items)} property.");
+                        }
+
                         content.AddContent(5, GetOptionText(item));
-                        if (item!.GetType().IsGenericType && item.GetType().GetGenericTypeDefinition() == typeof(Option<>))
+                        if (item.GetType().IsGenericType && item.GetType().GetGenericTypeDefinition() == typeof(Option<>))
                         {
                             Option<string>? t = item as Option<string>;
                             if (t is not null)

--- a/src/Core/Components/List/ListComponentBase.cs
+++ b/src/Core/Components/List/ListComponentBase.cs
@@ -131,6 +131,7 @@ public abstract class ListComponentBase<TOption> : FluentComponentBase where TOp
 
     /// <summary>
     /// Gets or sets the content source of all items to display in this list.
+    /// Each item must be instantiated (cannot be null).
     /// </summary>
     [Parameter]
     public virtual IEnumerable<TOption>? Items { get; set; }


### PR DESCRIPTION
# [List components] Each item must be instantiated (cannot be null).

If an element is null, rendering fails with an unclear message.
The documentation has been updated and a clear message will be displayed, during the execution.

## Before

    Error: System.NullReferenceException: 
    Object reference not set to an instance of an object.

## Now

    Error: System.NullReferenceException: 
    You cannot use a null element as an option in the Items property.
