### PR TITLE
[FluentWizard] Fix ValueChanged never trigerred in FluentWizard

### DIFF
--- a/examples/Demo/Shared/Pages/Wizard/Examples/WizardCustomized.razor
+++ b/examples/Demo/Shared/Pages/Wizard/Examples/WizardCustomized.razor
@@ -1,4 +1,4 @@
-@inject IDialogService DialogService
+﻿@inject IDialogService DialogService
 
 <style>
     #customized-wizard li[status="current"] > div {

--- a/src/Core/Components/Wizard/FluentWizard.razor.cs
+++ b/src/Core/Components/Wizard/FluentWizard.razor.cs
@@ -180,6 +180,7 @@ public partial class FluentWizard : FluentComponentBase
     protected virtual async Task<FluentWizardStepChangeEventArgs> OnStepChangeHandlerAsync(int targetIndex)
     {
         var stepChangeArgs = new FluentWizardStepChangeEventArgs(targetIndex, _steps[targetIndex].Label);
+        await ValueChanged.InvokeAsync(targetIndex);
         return await OnStepChangeHandlerAsync(stepChangeArgs);
     }
 

--- a/tests/Core/Wizard/FluentWizardTests.razor
+++ b/tests/Core/Wizard/FluentWizardTests.razor
@@ -1,4 +1,4 @@
-@using Xunit;
+﻿@using Xunit;
 @inherits TestContext
 @code
 {
@@ -136,6 +136,35 @@
 
         // Assert
         cut.FindAll("li")[1].ToMarkup().Contains("status=\"current\"");
+    }
+
+    [Fact]
+    public void FluentWizard_NavigateWithBindedValue()
+    {
+        int stepIndex = 0;
+
+        // Arrange
+        var cut = Render(@<FluentWizard @bind-Value="@stepIndex">
+        <Steps>
+            <FluentWizardStep Label="Step1" Summary="Summary 1">
+                Content 1
+            </FluentWizardStep>
+            <FluentWizardStep Label="Step2" Summary="Summary 2">
+                Content 2
+            </FluentWizardStep>
+            <FluentWizardStep Label="Step3" Summary="Summary 3">
+                Content 3
+            </FluentWizardStep>
+        </Steps>
+    </FluentWizard>
+    );
+
+        var nextButton = cut.Find("fluent-button[appearance='accent']");
+        nextButton.Click();
+
+        // Assert
+        cut.FindAll("li")[1].ToMarkup().Contains("status=\"current\"");
+        Assert.Equal(1, stepIndex);
     }
 
     [Fact]


### PR DESCRIPTION
# [FluentWizard] Fix ValueChanged never trigerred in FluentWizard

To fix #1534 detected by @ejalbertinfoej (Thanks).

## Issue

Using the sample demo code, we have this code:

```razor
@code
{
    int Value = 0;
}

<FluentWizard Id="customized-wizard"
              @bind-Value="@Value"
              StepTitleHiddenWhen="@GridItemHidden.XsAndDown"
              Height="300px">
```

When clicking **Next** button in the wizard, the `Value` stays at 0. The `ValueChanged` callback method is never called.

## Solution 

1. Adding the fix.
2. Adding Unit Test to verify this case.