### PR TITLE
# [DatePicker] Add DateOnly and TimeOnly extensions 

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -12426,6 +12426,13 @@
             <param name="value"></param>
             <returns></returns>
         </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.DateTimeExtensions.ToDateTime(System.TimeOnly)">
+            <summary>
+            Converts the TimeOnly to an equivalent DateTime.
+            </summary>
+            <param name="value"></param>
+            <returns></returns>
+        </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.DateTimeExtensions.ToDateTime(System.Nullable{System.DateOnly})">
             <summary>
             Converts the nullable DateOnly to an equivalent DateTime.
@@ -12434,10 +12441,24 @@
             <param name="value"></param>
             <returns></returns>
         </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.DateTimeExtensions.ToDateTime(System.Nullable{System.TimeOnly})">
+            <summary>
+            Converts the nullable TimeOnly to an equivalent DateTime.
+            Returns <see cref="F:System.DateTime.MinValue"/> if the <paramref name="value"/> is null.
+            </summary>
+            <param name="value"></param>
+            <returns></returns>
+        </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.DateTimeExtensions.ToDateTimeNullable(System.Nullable{System.DateOnly})">
             <summary>
             Converts the nullable DateOnly to an equivalent DateTime.
-            Returns <see cref="P:System.DateOnly.MinValue"/> if the <paramref name="value"/> is null.
+            </summary>
+            <param name="value"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.DateTimeExtensions.ToDateTimeNullable(System.Nullable{System.TimeOnly})">
+            <summary>
+            Converts the nullable TimeOnly to an equivalent DateTime.
             </summary>
             <param name="value"></param>
             <returns></returns>
@@ -12458,10 +12479,24 @@
             <param name="value"></param>
             <returns></returns>
         </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.DateTimeExtensions.ToTimeOnly(System.Nullable{System.DateTime})">
+            <summary>
+            Converts the nullable DateTime to an equivalent TimeOnly, removing the time part.
+            Returns <see cref="P:System.TimeOnly.MinValue"/> if the <paramref name="value"/> is null.
+            </summary>
+            <param name="value"></param>
+            <returns></returns>
+        </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.DateTimeExtensions.ToDateOnlyNullable(System.Nullable{System.DateTime})">
             <summary>
             Converts the nullable DateTime to an equivalent DateOnly?, removing the time part.
-            Returns <see cref="P:System.DateOnly.MinValue"/> if the <paramref name="value"/> is null.
+            </summary>
+            <param name="value"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.DateTimeExtensions.ToTimeOnlyNullable(System.Nullable{System.DateTime})">
+            <summary>
+            Converts the nullable DateTime to an equivalent TimeOnly?, removing the time part.
             </summary>
             <param name="value"></param>
             <returns></returns>

--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -12419,6 +12419,37 @@
             <returns></returns>
             <remarks>Inspired from https://github.com/NickStrupat/TimeAgo.</remarks>
         </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.DateTimeExtensions.ToDateTime(System.DateOnly)">
+            <summary>
+            Converts the DateOnly to an equivalent DateTime.
+            </summary>
+            <param name="value"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.DateTimeExtensions.ToDateTime(System.Nullable{System.DateOnly})">
+            <summary>
+            Converts the nullable DateOnly to an equivalent DateTime.
+            Returns <see cref="P:System.DateOnly.MinValue"/> if the <paramref name="value"/> is null.
+            </summary>
+            <param name="value"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.DateTimeExtensions.ToDateTime(System.Nullable{System.DateTime})">
+            <summary>
+            Converts the nullable DateTime to an equivalent DateTime.
+            Returns <see cref="P:System.DateOnly.MinValue"/> if the <paramref name="value"/> is null.
+            </summary>
+            <param name="value"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.DateTimeExtensions.ToDateOnly(System.Nullable{System.DateTime})">
+            <summary>
+            Converts the nullable DateTime to an equivalent DateOnly, removing the time part.
+            Returns <see cref="P:System.DateOnly.MinValue"/> if the <paramref name="value"/> is null.
+            </summary>
+            <param name="value"></param>
+            <returns></returns>
+        </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.ServiceCollectionExtensions.AddFluentUIComponents(Microsoft.Extensions.DependencyInjection.IServiceCollection,Microsoft.FluentUI.AspNetCore.Components.LibraryConfiguration)">
             <summary>
             Add common services required by the Fluent UI Web Components for Blazor library

