### PR TITLE
Derive Calendar and DatePicker from InputBase (instead of ComponentBase)

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -1686,9 +1686,6 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentCalendar.ClassValue">
             <summary />
         </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentCalendar.StyleValue">
-            <summary />
-        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentCalendar.PickerMonth">
             <summary>
             Gets or sets the current month of the date picker (two-way bindable).
@@ -1797,11 +1794,6 @@
             <param name="year"></param>
             <returns></returns>
         </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentCalendarBase.ReadOnly">
-            <summary>
-            Gets or sets a value indicating whether the calendar is readonly.
-            </summary>
-        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentCalendarBase.Culture">
             <summary>
             Gets or sets the culture of the component.
@@ -1827,11 +1819,6 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentCalendarBase.Value">
             <summary>
             Gets or sets the selected date (two-way bindable).
-            </summary>
-        </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentCalendarBase.ValueChanged">
-            <summary>
-            Fired when the display month changes.
             </summary>
         </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentCalendarBase.OnSelectedDateHandlerAsync(System.Nullable{System.DateTime})">
@@ -1982,52 +1969,9 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDatePicker.ClassValue">
             <summary />
         </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDatePicker.StyleValue">
-            <summary />
-        </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDatePicker.Label">
-            <summary>
-            Text displayed just above the component
-            </summary>
-        </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDatePicker.LabelTemplate">
-            <summary>
-            Content displayed just above the component
-            </summary>
-        </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDatePicker.AriaLabel">
-            <summary>
-            Text used on aria-label attribute.
-            </summary>
-        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDatePicker.Appearance">
             <summary>
             Gets or sets the design of this input.
-            </summary>
-        </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDatePicker.Disabled">
-            <summary>
-            Disables the form control, ensuring it doesn't participate in form submission.
-            </summary>
-        </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDatePicker.Name">
-            <summary>
-            Gets or sets the name of the element. Allows access by name from the associated form.
-            </summary>
-        </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDatePicker.Required">
-            <summary>
-            Gets or sets a value indicating whether the element needs to have a value.
-            </summary>
-        </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDatePicker.Autofocus">
-            <summary>
-            Determines if the element should receive document focus on page load.
-            </summary>
-        </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDatePicker.Placeholder">
-            <summary>
-            Gets or sets the short hint displayed in the input before the user enters a value.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentTimePicker.StyleValue">

--- a/examples/Demo/Shared/Pages/BasicFormBlazorComponents.razor
+++ b/examples/Demo/Shared/Pages/BasicFormBlazorComponents.razor
@@ -6,18 +6,20 @@
 
 <EditForm Model="@starship" OnValidSubmit="@HandleValidSubmit">
     <DataAnnotationsValidator />
-    <FluentValidationSummary />
+    <ValidationSummary />
 
     <p>
         <label>
             Identifier:
             <InputText @bind-Value="starship.Identifier" />
+            <ValidationMessage For="@(() => starship.Identifier)" />
         </label>
     </p>
     <p>
         <label>
             Description (optional):
             <InputTextArea @bind-Value="starship.Description" />
+            <ValidationMessage For="@(() => starship.Description)" />
         </label>
     </p>
     <p>
@@ -29,24 +31,28 @@
                 <option value="Diplomacy">Diplomacy</option>
                 <option value="Defense">Defense</option>
             </InputSelect>
+            <ValidationMessage For="@(() => starship.Classification)" />
         </label>
     </p>
     <p>
         <label>
             Maximum Accommodation:
             <InputNumber @bind-Value="starship.MaximumAccommodation" />
+            <ValidationMessage For="@(() => starship.MaximumAccommodation)" />
         </label>
     </p>
     <p>
         <label>
             Engineering Approval:
             <InputCheckbox @bind-Value="starship.IsValidatedDesign" />
+            <ValidationMessage For="@(() => starship.IsValidatedDesign)" />
         </label>
     </p>
     <p>
         <label>
             Production Date:
             <InputDate @bind-Value="starship.ProductionDate" />
