### PR TITLE
[Templates] Fix spelling and use `FluentValidationSummary`

### DIFF
--- a/examples/Demo/Shared/Pages/ComponentBindings.razor
+++ b/examples/Demo/Shared/Pages/ComponentBindings.razor
@@ -111,7 +111,7 @@
             <EditForm Model="Form">
                 <DataAnnotationsValidator />
                 <div>
-                    <ValidationSummary />
+                    <FluentValidationSummary />
                 </div>
                 <div>
                     <p><label for="SelectValue">Select Value</label></p>

--- a/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/ExternalLogin.razor
+++ b/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/ExternalLogin.razor
@@ -33,7 +33,7 @@
     <FluentGridItem xs="8" sm="4">
         <EditForm Model="Input" OnValidSubmit="OnValidSubmitAsync" FormName="confirmation" method="post">
             <DataAnnotationsValidator />
-            <ValidationSummary class="text-danger" role="alert" />
+            <FluentValidationSummary class="text-danger" role="alert" />
             <FluentTextField Name="Input.Email" @bind-Value="Input.Email" AutoComplete="email" Placeholder="Please enter your email." Label="Email" Style="width: 100%;"/>
             <FluentValidationMessage For="() => Input.Email" />
             <FluentButton Type="ButtonType.Submit" Appearance="Appearance.Accent" Style="width: 100%;">Register</FluentButton>

--- a/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/ForgotPassword.razor
+++ b/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/ForgotPassword.razor
@@ -21,7 +21,7 @@
     <FluentGridItem xs="8" sm="4">
         <EditForm Model="Input" FormName="forgot-password" OnValidSubmit="OnValidSubmitAsync" method="post">
             <DataAnnotationsValidator />
-            <ValidationSummary class="text-danger" role="alert" />
+            <FluentValidationSummary class="text-danger" role="alert" />
             <FluentTextField Name="Input.Email" @bind-Value="Input.Email" AutoComplete="username" Required="true" Placeholder="name@example.com" Label="Email" Style="width: 100%;" />
             <FluentValidationMessage For="() => Input.Email" class="text-danger" />
             <FluentButton Type="ButtonType.Submit" Appearance="Appearance.Accent" Style="width: 100%;">Reset password</FluentButton>

--- a/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/ForgotPassword.razor
+++ b/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/ForgotPassword.razor
@@ -23,7 +23,7 @@
             <DataAnnotationsValidator />
             <ValidationSummary class="text-danger" role="alert" />
             <FluentTextField Name="Input.Email" @bind-Value="Input.Email" AutoComplete="username" Required="true" Placeholder="name@example.com" Label="Email" Style="width: 100%;" />
-            <FluentValidationMesssage For="() => Input.Email" class="text-danger" />
+            <FluentValidationMessage For="() => Input.Email" class="text-danger" />
             <FluentButton Type="ButtonType.Submit" Appearance="Appearance.Accent" Style="width: 100%;">Reset password</FluentButton>
         </EditForm>
     </FluentGridItem>

--- a/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Login.razor
+++ b/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Login.razor
@@ -23,9 +23,9 @@
             <FluentValidationSummary class="text-danger" role="alert" />
             <FluentStack Orientation="Orientation.Vertical">
                 <FluentTextField Name="Input.Email" @bind-Value="Input.Email" AutoComplete="username" Required="true" Placeholder="name@example.com" Label="Email" Style="width: 100%" />
-                <FluentValidationMesssage For="() => Input.Email" class="text-danger" />
+                <FluentValidationMessage For="() => Input.Email" class="text-danger" />
                 <FluentTextField type="password" Name="Input.Password" @bind-Value="Input.Password" AutoComplete="current-password" Required="true" Placeholder="password" Label="Password" Style="width: 100%" />
-                <FluentValidationMesssage For="() => Input.Password" class="text-danger" />
+                <FluentValidationMessage For="() => Input.Password" class="text-danger" />
                 <FluentCheckbox Name="Input.RememberMe" @bind-Value="Input.RememberMe" Label="Remember me" />
                 <FluentButton Type="ButtonType.Submit" Appearance="Appearance.Accent" Style="width: 100%">Log in</FluentButton>
                 <div>

--- a/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/LoginWith2fa.razor
+++ b/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/LoginWith2fa.razor
@@ -21,10 +21,10 @@
             <input type="hidden" name="ReturnUrl" value="@ReturnUrl" />
             <input type="hidden" name="RememberMe" value="@RememberMe" />
             <DataAnnotationsValidator />
