### PR TITLE
Fix `JustifyContent` enum documentation description

### DIFF
--- a/src/Core/Enums/JustifyContent.cs
+++ b/src/Core/Enums/JustifyContent.cs
@@ -3,8 +3,7 @@
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 /// <summary>
-/// The size of the emoji (in multiples of 32).
-/// Defauts to Size32
+/// Defines the alignment of items along the main axis of a flex container.
 /// </summary>
 public enum JustifyContent
 {


### PR DESCRIPTION
# Pull Request
Changes the `JustifyContent` enum description to better refer to what it is doing, instead of referring to emojis.

## 📖 Description
Hey folks, I noticed a small documentation error with the `JustifyContent` while I was developing a side project with the library. Currently it refers to emojis when it seems like it should be referring to what Justify Content is doing.

### 🎫 Issues
Did not find an open issue for this.

## 👩‍💻 Reviewer Notes
N/A

## 📑 Test Plan
N/A

## ✅ Checklist

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ X] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

Feel free to let me know if you would like me to make any changes to the description on the enum, or with the pull request in general.

Thank you all for your hard work on the library! I've enjoyed working with it a lot.