--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -12434,6 +12434,14 @@
             <param name="value"></param>
             <returns></returns>
         </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.DateTimeExtensions.ToDateTimeNullable(System.Nullable{System.DateOnly})">
+            <summary>
+            Converts the nullable DateOnly to an equivalent DateTime.
+            Returns <see cref="P:System.DateOnly.MinValue"/> if the <paramref name="value"/> is null.
+            </summary>
+            <param name="value"></param>
+            <returns></returns>
+        </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.DateTimeExtensions.ToDateTime(System.Nullable{System.DateTime})">
             <summary>
             Converts the nullable DateTime to an equivalent DateTime.
@@ -12445,6 +12453,14 @@
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.DateTimeExtensions.ToDateOnly(System.Nullable{System.DateTime})">
             <summary>
             Converts the nullable DateTime to an equivalent DateOnly, removing the time part.
+            Returns <see cref="P:System.DateOnly.MinValue"/> if the <paramref name="value"/> is null.
+            </summary>
+            <param name="value"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.DateTimeExtensions.ToDateOnlyNullable(System.Nullable{System.DateTime})">
+            <summary>
+            Converts the nullable DateTime to an equivalent DateOnly?, removing the time part.
             Returns <see cref="P:System.DateOnly.MinValue"/> if the <paramref name="value"/> is null.
             </summary>
             <param name="value"></param>

--- a/examples/Demo/Shared/Pages/DateTimes/DateTimesPage.razor
+++ b/examples/Demo/Shared/Pages/DateTimes/DateTimesPage.razor
@@ -1,4 +1,4 @@
-@page "/DateTime"
+﻿@page "/DateTime"
 
 @using FluentUI.Demo.Shared.Pages.DateTimes.Examples
 
@@ -30,6 +30,25 @@
 <DemoSection Title="Default Date Picker" Component="@typeof(DatePickerDefault)"></DemoSection>
 
 <DemoSection Title="Default Time Picker" Component="@typeof(TimePickerDefault)"></DemoSection>
+
+<h2 id="conversion">DateOnly, TimeOnly bindings</h2>
+
+<p>
+    By design, the <b>DatePicker</b> component uses a <b>Value</b> property of type <b>DateTime?</b>
+    To facilitate binding to a <b>DateOnly</b> type, you can use the methods
+    <code>ToDateTime</code> and <code>ToDateOnly</code> methods.
+</p>
+
+<b>Example</b>
+<CodeSnippet>
+    &lt;FluentDatePicker Value="@@MyDate.ToDateTime()"
+                      ValueChanged="@@(e => MyDate = e.ToDateOnly())" />
+    @@code {
+        private DateOnly MyDate = DateOnly.FromDateTime(DateTime.Today);
+    }
+</CodeSnippet>
+
+<DemoSection Component="@typeof(DateTimeConversionExample)"></DemoSection>
 
 <h2 id="totimeago">ToTimeAgo() method</h2>
 

--- a/examples/Demo/Shared/Pages/DateTimes/DateTimesPage.razor
+++ b/examples/Demo/Shared/Pages/DateTimes/DateTimesPage.razor
@@ -39,6 +39,12 @@
     <code>ToDateTime</code> and <code>ToDateOnly</code> methods.
 </p>
 
+<p>
+    If your variable is of type <code>Nullable&lt;DateTime></code>, you can continue
+    to use <code>@@bind-Value</code>.
+    For other types, you must use the syntax <code>value="..." ValueChanged="..."</code>.
+</p>
+
 <b>Example</b>
 <CodeSnippet>
     &lt;FluentDatePicker Value="@@MyDate.ToDateTime()"

