### PR TITLE
[PageScript] Move script visibility inside the web component

### DIFF
--- a/src/Core.Assets/src/PageScript.ts
+++ b/src/Core.Assets/src/PageScript.ts
@@ -3,7 +3,7 @@ class PageScript extends HTMLElement {
   static observedAttributes = ['src'];
   src: string | null = null;
 
-  attributeChangedCallback(name: any, oldValue: any, newValue: any) {
+  attributeChangedCallback(name: string | null, oldValue: string | null, newValue: string | null) {
     if (name !== 'src') {
       return;
     }
@@ -18,7 +18,7 @@ class PageScript extends HTMLElement {
     this.unregisterPageScriptElement(this.src);
   }
 
-  registerPageScriptElement(src: any) {
+  registerPageScriptElement(src: string | null) {
     if (!src) {
       throw new Error('Must provide a non-empty value for the "src" attribute.');
     }
@@ -34,7 +34,7 @@ class PageScript extends HTMLElement {
     }
   }
 
-  unregisterPageScriptElement(src: any) {
+  unregisterPageScriptElement(src: string | null) {
     if (!src) {
       return;
     }
@@ -47,7 +47,7 @@ class PageScript extends HTMLElement {
     pageScriptInfo.referenceCount--;
   }
 
-  async initializePageScriptModule(src: any, pageScriptInfo: any) {
+  async initializePageScriptModule(src: string, pageScriptInfo: any) {
     if (src.startsWith("./")) {
       src = new URL(src.substr(2), document.baseURI).toString();
     }

--- a/src/Core.Assets/src/PageScript.ts
+++ b/src/Core.Assets/src/PageScript.ts
@@ -8,6 +8,7 @@ class PageScript extends HTMLElement {
       return;
     }
 
+    this.style.display = 'none';
     this.src = newValue;
     this.unregisterPageScriptElement(oldValue);
     this.registerPageScriptElement(newValue);

--- a/src/Core/Components/PageScript.razor
+++ b/src/Core/Components/PageScript.razor
@@ -1,7 +1,6 @@
-﻿@using System.Text.Json
-@namespace Microsoft.FluentUI.AspNetCore.Components
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 @* code from https://learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/static-server-rendering?view=aspnetcore-8.0 *@
-<page-script src="@Src" style="display: none;"></page-script>
+<page-script src="@Src"></page-script>
 
 @code {
     [Parameter]


### PR DESCRIPTION
## Problem

When using a container with `display: flex; justify-content: space-between;` this result fails.

```xml
<div style="display: flex; justify-content: space-between;">
    <div style="border: 1px solid red;">First</div>
    <PageScript Src="." />
    <div style="border: 1px solid Yellow;">Second</div>
    <div style="border: 1px solid blue;">Last</div>
</div>
```

![image](https://github.com/microsoft/fluentui-blazor/assets/8350694/041b4539-6b74-4bf1-b215-d30bfc8f3441)

## Solution

Adding this style `display: none;` the result is correct. This PR apply this style inside the web component.

![image](https://github.com/microsoft/fluentui-blazor/assets/8350694/294f75e5-6a00-415f-89a5-1acd18d5f775)

## Unit Tests

The Unit Tests are now corrects
