### PR TITLE
docs: fix outdated w3.org link

### DIFF
--- a/examples/Demo/Shared/Pages/Listbox/ListboxPage.razor
+++ b/examples/Demo/Shared/Pages/Listbox/ListboxPage.razor
@@ -5,7 +5,7 @@
 <h1>Listbox</h1>
 
 <p>
-    An implementation of a <a href="https://www.w3.org/TR/wai-aria-practices-1.2/#Listbox" target="_blank" rel="noopener noreferrer">listbox</a>. While any
+    An implementation of a <a href="https://www.w3.org/WAI/ARIA/apg/patterns/listbox/" target="_blank" rel="noopener noreferrer">listbox</a>. While any
     DOM content is permissible as a child of the listbox, only <code>FluentOption</code> elements,
     <code>option</code> elements, and slotted items with <code>role="option"</code> will be treated as options and receive keyboard support.
 </p>


### PR DESCRIPTION
# Pull Request

## 📖 Description

Hello. This PR fixes the outdated w3.org link to the [Listbox Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/listbox/).

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.