### PR TITLE
[FluentDesignTheme] Fix the Random color annoys other fillers

### DIFF
--- a/src/Core/Components/DesignSystemProvider/FluentDesignTheme.razor.cs
+++ b/src/Core/Components/DesignSystemProvider/FluentDesignTheme.razor.cs
@@ -268,7 +268,7 @@ public partial class FluentDesignTheme : ComponentBase
             return Enum.GetName(OfficeColor.Value);
         }
 
-        return OfficeColorUtilities.GetRandom().ToAttributeValue();
+        return null;
     }
 
     private string? GetMode()


### PR DESCRIPTION
# [FluentDesignTheme] Fix the Random color annoys other fillers

When a `FluentThemeDesign` is used without parameters, a random color was selected.
It polished the next updates, mainly after a processing time.

This random color processing should be done outside the Fluent components, only in the Demo site :-)

Issue #1455

![Fix-ThemeDesign](https://github.com/microsoft/fluentui-blazor/assets/8350694/c38fabce-7610-4c6c-b038-9fd54ed1072d)
