### PR TITLE
Better fix for #1205 / #1225 which fixes #1294

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -2838,7 +2838,7 @@
         </member>
         <member name="E:Microsoft.FluentUI.AspNetCore.Components.DialogService.OnShow">
             <summary>
-            A event that will be invoked when showing a dialog with a custom component
+            An event that will be invoked when showing a dialog with a custom component
             </summary>
         </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.IDialogService.ShowDialogAsync``1(System.Type,``0,Microsoft.FluentUI.AspNetCore.Components.DialogParameters)">
@@ -2901,7 +2901,7 @@
         </member>
         <member name="E:Microsoft.FluentUI.AspNetCore.Components.IDialogService.OnShow">
             <summary>
-            A event that will be invoked when showing a dialog with a custom component
+            An event that will be invoked when showing a dialog with a custom component
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDivider.Role">

--- a/src/Core/Components/Button/FluentButton.razor.js
+++ b/src/Core/Components/Button/FluentButton.razor.js
@@ -5,7 +5,12 @@ export function updateProxy(id) {
     }
     const element = document.getElementById(id);
 
-    if (!!element && !!element.form) {
-        element.proxy.setAttribute("form", element.form.id)
+    if (element.form) {
+        if (element.form.id !== '') {
+            element.proxy.setAttribute("form", element.form.id)
+        }
+        else {
+            console.warn("When the submit button is placed outside of the EditForm, make sure to supply an id attribute to the EditForm.");
+        }
     }
 }

--- a/src/Core/Components/Button/FluentButton.razor.js
+++ b/src/Core/Components/Button/FluentButton.razor.js
@@ -5,7 +5,7 @@ export function updateProxy(id) {
     }
     const element = document.getElementById(id);
 
-    if (element.form) {
+    if (element && element.form) {
         if (element.form.id !== '') {
             element.proxy.setAttribute("form", element.form.id)
         }


### PR DESCRIPTION
With earlier fixes, we made it possible to have submit button be outside of `EditForm`. This requires to have an `id` set on the `EditForm`. However, the `id` was now also required when the submit was placed inside the `EditForm`. This PR fixes that. It will also show a warning now in the browser console when submit is placed outside of `EditForm` and no `id` is supplied.