### PR TITLE
[Grid] Fix breakpoints not working with fractional pixels

### DIFF
--- a/src/Core/Components/Grid/FluentGrid.razor.css
+++ b/src/Core/Components/Grid/FluentGrid.razor.css
@@ -668,31 +668,31 @@
 
 /* Hidden */
 
-@media (max-width: 599px) {
+@media (max-width: 599.98px) {
     .fluent-grid ::deep > div[hidden-when~="xs"] {
         display: none;
     }
 }
 
-@media (min-width: 600px) and (max-width: 959px) {
+@media (min-width: 600px) and (max-width: 959.98px) {
     .fluent-grid ::deep > div[hidden-when~="sm"] {
         display: none;
     }
 }
 
-@media (min-width: 960px) and (max-width: 1279px) {
+@media (min-width: 960px) and (max-width: 1279.98px) {
     .fluent-grid ::deep > div[hidden-when~="md"] {
         display: none;
     }
 }
 
-@media (min-width: 1280px) and (max-width: 1919px) {
+@media (min-width: 1280px) and (max-width: 1919.98px) {
     .fluent-grid ::deep > div[hidden-when~="lg"] {
         display: none;
     }
 }
 
-@media (min-width: 1920px) and (max-width: 2559px) {
+@media (min-width: 1920px) and (max-width: 2559.98px) {
     .fluent-grid ::deep > div[hidden-when~="xl"] {
         display: none;
     }

--- a/src/Core/Components/Grid/FluentGrid.razor.js
+++ b/src/Core/Components/Grid/FluentGrid.razor.js
@@ -1,10 +1,10 @@
 ﻿function GetMediaQueries() {
     return [
-        { id: 'xs', items: document._fluentGrid.mediaXS, query: '(max-width: 599px)' },
-        { id: 'sm', items: document._fluentGrid.mediaSM, query: '(min-width: 600px) and (max-width: 959px)' },
-        { id: 'md', items: document._fluentGrid.mediaMD, query: '(min-width: 960px) and (max-width: 1279px)' },
-        { id: 'lg', items: document._fluentGrid.mediaLG, query: '(min-width: 1280px) and (max-width: 1919px)' },
-        { id: 'xl', items: document._fluentGrid.mediaXL, query: '(min-width: 1920px) and (max-width: 2559px)' },
+        { id: 'xs', items: document._fluentGrid.mediaXS, query: '(max-width: 599.98px)' },
+        { id: 'sm', items: document._fluentGrid.mediaSM, query: '(min-width: 600px) and (max-width: 959.98px)' },
+        { id: 'md', items: document._fluentGrid.mediaMD, query: '(min-width: 960px) and (max-width: 1279.98px)' },
+        { id: 'lg', items: document._fluentGrid.mediaLG, query: '(min-width: 1280px) and (max-width: 1919.98px)' },
+        { id: 'xl', items: document._fluentGrid.mediaXL, query: '(min-width: 1920px) and (max-width: 2559.98px)' },
         { id: 'xxl', items: document._fluentGrid.mediaXXL, query: '(min-width: 2560px)' },
     ];
 }

--- a/src/Core/Components/Wizard/FluentWizardStep.razor.css
+++ b/src/Core/Components/Wizard/FluentWizardStep.razor.css
@@ -129,31 +129,31 @@
 }
 
 /* Hidden */
-@media (max-width: 599px) {
+@media (max-width: 599.98px) {
     .fluent-wizard > ol > li ::deep > div[hidden-when~="xs"] {
         display: none;
     }
 }
 
-@media (min-width: 600px) and (max-width: 959px) {
+@media (min-width: 600px) and (max-width: 959.98px) {
     .fluent-wizard > ol > li ::deep > div[hidden-when~="sm"] {
         display: none;
     }
 }
 
-@media (min-width: 960px) and (max-width: 1279px) {
+@media (min-width: 960px) and (max-width: 1279.98px) {
     .fluent-wizard > ol > li ::deep > div[hidden-when~="md"] {
         display: none;
     }
 }
 
-@media (min-width: 1280px) and (max-width: 1919px) {
+@media (min-width: 1280px) and (max-width: 1919.98px) {
     .fluent-wizard > ol > li ::deep > div[hidden-when~="lg"] {
         display: none;
     }
 }
 
-@media (min-width: 1920px) and (max-width: 2559px) {
+@media (min-width: 1920px) and (max-width: 2559.98px) {
     .fluent-wizard > ol > li ::deep > div[hidden-when~="xl"] {
         display: none;
     }


### PR DESCRIPTION
# Pull Request

## 📖 Description

I noticed that the `FluentGrid` component displayed grid items that were meant to be hidden at fractional pixel sizes.
For example, the `FluentCard` labeled 'xs="12" sm="6" Hidden="SmAndDown"' in following screenshot is hidden with a browser size '<= 599px' or '>= 600px and <= 959px' but not inbetween those values (i.e. 599.33px):
<img width="449" alt="image" src="https://github.com/microsoft/fluentui-blazor/assets/143792830/3e388efc-6e18-4ab7-a7df-a9471f733bb5">

To fix this, I added .98px to the max-width breakpoints, as explained under following link:
https://stackoverflow.com/questions/54596219/why-do-some-max-width-media-queries-use-a-98px

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new compontent
- [x] I have modified an existing component
- [ ] I have validate [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component 