+            <ValidationMessage For="@(() => starship.ProductionDate)" />
         </label>
     </p>
 

--- a/src/Core/Components/Base/FluentInputBase.cs
+++ b/src/Core/Components/Base/FluentInputBase.cs
@@ -81,7 +81,7 @@ public abstract partial class FluentInputBase<TValue> : FluentComponentBase, IDi
     /// @bind-Value="model.PropertyName"
     /// </example>
     [Parameter]
-    public TValue? Value { get; set; }
+    public virtual TValue? Value { get; set; }
 
     /// <summary>
     /// Gets or sets a callback that updates the bound value.

--- a/src/Core/Components/DateTime/FluentCalendar.razor.cs
+++ b/src/Core/Components/DateTime/FluentCalendar.razor.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.FluentUI.AspNetCore.Components.Utilities;
 
@@ -19,15 +21,18 @@ public partial class FluentCalendar : FluentCalendarBase
     private CalendarExtended? _calendarExtended = null;
 
     /// <summary />
-    protected string? ClassValue => new CssBuilder(Class)
-        .AddClass("fluent-calendar", () => View == CalendarViews.Days)
-        .AddClass("fluent-month", () => View == CalendarViews.Months)
-        .AddClass("fluent-year", () => View == CalendarViews.Years)
-        .Build();
-
-    /// <summary />
-    protected string? StyleValue => new StyleBuilder(Style).Build();
-
+    protected override string? ClassValue
+    {
+        get
+        {
+            return new CssBuilder(base.ClassValue)
+                .AddClass("fluent-calendar", () => View == CalendarViews.Days)
+                .AddClass("fluent-month", () => View == CalendarViews.Months)
+                .AddClass("fluent-year", () => View == CalendarViews.Years)
+                .Build();
+        }
+    }
+    
     /// <summary>
     /// Gets or sets the current month of the date picker (two-way bindable).
     /// This changes when the user browses through the calendar.
@@ -249,7 +254,7 @@ public partial class FluentCalendar : FluentCalendarBase
     /// <returns></returns>
     private async Task PickerMonthSelect(DateTime? month)
     {
-        PickerMonth = month.HasValue ? month.Value : DateTime.Today;
+        PickerMonth = month ?? DateTime.Today;
         _pickerView = CalendarViews.Days;
         await Task.CompletedTask;
     }
@@ -261,8 +266,15 @@ public partial class FluentCalendar : FluentCalendarBase
     /// <returns></returns>
     private async Task PickerYearSelect(DateTime? year)
     {
-        PickerMonth = year.HasValue ? year.Value : DateTime.Today;
+        PickerMonth = year ?? DateTime.Today;
         _pickerView = CalendarViews.Days;
         await Task.CompletedTask;
+    }
+
+    protected override bool TryParseValueFromString(string? value, out DateTime? result, [NotNullWhen(false)] out string? validationErrorMessage)
+    {
+        BindConverter.TryConvertTo(value, Culture, out result);
+        validationErrorMessage = null;
+        return true;
     }
 }

--- a/src/Core/Components/DateTime/FluentCalendarBase.cs
+++ b/src/Core/Components/DateTime/FluentCalendarBase.cs
@@ -3,15 +3,9 @@ using Microsoft.AspNetCore.Components;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
-public abstract class FluentCalendarBase : FluentComponentBase
+public abstract class FluentCalendarBase : FluentInputBase<DateTime?>
 {
     private DateTime? _selectedDate = null;
-
-    /// <summary>
-    /// Gets or sets a value indicating whether the calendar is readonly.
-    /// </summary>
-    [Parameter]
-    public bool ReadOnly { get; set; } = false;
 
     /// <summary>
     /// Gets or sets the culture of the component.
@@ -43,7 +37,7 @@ public abstract class FluentCalendarBase : FluentComponentBase
     /// Gets or sets the selected date (two-way bindable).
     /// </summary>
     [Parameter]
-    public virtual DateTime? Value
+    public override DateTime? Value
     {
         get
         {
@@ -65,12 +59,6 @@ public abstract class FluentCalendarBase : FluentComponentBase
             }
         }
     }
