### PR TITLE
Remove background color for FluentPaginator nav

### DIFF
--- a/src/Core/Components/Pagination/FluentPaginator.razor.css
+++ b/src/Core/Components/Pagination/FluentPaginator.razor.css
@@ -17,7 +17,6 @@
     margin-inline-end: 0;
     gap: 0.5rem;
     align-items: center;
-    background-color: var(--neutral-layer-1);
 }
 
     


### PR DESCRIPTION
# Pull Request

## 📖 Description

The navigation child element of the `FluentPaginator` has a background color set.
This seems to be off, as it looks like this when placing it on a `FluentCard` for example:

![image](https://github.com/microsoft/fluentui-blazor/assets/46935044/7f9e7fa9-d4fe-4628-bad6-1db3972df76d)

By removing the background color, it simply inherits the background color of the element it is placed on:

![image](https://github.com/microsoft/fluentui-blazor/assets/46935044/f766d672-93b1-4d32-aeda-1330aff4f12b)

## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new compontent
- [x] I have modified an existing component
- [ ] I have validate [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component 