### PR TITLE
fix: FluentMessageBar onclick bug and not using Link?.Target

### DIFF
--- a/examples/Demo/Shared/Components/NotificationCenterPanel.razor
+++ b/examples/Demo/Shared/Components/NotificationCenterPanel.razor
@@ -6,7 +6,7 @@
     <FluentStack>
         <FluentSpacer />
         
-        <FluentAnchor Appearance="@Appearance.Hypertext" Href="" @onclick="@(e => MessageService.Clear(App.MESSAGES_NOTIFICATION_CENTER) )">
+        <FluentAnchor Appearance="@Appearance.Hypertext" Href="" OnClick="@(e => MessageService.Clear(App.MESSAGES_NOTIFICATION_CENTER) )">
             Dismiss all
         </FluentAnchor>
     </FluentStack>

--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -4836,7 +4836,7 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentMessageBar.ShowSecondaryAction">
             <summary />
         </member>
-        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentMessageBar.LinkClickedAsync(Microsoft.AspNetCore.Components.Web.MouseEventArgs)">
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentMessageBar.LinkClickedAsync">
             <summary />
         </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentMessageBar.PrimaryActionClickedAsync(Microsoft.AspNetCore.Components.Web.MouseEventArgs)">

--- a/src/Core/Components/MessageBar/FluentMessageBar.razor
+++ b/src/Core/Components/MessageBar/FluentMessageBar.razor
@@ -31,8 +31,8 @@
                 {
                     <FluentAnchor Href="@(String.IsNullOrEmpty(Link?.Href) ? "#" : Link?.Href)"
                                   Appearance="Appearance.Hypertext"
-                                  Target="_blank"
-                                  @onclick="@LinkClickedAsync"
+                                  Target="@(Link?.Target ?? "_blank")"
+                                  OnClick="@LinkClickedAsync"
                                   title="Link">
                         @Link?.Text
                     </FluentAnchor>
@@ -42,7 +42,7 @@
                 @if (ShowPrimaryAction)
                 {
                     <FluentButton Appearance="@Appearance.Neutral"
-                                    @onclick="@PrimaryActionClickedAsync"
+                                    OnClick="@PrimaryActionClickedAsync"
                                     title="Alert action"
                                     Class="fluent-messagebar-action">
                         @PrimaryAction?.Text
@@ -51,7 +51,7 @@
                 @if (ShowSecondaryAction)
                 {
                     <FluentButton Appearance="@Appearance.Neutral"
-                                  @onclick="@SecondaryActionClickedAsync"
+                                  OnClick="@SecondaryActionClickedAsync"
                                   title="Alert action"
                                   Class="fluent-messagebar-action">
                         @SecondaryAction?.Text
@@ -107,16 +107,16 @@
                 {
                     <FluentAnchor Href="@(String.IsNullOrEmpty(Link?.Href) ? "#" : Link?.Href)"
                                   Appearance="Appearance.Hypertext"
-                                  Target="_blank"
-                                  @onclick="@LinkClickedAsync"
+                                  Target="@(Link?.Target ?? "_blank")"
+                                  OnClick="@LinkClickedAsync"
                                   title="Link">
                         @Link?.Text
                     </FluentAnchor>
                 }
                 @if (ShowPrimaryAction)
                 {
-                    <FluentButton Appearance="Appearance.Hypertext"
-                                  @onclick="@PrimaryActionClickedAsync"
+                    <FluentButton Appearance="Appearance.Neutral"
+                                  OnClick="@PrimaryActionClickedAsync"
                                   title="Notification action"
                                   Class="fluent-messagebar-action">
                         @PrimaryAction?.Text

--- a/src/Core/Components/MessageBar/FluentMessageBar.razor.cs
+++ b/src/Core/Components/MessageBar/FluentMessageBar.razor.cs
@@ -205,7 +205,7 @@ public partial class FluentMessageBar : FluentComponentBase, IDisposable
     }
 
     /// <summary />
-    protected Task LinkClickedAsync(MouseEventArgs e)
+    protected Task LinkClickedAsync()
     {
         if (Link?.OnClick != null)
         {


### PR DESCRIPTION
In the FluentMessageBar some @onclick event bindings were broken since version 4.4.0, I replaced them with the new OnClick. If a Target was specified in the Link of a notification, it was not used in the FluentMessageBar and always fell back to _blank.

# Pull Request

## 📖 Description
1. Fix: When opening the FluentMessageBar, it would create the unhandledexception "Unhandled exception rendering component: Unable to set property 'onclick' on object of type 'Microsoft.FluentUI.AspNetCore.Components.FluentAnchor'. The error was: Arg_InvalidCastException", this has been fixed by replacing the @onclick with OnClick

2. If the Link in the Message would contain a target, this target was not used (hardcoded to _blank). Now it user the target in the link or _blank in case no target has been specified.

## 👩‍💻 Reviewer Notes
Add messages to the FluentMessageBar and open it.

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- ✅ I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new compontent
- ✅ I have modified an existing component
- [ ] I have validate [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component 

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->