### PR TITLE
[FluentSliderLabel] Update the sub-label MaxWidth style

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -6095,6 +6095,12 @@
             <param name = "value">The value to format.</param>
             <returns>A string representation of the value.</returns>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentSliderLabel`1.JSRuntime">
+            <summary />
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentSliderLabel`1.Module">
+            <summary />
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentSliderLabel`1.Position">
             <summary>
             Gets or sets the value for this slider position.
@@ -6114,6 +6120,9 @@
             <summary>
             Gets or sets the content to be rendered inside the component.
             </summary>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentSliderLabel`1.OnAfterRenderAsync(System.Boolean)">
+            <summary />
         </member>
         <member name="T:Microsoft.FluentUI.AspNetCore.Components.FluentSpacer">
             <summary />

--- a/src/Core/Components/Slider/FluentSliderLabel.razor
+++ b/src/Core/Components/Slider/FluentSliderLabel.razor
@@ -2,6 +2,7 @@
 @inherits FluentComponentBase
 @typeparam TValue
 <fluent-slider-label @ref=Element
+                     id="@Id"
                      class="@Class"
                      style="@Style"
                      position="@FormatValueAsString(Position)"

--- a/src/Core/Components/Slider/FluentSliderLabel.razor.cs
+++ b/src/Core/Components/Slider/FluentSliderLabel.razor.cs
@@ -1,10 +1,25 @@
 using System.Globalization;
 using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 public partial class FluentSliderLabel<TValue> : FluentComponentBase
 {
+    private const string JAVASCRIPT_FILE = "./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Slider/FluentSliderLabel.razor.js";
+
+    public FluentSliderLabel()
+    {
+        Id = Identifier.NewId();
+    }
+
+    /// <summary />
+    [Inject]
+    private IJSRuntime JSRuntime { get; set; } = default!;
+
+    /// <summary />
+    private IJSObjectReference? Module { get; set; }
+
     /// <summary>
     /// Gets or sets the value for this slider position.
     /// </summary>
@@ -43,5 +58,15 @@ public partial class FluentSliderLabel<TValue> : FluentComponentBase
             decimal @decimal => BindConverter.FormatValue(@decimal, CultureInfo.InvariantCulture),
             _ => throw new InvalidOperationException($"Unsupported type {value.GetType()}"),
         };
+    }
+
+    /// <summary />
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            Module ??= await JSRuntime.InvokeAsync<IJSObjectReference>("import", JAVASCRIPT_FILE);
+            await Module.InvokeVoidAsync("updateSliderLabel", Id);
+        }
     }
 }

--- a/src/Core/Components/Slider/FluentSliderLabel.razor.js
+++ b/src/Core/Components/Slider/FluentSliderLabel.razor.js
@@ -1,0 +1,13 @@
+﻿export function updateSliderLabel(id) {
+
+    const element = document.getElementById(id);
+
+    if (!!element) {
+        const labelElement = element.shadowRoot?.querySelector(".label");
+
+        // label included in Shadow DOM
+        if (!!labelElement) {
+            labelElement.style.maxWidth = "unset";
+        }
+    }
+}

--- a/tests/Core/Slider/FluentSliderLaberTests.cs
+++ b/tests/Core/Slider/FluentSliderLaberTests.cs
@@ -1,13 +1,15 @@
-using Bunit;
-using Xunit;
-
 namespace Microsoft.FluentUI.AspNetCore.Components.Tests.Slider;
+
 using Bunit;
-using Newtonsoft.Json.Linq;
 using Xunit;
 
-public class FluentSliderLabelTests: TestBase
+public class FluentSliderLabelTests : TestBase
+{
+    public FluentSliderLabelTests()
     {
+        TestContext.JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
     [Fact]
     public void FluentSliderLaber_Default()
     {
@@ -25,7 +27,7 @@ public class FluentSliderLabelTests: TestBase
         //Act
 
         //Assert
-		cut.Verify();
+        cut.Verify();
     }
 }
 


### PR DESCRIPTION
# [FluentSliderLabel] Update MaxWidth style of sub-label

To fix the issue #1204.
Added JS code to update the `max-width` **label included in the `fluent-slider-label**.

![292909677-5236b797-f44b-48ed-a9bb-4963b34db90e](https://github.com/microsoft/fluentui-blazor/assets/8350694/82d8f701-be77-4439-ab81-9e85677f46de)