-
-    /// <summary>
-    /// Fired when the display month changes.
-    /// </summary>
-    [Parameter]
-    public virtual EventCallback<DateTime?> ValueChanged { get; set; }
 
     /// <summary />
     protected virtual Task OnSelectedDateHandlerAsync(DateTime? value)

--- a/src/Core/Components/DateTime/FluentDatePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.FluentUI.AspNetCore.Components.Utilities;
@@ -14,66 +15,23 @@ public partial class FluentDatePicker : FluentCalendarBase
     {
         Id = Identifier.NewId();
     }
-
+    
     /// <summary />
-    protected string? ClassValue => new CssBuilder(Class).AddClass("fluent-datepicker").Build();
-
-    /// <summary />
-    protected string? StyleValue => new StyleBuilder(Style).Build();
-
-    /// <summary>
-    /// Text displayed just above the component
-    /// </summary>
-    [Parameter]
-    public string? Label { get; set; }
-
-    /// <summary>
-    /// Content displayed just above the component
-    /// </summary>
-    [Parameter]
-    public RenderFragment? LabelTemplate { get; set; }
-
-    /// <summary>
-    /// Text used on aria-label attribute.
-    /// </summary>
-    [Parameter]
-    public virtual string? AriaLabel { get; set; }
+    protected override string? ClassValue
+    {
+        get
+        {
+            return new CssBuilder(base.ClassValue)
+                .AddClass("fluent-datepicker")
+                .Build();
+        }
+    }
 
     /// <summary>
     /// Gets or sets the design of this input.
     /// </summary>
     [Parameter]
     public virtual FluentInputAppearance Appearance { get; set; } = FluentInputAppearance.Outline;
-
-    /// <summary>
-    /// Disables the form control, ensuring it doesn't participate in form submission.
-    /// </summary>
-    [Parameter]
-    public bool Disabled { get; set; }
-
-    /// <summary>
-    /// Gets or sets the name of the element. Allows access by name from the associated form.
-    /// </summary>
-    [Parameter]
-    public string? Name { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether the element needs to have a value.
-    /// </summary>
-    [Parameter]
-    public bool Required { get; set; }
-
-    /// <summary>
-    /// Determines if the element should receive document focus on page load.
-    /// </summary>
-    [Parameter]
-    public virtual bool Autofocus { get; set; } = false;
-
-    /// <summary>
-    /// Gets or sets the short hint displayed in the input before the user enters a value.
-    /// </summary>
-    [Parameter]
-    public virtual string? Placeholder { get; set; }
 
     [Parameter]
     public EventCallback<bool> OnCalendarOpen { get; set; }
@@ -138,5 +96,12 @@ public partial class FluentDatePicker : FluentCalendarBase
         }
 
         return Task.CompletedTask;
+    }
+
+    protected override bool TryParseValueFromString(string? value, out DateTime? result, [NotNullWhen(false)] out string? validationErrorMessage)
+    {
+        BindConverter.TryConvertTo(value, Culture, out result);
+        validationErrorMessage = null;
+        return true;
     }
 }


### PR DESCRIPTION
By deriving from InputBase, the components can hook into the validation process and respond to classes being added for modified/invalid/valid:
Before: invalid value is detected but input field does not get border added
![image](https://github.com/microsoft/fluentui-blazor/assets/1761079/28d530c1-0cea-4d3e-a634-e790c412aa97)

After: invalid value is detected and input field gets border added
![image](https://github.com/microsoft/fluentui-blazor/assets/1761079/c07767d0-4a6b-4897-9f44-544e1e3eb0bc)
