### PR TITLE
Temporary fix #1391

### DIFF
--- a/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Shared/ExternalLoginPicker.razor
+++ b/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Shared/ExternalLoginPicker.razor
@@ -23,7 +23,8 @@ else
             <p>
                 @foreach (var provider in externalLogins)
                 {
-                    <FluentButton Type="ButtonType.Submit" Appearance="Appearance.Accent"  name="provider" Value="@provider.Name" Title="@($"Log in using your {provider.DisplayName} account")">@provider.DisplayName</FluentButton>
+                    <input type="hidden" name="provider" value="@provider.Name" />
+                    <FluentButton Type="ButtonType.Submit" Appearance="Appearance.Accent" Title="@($"Log in using your {provider.DisplayName} account")">@provider.DisplayName</FluentButton>
                 }
             </p>
         </div>


### PR DESCRIPTION
Temporary fix for #1391 by adding a hidden input with name and value because when these are set on the FluentButton the web component posts the name and value **twice**, which leads to issues in the `PerformExternalLogin` handler.

Issue has been reported to the Fluent team. Once fixed there, this workaround can/shoud be undone.