-            <ValidationSummary class="text-danger" role="alert" />
-                <FluentTextField Name="Input.TwoFactorCode" @bind-Value="Input.TwoFactorCode" class="form-control" AutoComplete="off" Label="Authenticator code" Style="width: 100%;"/>
-                <FluentValidationMessage For="() => Input.TwoFactorCode" class="text-danger" />
-                <FluentCheckbox Name="Input.RememberMachine" @bind-Value="Input.RememberMachine" Label="Remember this machine" Style="width: 100%;"/>
+            <FluentValidationSummary class="text-danger" role="alert" />
+            <FluentTextField Name="Input.TwoFactorCode" @bind-Value="Input.TwoFactorCode" class="form-control" AutoComplete="off" Label="Authenticator code" Style="width: 100%;" />
+            <FluentValidationMessage For="() => Input.TwoFactorCode" class="text-danger" />
+            <FluentCheckbox Name="Input.RememberMachine" @bind-Value="Input.RememberMachine" Label="Remember this machine" Style="width: 100%;" />
             <FluentButton Type="ButtonType.Submit" Appearance="Appearance.Accent" Style="width: 100%;">Log in</FluentButton>
         </EditForm>
     </FluentGridItem>

--- a/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/LoginWith2fa.razor
+++ b/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/LoginWith2fa.razor
@@ -23,7 +23,7 @@
             <DataAnnotationsValidator />
             <ValidationSummary class="text-danger" role="alert" />
                 <FluentTextField Name="Input.TwoFactorCode" @bind-Value="Input.TwoFactorCode" class="form-control" AutoComplete="off" Label="Authenticator code" Style="width: 100%;"/>
-                <FluentValidationMesssage For="() => Input.TwoFactorCode" class="text-danger" />
+                <FluentValidationMessage For="() => Input.TwoFactorCode" class="text-danger" />
                 <FluentCheckbox Name="Input.RememberMachine" @bind-Value="Input.RememberMachine" Label="Remember this machine" Style="width: 100%;"/>
             <FluentButton Type="ButtonType.Submit" Appearance="Appearance.Accent" Style="width: 100%;">Log in</FluentButton>
         </EditForm>

--- a/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/LoginWithRecoveryCode.razor
+++ b/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/LoginWithRecoveryCode.razor
@@ -24,7 +24,7 @@
             <DataAnnotationsValidator />
             <ValidationSummary class="text-danger" role="alert" />
             <FluentTextField Name="Input.RecoveryCode" @bind-Value="Input.RecoveryCode" class="form-control" AutoComplete="off" Placeholder="Recovery code" Label="Recovery code" Style="width: 100%;" />
-            <FluentValidationMesssage For="() => Input.RecoveryCode" class="text-danger" />
+            <FluentValidationMessage For="() => Input.RecoveryCode" class="text-danger" />
             <FluentButton Type="ButtonType.Submit" Appearance="Appearance.Accent" Style="width: 100%;">Log in</FluentButton>
         </EditForm>
     </FluentGridItem>

--- a/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/LoginWithRecoveryCode.razor
+++ b/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/LoginWithRecoveryCode.razor
@@ -22,7 +22,7 @@
     <FluentGridItem xs="8" sm="4">
         <EditForm Model="Input" FormName="login-with-recovery-code" OnValidSubmit="OnValidSubmitAsync" method="post">
             <DataAnnotationsValidator />
-            <ValidationSummary class="text-danger" role="alert" />
+            <FluentValidationSummary class="text-danger" role="alert" />
             <FluentTextField Name="Input.RecoveryCode" @bind-Value="Input.RecoveryCode" class="form-control" AutoComplete="off" Placeholder="Recovery code" Label="Recovery code" Style="width: 100%;" />
             <FluentValidationMessage For="() => Input.RecoveryCode" class="text-danger" />
             <FluentButton Type="ButtonType.Submit" Appearance="Appearance.Accent" Style="width: 100%;">Log in</FluentButton>

--- a/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/ChangePassword.razor
+++ b/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/ChangePassword.razor
@@ -20,11 +20,11 @@
             <DataAnnotationsValidator />
             <ValidationSummary class="text-danger" role="alert" />
             <FluentTextField type="password" Name="Input.OldPassword" @bind-Value="Input.OldPassword" class="form-control" AutoComplete="current-password" Required="true" Placeholder="Please enter your old password." Label="Old password" Style="width: 100%" />
