### PR TITLE
[Spliiter]: Add parameter to hide/show bar handle

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -2838,7 +2838,7 @@
         </member>
         <member name="E:Microsoft.FluentUI.AspNetCore.Components.DialogService.OnShow">
             <summary>
-            A event that will be invoked when showing a dialog with a custom component
+            An event that will be invoked when showing a dialog with a custom component
             </summary>
         </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.IDialogService.ShowDialogAsync``1(System.Type,``0,Microsoft.FluentUI.AspNetCore.Components.DialogParameters)">
@@ -2901,7 +2901,7 @@
         </member>
         <member name="E:Microsoft.FluentUI.AspNetCore.Components.IDialogService.OnShow">
             <summary>
-            A event that will be invoked when showing a dialog with a custom component
+            An event that will be invoked when showing a dialog with a custom component
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDivider.Role">

--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -6180,6 +6180,12 @@
             Default is 8.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentSplitter.BarHandle">
+            <summary>
+            Gets or sets a value indicating whether the splitter bar handle is visible.
+            Default is true.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentSplitter.Collapsed">
             <summary>
             Gets or sets a value indicating whether the splitter is collapsed.

--- a/examples/Demo/Shared/Pages/Splitter/Examples/SplitterBarHandle.razor
+++ b/examples/Demo/Shared/Pages/Splitter/Examples/SplitterBarHandle.razor
@@ -1,0 +1,41 @@
+﻿<FluentSwitch CheckedMessage="Bar handle shown" UncheckedMessage="Bar handle hidden" @bind-Value="_barhandle" />
+<br />
+<br />
+
+<FluentSplitter OnResized=OnResizedHandler BarSize="6" ShowBarHandle="_barhandle" Panel1MinSize="15%" Panel2MinSize="50px">
+    <Panel1>
+        <div class="demopanel">
+            <p>
+                Panel 1 -  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+                Eget dolor morbi non arcu risus quis varius. Turpis tincidunt id aliquet risus feugiat in ante. Eros donec ac odio tempor orci 
+                dapibus ultrices in iaculis. Sit amet justo donec enim diam vulputate ut. Morbi blandit cursus risus at ultrices mi tempus. Sed 
+                ullamcorper morbi tincidunt ornare massa eget egestas. Mi eget mauris pharetra et ultrices neque. Sit amet porttitor eget dolor 
+                morbi non arcu risus quis. Tempus egestas sed sed risus pretium quam vulputate dignissim. Diam vel quam elementum pulvinar. Enim 
+                nulla aliquet porttitor lacus luctus accumsan. Convallis tellus id interdum velit laoreet id donec ultrices. Dui faucibus in ornare 
+                quam viverra orci sagittis.
+            </p>
+        </div>
+    </Panel1>
+    <Panel2>
+        <div class="demopanel">
+            <p>
+                Panel 2 - Neque laoreet suspendisse interdum consectetur libero id faucibus nisl tincidunt. Suspendisse faucibus interdum posuere lorem ipsum 
+                dolor sit amet. Imperdiet sed euismod nisi porta lorem mollis aliquam. Malesuada proin libero nunc consequat interdum. Amet nisl purus
+                in mollis nunc sed id semper risus. Nunc sed augue lacus viverra vitae congue eu. Fermentum dui faucibus in ornare quam viverra. Ut eu 
+                sem integer vitae. Interdum velit laoreet id donec ultrices tincidunt arcu non. Pellentesque dignissim enim sit amet. Scelerisque purus
+                semper eget duis at.
+            </p>
+        </div>
+    </Panel2>
+</FluentSplitter>
+
+
+@code
+{
+    bool _barhandle = false;
+
+    private void OnResizedHandler(SplitterResizedEventArgs args)
+    {
+       DemoLogger.WriteLine($"Size changed: {args.Panel1Size}, {args.Panel2Size}");
+    }
+}

