### PR TITLE
Fix #1185: NavMenu Collapse button behavior in SRR only woks once

### DIFF
--- a/src/Core/Components/NavMenu/FluentNavMenu.razor.js
+++ b/src/Core/Components/NavMenu/FluentNavMenu.razor.js
@@ -1,16 +1,18 @@
-export function onUpdate() {
+export function onLoad() {
     for (let expander of document.getElementsByClassName("expander")) {
         if (expander) {
             const origStyle = expander.parentElement.style.cssText;
-            expander.addEventListener('click', () => toggleMenuExpandedAsync(expander, origStyle));
-            expander.parentElement.addEventListener('keydown', (ev) => handleMenuExpanderKeyDownAsync(expander, origStyle, ev));
+            expander.addEventListener('click', (ev) => toggleMenuExpandedAsync(expander, origStyle, ev), true);
+            expander.parentElement.addEventListener('keydown', (ev) => handleMenuExpanderKeyDownAsync(expander, origStyle, ev), true);
         }
     }
-
+}
+export function onUpdate() {
     for (let element of document.getElementsByClassName("fluent-nav-group")) {
         attachEventHandlers(element);
     }
 }
+
 function attachEventHandlers(element) {
     let navlink = element.getElementsByClassName("fluent-nav-link")[0];
     if (!navlink.href) {
@@ -71,7 +73,7 @@ function handleMenuExpanderKeyDownAsync(element, origStyle, event) {
     switch (event.code) {
         case "NumpadEnter":
         case "Enter":
-            toggleMenuExpandedAsync(element, origStyle);
+            toggleMenuExpandedAsync(element, origStyle, event);
             break;
         case "NumpadArrowRight":
         case "ArrowRight":

--- a/tests/TemplateValidation/SSR/Components/Layout/NavMenu.razor
+++ b/tests/TemplateValidation/SSR/Components/Layout/NavMenu.razor
@@ -2,7 +2,7 @@
 <div class="navmenu">
     <input type="checkbox" id="navmenu-toggle" />
     <nav class="sitenav" aria-labelledby="main-menu" onclick="document.getElementById('navmenu-toggle').click();">
-        <FluentNavMenu Id="main-menu" Width="250" Title="Navigation menu" @bind-Expanded="expanded">
+        <FluentNavMenu Id="main-menu" Collapsible="true" Width="250" Title="Navigation menu" @bind-Expanded="expanded">
             <FluentNavLink Href="/" Match="NavLinkMatch.All" Icon="@(new Icons.Regular.Size20.Home())" IconColor="Color.Accent">Home</FluentNavLink>
             <FluentNavLink Href="weather" Icon="@(new Icons.Regular.Size20.WeatherPartlyCloudyDay())" IconColor="Color.Accent">Weather</FluentNavLink>
             <FluentNavLink Href="test" Icon="@(new Icons.Regular.Size20.Beaker())" IconColor="Color.Accent">Test</FluentNavLink>


### PR DESCRIPTION
Before this change:

1. Run the project.
2. Click the collapse button. -- it works now
3. Click a menu item Home or Weather.
4. Click the collapse button again -- it doesn't work.

For step 4 it actually did work, but the event was triggered twice, so a collapse was triggered which triggered an expand. For the naked eye nothing happened. With theis change the the adding of the eventlistener is moved to the `onLoad` function so it gets registered only once.