-            <FluentValidationMesssage For="() => Input.OldPassword" class="text-danger" />
+            <FluentValidationMessage For="() => Input.OldPassword" class="text-danger" />
             <FluentTextField type="password" Name="Input.NewPassword" @bind-Value="Input.NewPassword" class="form-control" AutoComplete="new-password" Required="true" Placeholder="Please enter your new password." Label="New password" Style="width: 100%" />
-            <FluentValidationMesssage For="() => Input.NewPassword" class="text-danger" />
+            <FluentValidationMessage For="() => Input.NewPassword" class="text-danger" />
             <FluentTextField type="password" Name="Input.ConfirmPassword" @bind-Value="Input.ConfirmPassword" class="form-control" AutoComplete="new-password" Required="true" Placeholder="Please confirm your new password." Label="Confirm password" Style="width: 100%" />
-            <FluentValidationMesssage For="() => Input.ConfirmPassword" class="text-danger" />
+            <FluentValidationMessage For="() => Input.ConfirmPassword" class="text-danger" />
             <FluentButton Type="ButtonType.Submit" Appearance="Appearance.Accent" Style="width: 100%;">Update password</FluentButton>
         </EditForm>
     </FluentGridItem>

--- a/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/ChangePassword.razor
+++ b/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/ChangePassword.razor
@@ -18,7 +18,7 @@
     <FluentGridItem xs="12" sm="6">
         <EditForm Model="Input" FormName="change-password" OnValidSubmit="OnValidSubmitAsync" method="post">
             <DataAnnotationsValidator />
-            <ValidationSummary class="text-danger" role="alert" />
+            <FluentValidationSummary class="text-danger" role="alert" />
             <FluentTextField type="password" Name="Input.OldPassword" @bind-Value="Input.OldPassword" class="form-control" AutoComplete="current-password" Required="true" Placeholder="Please enter your old password." Label="Old password" Style="width: 100%" />
             <FluentValidationMessage For="() => Input.OldPassword" class="text-danger" />
             <FluentTextField type="password" Name="Input.NewPassword" @bind-Value="Input.NewPassword" class="form-control" AutoComplete="new-password" Required="true" Placeholder="Please enter your new password." Label="New password" Style="width: 100%" />

--- a/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/DeletePersonalData.razor
+++ b/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/DeletePersonalData.razor
@@ -25,7 +25,7 @@
         </div>
         <EditForm Model="Input" FormName="delete-user" OnValidSubmit="OnValidSubmitAsync" method="post">
             <DataAnnotationsValidator />