--- a/examples/Demo/Shared/Pages/DateTimes/Examples/DateTimeConversionExample.razor
+++ b/examples/Demo/Shared/Pages/DateTimes/Examples/DateTimeConversionExample.razor
@@ -13,13 +13,13 @@
 <br />
 
 <FluentDatePicker Value="@MyDate2.ToDateTimeNullable()" ValueChanged="@(e => MyDate2 = e.ToDateOnlyNullable())" />
-<FluentDatePicker Value="@MyTime2.ToDateTimeNullable()" ValueChanged="@(e => MyTime2 = e.ToTimeOnlyNullable())" />
+<FluentTimePicker Value="@MyTime2.ToDateTimeNullable()" ValueChanged="@(e => MyTime2 = e.ToTimeOnlyNullable())" />
 <b>Date:</b> @(MyDate2?.ToString("yyyy-MM-dd"))
 <b>Time:</b> @(MyTime2?.ToString("HH:mm"))
 <br />
 
 <FluentDatePicker Value="@MyDate3.ToDateTime()" ValueChanged="@(e => MyDate3 = e.ToDateOnly())" />
-<FluentDatePicker Value="@MyTime3.ToDateTime()" ValueChanged="@(e => MyTime3 = e.ToTimeOnly())" />
+<FluentTimePicker Value="@MyTime3.ToDateTime()" ValueChanged="@(e => MyTime3 = e.ToTimeOnly())" />
 <b>Date:</b> @(MyDate3.ToString("yyyy-MM-dd"))
 <b>Time:</b> @(MyTime3.ToString("HH:mm"))
 <br />

--- a/examples/Demo/Shared/Pages/DateTimes/Examples/DateTimeConversionExample.razor
+++ b/examples/Demo/Shared/Pages/DateTimes/Examples/DateTimeConversionExample.razor
@@ -1,25 +1,38 @@
 ﻿<!-- Default usage -->
 <FluentDatePicker @bind-Value="@MyDate0" />
+<FluentTimePicker @bind-Value="@MyTime0" />
 <b>Date:</b> @(MyDate0?.ToString("yyyy-MM-dd"))
+<b>Time:</b> @(MyTime0?.ToString("HH:mm"))
 <br />
 
 <!-- Using conversion methods -->
 <FluentDatePicker Value="@MyDate1" ValueChanged="@(e => MyDate1 = e.ToDateTime())" />
+<FluentTimePicker Value="@MyTime1" ValueChanged="@(e => MyTime1 = e.ToDateTime())" />
 <b>Date:</b> @(MyDate1.ToString("yyyy-MM-dd"))
+<b>Time:</b> @(MyTime1.ToString("HH:mm"))
 <br />
 
 <FluentDatePicker Value="@MyDate2.ToDateTimeNullable()" ValueChanged="@(e => MyDate2 = e.ToDateOnlyNullable())" />
+<FluentDatePicker Value="@MyTime2.ToDateTimeNullable()" ValueChanged="@(e => MyTime2 = e.ToTimeOnlyNullable())" />
 <b>Date:</b> @(MyDate2?.ToString("yyyy-MM-dd"))
+<b>Time:</b> @(MyTime2?.ToString("HH:mm"))
 <br />
 
 <FluentDatePicker Value="@MyDate3.ToDateTime()" ValueChanged="@(e => MyDate3 = e.ToDateOnly())" />
+<FluentDatePicker Value="@MyTime3.ToDateTime()" ValueChanged="@(e => MyTime3 = e.ToTimeOnly())" />
 <b>Date:</b> @(MyDate3.ToString("yyyy-MM-dd"))
