### PR TITLE
[Tabs]: Add GoToTabAsync() method. Fixes #1314

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -6445,6 +6445,13 @@
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentTabs.DisplayMoreTabAsync(Microsoft.FluentUI.AspNetCore.Components.FluentTab)">
             <summary />
         </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentTabs.GoToTab(System.String)">
+            <summary>
+            Go to a specific tab by specifying an id
+            </summary>
+            <param name="TabId">Id of the tab to goto</param>
+            <returns></returns>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentTextArea.Resize">
             <summary>
             Gets or sets a value indicating whether the text area is resizeable. See <see cref="T:Microsoft.FluentUI.AspNetCore.Components.TextAreaResize"/>

--- a/src/Core/Components/Tabs/FluentTabs.razor.cs
+++ b/src/Core/Components/Tabs/FluentTabs.razor.cs
@@ -271,7 +271,7 @@ public partial class FluentTabs : FluentComponentBase
     /// </summary>
     /// <param name="TabId">Id of the tab to goto</param>
     /// <returns></returns>
-    public async Task GoToTab(string TabId)
+    public async Task GoToTabAsync(string TabId)
     {
         await OnTabChangeHandlerAsync(new TabChangeEventArgs()
         {

--- a/src/Core/Components/Tabs/FluentTabs.razor.cs
+++ b/src/Core/Components/Tabs/FluentTabs.razor.cs
@@ -223,6 +223,7 @@ public partial class FluentTabs : FluentComponentBase
         {
             await OnTabSelect.InvokeAsync(ActiveTab);
         }
+        _shouldRender = true;
     }
 
     /// <summary />
@@ -263,5 +264,19 @@ public partial class FluentTabs : FluentComponentBase
         {
             ActiveId = tab.Id,
         });
+    }
+
+    /// <summary>
+    /// Go to a specific tab by specifying an id
+    /// </summary>
+    /// <param name="TabId">Id of the tab to goto</param>
+    /// <returns></returns>
+    public async Task GoToTab(string TabId)
+    {
+        await OnTabChangeHandlerAsync(new TabChangeEventArgs()
+        {
+            ActiveId = TabId,
+        });
+        
     }
 }


### PR DESCRIPTION
Add a `GoToTabAsync(stringTabId)` method to FluentTabs to fix issue #1314.