### PR TITLE
Fix #1305 by overriding SetParametersAsync for Combobox

### DIFF
--- a/src/Core/Components/List/FluentCombobox.razor.cs
+++ b/src/Core/Components/List/FluentCombobox.razor.cs
@@ -41,6 +41,13 @@ public partial class FluentCombobox<TOption> : ListComponentBase<TOption> where 
         .AddStyle("min-width", Width, when: !string.IsNullOrEmpty(Width))
         .Build();
 
+    public override async Task SetParametersAsync(ParameterView parameters)
+    {
+        parameters.SetParameterProperties(this);
+
+        await base.SetParametersAsync(ParameterView.Empty);
+    }
+
     protected override async Task OnChangedHandlerAsync(ChangeEventArgs e)
     {
         if (e.Value is not null && Items is not null)


### PR DESCRIPTION
In v4.3 we merged in a change to `SetParametersAsync` in `ListComponentBase` to sync `Selectedoption` with `Value`. This interferes with how a Combobox works. By adding its own overridden `SetParametersAsync` to `FluentComnbobox` this works again as it should.