+<b>Time:</b> @(MyTime3.ToString("HH:mm"))
 <br />
 
 @code
 {
-    private DateTime? MyDate0 = DateTime.Today;
-    private DateTime MyDate1 = DateTime.Today;
-    private DateOnly? MyDate2 = DateOnly.FromDateTime(DateTime.Today);
-    private DateOnly MyDate3 = DateOnly.FromDateTime(DateTime.Today);
+    private DateTime? MyDate0 = DateTime.Now;
+    private DateTime MyDate1 = DateTime.Now;
+    private DateOnly? MyDate2 = DateOnly.FromDateTime(DateTime.Now);
+    private DateOnly MyDate3 = DateOnly.FromDateTime(DateTime.Now);
+
+    private DateTime? MyTime0 = DateTime.Now;
+    private DateTime MyTime1 = DateTime.Now;
+    private TimeOnly? MyTime2 = TimeOnly.FromDateTime(DateTime.Now);
+    private TimeOnly MyTime3 = TimeOnly.FromDateTime(DateTime.Now);
 }

--- a/examples/Demo/Shared/Pages/DateTimes/Examples/DateTimeConversionExample.razor
+++ b/examples/Demo/Shared/Pages/DateTimes/Examples/DateTimeConversionExample.razor
@@ -1,0 +1,25 @@
+﻿<!-- Default usage -->
+<FluentDatePicker @bind-Value="@MyDate0" />
+<b>Date:</b> @(MyDate0?.ToString("yyyy-MM-dd"))
+<br />
+
+<!-- Using conversion methods -->
+<FluentDatePicker Value="@MyDate1" ValueChanged="@(e => MyDate1 = e.ToDateTime())" />
+<b>Date:</b> @(MyDate1.ToString("yyyy-MM-dd"))
+<br />
+
+<FluentDatePicker Value="@MyDate2.ToDateTimeNullable()" ValueChanged="@(e => MyDate2 = e.ToDateOnlyNullable())" />
+<b>Date:</b> @(MyDate2?.ToString("yyyy-MM-dd"))
+<br />
+
+<FluentDatePicker Value="@MyDate3.ToDateTime()" ValueChanged="@(e => MyDate3 = e.ToDateOnly())" />
+<b>Date:</b> @(MyDate3.ToString("yyyy-MM-dd"))
+<br />
+
+@code
+{
+    private DateTime? MyDate0 = DateTime.Today;
+    private DateTime MyDate1 = DateTime.Today;
+    private DateOnly? MyDate2 = DateOnly.FromDateTime(DateTime.Today);
+    private DateOnly MyDate3 = DateOnly.FromDateTime(DateTime.Today);
+}

--- a/src/Core/Extensions/DateTimeExtensions.cs
+++ b/src/Core/Extensions/DateTimeExtensions.cs
@@ -138,6 +138,16 @@ public static class DateTimeExtensions
     }
 
     /// <summary>
+    /// Converts the TimeOnly to an equivalent DateTime.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static DateTime ToDateTime(this TimeOnly value)
+    {
+        return new DateTime(value.Ticks);
+    }
+
+    /// <summary>
     /// Converts the nullable DateOnly to an equivalent DateTime.
     /// Returns <see cref="DateOnly.MinValue"/> if the <paramref name="value"/> is null.
     /// </summary>
@@ -149,14 +159,34 @@ public static class DateTimeExtensions
     }
 
     /// <summary>
+    /// Converts the nullable TimeOnly to an equivalent DateTime.
+    /// Returns <see cref="DateTime.MinValue"/> if the <paramref name="value"/> is null.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static DateTime ToDateTime(this TimeOnly? value)
+    {
+        return value == null ? DateTime.MinValue : value.Value.ToDateTime();
+    }
+
+    /// <summary>
     /// Converts the nullable DateOnly to an equivalent DateTime.
-    /// Returns <see cref="DateOnly.MinValue"/> if the <paramref name="value"/> is null.
     /// </summary>
     /// <param name="value"></param>
     /// <returns></returns>
     public static DateTime? ToDateTimeNullable(this DateOnly? value)
     {
         return value == null ? (DateTime?)null : value.Value.ToDateTime(TimeOnly.MinValue);
+    }
+
+    /// <summary>
+    /// Converts the nullable TimeOnly to an equivalent DateTime.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static DateTime? ToDateTimeNullable(this TimeOnly? value)
+    {
+        return value == null ? (DateTime?)null : value.Value.ToDateTime();
     }
 
     /// <summary>
