### PR TITLE
Fix problems with validation border color / validation classes

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -416,6 +416,12 @@
             Gets or sets the short hint displayed in the input before the user enters a value.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentInputBase`1.Embedded">
+            <summary>
+            Gets or sets if the derived component is embedded in another component. 
+            If true, the ClassValue property will not include the EditContext's FieldCssClass.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentInputBase`1.EditContext">
             <summary>
             Gets the associated <see cref="T:Microsoft.AspNetCore.Components.Forms.EditContext"/>.

--- a/examples/Demo/Shared/Pages/BasicFormFluentUIComponents.razor
+++ b/examples/Demo/Shared/Pages/BasicFormFluentUIComponents.razor
@@ -39,7 +39,7 @@
             <FluentValidationMessage For="@(() => starship.IsValidatedDesign)" />
         </div>
         <div>
-            <FluentDatePicker Name="producion_date" Id="proddate" @bind-Value="starship.ProductionDate" Label="Production Date" Required />
+            <FluentDatePicker Name="production_date" Id="proddate" @bind-Value="starship.ProductionDate" Label="Production Date" Required />
             <FluentValidationMessage For="@(() => starship.ProductionDate)" />
         </div>
         <FluentButton Type="ButtonType.Submit" Appearance="Appearance.Accent">Submit</FluentButton>

--- a/src/Core.Assets/src/index.ts
+++ b/src/Core.Assets/src/index.ts
@@ -291,7 +291,9 @@ export function afterStarted(blazor: Blazor) {
     }
   }
 
-  blazor.addEventListener('enhancedload', onEnhancedLoad);
+  if (typeof blazor.addEventListener === 'function') {
+    blazor.addEventListener('enhancedload', onEnhancedLoad);
+  }
 
   afterStartedCalled = true;
 }

--- a/src/Core/Components/Base/FluentInputBase.cs
+++ b/src/Core/Components/Base/FluentInputBase.cs
@@ -115,6 +115,13 @@ public abstract partial class FluentInputBase<TValue> : FluentComponentBase, IDi
     public virtual string? Placeholder { get; set; }
 
     /// <summary>
+    /// Gets or sets if the derived component is embedded in another component. 
+    /// If true, the ClassValue property will not include the EditContext's FieldCssClass.
+    /// </summary>
+    [Parameter]
+    public virtual bool Embedded { get; set; } = false;
+
+    /// <summary>
     /// Gets the associated <see cref="Microsoft.AspNetCore.Components.Forms.EditContext"/>.
     /// This property is uninitialized if the input does not have a parent <see cref="EditForm"/>.
     /// </summary>
@@ -258,7 +265,7 @@ public abstract partial class FluentInputBase<TValue> : FluentComponentBase, IDi
     {
         get
         {
-            string? fieldClass = FieldBound ? EditContext?.FieldCssClass(FieldIdentifier) : null;
+            string? fieldClass = (FieldBound && !Embedded) ? EditContext?.FieldCssClass(FieldIdentifier) : null;
 
             string? cssClass = CombineClassNames(AdditionalAttributes, fieldClass);
 

--- a/src/Core/Components/DateTime/FluentDatePicker.razor
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor
@@ -3,18 +3,20 @@
 
 <FluentInputLabel ForId="@Id" Label="@Label" AriaLabel="@AriaLabel" ChildContent="@LabelTemplate" Required="@Required" />
 <FluentTextField Id="@Id"
-                    Class="@ClassValue"
-                    Style="@StyleValue"
-                    Autofocus="@Autofocus"
-                    Appearance="@Appearance"
-                    @bind-Value="@DateAsString"
-                    @onclick="@OnCalendarOpenHandlerAsync" 
-                    ReadOnly="@ReadOnly"
-                    Disabled="@Disabled"
-                    Required="@Required"
-                    Placeholder="@(Placeholder ?? Culture.DateTimeFormat.ShortDatePattern)"
-                    Name="@Name"
-                    @attributes="@AdditionalAttributes">
+                 Embedded="true"
+                 Class="@ClassValue"
+                 Style="@StyleValue"
+                 AutoComplete="off"
+                 Autofocus="@Autofocus"
+                 Appearance="@Appearance"
+                 @bind-Value="@CurrentValueAsString"
+                 @onclick="@OnCalendarOpenHandlerAsync" 
+                 ReadOnly="@ReadOnly"
+                 Disabled="@Disabled"
+                 Required="@Required"
+                 Placeholder="@(Placeholder ?? Culture.DateTimeFormat.ShortDatePattern)"
+                 Name="@Name"
+                 @attributes="@AdditionalAttributes">
     @((MarkupString)CalendarIcon)
 </FluentTextField>
 

--- a/src/Core/Components/DateTime/FluentDatePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.FluentUI.AspNetCore.Components.Utilities;
@@ -15,7 +14,7 @@ public partial class FluentDatePicker : FluentCalendarBase
     {
         Id = Identifier.NewId();
     }
-    
+
     /// <summary />
     protected override string? ClassValue
     {
@@ -24,8 +23,8 @@ public partial class FluentDatePicker : FluentCalendarBase
             return new CssBuilder(base.ClassValue)
                 .AddClass("fluent-datepicker")
                 .Build();
-        }
-    }
+                }
+            }
 
     /// <summary>
     /// Gets or sets the design of this input.
