### PR TITLE
[Autocomplete] Fix Disabled item using keyboard and re-enables the ability to click on an element

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -93,6 +93,53 @@
             <param name="targetId"></param>
             <returns></returns>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentKeyCodeEventArgs.Location">
+            <summary>
+            Gets an <see cref="T:Microsoft.FluentUI.AspNetCore.Components.KeyLocation" /> representing the location of the key on the keyboard or other input device.
+            <see href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/location"/>
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentKeyCodeEventArgs.Key">
+            <summary>
+            Gets the <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentKeyCodeEventArgs.KeyCode"/> equivalent value.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentKeyCodeEventArgs.KeyCode">
+            <summary>
+            Gets the system- and implementation-dependent numerical code identifying the unmodified value of the pressed key.
+            <see href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode"/>
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentKeyCodeEventArgs.Value">
+            <summary>
+            Gets the value of the key pressed by the user
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentKeyCodeEventArgs.CtrlKey">
+            <summary>
+            Gets a boolean value that indicates if the Control key was pressed
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentKeyCodeEventArgs.ShiftKey">
+            <summary>
+            Gets a boolean value that indicates if the Shift key was pressed
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentKeyCodeEventArgs.AltKey">
+            <summary>
+            Gets a boolean value that indicates if the Alt key was pressed
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentKeyCodeEventArgs.MetaKey">
+            <summary>
+            Gets a boolean value that indicates if the Meta key was pressed
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentKeyCodeEventArgs.TargetId">
+            <summary>
+            Gets the identifier of the targeted DOM element.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAccordion.ExpandMode">
             <summary>
             Controls the expand mode of the Accordion, either allowing

--- a/examples/Demo/Shared/Pages/List/Autocomplete/Examples/AutocompleteDefault.razor
+++ b/examples/Demo/Shared/Pages/List/Autocomplete/Examples/AutocompleteDefault.razor
@@ -6,6 +6,7 @@
                     Width="250px"
                     Placeholder="Select countries"
                     OnOptionsSearch="@OnSearchAsync"
+                    OptionDisabled="@(e => e.Code == "au")"
                     MaximumSelectedOptions="3"
                     OptionText="@(item => item.Name)"
                     @bind-SelectedOptions="@SelectedItems" />

--- a/src/Core/Components/Accessibility/FluentKeyCodeEventArgs.cs
+++ b/src/Core/Components/Accessibility/FluentKeyCodeEventArgs.cs
@@ -2,13 +2,50 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 
 public class FluentKeyCodeEventArgs
 {
+    /// <summary>
+    /// Gets an <see cref="KeyLocation" /> representing the location of the key on the keyboard or other input device.
+    /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/location"/>
+    /// </summary>
     public KeyLocation Location { get; init; }
+
+    /// <summary>
+    /// Gets the <see cref="KeyCode"/> equivalent value.
+    /// </summary>
     public KeyCode Key { get; init; }
+
+    /// <summary>
+    /// Gets the system- and implementation-dependent numerical code identifying the unmodified value of the pressed key.
+    /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode"/>
+    /// </summary>
     public int KeyCode { get; init; }
+
+    /// <summary>
+    /// Gets the value of the key pressed by the user
+    /// </summary>
     public string Value { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets a boolean value that indicates if the Control key was pressed
+    /// </summary>
     public bool CtrlKey { get; init; }
+
+    /// <summary>
+    /// Gets a boolean value that indicates if the Shift key was pressed
+    /// </summary>
     public bool ShiftKey { get; init; }
+
+    /// <summary>
+    /// Gets a boolean value that indicates if the Alt key was pressed
+    /// </summary>
     public bool AltKey { get; init; }
+
+    /// <summary>
+    /// Gets a boolean value that indicates if the Meta key was pressed
+    /// </summary>
     public bool MetaKey { get; init; }
-    public string TargetId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the identifier of the targeted DOM element.
+    /// </summary>
+    public string TargetId { get; init; } = string.Empty;
 }

--- a/src/Core/Components/List/FluentAutocomplete.razor
+++ b/src/Core/Components/List/FluentAutocomplete.razor
@@ -22,7 +22,7 @@
                          Required="@Required"
                          @onclick="@OnDropDownExpandedAsync"
                          @oninput="@InputHandlerAsync"
-                         @onfocusout="@(e => { IsReachedMaxItems = false; IsMultiSelectOpened = false; })"
+                         @onfocusout="@(e => { IsReachedMaxItems = false; })"
                          Style="@ComponentWidth">
             @* Selected Items *@
             @if (this.SelectedOptions?.Any() == true)

--- a/src/Core/Components/List/FluentAutocomplete.razor.cs
+++ b/src/Core/Components/List/FluentAutocomplete.razor.cs
@@ -227,7 +227,17 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
             case KeyCode.Enter:
                 if (IsMultiSelectOpened)
                 {
-                    await KeyDown_Enter();
+                    var optionDisabled = SelectableItem != null && OptionDisabled != null
+                                       ? OptionDisabled.Invoke(SelectableItem)
+                                       : false;
+                    if (optionDisabled)
+                    {
+                        await KeyDown_Escape();
+                    }
+                    else
+                    {
+                        await KeyDown_Enter();
+                    }
                 }
                 else
                 {
@@ -291,9 +301,18 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
             if (Items != null && Items.Any())
             {
                 var index = Items.ToList().IndexOf(SelectableItem ?? Items.First());
-                if (index > 0)
+
+                // Previous available item
+                for (var i = index - 1; i >= 0; i--)
                 {
-                    SelectableItem = Items.ElementAt(index - 1);
+                    var item = Items.ElementAt(i);
+                    var disabled = OptionDisabled?.Invoke(item) ?? false;
+
+                    if (!disabled)
+                    {
+                        SelectableItem = Items.ElementAt(i);
+                        break;
+                    }
                 }
             }
 
@@ -306,9 +325,18 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
             if (Items != null && Items.Any())
             {
                 var index = Items.ToList().IndexOf(SelectableItem ?? Items.First());
-                if (index < Items.Count() - 1)
+
+                // Next available item
+                for (var i = index + 1; i < Items.Count(); i++)
                 {
-                    SelectableItem = Items.ElementAt(index + 1);
+                    var item = Items.ElementAt(i);
+                    var disabled = OptionDisabled?.Invoke(item) ?? false;
+
+                    if (!disabled)
+                    {
+                        SelectableItem = Items.ElementAt(i);
+                        break;
+                    }
                 }
             }
 


### PR DESCRIPTION
# [Autocomplete] Fix Disabled item using keyboard and re-enables the ability to click on an element

Fixes these Autocomplete problems:

1. Prevents the `Enter` key from selecting a deactivated item.
2. Prevents selection of disabled items when navigating with the `Up` and `Down` arrows.
3. Re-enables the ability to click on an element to select / deselect it.

![Autocomplete-fix](https://github.com/microsoft/fluentui-blazor/assets/8350694/8badb5d1-210d-4742-8129-ec45cb77e7f1)