@@ -182,13 +212,33 @@ public static class DateTimeExtensions
     }
 
     /// <summary>
+    /// Converts the nullable DateTime to an equivalent TimeOnly, removing the time part.
+    /// Returns <see cref="TimeOnly.MinValue"/> if the <paramref name="value"/> is null.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static TimeOnly ToTimeOnly(this DateTime? value)
+    {
+        return value == null ? TimeOnly.MinValue : TimeOnly.FromDateTime(value.Value);
+    }
+
+    /// <summary>
     /// Converts the nullable DateTime to an equivalent DateOnly?, removing the time part.
-    /// Returns <see cref="DateOnly.MinValue"/> if the <paramref name="value"/> is null.
     /// </summary>
     /// <param name="value"></param>
     /// <returns></returns>
     public static DateOnly? ToDateOnlyNullable(this DateTime? value)
     {
         return value == null ? (DateOnly?)null : DateOnly.FromDateTime(value.Value);
+    }
+
+    /// <summary>
+    /// Converts the nullable DateTime to an equivalent TimeOnly?, removing the time part.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static TimeOnly? ToTimeOnlyNullable(this DateTime? value)
+    {
+        return value == null ? (TimeOnly?)null : TimeOnly.FromDateTime(value.Value);
     }
 }

--- a/src/Core/Extensions/DateTimeExtensions.cs
+++ b/src/Core/Extensions/DateTimeExtensions.cs
@@ -126,4 +126,47 @@ public static class DateTimeExtensions
 
         throw new NotSupportedException("The DateTime object does not have a supported value.");
     }
+
+    /// <summary>
+    /// Converts the DateOnly to an equivalent DateTime.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static DateTime ToDateTime(this DateOnly value)
+    {
+        return value.ToDateTime(TimeOnly.MinValue);
+    }
+
+    /// <summary>
+    /// Converts the nullable DateOnly to an equivalent DateTime.
+    /// Returns <see cref="DateOnly.MinValue"/> if the <paramref name="value"/> is null.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static DateTime ToDateTime(this DateOnly? value)
+    {
+        return value == null ? DateTime.MinValue : value.Value.ToDateTime(TimeOnly.MinValue);
+    }
+
+    /// <summary>
+    /// Converts the nullable DateTime to an equivalent DateTime.
+    /// Returns <see cref="DateOnly.MinValue"/> if the <paramref name="value"/> is null.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static DateTime ToDateTime(this DateTime? value)
+    {
+        return value == null ? DateTime.MinValue : value.Value;
+    }
+
+    /// <summary>
+    /// Converts the nullable DateTime to an equivalent DateOnly, removing the time part.
+    /// Returns <see cref="DateOnly.MinValue"/> if the <paramref name="value"/> is null.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static DateOnly ToDateOnly(this DateTime? value)
+    {
+        return value == null ? DateOnly.MinValue : DateOnly.FromDateTime(value.Value);
+    }
 }

--- a/src/Core/Extensions/DateTimeExtensions.cs
+++ b/src/Core/Extensions/DateTimeExtensions.cs
@@ -149,6 +149,17 @@ public static class DateTimeExtensions
     }
 
     /// <summary>
+    /// Converts the nullable DateOnly to an equivalent DateTime.
+    /// Returns <see cref="DateOnly.MinValue"/> if the <paramref name="value"/> is null.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static DateTime? ToDateTimeNullable(this DateOnly? value)
+    {
+        return value == null ? (DateTime?)null : value.Value.ToDateTime(TimeOnly.MinValue);
+    }
+
+    /// <summary>
     /// Converts the nullable DateTime to an equivalent DateTime.
     /// Returns <see cref="DateOnly.MinValue"/> if the <paramref name="value"/> is null.
     /// </summary>
