### PR TITLE
Fix Combobox and Select width property

### DIFF
--- a/src/Core/Components/List/FluentCombobox.razor.cs
+++ b/src/Core/Components/List/FluentCombobox.razor.cs
@@ -37,8 +37,7 @@ public partial class FluentCombobox<TOption> : ListComponentBase<TOption> where 
     [Parameter]
     public Appearance? Appearance { get; set; }
 
-    protected override string? StyleValue => new StyleBuilder(Style)
-        .AddStyle("width", Width, when: !string.IsNullOrEmpty(Width))
+    protected override string? StyleValue => new StyleBuilder(base.StyleValue)
         .AddStyle("min-width", Width, when: !string.IsNullOrEmpty(Width))
         .Build();
 

--- a/src/Core/Components/List/FluentSelect.razor.cs
+++ b/src/Core/Components/List/FluentSelect.razor.cs
@@ -16,6 +16,10 @@ public partial class FluentSelect<TOption> : ListComponentBase<TOption> where TO
         .AddStyle($"#{Id}::part(selected-value)", "text-overflow", "ellipsis")
         .BuildMarkupString();
 
+    protected override string? StyleValue => new StyleBuilder(base.StyleValue)
+        .AddStyle("min-width", Width, when: !string.IsNullOrEmpty(Width))
+        .Build();
+
     /// <summary>
     /// Gets or sets the open attribute.
     /// </summary>

--- a/src/Core/Components/List/FluentSelect.razor.css
+++ b/src/Core/Components/List/FluentSelect.razor.css
@@ -1,3 +1,0 @@
-fluent-select {
-    min-width: unset !important;
-}


### PR DESCRIPTION
Fix the #1274 issue without using a `!important` mark... and for FluentCombobox **_and_** FluentSelect components.