### PR TITLE
[DataGrid] - Add Loading and LoadingContent parameters

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -1266,6 +1266,12 @@
             If specified, grids render this fragment when there is no content.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.LoadingContent">
+            <summary>
+            Gets or sets the content to render when <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.Loading"/> is true.
+            A default fragment is used if this is not specified.
+            </summary>
+        </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.#ctor">
             <summary>
             Constructs an instance of <see cref="T:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1"/>.

--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -1269,7 +1269,7 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.LoadingContent">
             <summary>
             Gets or sets the content to render when <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.Loading"/> is true.
-            A default fragment is used if this is not specified.
+            A default fragment is used if loading content is not specified.
             </summary>
         </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.#ctor">

--- a/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridRemoteData.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridRemoteData.razor
@@ -4,7 +4,7 @@
 @inject NavigationManager NavManager
 
 <div style="height: 434px; overflow:auto;" tabindex="-1">
-    <FluentDataGrid ItemsProvider="foodRecallProvider" Virtualize="true" ItemSize="46" GenerateHeader="GenerateHeaderOption.Sticky" TGridItem="FoodRecall" >
+    <FluentDataGrid Loading="true" ItemsProvider="foodRecallProvider" Virtualize="true" ItemSize="46" GenerateHeader="GenerateHeaderOption.Sticky" TGridItem="FoodRecall" >
         <PropertyColumn Title="ID" Property="@(c => c!.Event_Id)" />
         <PropertyColumn Property="@(c => c!.State)" Style="color:burlywood" />
         <PropertyColumn Property="@(c => c!.City)" />
@@ -38,6 +38,9 @@
             });
 
             var response = await Http.GetFromJsonAsync<FoodRecallQueryResult>(url, req.CancellationToken);
+            
+            // Simulate a slow data retrieval process
+            await Task.Delay(5500);
             return GridItemsProviderResult.From(
                 items: response!.Results,
                 totalItemCount: response!.Meta.Results.Total);

--- a/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridTypical.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridTypical.razor
@@ -1,7 +1,7 @@
 ﻿@inject DataSource Data
 
 
-<FluentDataGrid Items="@FilteredItems" ResizableColumns=true Pagination="@pagination" GridTemplateColumns="0.2fr 1fr 0.2fr 0.2fr 0.2fr 0.2fr" RowClass="@rowClass" RowStyle="@rowStyle" Style="height: 405px; overflow:auto;">
+<FluentDataGrid Items="@FilteredItems" ResizableColumns=true Pagination="@pagination" GridTemplateColumns="0.2fr 1fr 0.2fr 0.2fr 0.2fr 0.2fr" RowClass="@rowClass" RowStyle="@rowStyle" Style="overflow:auto;">
     <TemplateColumn Tooltip="true" TooltipText="@(c => "Flag of " + c.Name)" Title="Rank" SortBy="@rankSort" Align="Align.Center" InitialSortDirection="SortDirection.Ascending" IsDefaultSortColumn=true>
         <img class="flag" src="_content/FluentUI.Demo.Shared/flags/@(context.Code).svg" alt="Flag of @(context.Code)" />
     </TemplateColumn>

--- a/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridVirtualize.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridVirtualize.razor
@@ -1,5 +1,5 @@
 <div style="height: 400px; overflow-y: scroll;">
-    <FluentDataGrid @ref="grid" Items=@items Virtualize="true" ItemSize="54" GridTemplateColumns="1fr 1fr 1fr 1fr">
+    <FluentDataGrid @ref="grid" Items=@items Virtualize="true" ItemSize="54" GridTemplateColumns="1fr 1fr 1fr 1fr" Style="height: 100%;">
         <ChildContent>
             <PropertyColumn Property="@(c => c.Item1)" Sortable="true" />
             <PropertyColumn Property="@(c => c.Item2)" />
@@ -7,17 +7,19 @@
             <PropertyColumn Property="@(c => c.Item4)" Align="Align.End" />
         </ChildContent>
         <EmptyContent>