@@ -168,5 +179,16 @@ public static class DateTimeExtensions
     public static DateOnly ToDateOnly(this DateTime? value)
     {
         return value == null ? DateOnly.MinValue : DateOnly.FromDateTime(value.Value);
+    }
+
+    /// <summary>
+    /// Converts the nullable DateTime to an equivalent DateOnly?, removing the time part.
+    /// Returns <see cref="DateOnly.MinValue"/> if the <paramref name="value"/> is null.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static DateOnly? ToDateOnlyNullable(this DateTime? value)
+    {
+        return value == null ? (DateOnly?)null : DateOnly.FromDateTime(value.Value);
     }
 }

--- a/tests/Core/DateTime/ToDateTimeExtensionsTests.cs
+++ b/tests/Core/DateTime/ToDateTimeExtensionsTests.cs
@@ -27,6 +27,17 @@ public class ToDateTimeExtensionsTests : TestBase
 
     [Theory]
     [InlineData("2024-02-11", "2024-02-11 00:00:00")]
+    [InlineData(null, null)]
+    public void DateOnlyNullable_ToDateTimeNullable(string? dateOnly, string? expected)
+    {
+        var value = string.IsNullOrEmpty(dateOnly) ? (DateOnly?)null : DateOnly.Parse(dateOnly);
+        var dateTime = DateTimeExtensions.ToDateTimeNullable(value);
+
+        Assert.Equal(expected, dateTime?.ToString("yyyy-MM-dd HH:mm:ss"));
+    }
+
+    [Theory]
+    [InlineData("2024-02-11", "2024-02-11 00:00:00")]
     [InlineData("2024-02-11 14:23:45", "2024-02-11 14:23:45")]
     [InlineData(null, "0001-01-01 00:00:00")]
     public void DateTimeNullable_ToDateTime(string? dateTime, string expected)
@@ -47,5 +58,17 @@ public class ToDateTimeExtensionsTests : TestBase
         var newDateTime = DateTimeExtensions.ToDateOnly(value);
 
         Assert.Equal(expected, newDateTime.ToString("yyyy-MM-dd"));
+    }
+
+    [Theory]
+    [InlineData("2024-02-11", "2024-02-11")]
+    [InlineData("2024-02-11 14:23:45", "2024-02-11")]
+    [InlineData(null, null)]
+    public void DateTimeNullable_ToDateOnlyNullable(string? dateTime, string? expected)
+    {
+        var value = string.IsNullOrEmpty(dateTime) ? (System.DateTime?)null : System.DateTime.Parse(dateTime);
+        var newDateTime = DateTimeExtensions.ToDateOnlyNullable(value);
+
+        Assert.Equal(expected, newDateTime?.ToString("yyyy-MM-dd"));
     }
 }

