### PR TITLE
[Icon] Fix Icon color using `ColorWith` and a `CustomColor` attribute

### DIFF
--- a/src/Core/Components/Icons/FluentIcon.razor.cs
+++ b/src/Core/Components/Icons/FluentIcon.razor.cs
@@ -112,6 +112,11 @@ public partial class FluentIcon<Icon> : FluentComponentBase
             return CustomColor;
         }
 
+        if (Color == AspNetCore.Components.Color.Custom && !string.IsNullOrEmpty(_icon.Color))
+        {
+            return _icon.Color;
+        }
+
         if (Color != null)
         {
             return Color.ToAttributeValue() ?? defaultColor;

--- a/tests/Core/Icons/FluentIconTests.razor
+++ b/tests/Core/Icons/FluentIconTests.razor
@@ -1,4 +1,4 @@
-@using Microsoft.FluentUI.AspNetCore.Components.Tests.Extensions
+﻿@using Microsoft.FluentUI.AspNetCore.Components.Tests.Extensions
 @using Xunit;
 @inherits TestContext
 @code
@@ -147,6 +147,19 @@
 
         // Assert
         cut.Verify();
+    }
+
+    [Fact]
+    public void FluentIcon_Icon_WithCustomColorRed()
+    {
+        // Arrange && Act
+        var icon = new SampleIcons.Samples.Info();
+        var cut = Render(@<FluentIcon Value="@(icon.WithColor("red"))" Color="Color.Custom" />);
+
+        // Assert
+        var html = cut.Markup;
+
+        Assert.Contains("red", html);
     }
 
     [Fact]


### PR DESCRIPTION
# [Icon] Fix Icon color using `ColorWith` and a `CustomColor` attribute

This fix, which was discovered in `FluentNavLink` via this issue #1535, checks to see if `ColorWith` and `CustomColor` are used together.

- Including this fix

```csharp
if (Color == AspNetCore.Components.Color.Custom && !string.IsNullOrEmpty(_icon.Color))
{
    return _icon.Color;
}
```

- Adding associated unit test