### PR TITLE
Fixes #1442 - fluentblazor template does not build using 4.4.0 nuget templates

### DIFF
--- a/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Pages/Weather.razor
+++ b/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Pages/Weather.razor
@@ -25,7 +25,7 @@ else
     ##else
     <!-- This page is rendered in SSR mode, so the FluentDataGrid component does not offer any interactivity (like sorting). -->
     <FluentDataGrid Id="weathergrid" Items=@forecasts GridTemplateColumns="1fr 1fr 1fr 2fr" TGridItem=WeatherForecast>
-        <PropertyColumn Title="Date" Property="@(c => c!.Date)" Align=Align.Start"/>
+        <PropertyColumn Title="Date" Property="@(c => c!.Date)" Align="Align.Start"/>
         <PropertyColumn Title="Temp. (C)" Property="@(c => c!.TemperatureC)" Align="Align.Center"/>
         <PropertyColumn Title="Temp. (F)" Property="@(c => c!.TemperatureF)" Align="Align.Center"/>
         <PropertyColumn Title="Summary" Property="@(c => c!.Summary)" Align="Align.End"/>


### PR DESCRIPTION
# Pull Request

Fixes **fluentblazor** template

## 📖 Description

Creating a new fluent blazor application using 4.4.0 templates does not build. See #1442 

### 🎫 Issues

Missing a **"** in the **Weather.razor** file.

## 👩‍💻 Reviewer Notes

To reproduce from the cli 

```powershell
dotnet new fluentblazor
dotnet build
```

## 📑 Test Plan

## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [X] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new compontent
- [ ] I have modified an existing component
- [ ] I have validate [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component 

## ⏭ Next Steps
