### PR TITLE
[Checkbox] Fix missing Checkbox "disabled" class [v3]

### DIFF
--- a/src/Core/Components/Checkbox/FluentCheckbox.razor.cs
+++ b/src/Core/Components/Checkbox/FluentCheckbox.razor.cs
@@ -85,6 +85,7 @@ public partial class FluentCheckbox : FluentInputBase<bool>
         get
         {
             return new CssBuilder(base.ClassValue)
+                .AddClass("disabled", when: Disabled)
                 .AddClass("checked", when: Value)
                 .AddClass("indeterminate", when: ThreeState && CheckState is null)
                 .Build();

--- a/tests/Core/Checkbox/FluentCheckboxTests.FluentCheckbox_DisabledParameter.verified.html
+++ b/tests/Core/Checkbox/FluentCheckboxTests.FluentCheckbox_DisabledParameter.verified.html
@@ -1,2 +1,2 @@
 
-<fluent-checkbox class="checked" id="xxx" value="True" current-value="" disabled="" current-checked="" blazor:oncheckedchange="1" blazor:elementreference="xxx">childContent</fluent-checkbox>
+<fluent-checkbox class="checked disabled" id="xxx" value="True" current-value="" disabled="" current-checked="" blazor:oncheckedchange="1" blazor:elementreference="xxx">childContent</fluent-checkbox>


### PR DESCRIPTION
[Checkbox] Fix missing Checkbox "disabled" class

After updating the value of a disabled component checkbox, the disabled checkbox displays the current HTML code.
Note the absence of class="disabled".

```html
<fluent-checkbox disabled="" role="checkbox" aria-checked="false" aria-required="false" aria-disabled="true">Disabled</fluent-checkbox>
```

This PR adapts the class by adding `disabled` when the control is disabled.