@@ -38,32 +37,9 @@ public partial class FluentDatePicker : FluentCalendarBase
 
     public bool Opened { get; set; } = false;
 
-    private string? DateAsString
+    protected override string? FormatValueAsString(DateTime? value)
     {
-        get
-        {
-            return Value?.ToString(Culture.DateTimeFormat.ShortDatePattern);
-        }
-
-        set
-        {
-            var datePattern = Culture.DateTimeFormat.ShortDatePattern;
-            var isValid = DateTime.TryParseExact(
-                Convert.ToString(value),
-                datePattern,
-                Culture,
-                DateTimeStyles.None,
-                out var newDate);
-
-            if (isValid)
-            {
-                Value = newDate + (Value?.TimeOfDay ?? TimeSpan.Zero);
-            }
-            else
-            {
-                Value = null;
-            }
-        }
+        return Value?.ToString(Culture.DateTimeFormat.ShortDatePattern);
     }
 
     protected Task OnCalendarOpenHandlerAsync(MouseEventArgs e)

--- a/tests/Core/DateTime/FluentDatePickerTests.cs
+++ b/tests/Core/DateTime/FluentDatePickerTests.cs
@@ -17,6 +17,7 @@ public class FluentDatePickerTests : TestBase
     {
         // Arrange
         using var ctx = new TestContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
         ctx.Services.AddSingleton(LibraryConfiguration);
 
         // Act
@@ -40,6 +41,7 @@ public class FluentDatePickerTests : TestBase
     {
         // Arrange
         using var ctx = new TestContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
         ctx.Services.AddSingleton(LibraryConfiguration);
 
         // Act
@@ -65,6 +67,7 @@ public class FluentDatePickerTests : TestBase
     {
         // Arrange
         using var ctx = new TestContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
         ctx.Services.AddSingleton(LibraryConfiguration);
         var today = System.DateTime.Today;
 
@@ -88,6 +91,7 @@ public class FluentDatePickerTests : TestBase
     {
         // Arrange
         using var ctx = new TestContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
         ctx.Services.AddSingleton(LibraryConfiguration);
 
         // Act
@@ -110,6 +114,7 @@ public class FluentDatePickerTests : TestBase
     {
         // Arrange
         using var ctx = new TestContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
         ctx.Services.AddSingleton(LibraryConfiguration);
 
         // Act
@@ -129,8 +134,11 @@ public class FluentDatePickerTests : TestBase
     [Fact]
     public void FluentCalendar_DisabledDate()
     {
+        
+
         // Arrange
         using var ctx = new TestContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
         ctx.Services.AddSingleton(LibraryConfiguration);
 
         // Act


### PR DESCRIPTION
Because both `FluentDatePicker` and the contained `FluentTextField` derive from `FluentInputBase` the `ClassValue` is set twice and that in the end leads to inconsistent values for validation in the class attribute. 

To solve, I'm adding a `bool` parameter `Embedded` to `FluentInputBase` (defaults to false). If set to true, `ClassValue` will not include the `FieldCssClass` for that component. 

Because it is a parameter on `FluentInputBase`, we can apply this fix to all input components that have other embedded input components.

- Add `Embedded` parameter to `FluentInputBase`
- [DatePicker] Use `Embedded`
- [DatePicker] Use `CurrentValueAsString` and `FormatValueAsString` from base class
- [DatePicker] turn off `AutoComplete`

Fix #1311 

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [X] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new compontent
- [ ] I have modified an existing component
- [ ] I have validate [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component 

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->