-            <FluentIcon Value="@(new Icons.Filled.Size24.Crown())" Color="@Color.Accent"/>&nbsp; Nothing to see here. Carry on!
+            <FluentIcon Value="@(new Icons.Filled.Size24.Crown())" Color="@Color.Accent" />&nbsp; Nothing to see here. Carry on!
         </EmptyContent>
         <LoadingContent>
-            Loading...<br />
-            <FluentProgress Width="240px" />
+            <FluentStack Orientation="Orientation.Vertical" HorizontalAlignment="HorizontalAlignment.Center">
+                Loading...<br />
+                <FluentProgress Width="240px" />
+            </FluentStack>
         </LoadingContent>
     </FluentDataGrid>
 </div>
 <br />
-<FluentSwitch @bind-Value="@_clearItems" 
-              @bind-Value:after="ToggleItems" 
+<FluentSwitch @bind-Value="@_clearItems"
+              @bind-Value:after="ToggleItems"
               UncheckedMessage="Clear all results"
               CheckedMessage="Restore all results">
 </FluentSwitch>

--- a/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridVirtualize.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridVirtualize.razor
@@ -1,5 +1,5 @@
 <div style="height: 400px; overflow-y: scroll;">
-    <FluentDataGrid Items=@items Virtualize="true" ItemSize="54" GridTemplateColumns="1fr 1fr 1fr 1fr">
+    <FluentDataGrid @ref="grid" Items=@items Virtualize="true" ItemSize="54" GridTemplateColumns="1fr 1fr 1fr 1fr">
         <ChildContent>
             <PropertyColumn Property="@(c => c.Item1)" Sortable="true" />
             <PropertyColumn Property="@(c => c.Item2)" />
@@ -9,6 +9,10 @@
         <EmptyContent>
             <FluentIcon Value="@(new Icons.Filled.Size24.Crown())" Color="@Color.Accent"/>&nbsp; Nothing to see here. Carry on!
         </EmptyContent>
+        <LoadingContent>
+            Loading...<br />
+            <FluentProgress Width="240px" />
+        </LoadingContent>
     </FluentDataGrid>
 </div>
 <br />
@@ -17,9 +21,12 @@
               UncheckedMessage="Clear all results"
               CheckedMessage="Restore all results">
 </FluentSwitch>
+<FluentButton OnClick="SimulateDataLoading">Simulate data loading</FluentButton>
 
 
 @code {
+    FluentDataGrid<SampleGridData>? grid;
+
     bool _clearItems = false;
     public record SampleGridData(string Item1, string Item2, string Item3, string Item4);
 
@@ -43,12 +50,19 @@
     private void ToggleItems()
     {
         if (_clearItems)
-		{
-			items = null;
-		}
-		else
-		{
-			items =GenerateSampleGridData(5000);;
-		}
+        {
+            items = null;
+        }
+        else
+        {
+            items = GenerateSampleGridData(5000);
+        }
+    }
+
+    private async Task SimulateDataLoading()
+    {
+        grid?.SetLoadingState(true);
+        await Task.Delay(2500);
+        grid?.SetLoadingState(false);
     }
 }

--- a/examples/Demo/Shared/Pages/Lab/IssueTester.razor
+++ b/examples/Demo/Shared/Pages/Lab/IssueTester.razor
@@ -6,7 +6,7 @@
 @inject NavigationManager NavManager
 
 <div style="height: 434px; overflow:auto;" tabindex="-1">
-    <FluentDataGrid Loading="true" ItemsProvider="foodRecallProvider" Virtualize="true" ItemSize="46" GenerateHeader="GenerateHeaderOption.Sticky" TGridItem="FoodRecall">
+    <FluentDataGrid Loading="true" ItemsProvider="foodRecallProvider" Virtualize="true" ItemSize="46" GenerateHeader="GenerateHeaderOption.Sticky" TGridItem="FoodRecall" Style="height: 300px;">
         <PropertyColumn Title="ID" Property="@(c => c!.Event_Id)" />
         <PropertyColumn Property="@(c => c!.State)" Style="color:burlywood" />
         <PropertyColumn Property="@(c => c!.City)" />

--- a/examples/Demo/Shared/Pages/Lab/IssueTester.razor
+++ b/examples/Demo/Shared/Pages/Lab/IssueTester.razor
@@ -1,1 +1,57 @@
 ﻿@page "/IssueTester"