--- a/examples/Demo/Shared/Pages/Splitter/Examples/SplitterBarHandle.razor
+++ b/examples/Demo/Shared/Pages/Splitter/Examples/SplitterBarHandle.razor
@@ -2,7 +2,7 @@
 <br />
 <br />
 
-<FluentSplitter OnResized=OnResizedHandler BarSize="6" ShowBarHandle="_barhandle" Panel1MinSize="15%" Panel2MinSize="50px">
+<FluentSplitter OnResized=OnResizedHandler BarSize="6" BarHandle="_barhandle" Panel1MinSize="15%" Panel2MinSize="50px">
     <Panel1>
         <div class="demopanel">
             <p>

--- a/examples/Demo/Shared/Pages/Splitter/SplitterPage.razor
+++ b/examples/Demo/Shared/Pages/Splitter/SplitterPage.razor
@@ -19,8 +19,8 @@
             See the 'Razor' tab for the code
         </p>
     </Description>
-</DemoSection>
-    
+</DemoSection> 
+   
 <DemoSection Component="typeof(SplitterNested)" Title="Nested splitters">
     <Description>
         <p>
@@ -37,6 +37,14 @@
             The <code>FluentSplitter</code> component has a <code>Collapsed</code> parameter that can be set to hide the splitter bar
             and the contents of Panel2. This can be useful for things like a Summary/Detail view where you don't always want the splitter
             to be visible.
+        </p>
+    </Description>
+</DemoSection>
+
+<DemoSection Component="typeof(SplitterBarHandle)" Title="Hide the bar handle">
+    <Description>
+        <p>
+            You can hide the bar handle by setting <code>ShowBarHandle</code> to false.
         </p>
     </Description>
 </DemoSection>