--- a/tests/Core/DateTime/ToDateTimeExtensionsTests.cs
+++ b/tests/Core/DateTime/ToDateTimeExtensionsTests.cs
@@ -1,0 +1,51 @@
+using Xunit;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Tests.DateTime;
+
+public class ToDateTimeExtensionsTests : TestBase
+{
+    [Theory]
+    [InlineData("2024-02-11", "2024-02-11 00:00:00")]
+    public void DateOnly_ToDateTime(string dateOnly, string expected)
+    {
+        var value = DateOnly.Parse(dateOnly);
+        var dateTime = DateTimeExtensions.ToDateTime(value);
+
+        Assert.Equal(expected, dateTime.ToString("yyyy-MM-dd HH:mm:ss"));
+    }
+
+    [Theory]
+    [InlineData("2024-02-11", "2024-02-11 00:00:00")]
+    [InlineData(null, "0001-01-01 00:00:00")]
+    public void DateOnlyNullable_ToDateTime(string? dateOnly, string expected)
+    {
+        var value = string.IsNullOrEmpty(dateOnly) ? (DateOnly?)null : DateOnly.Parse(dateOnly);
+        var dateTime = DateTimeExtensions.ToDateTime(value);
+
+        Assert.Equal(expected, dateTime.ToString("yyyy-MM-dd HH:mm:ss"));
+    }
+
+    [Theory]
+    [InlineData("2024-02-11", "2024-02-11 00:00:00")]
+    [InlineData("2024-02-11 14:23:45", "2024-02-11 14:23:45")]
+    [InlineData(null, "0001-01-01 00:00:00")]
+    public void DateTimeNullable_ToDateTime(string? dateTime, string expected)
+    {
+        var value = string.IsNullOrEmpty(dateTime) ? (System.DateTime?)null : System.DateTime.Parse(dateTime);
+        var newDateTime = DateTimeExtensions.ToDateTime(value);
+
+        Assert.Equal(expected, newDateTime.ToString("yyyy-MM-dd HH:mm:ss"));
+    }
+
+    [Theory]
+    [InlineData("2024-02-11", "2024-02-11")]
+    [InlineData("2024-02-11 14:23:45", "2024-02-11")]
+    [InlineData(null, "0001-01-01")]
+    public void DateTimeNullable_ToDateOnly(string? dateTime, string expected)
+    {
+        var value = string.IsNullOrEmpty(dateTime) ? (System.DateTime?)null : System.DateTime.Parse(dateTime);
+        var newDateTime = DateTimeExtensions.ToDateOnly(value);
+
+        Assert.Equal(expected, newDateTime.ToString("yyyy-MM-dd"));
+    }
+}

--- a/tests/Core/DateTime/ToDateTimeExtensionsTests.cs
+++ b/tests/Core/DateTime/ToDateTimeExtensionsTests.cs
@@ -15,6 +15,16 @@ public class ToDateTimeExtensionsTests : TestBase
     }
 
     [Theory]
+    [InlineData("14:23:45", "0001-01-01 14:23:45")]
+    public void TimeOnly_ToDateTime(string timeOnly, string expected)
+    {
+        var value = TimeOnly.Parse(timeOnly);
+        var dateTime = DateTimeExtensions.ToDateTime(value);
+
+        Assert.Equal(expected, dateTime.ToString("yyyy-MM-dd HH:mm:ss"));
+    }
+
+    [Theory]
     [InlineData("2024-02-11", "2024-02-11 00:00:00")]
     [InlineData(null, "0001-01-01 00:00:00")]
     public void DateOnlyNullable_ToDateTime(string? dateOnly, string expected)
@@ -26,11 +36,33 @@ public class ToDateTimeExtensionsTests : TestBase
     }
 
     [Theory]
+    [InlineData("14:23:45", "0001-01-01 14:23:45")]
+    [InlineData(null, "0001-01-01 00:00:00")]
+    public void TimeOnlyNullable_ToDateTime(string? timeOnly, string expected)
+    {
+        var value = string.IsNullOrEmpty(timeOnly) ? (TimeOnly?)null : TimeOnly.Parse(timeOnly);
+        var dateTime = DateTimeExtensions.ToDateTime(value);
+
+        Assert.Equal(expected, dateTime.ToString("yyyy-MM-dd HH:mm:ss"));
+    }
+
+    [Theory]
     [InlineData("2024-02-11", "2024-02-11 00:00:00")]
     [InlineData(null, null)]
     public void DateOnlyNullable_ToDateTimeNullable(string? dateOnly, string? expected)
     {
         var value = string.IsNullOrEmpty(dateOnly) ? (DateOnly?)null : DateOnly.Parse(dateOnly);
+        var dateTime = DateTimeExtensions.ToDateTimeNullable(value);
+
+        Assert.Equal(expected, dateTime?.ToString("yyyy-MM-dd HH:mm:ss"));
+    }
+
+    [Theory]
+    [InlineData("14:23:45", "0001-01-01 14:23:45")]
+    [InlineData(null, null)]
+    public void TimeOnlyNullable_ToDateTimeNullable(string? timeOnly, string? expected)
+    {
+        var value = string.IsNullOrEmpty(timeOnly) ? (TimeOnly?)null : TimeOnly.Parse(timeOnly);
         var dateTime = DateTimeExtensions.ToDateTimeNullable(value);
 
         Assert.Equal(expected, dateTime?.ToString("yyyy-MM-dd HH:mm:ss"));
@@ -61,6 +93,18 @@ public class ToDateTimeExtensionsTests : TestBase
     }
 
     [Theory]