+
+@using Microsoft.FluentUI.AspNetCore.Components
+
+@inject HttpClient Http
+@inject NavigationManager NavManager
+
+<div style="height: 434px; overflow:auto;" tabindex="-1">
+    <FluentDataGrid Loading="true" ItemsProvider="foodRecallProvider" Virtualize="true" ItemSize="46" GenerateHeader="GenerateHeaderOption.Sticky" TGridItem="FoodRecall">
+        <PropertyColumn Title="ID" Property="@(c => c!.Event_Id)" />
+        <PropertyColumn Property="@(c => c!.State)" Style="color:burlywood" />
+        <PropertyColumn Property="@(c => c!.City)" />
+        <PropertyColumn Title="Company" Property="@(c => c!.Recalling_Firm)" Tooltip="true" />
+        <PropertyColumn Property="@(c => c!.Status)" />
+        <TemplateColumn Title="Actions" Align="@Align.End">
+            <FluentButton IconEnd="@(new Icons.Regular.Size16.Edit())" OnClick="@(() => DemoLogger.WriteLine("Edit clicked"))" />
+            <FluentButton IconEnd="@(new Icons.Regular.Size16.Delete())" OnClick="@(() => DemoLogger.WriteLine("Delete clicked"))" />
+        </TemplateColumn>
+    </FluentDataGrid>
+</div>
+
+<p>Total: <strong>@numResults results found</strong></p>
+
+@code {
+    GridItemsProvider<FoodRecall> foodRecallProvider = default!;
+    int numResults;
+
+    protected override async Task OnInitializedAsync()
+    {
+        // Define the GridRowsDataProvider. Its job is to convert QuickGrid's GridRowsDataProviderRequest into a query against
+        // an arbitrary data soure. In this example, we need to translate query parameters into the particular URL format
+        // supported by the external JSON API. It's only possible to perform whatever sorting/filtering/etc is supported
+        // by the external API.
+        foodRecallProvider = async req =>
+        {
+            var url = NavManager.GetUriWithQueryParameters("https://api.fda.gov/food/enforcement.json", new Dictionary<string, object?>
+                {
+                { "skip", req.StartIndex },
+                { "limit", req.Count },
+                });
+
+            var response = await Http.GetFromJsonAsync<FoodRecallQueryResult>(url, req.CancellationToken);
+
+            // Simulate a slow data retrieval process
+            if (req.Count is null)
+            {
+                await Task.Delay(2500);
+            }
+            return GridItemsProviderResult.From(
+                items: response!.Results,
+                totalItemCount: response!.Meta.Results.Total);
+        };
+
+        // Display the number of results just for information. This is completely separate from the grid.
+        numResults = (await Http.GetFromJsonAsync<FoodRecallQueryResult>("https://api.fda.gov/food/enforcement.json"))!.Meta.Results.Total;
+    }
+}

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor
@@ -129,7 +129,7 @@
 
     private void RenderPlaceholderRow(RenderTreeBuilder __builder, PlaceholderContext placeholderContext)
     {
-        string? _rowsDataSize = Loading ? "height: 100%;" : $"height: {ItemSize}px";
+        string? _rowsDataSize = Loading ? "height: 100%;" : $"height: {ItemSize}px;";
 
         <FluentDataGridRow GridTemplateColumns=@GridTemplateColumns aria-rowindex="@(placeholderContext.Index + 1)" Style="@_rowsDataSize" TGridItem="TGridItem">
             @for (var colIndex = 0; colIndex < _columns.Count; colIndex++)

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor
@@ -129,7 +129,7 @@
 
     private void RenderPlaceholderRow(RenderTreeBuilder __builder, PlaceholderContext placeholderContext)
     {
-        string? _rowsDataSize = $"height: {ItemSize}px";
+        string? _rowsDataSize = Loading ? "height: 100%;" : $"height: {ItemSize}px";
 
         <FluentDataGridRow GridTemplateColumns=@GridTemplateColumns aria-rowindex="@(placeholderContext.Index + 1)" Style="@_rowsDataSize" TGridItem="TGridItem">
             @for (var colIndex = 0; colIndex < _columns.Count; colIndex++)

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor
@@ -37,38 +37,58 @@
                 </FluentDataGridRow>
             }
 
-            @if (_ariaBodyRowCount == 0 && !_manualGrid)
+            @if (Loading)
             {
-                <div class="empty-content-row" role="row">
-                    <div class="empty-content-cell" role="gridcell">
-                        @if (EmptyContent is null)
+                <FluentDataGridRow TGridItem="TGridItem" Class="loading-content-row">
+                    <FluentDataGridCell Class="loading-content-cell">
+                        @if (LoadingContent is null)
                         {
-                            @("No data to show!")
-                            ;
+                            <FluentStack HorizontalGap="3">
+                                <FluentProgressRing Width="24px" /> <div>Loading...</div>
+                            </FluentStack>
                         }
                         else
                         {
-                            @EmptyContent
+                            @LoadingContent
                         }
-                    </div>
-                </div>
+                    </FluentDataGridCell>
+                </FluentDataGridRow>
             }
             else
             {
-                @if (Virtualize)
+                @if (_ariaBodyRowCount == 0 && !_manualGrid)
                 {
-                    <Virtualize @ref="@_virtualizeComponent"
-                                TItem="(int RowIndex, TGridItem Data)"
-                                ItemSize="@ItemSize"
-                                ItemsProvider="@ProvideVirtualizedItems"
-                                ItemContent="@(item => builder => RenderRow(builder, item.RowIndex, item.Data))"
-                                Placeholder="@(placeholderContext => builder => RenderPlaceholderRow(builder, placeholderContext))" />
+                    <FluentDataGridRow TGridItem="TGridItem" Class="empty-content-row">
+                        <FluentDataGridCell Class="empty-content-cell">
+                            @if (EmptyContent is null)
+                            {
+                                @("No data to show!")
+                            }
+                            else
+                            {
+                                @EmptyContent
+                            }
+                        </FluentDataGridCell>
+                    </FluentDataGridRow>
                 }
                 else
                 {
-                    @_renderNonVirtualizedRows
+                    @if (Virtualize)
+                    {
+                        <Virtualize @ref="@_virtualizeComponent"
+                                    TItem="(int RowIndex, TGridItem Data)"
+                                    ItemSize="@ItemSize"
+                                    ItemsProvider="@ProvideVirtualizedItems"
+                                    ItemContent="@(item => builder => RenderRow(builder, item.RowIndex, item.Data))"
+                                    Placeholder="@(placeholderContext => builder => RenderPlaceholderRow(builder, placeholderContext))" />
+                    }
+                    else
+                    {
+                        @_renderNonVirtualizedRows
+                    }
                 }
             }
+
             @if (_manualGrid)
             {
                 @ChildContent

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -139,7 +139,7 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
 
     /// <summary>
     /// Gets or sets the content to render when <see cref="Loading"/> is true.
-    /// A default fragment is used if this is not specified.
+    /// A default fragment is used if loading content is not specified.
     /// </summary>
     [Parameter] public RenderFragment? LoadingContent { get; set; }
 

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -135,6 +135,14 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     /// </summary>
     [Parameter] public RenderFragment? EmptyContent { get; set; }
 
+    [Parameter] public bool Loading { get; set; }
+
+    /// <summary>
+    /// Gets or sets the content to render when <see cref="Loading"/> is true.
+    /// A default fragment is used if this is not specified.
+    /// </summary>
+    [Parameter] public RenderFragment? LoadingContent { get; set; }
+
     [Inject] private IServiceProvider Services { get; set; } = default!;
     [Inject] private IJSRuntime JSRuntime { get; set; } = default!;
 
@@ -317,6 +325,12 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
         //StateHasChanged();
     }
 
+    public void SetLoadingState(bool loading)
+    {
+        Loading = loading;
+        StateHasChanged();
+    }
+
     // Same as RefreshDataAsync, except without forcing a re-render. We use this from OnParametersSetAsync
     // because in that case there's going to be a re-render anyway.
     private async Task RefreshDataCoreAsync()
@@ -347,6 +361,7 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
                 _ariaBodyRowCount = _currentNonVirtualizedViewItems.Count;
                 Pagination?.SetTotalItemCountAsync(result.TotalItemCount);
                 _pendingDataLoadCancellationTokenSource = null;
+                Loading = false;
             }
             _internalGridContext.ResetRowIndexes(startIndex);
         }