--- a/src/Core.Assets/src/SplitPanels.ts
+++ b/src/Core.Assets/src/SplitPanels.ts
@@ -11,7 +11,7 @@ styleSheet.replaceSync(`
     :host([direction=row]) { grid-template-columns: var(--first-size, 1fr) max-content var(--second-size, 1fr); }
     :host([direction=row]) #median { grid-column: 2 / 3; }
     :host([direction=row]) #median:hover { cursor: col-resize; }
-    :host([direction=row]) #median span[part="handle"] { height: 16px; margin: 2px 0;}
+    :host([direction=row]) #median span[part="handle"] { height: 16px; margin: 2px 0; display: none}
     :host([direction=row]) #slot1 { grid-column: 1 / 2; grid-row: 1 / 1; }
     :host([direction=row]) #slot2 { grid-column: 3 / 4; grid-row: 1 / 1; }
 
@@ -19,7 +19,7 @@ styleSheet.replaceSync(`
     :host([direction=column]) { grid-template-rows: var(--first-size, 1fr) max-content var(--second-size, 1fr); }
     :host([direction=column]) #median { grid-row: 2 / 3; }
     :host([direction=column]) #median:hover { cursor: row-resize; }
-    :host([direction=column]) #median span[part="handle"] { width: 16px; margin: 0 2px;}
+    :host([direction=column]) #median span[part="handle"] { width: 16px; margin: 0 2px; display: none}
     :host([direction=column]) #slot1 { grid-row: 1 / 2; grid-column: 1 / 1; }
     :host([direction=column]) #slot2 { grid-row: 3 / 4; grid-column: 1 / 1; }
 
@@ -35,6 +35,8 @@ styleSheet.replaceSync(`
     :host([collapsed]) { grid-template-columns: 1fr !important; grid-template-rows: none !important; }
     :host([collapsed]) #median { display: none; }
     :host([collapsed]) #slot2 { display: none; }
+
+    :host([barhandle]) #median span[part="handle"] { display: block; }
 `);
 
 const template = `
@@ -46,11 +48,12 @@ const template = `
 `;
 
 class SplitPanels extends HTMLElement {
-  static observedAttributes = ["direction", "collapsed", "barsize", "slot1minsize", "slot2minsize"];
+  static observedAttributes = ["direction", "collapsed", "barsize", "barhandle", "slot1minsize", "slot2minsize"];
   #direction = "row";
   #isResizing = false;
   #collapsed = false;
   #barsize: number = 8;
+  #barhandle = true;
   #slot1size: number = 0;
   #slot2size: number = 0;
   #slot1minsize: number = 0;
@@ -177,6 +180,9 @@ class SplitPanels extends HTMLElement {
     if (newValue != oldValue) {
       (this as any as DOMStringMap)[name] = newValue;
     }
+    console.log(
+      `Attribute ${name} has changed from ${oldValue} to ${newValue}.`,
+    );
   }
   ensurevalue(value: string | number | any) {
     if (!value)
@@ -255,6 +261,22 @@ class SplitPanels extends HTMLElement {
   get barsize() {
     return this.#barsize;
   }
+
+  set barhandle(value) {
+    const realValue = value !== null && value !== undefined && value !== false;
+    if (this.#barhandle !== realValue) {
+      this.#barhandle = realValue;
+      if (this.#barhandle) {
+        this.setAttribute("barhandle", "");
+      } else {
+        this.removeAttribute("barhandle");
+      }
+    }
+  }
+  get barhandle() {
+    return this.#barhandle;
+  }
+ 
 }
 
 export { SplitPanels };

--- a/src/Core.Assets/src/SplitPanels.ts
+++ b/src/Core.Assets/src/SplitPanels.ts
@@ -11,7 +11,7 @@ styleSheet.replaceSync(`
     :host([direction=row]) { grid-template-columns: var(--first-size, 1fr) max-content var(--second-size, 1fr); }
     :host([direction=row]) #median { grid-column: 2 / 3; }
     :host([direction=row]) #median:hover { cursor: col-resize; }
-    :host([direction=row]) #median span[part="handle"] { height: 16px; margin: 2px 0; display: none}
+    :host([direction=row]) #median span[part="handle"] { height: 16px; margin: 2px 0; }
     :host([direction=row]) #slot1 { grid-column: 1 / 2; grid-row: 1 / 1; }
     :host([direction=row]) #slot2 { grid-column: 3 / 4; grid-row: 1 / 1; }
 
@@ -19,7 +19,7 @@ styleSheet.replaceSync(`
     :host([direction=column]) { grid-template-rows: var(--first-size, 1fr) max-content var(--second-size, 1fr); }
     :host([direction=column]) #median { grid-row: 2 / 3; }
     :host([direction=column]) #median:hover { cursor: row-resize; }
-    :host([direction=column]) #median span[part="handle"] { width: 16px; margin: 0 2px; display: none}
+    :host([direction=column]) #median span[part="handle"] { width: 16px; margin: 0 2px; }
     :host([direction=column]) #slot1 { grid-row: 1 / 2; grid-column: 1 / 1; }
     :host([direction=column]) #slot2 { grid-row: 3 / 4; grid-column: 1 / 1; }
 
@@ -36,7 +36,7 @@ styleSheet.replaceSync(`
     :host([collapsed]) #median { display: none; }
     :host([collapsed]) #slot2 { display: none; }
 
-    :host([barhandle]) #median span[part="handle"] { display: block; }
+    :host([no-barhandle]) #median span[part="handle"] { display: none; }
 `);
 
 const template = `
@@ -48,7 +48,7 @@ const template = `
 `;
 
 class SplitPanels extends HTMLElement {
-  static observedAttributes = ["direction", "collapsed", "barsize", "barhandle", "slot1minsize", "slot2minsize"];
+  static observedAttributes = ["direction", "collapsed", "barsize", "no-barhandle", "slot1minsize", "slot2minsize"];
   #direction = "row";
   #isResizing = false;
   #collapsed = false;
@@ -267,9 +267,10 @@ class SplitPanels extends HTMLElement {
     if (this.#barhandle !== realValue) {
       this.#barhandle = realValue;
       if (this.#barhandle) {
-        this.setAttribute("barhandle", "");
+        this.removeAttribute("no-barhandle");
       } else {
-        this.removeAttribute("barhandle");
+        this.setAttribute("no-barhandle", "");
+        
       }
     }
   }

--- a/src/Core/Components/Splitter/FluentSplitter.razor
+++ b/src/Core/Components/Splitter/FluentSplitter.razor
@@ -9,6 +9,7 @@
               direction="@_direction" 
               collapsed="@Collapsed" 
               barsize="@BarSize"
+              barhandle="@ShowBarHandle"
               slot1minsize="@Panel1MinSize"
               slot2minsize="@Panel2MinSize"
               @onsplittercollapsed="OnCollapsedHandler"

--- a/src/Core/Components/Splitter/FluentSplitter.razor
+++ b/src/Core/Components/Splitter/FluentSplitter.razor
@@ -9,7 +9,7 @@
               direction="@_direction" 
               collapsed="@Collapsed" 
               barsize="@BarSize"
-              barhandle="@ShowBarHandle"
+              no-barhandle="@(!BarHandle)"
               slot1minsize="@Panel1MinSize"
               slot2minsize="@Panel2MinSize"
               @onsplittercollapsed="OnCollapsedHandler"

--- a/src/Core/Components/Splitter/FluentSplitter.razor.cs
+++ b/src/Core/Components/Splitter/FluentSplitter.razor.cs
@@ -78,6 +78,9 @@ public partial class FluentSplitter : FluentComponentBase
     [Parameter]
     public int BarSize { get; set; } = 8;
 
+    [Parameter]
+    public bool ShowBarHandle { get; set; } = true;
+
     /// <summary>
     /// Gets or sets a value indicating whether the splitter is collapsed.
     /// If set to true, Panel1 will take up all the space and Panel2 as well as the splitter bar will be hidden.

--- a/src/Core/Components/Splitter/FluentSplitter.razor.cs
+++ b/src/Core/Components/Splitter/FluentSplitter.razor.cs
@@ -78,8 +78,12 @@ public partial class FluentSplitter : FluentComponentBase
     [Parameter]
     public int BarSize { get; set; } = 8;
 
+    /// <summary>
+    /// Gets or sets a value indicating whether the splitter bar handle is visible.
+    /// Default is true.
+    /// </summary>
     [Parameter]
-    public bool ShowBarHandle { get; set; } = true;
+    public bool BarHandle { get; set; } = true;
 
     /// <summary>
     /// Gets or sets a value indicating whether the splitter is collapsed.

--- a/tests/Core/Splitter/FluentSplitterTests.FluentSplitter_BarHandle.verified.razor.html
+++ b/tests/Core/Splitter/FluentSplitterTests.FluentSplitter_BarHandle.verified.razor.html
@@ -1,0 +1,5 @@
+
+<split-panels id="xxx" class="fluent-splitter" direction="row" barsize="4" no-barhandle="" blazor:onsplittercollapsed="1" blazor:onsplitterresized="2">
+  <div slot="1">render me</div>
+  <div slot="2">render me</div>
+</split-panels>

--- a/tests/Core/Splitter/FluentSplitterTests.razor
+++ b/tests/Core/Splitter/FluentSplitterTests.razor
@@ -92,6 +92,19 @@
         // Assert
         cut.Verify();
     }
+
+    [Fact]
+    public void FluentSplitter_BarHandle()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentSplitter Id="split-test" BarSize="4" BarHandle="false">
+        <Panel1>render me</Panel1>
+        <Panel2>render me</Panel2>
+        </FluentSplitter>);
+
+        // Assert
+        cut.Verify();
+    }
     
     [Fact]
     public void FluentSplitter_Panel1MinSizePercent()


### PR DESCRIPTION
Based on discussion in Aspire (https://github.com/dotnet/aspire/pull/1506) a `BarHandle` parameter has been added to the `FluentSplitter`. 
To not break any existing setups, the default for the parameter is set to 'true'.  So not specifying the parameter means the bar is (still) shown. 

An example of using this has been added to the documentation page