### PR TITLE
fix: add 'required' binding to the autocomplete label

### DIFF
--- a/src/Core/Components/List/FluentAutocomplete.razor
+++ b/src/Core/Components/List/FluentAutocomplete.razor
@@ -5,7 +5,7 @@
 <CascadingValue Value=@_internalListContext Name="ListContext" TValue="InternalListContext<TOption>" IsFixed=true>
     <div class="@ClassValue fluent-autocomplete-multiselect"
          style="@StyleValue">
-        <FluentInputLabel ForId="@Id" Label="@Label" AriaLabel="@GetAriaLabel()" ChildContent="@LabelTemplate" />
+        <FluentInputLabel ForId="@Id" Label="@Label" AriaLabel="@GetAriaLabel()" ChildContent="@LabelTemplate" Required="@Required" />
         <FluentKeyCode Anchor="@Id" OnKeyDown="@KeyDownHandlerAsync" Only="@CatchOnly" StopPropagation="true" PreventDefault="true" />
 
         <FluentTextField role="combobox"


### PR DESCRIPTION
# Pull Request

## 📖 Description
The Required property from the FluentAutoComplete was not passed on to its label, making it not look required.
a small fix, that took a full 2min to fix :p

### 🎫 Issues

![image](https://github.com/microsoft/fluentui-blazor/assets/87806863/7adef290-dc83-4059-b42e-c34146024dde)
autocomplete didn't look like it was required, while it was set

## 👩‍💻 Reviewer Notes
didn't find any tests to test this with, does autocomplete have any tests/html it compares to that i might have missed?

## 📑 Test Plan
I added Required to the storyboard's country autocomplete and got a nice '*' to indicate required now

![image](https://github.com/microsoft/fluentui-blazor/assets/87806863/083fc45f-aeab-421a-9e6b-fb1cbfaab3e5)


## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new compontent
- [x] I have modified an existing component
- [ ] I have validate [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component 

## ⏭ Next Steps
none required :)