@@ -391,6 +406,7 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
             _ariaBodyRowCount = Pagination is null ? providerResult.TotalItemCount : Pagination.ItemsPerPage;
 
             Pagination?.SetTotalItemCountAsync(providerResult.TotalItemCount);
+            Loading = false;
 
             // We're supplying the row _index along with each row's data because we need it for aria-rowindex, and we have to account for
             // the virtualized start _index. It might be more performant just to have some _latestQueryRowStartIndex field, but we'd have

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.css
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.css
@@ -2,7 +2,8 @@ fluent-data-grid {
     --col-gap: 1rem;
 }
 
-::deep .empty-content-row {
+::deep .empty-content-row,
+::deep .loading-content-row {
     width: 100%;
     height: 100%;
     display: flex;
@@ -10,10 +11,9 @@ fluent-data-grid {
     align-items: center;
 }
 
-::deep .empty-content-cell {
-    display: flex;
-    justify-content: center;
-    align-items: center;
+::deep .empty-content-cell, 
+::deep .loading-content-cell {
+
     font-weight: 600;
 }
 
@@ -30,7 +30,6 @@ fluent-data-grid {
 
 [dir=rtl] .col-options {
     left: unset;
-    
 }
 
 .col-justify-end .col-options, .col-justify-right .col-options {
@@ -59,7 +58,6 @@ fluent-data-grid {
     cursor: col-resize;
 }
 
-    .col-width-draghandle:hover, .col-width-draghandle:active {
-        background: var(--neutral-stroke-divider-rest);
-    }
-
+.col-width-draghandle:hover, .col-width-draghandle:active {
+    background: var(--neutral-stroke-divider-rest);
+}

--- a/src/Core/Components/DataGrid/FluentDataGridRow.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGridRow.razor.cs
@@ -54,7 +54,8 @@ public partial class FluentDataGridRow<TGridItem> : FluentComponentBase, IHandle
     private InternalGridContext<TGridItem> Owner { get; set; } = default!;
 
     protected string? StyleValue => new StyleBuilder(Style)
-       .AddStyle("height", $"{Owner.Grid.ItemSize}px", () => Owner.Grid.Virtualize && RowType == DataGridRowType.Default)
+       .AddStyle("height", $"{Owner.Grid.ItemSize}px", () => Owner.Grid.Virtualize && !Owner.Grid.Loading && RowType == DataGridRowType.Default)
+       .AddStyle("height", "100%", () => Owner.Grid.Loading && RowType == DataGridRowType.Default)
        .AddStyle("align-items", "center", () => Owner.Grid.Virtualize && RowType == DataGridRowType.Default && string.IsNullOrEmpty(Style))
        .Build();
 


### PR DESCRIPTION
This PR adds `Loading` (bool, default = false) and `LoadingContent` (RenderFragment?) parameters to the FluentDataGrid. 

By default, when `Loading` is set to true, the loading content will be a progress ring with the text 'Loading...'  shown besides it. You can replace that with your own content through this parameter.

To change the state of the `Loading` parameter at a later stage, use the `SetLoadingState(bool loading)` method on the `FluentDataGrid`. To be able to call this method from your code, you need to add a `@ref` to your grid

The loading content is rendered in a `FluentDataGridRow` with one `FluentDataGridCell` inside of it. The row height will be set to 100%. If no height is set for the grid this will be a normal row height. It a height is set for the grid, the row will take up all remaining height. In the example below, no height was specified for the grid.

![datagrid-1317](https://github.com/microsoft/fluentui-blazor/assets/1761079/ad35c117-bb7d-4c03-ade9-8c46a988afff)

In this example te height of the grid is set to 100% of its container. Loading content takes full height (minus header height)
![image](https://github.com/microsoft/fluentui-blazor/assets/1761079/3f41727d-c88d-4cff-9219-d392acca7d5b)

With this PR we are also chaging the way the EmptyContent is rendered to use the same approach (`FluentDataGridRow` with one `FluentDataGridCell` inside and following same height settings). As this is a change from earlier versions, please check your results!
