### PR TITLE
[FluentButton Loading] Fix button when style is applied

### DIFF
--- a/src/Core/Components/Button/FluentButton.razor
+++ b/src/Core/Components/Button/FluentButton.razor
@@ -7,10 +7,9 @@
     <style>@CustomStyle</style>
 }
 
-
-@if (Loading && IconStart == null && IconEnd == null)
+@if (LoadingOverlay)
 {
-    <span class="loading-button">
+    <span class="@($"{Class} loading-button")" style="@Style">
         @_renderButton
         <FluentProgressRing />
     </span>
@@ -24,8 +23,8 @@ else
     protected void RenderButton(RenderTreeBuilder __builder)
     {
         <fluent-button @ref=Element
-               class="@Class"
-               style="@Style"
+               class="@(LoadingOverlay ? string.Empty : Class)"
+               style="@(LoadingOverlay ? "width: 100%;" : Style)"
                autofocus=@Autofocus
                form=@FormId
                formaction=@Action

--- a/src/Core/Components/Button/FluentButton.razor.cs
+++ b/src/Core/Components/Button/FluentButton.razor.cs
@@ -1,11 +1,14 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.FluentUI.AspNetCore.Components.Utilities;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
 public partial class FluentButton : FluentComponentBase
 {
     private readonly string _customId = Identifier.NewId();
     private readonly RenderFragment _renderButton;
+
+    private bool LoadingOverlay => Loading && IconStart == null && IconEnd == null;
 
     /// <summary>
     /// Determines if the element should receive document focus on page load.

--- a/src/Core/Components/Button/FluentButton.razor.css
+++ b/src/Core/Components/Button/FluentButton.razor.css
@@ -1,12 +1,12 @@
 .loading-button {
-    display: flex;
-    align-items: center;
-    width: fit-content;
-    justify-content: center;
+    position: relative;
 }
 
     .loading-button ::deep fluent-progress-ring {
         position: absolute;
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%, -50%);
         width: 16px;
         height: 16px;
         cursor: not-allowed;


### PR DESCRIPTION
# [FluentButton Loading] Fix button when style is applied

```razor
    <FluentButton Loading="@loading"
                  OnClick="@StartLoadingAsync" 
                  Appearance="Appearance.Accent">
        Loading
    </FluentButton>

    <FluentButton Style="width: 70%"
                  Appearance="Appearance.Accent"
                  Loading="@loading"
                  OnClick="@StartLoadingAsync">
        Load
    </FluentButton>

```
![peek](https://github.com/microsoft/fluentui-blazor/assets/8350694/7372d87a-c717-4ac0-b494-55e1e75366cf)