+    [InlineData("2024-02-11", "00:00:00")]
+    [InlineData("2024-02-11 14:23:45", "14:23:45")]
+    [InlineData(null, "00:00:00")]
+    public void DateTimeNullable_ToTimeOnly(string? dateTime, string expected)
+    {
+        var value = string.IsNullOrEmpty(dateTime) ? (System.DateTime?)null : System.DateTime.Parse(dateTime);
+        var newDateTime = DateTimeExtensions.ToTimeOnly(value);
+
+        Assert.Equal(expected, newDateTime.ToString("HH:mm:ss"));
+    }
+
+    [Theory]
     [InlineData("2024-02-11", "2024-02-11")]
     [InlineData("2024-02-11 14:23:45", "2024-02-11")]
     [InlineData(null, null)]
@@ -70,5 +114,17 @@ public class ToDateTimeExtensionsTests : TestBase
         var newDateTime = DateTimeExtensions.ToDateOnlyNullable(value);
 
         Assert.Equal(expected, newDateTime?.ToString("yyyy-MM-dd"));
+    }
+
+    [Theory]
+    [InlineData("2024-02-11", "00:00:00")]
+    [InlineData("2024-02-11 14:23:45", "14:23:45")]
+    [InlineData(null, null)]
+    public void DateTimeNullable_ToTimeOnlyNullable(string? dateTime, string? expected)
+    {
+        var value = string.IsNullOrEmpty(dateTime) ? (System.DateTime?)null : System.DateTime.Parse(dateTime);
+        var newDateTime = DateTimeExtensions.ToTimeOnlyNullable(value);
+
+        Assert.Equal(expected, newDateTime?.ToString("HH:mm:ss"));
     }
 }


### PR DESCRIPTION
# [DatePicker] Add DateOnly and TimeOnly extensions 

To simplify the use of `DateTime`, `DateOnly` and `TimeOnly`, these extension methods could be used like in the following example.

- `DateTime DateOnly.ToDateTime()`
- `DateTime? DateOnly.ToDateTimeNullable()`
- `DateOnly DateTime.ToDateOnly()`
- `DateOnly? DateTime.ToDateOnlyNullable()`

- `DateTime TimeOnly.ToDateTime()`
- `DateTime? TimeOnly.ToDateTimeNullable()`
- `TimeOnly DateTime.ToTimeOnly()`
- `TimeOnly? DateTime.ToTimeOnlyNullable()`

If your variable is of type `Nullable<DateTime>`, you can continue to use `@bind-Value`.
For other types, you must use the syntax `value="..." ValueChanged="..."`

```razor
<!-- Default usage -->
<FluentDatePicker @bind-Value="@MyDate0" />

<!-- Using conversion methods -->
<FluentDatePicker Value="@MyDate1" ValueChanged="@(e => MyDate1 = e.ToDateTime())" />
<FluentDatePicker Value="@MyDate2.ToDateTimeNullable()" ValueChanged="@(e => MyDate2 = e.ToDateOnlyNullable())" />
<FluentDatePicker Value="@MyDate3.ToDateTime()" ValueChanged="@(e => MyDate3 = e.ToDateOnly())" />

@code
{
    private DateTime? MyDate0 = DateTime.Now;
    private DateTime MyDate1 = DateTime.Now;
    private DateOnly? MyDate2 = DateOnly.FromDateTime(DateTime.Now);
    private DateOnly MyDate3 = DateOnly.FromDateTime(DateTime.Now);
}
```