### PR TITLE
Improve navmenu-icon position demo

### DIFF
--- a/examples/Demo/Shared/Shared/DemoMainLayout.razor
+++ b/examples/Demo/Shared/Shared/DemoMainLayout.razor
@@ -41,6 +41,9 @@
             <div class="settings">
                 <SiteSettings />
             </div>
+            <div class="navigation">
+                <label for="navmenu-toggle" class="navmenu-icon"><FluentIcon Value="@(new Icons.Regular.Size20.Navigation())" Color="Color.Neutral" /></label>
+            </div>
         </FluentHeader>
 
         <FluentStack Class="body-stack" Orientation="Orientation.Horizontal" Width="100%" HorizontalGap="0">

--- a/examples/Demo/Shared/Shared/DemoNavMenu.razor
+++ b/examples/Demo/Shared/Shared/DemoNavMenu.razor
@@ -1,6 +1,5 @@
-<div class="navmenu">
-    <input type="checkbox" title="Menu expand/collapse toggle" id="navmenu-toggle" class="navmenu-icon" />
-    <label for="navmenu-toggle" class="navmenu-icon"><FluentIcon Value="@(new Icons.Regular.Size20.Navigation())" Color="Color.Neutral" /></label>
+﻿<div class="navmenu">
+    <input type="checkbox" title="Menu expand/collapse toggle" id="navmenu-toggle" style="display:none" />
     <nav class="sitenav" aria-labelledby="main-menu" onclick="document.getElementById('navmenu-toggle').click()">
         <FluentNavMenu Id="main-menu" Title="Main menu">
             <FluentNavLink Icon="@(new Icons.Regular.Size20.Home())" Href="/" Match="NavLinkMatch.All">

--- a/examples/Demo/Shared/wwwroot/css/site.css
+++ b/examples/Demo/Shared/wwwroot/css/site.css
@@ -1,4 +1,4 @@
-﻿@import '/_content/Microsoft.FluentUI.AspNetCore.Components/css/reboot.css';
+@import '/_content/Microsoft.FluentUI.AspNetCore.Components/css/reboot.css';
 
 body {
     height: 100%;
@@ -30,6 +30,11 @@ body {
 
     .siteheader .settings {
         padding-right: 6px;
+        display: flex;
+        align-items: center;
+    }
+
+    .siteheader .navigation {
         display: flex;
         align-items: center;
     }
@@ -284,12 +289,8 @@ code {
 
     .navmenu-icon {
         cursor: pointer;
-        z-index: 10;
         display: block;
-        position: absolute;
-        top: 15px;
-        left: unset;
-        right: 20px;
+        position: relative;
         width: 20px;
         height: 20px;
         border: none;


### PR DESCRIPTION
I've moved the icon to the header section so that it can be relatively positioned and not fixed with hard coded values, improving its position with a clear separation. 

Before: 
![Screenshot 2024-01-29 155028](https://github.com/microsoft/fluentui-blazor/assets/49217428/1a5989d4-e352-40c1-9063-5a76a1b2f601)

After:
![Screenshot 2024-01-29 165009](https://github.com/microsoft/fluentui-blazor/assets/49217428/7d537dda-ebbf-4f60-ab74-ed2e6a3d2fb2)
