### PR TITLE
Fix #1194 #v3

### DIFF
--- a/src/Core/Components/Tabs/FluentTabs.razor.cs
+++ b/src/Core/Components/Tabs/FluentTabs.razor.cs
@@ -14,6 +14,8 @@ public partial class FluentTabs : FluentComponentBase
     private DotNetObjectReference<FluentTabs>? _dotNetHelper = null;
     private IJSObjectReference _jsModuleOverflow = default!;
 
+    private bool _shouldRender = true;
+
     /// <summary />
     protected string? ClassValue => new CssBuilder(Class)
         .Build();
@@ -152,6 +154,11 @@ public partial class FluentTabs : FluentComponentBase
         }
     }
 
+    protected override bool ShouldRender()
+    {
+        return _shouldRender;
+    }
+
     private async Task HandleOnTabChanged(TabChangeEventArgs args)
     {
         if (args is not null)
@@ -163,6 +170,10 @@ public partial class FluentTabs : FluentComponentBase
                 ActiveTabId = tabId;
                 await ActiveTabIdChanged.InvokeAsync(tabId);
             }
+        }
+        else
+        {
+            _shouldRender = false;
         }
     }
 

--- a/src/Core/Components/Tabs/FluentTabs.razor.cs
+++ b/src/Core/Components/Tabs/FluentTabs.razor.cs
@@ -170,6 +170,7 @@ public partial class FluentTabs : FluentComponentBase
                 ActiveTabId = tabId;
                 await ActiveTabIdChanged.InvokeAsync(tabId);
             }
+            _shouldRender = true;
         }
         else
         {


### PR DESCRIPTION
When `HandleOnTabChange` is being called with `TabChangeEventArgs` being `null`, the component should not rerender itself (as no actual tab change has taken place) 
In troduced a `bool` _shouldRender which is set to `false` when the above happens. The overridden `ShouldRender` base method now returns the value of  `_shouldRender` and effectively cancels the re-render whna no tab change has occured.