-            <ValidationSummary class="text-danger" role="alert" />
+            <FluentValidationSummary class="text-danger" role="alert" />
             @if (requirePassword)
             {
                 <FluentTextField type="password" Name="Input.Password" @bind-Value="Input.Password" AutoComplete="new-password" Required="true" Placeholder="Please enter your password." Label="Password" Style="width: 100%" />

--- a/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/DeletePersonalData.razor
+++ b/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/DeletePersonalData.razor
@@ -29,7 +29,7 @@
             @if (requirePassword)
             {
                 <FluentTextField type="password" Name="Input.Password" @bind-Value="Input.Password" AutoComplete="new-password" Required="true" Placeholder="Please enter your password." Label="Password" Style="width: 100%" />
-                <FluentValidationMesssage For="() => Input.Password" class="text-danger" />
+                <FluentValidationMessage For="() => Input.Password" class="text-danger" />
             }
             <FluentButton Type="ButtonType.Submit" Appearance="Appearance.Accent" Style="width: 100%;">Delete data and close my account</FluentButton>
         </EditForm>

--- a/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/Email.razor
+++ b/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/Email.razor
@@ -24,7 +24,7 @@
         </form>
         <EditForm Model="Input" FormName="change-email" OnValidSubmit="OnValidSubmitAsync" method="post">
             <DataAnnotationsValidator />
-            <ValidationSummary class="text-danger" role="alert" />
+            <FluentValidationSummary class="text-danger" role="alert" />
             @if (isEmailConfirmed)
             {
                 <FluentTextField Value="@email" Placeholder="Please enter your email." Disabled Label="Email" Appearance=FluentInputAppearance.Filled Style="width: 100%">

--- a/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/Email.razor
+++ b/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/Email.razor
@@ -37,7 +37,7 @@
                 <FluentButton Type="ButtonType.Submit" Appearance="Appearance.Accent" Form="send-verification-form" Style="width: 100%">Send verification email</FluentButton>
             }
             <FluentTextField Name="Input.NewEmail" @bind-Value="Input.NewEmail" AutoComplete="email" Required="true" Placeholder="Please enter new email." Label="New email" Style="width: 100%" />
-            <FluentValidationMesssage For="() => Input.NewEmail" class="text-danger" />
+            <FluentValidationMessage For="() => Input.NewEmail" class="text-danger" />
             <FluentButton Type="ButtonType.Submit" Appearance="Appearance.Accent" Style="width: 100%;">Change email</FluentButton>
         </EditForm>
     </FluentGridItem>

--- a/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/EnableAuthenticator.razor
+++ b/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/EnableAuthenticator.razor
@@ -52,7 +52,7 @@ else
                     <EditForm Model="Input" FormName="send-code" OnValidSubmit="OnValidSubmitAsync" method="post">
                         <DataAnnotationsValidator />
                         <FluentTextField Name="Input.Code" @bind-Value="Input.Code" AutoComplete="off" Placeholder="Please enter the code." Style="width: 100%;" />
-                        <FluentValidationMesssage For="() => Input.Code" class="text-danger" />
+                        <FluentValidationMessage For="() => Input.Code" class="text-danger" />
                         <FluentButton Type="ButtonType.Submit" Appearance="Appearance.Accent" Style="width: 100%;">Verify</FluentButton>
                         <ValidationSummary class="text-danger" role="alert" />
                     </EditForm>

--- a/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/Index.razor
+++ b/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/Index.razor
@@ -21,7 +21,7 @@
             <ValidationSummary class="text-danger" role="alert" />
             <FluentTextField Value="@username" Placeholder="Please choose your username." Disabled Label="Username" Appearance=FluentInputAppearance.Filled Style="width: 100%" />
             <FluentTextField Name="Input.PhoneNumber" @bind-Value="Input.PhoneNumber" Paceholder="Please enter your phone number." Label="Phone number" Style="width: 100%" />
-            <FluentValidationMesssage For="() => Input.PhoneNumber" class="text-danger" />
+            <FluentValidationMessage For="() => Input.PhoneNumber" class="text-danger" />
             <FluentButton Type="ButtonType.Submit" Appearance="Appearance.Accent" Style="width: 100%;">Save</FluentButton>
         </EditForm>
     </FluentGridItem>

--- a/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/Index.razor
+++ b/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/Index.razor
@@ -18,7 +18,7 @@
     <FluentGridItem xs="12" sm="6">
         <EditForm Model="Input" FormName="profile" OnValidSubmit="OnValidSubmitAsync" method="post">
             <DataAnnotationsValidator />
-            <ValidationSummary class="text-danger" role="alert" />
+            <FluentValidationSummary class="text-danger" role="alert" />
             <FluentTextField Value="@username" Placeholder="Please choose your username." Disabled Label="Username" Appearance=FluentInputAppearance.Filled Style="width: 100%" />
             <FluentTextField Name="Input.PhoneNumber" @bind-Value="Input.PhoneNumber" Paceholder="Please enter your phone number." Label="Phone number" Style="width: 100%" />
             <FluentValidationMessage For="() => Input.PhoneNumber" class="text-danger" />

--- a/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/SetPassword.razor
+++ b/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/SetPassword.razor
@@ -21,7 +21,7 @@
     <FluentGridItem xs="12" sm="6">
         <EditForm Model="Input" FormName="set-password" OnValidSubmit="OnValidSubmitAsync" method="post">
             <DataAnnotationsValidator />
-            <ValidationSummary class="text-danger" role="alert" />
+            <FluentValidationSummary class="text-danger" role="alert" />
             <FluentTextField TextFieldType="TextFieldType.Password" Name="Input.NewPassword" @bind-Value="Input.NewPassword" AutoComplete="new-password" Placeholder="Please enter your new password." Label="New password" Style="width: 100%" />
             <FluentValidationMessage For="() => Input.NewPassword" class="text-danger" />
             <FluentTextField TextFieldType="TextFieldType.Password" Name="Input.ConfirmPassword" @bind-Value="Input.ConfirmPassword" AutoComplete="new-password" Placeholder="Please confirm your new password." Label="Confirm password" Style="width: 100%" />

--- a/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/SetPassword.razor
+++ b/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/SetPassword.razor
@@ -23,9 +23,9 @@
             <DataAnnotationsValidator />
             <ValidationSummary class="text-danger" role="alert" />
             <FluentTextField TextFieldType="TextFieldType.Password" Name="Input.NewPassword" @bind-Value="Input.NewPassword" AutoComplete="new-password" Placeholder="Please enter your new password." Label="New password" Style="width: 100%" />
-            <FluentValidationMesssage For="() => Input.NewPassword" class="text-danger" />
+            <FluentValidationMessage For="() => Input.NewPassword" class="text-danger" />
             <FluentTextField TextFieldType="TextFieldType.Password" Name="Input.ConfirmPassword" @bind-Value="Input.ConfirmPassword" AutoComplete="new-password" Placeholder="Please confirm your new password." Label="Confirm password" Style="width: 100%" />
-            <FluentValidationMesssage For="() => Input.ConfirmPassword" class="text-danger" />
+            <FluentValidationMessage For="() => Input.ConfirmPassword" class="text-danger" />
             <FluentButton Type="ButtonType.Submit" Appearance="Appearance.Accent" Style="width: 100%;">Set password</FluentButton>
         </EditForm>
     </FluentGridItem>

--- a/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Register.razor
+++ b/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Register.razor
@@ -29,11 +29,11 @@
             <FluentValidationSummary class="text-danger" role="alert" />
             <FluentStack Orientation="Orientation.Vertical">
                 <FluentTextField Name="Input.Email" @bind-Value="Input.Email" AutoComplete="username" Required="true" Placeholder="name@example.com" Label="Email" Style="width: 100%" />
-                <FluentValidationMesssage For="() => Input.Email" class="text-danger" />
+                <FluentValidationMessage For="() => Input.Email" class="text-danger" />
                 <FluentTextField type="password" Name="Input.Password" @bind-Value="Input.Password" AutoComplete="current-password" Required="true" Placeholder="password" Label="Password" Style="width: 100%" />
-                <FluentValidationMesssage For="() => Input.Password" class="text-danger" />
+                <FluentValidationMessage For="() => Input.Password" class="text-danger" />
                 <FluentTextField type="password" Name="Input.ConfirmPassword" @bind-Value="Input.ConfirmPassword" AutoComplete="new-password" Required="true" Placeholder="password" Label="Confirm Password" Style="width: 100%" />
-                <FluentValidationMesssage For="() => Input.ConfirmPassword" class="text-danger" />
+                <FluentValidationMessage For="() => Input.ConfirmPassword" class="text-danger" />
                 <FluentButton Type="ButtonType.Submit" Appearance="Appearance.Accent" Style="width: 100%">Log in</FluentButton>
             </FluentStack>
         </EditForm>

--- a/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/ResendEmailConfirmation.razor
+++ b/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/ResendEmailConfirmation.razor
@@ -22,7 +22,7 @@
     <FluentGridItem xs="8" sm="4">
         <EditForm Model="Input" FormName="resend-email-confirmation" OnValidSubmit="OnValidSubmitAsync" method="post">
             <DataAnnotationsValidator />
-            <ValidationSummary class="text-danger" role="alert" />
+            <FluentValidationSummary class="text-danger" role="alert" />
             <FluentTextField Name="Input.Email" @bind-Value="Input.Email" class="form-control" Required="true" Placeholder="name@example.com" Label="Email" Style="width: 100%;" />
             <FluentValidationMessage For="() => Input.Email" class="text-danger" />
             <FluentButton Type="ButtonType.Submit" Appearance="Appearance.Accent" Style="width: 100%;">Resend</FluentButton>

--- a/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/ResetPassword.razor
+++ b/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/ResetPassword.razor
@@ -19,7 +19,7 @@
         <StatusMessage Message="@Message" />
         <EditForm Model="Input" FormName="reset-password" OnValidSubmit="OnValidSubmitAsync" method="post">
             <DataAnnotationsValidator />
-            <ValidationSummary class="text-danger" role="alert" />
+            <FluentValidationSummary class="text-danger" role="alert" />
 
             <input type="hidden" name="Input.Code" value="@Input.Code" />
             <FluentTextField Name="Input.Email" @bind-Value="Input.Email" AutoComplete="username" Required="true" Placeholder="name@example.com" Label="Email" Style="width: 100%;" />


### PR DESCRIPTION
- Fix spelling mistake `FluentValidationMesssage` (3 x s)
- Replave `ValidationSummary` with `FluentValidationSummary`