### PR TITLE
[DialogService] Add a fake instance of DialogEventArgs #280

### DIFF
--- a/src/Core/Components/Dialog/Services/DialogService.cs
+++ b/src/Core/Components/Dialog/Services/DialogService.cs
@@ -1,14 +1,14 @@
-﻿using Microsoft.AspNetCore.Components;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Components;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 public partial class DialogService : IDialogService
 {
     /// <summary />
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(DialogEventArgs))]
     public DialogService()
     {
-        // Issue #280: to avoid the Trimming process to remove this class
-        _ = new DialogEventArgs() { Id = "0", Reason = "Unknown" };
     }
 
     /// <summary>

--- a/src/Core/Components/Dialog/Services/DialogService.cs
+++ b/src/Core/Components/Dialog/Services/DialogService.cs
@@ -4,6 +4,13 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 
 public partial class DialogService : IDialogService
 {
+    /// <summary />
+    public DialogService()
+    {
+        // Issue #280: to avoid the Trimming process to remove this class
+        _ = new DialogEventArgs() { Id = "0", Reason = "Unknown" };
+    }
+
     /// <summary>
     /// Convenience method to create a <see cref="EventCallback"/> for a dialog result.
     /// You can also call <code>EventCallback.Factory.Create</code> directly.


### PR DESCRIPTION
# [DialogService] Add a fake instance of DialogEventArgs #280

Add this line to prevent the _Trimming_ process from deleting this class?

```csharp
_ = new DialogEventArgs() { Id = "0", Reason = "Unknown" };
```