### PR TITLE
Fix Combobox width without a important mark

### DIFF
--- a/src/Core/Components/List/FluentCombobox.razor.cs
+++ b/src/Core/Components/List/FluentCombobox.razor.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Components;
+using Microsoft.FluentUI.AspNetCore.Components.Utilities;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
@@ -35,6 +36,11 @@ public partial class FluentCombobox<TOption> : ListComponentBase<TOption> where 
     /// </summary>
     [Parameter]
     public Appearance? Appearance { get; set; }
+
+    protected override string? StyleValue => new StyleBuilder(Style)
+        .AddStyle("width", Width, when: !string.IsNullOrEmpty(Width))
+        .AddStyle("min-width", Width, when: !string.IsNullOrEmpty(Width))
+        .Build();
 
     protected override async Task OnChangedHandlerAsync(ChangeEventArgs e)
     {

--- a/src/Core/Components/List/FluentCombobox.razor.css
+++ b/src/Core/Components/List/FluentCombobox.razor.css
@@ -1,3 +1,0 @@
-fluent-combobox {
-    min-width: unset !important;
-}


### PR DESCRIPTION
Fix the #1274 issue without using a `!important` mark.