### PR TITLE
 [FluentDesignTheme] Assertion failed "heap is currently locked when changing theme"

### DIFF
--- a/src/Core/Components/DesignSystemProvider/FluentDesignTheme.razor.js
+++ b/src/Core/Components/DesignSystemProvider/FluentDesignTheme.razor.js
@@ -1,10 +1,13 @@
-﻿export function addThemeChangeEvent(dotNetHelper, id) {
+export function addThemeChangeEvent(dotNetHelper, id) {
     const element = document.getElementById(id);
 
     if (element) {
         element.addEventListener("onchange", (e) => {
             try {
-                dotNetHelper.invokeMethodAsync("OnChangeRaisedAsync", e.detail.name, e.detail.newValue ?? "system");
+                // setTimeout: https://github.com/dotnet/aspnetcore/issues/26809
+                setTimeout(() => {
+                    dotNetHelper.invokeMethodAsync("OnChangeRaisedAsync", e.detail.name, e.detail.newValue ?? "system");
+                }, 0);
             } catch (error) {
                 console.error(`FluentDesignTheme: failing to call OnChangeRaisedAsync.`, error);
             }


### PR DESCRIPTION
# [FluentDesignTheme] Assertion failed "heap is currently locked when changing theme"

Like describe in this issue: #1182
this error may occur when the user changes Theme using FluentDesignTheme

![image](https://github.com/microsoft/fluentui-blazor/assets/8350694/7a1e37c1-cbbc-4b96-af65-11b3abc6d9cb)

SteveSandersonMS replied with [this anwser](https://github.com/dotnet/aspnetcore/issues/26809).

> What's happening here is that your JS code is trying to call back into .NET during the middle of applying a renderbatch 
> to the DOM. This isn't safe to do, because if .NET code runs at this time, it might modify the contents of .NET memory 
> and invalidate the renderbatch that's still being processed.
> 
> To avoid this problem, when performing JS interop calls that can occur while applying a renderbatch, be sure to defer 
> the call. For example, update your code as follows:
>
> ```js
>    window.document.addEventListener("focusout", function (e) {
>        console.log("focus out: " + new Date());
>
>        if (e.target.classList.contains("list-item-1")) {
>            setTimeout(invokeFocusOut, 0);
>        }
>    });
> ```

