### PR TITLE
[FluentAutocomplete] Fix Backspace usage

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -76,6 +76,12 @@
             Gets or sets a way to tells the user agent that if the event does not get explicitly handled, its default action should not be taken as it normally would be.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentKeyCode.PreventDefaultOnly">
+            <summary>
+            Gets or sets the list of <see cref="T:Microsoft.FluentUI.AspNetCore.Components.KeyCode"/> to tells the user agent that if the event does not get explicitly handled,
+            its default action should not be taken as it normally would be.
+            </summary>
+        </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentKeyCode.OnAfterRenderAsync(System.Boolean)">
             <summary />
         </member>

--- a/src/Core/Components/Accessibility/FluentKeyCode.razor.cs
+++ b/src/Core/Components/Accessibility/FluentKeyCode.razor.cs
@@ -63,6 +63,13 @@ public partial class FluentKeyCode
     [Parameter]
     public bool PreventDefault { get; set; } = false;
 
+    /// <summary>
+    /// Gets or sets the list of <see cref="KeyCode"/> to tells the user agent that if the event does not get explicitly handled,
+    /// its default action should not be taken as it normally would be.
+    /// </summary>
+    [Parameter]
+    public KeyCode[] PreventDefaultOnly { get; set; } = Array.Empty<KeyCode>();
+
     /// <summary />
     protected async override Task OnAfterRenderAsync(bool firstRender)
     {
@@ -71,7 +78,7 @@ public partial class FluentKeyCode
             Module ??= await JSRuntime.InvokeAsync<IJSObjectReference>("import", JAVASCRIPT_FILE);
             _dotNetHelper = DotNetObjectReference.Create(this);
 
-            await Module.InvokeVoidAsync("RegisterKeyCode", Anchor, Only, IgnoreModifier ? Ignore.Union(_Modifiers) : Ignore, StopPropagation, PreventDefault, _dotNetHelper);
+            await Module.InvokeVoidAsync("RegisterKeyCode", Anchor, Only, IgnoreModifier ? Ignore.Union(_Modifiers) : Ignore, StopPropagation, PreventDefault, PreventDefaultOnly, _dotNetHelper);
         }
     }
 

--- a/src/Core/Components/Accessibility/FluentKeyCode.razor.js
+++ b/src/Core/Components/Accessibility/FluentKeyCode.razor.js
@@ -1,4 +1,4 @@
-export function RegisterKeyCode(id, onlyCodes, excludeCodes, stopPropagation, preventDefault, dotNetHelper) {
+export function RegisterKeyCode(id, onlyCodes, excludeCodes, stopPropagation, preventDefault, preventDefaultOnly, dotNetHelper) {
     const element = document.getElementById(id);
     if (!!element) {
         element.addEventListener('keydown', function (e) {
@@ -7,13 +7,15 @@ export function RegisterKeyCode(id, onlyCodes, excludeCodes, stopPropagation, pr
             if (!!dotNetHelper && !!dotNetHelper.invokeMethodAsync) {
 
                 const targetId = e.currentTarget?.id ?? "";
+                const isPreventDefault = preventDefault || (preventDefaultOnly.length > 0 && preventDefaultOnly.includes(keyCode));
+                const isStopPropagation = stopPropagation;
 
                 // Exclude
                 if (excludeCodes.length > 0 && excludeCodes.includes(keyCode)) {
-                    if (preventDefault) {
+                    if (isPreventDefault) {
                         e.preventDefault();
                     }
-                    if (stopPropagation) {
+                    if (isStopPropagation) {
                         e.stopPropagation();
                     }
                     return;
@@ -21,10 +23,10 @@ export function RegisterKeyCode(id, onlyCodes, excludeCodes, stopPropagation, pr
 
                 // All or Include only
                 if (onlyCodes.length == 0 || (onlyCodes.length > 0 && onlyCodes.includes(keyCode))) {
-                    if (preventDefault) {
+                    if (isPreventDefault) {
                         e.preventDefault();
                     }
-                    if (stopPropagation) {
+                    if (isStopPropagation) {
                         e.stopPropagation();
                     }
                     dotNetHelper.invokeMethodAsync("OnKeyDownRaisedAsync", keyCode, e.key, e.ctrlKey, e.shiftKey, e.altKey, e.metaKey, e.location, targetId);

--- a/src/Core/Components/List/FluentAutocomplete.razor
+++ b/src/Core/Components/List/FluentAutocomplete.razor
@@ -6,7 +6,7 @@
     <div class="@ClassValue fluent-autocomplete-multiselect"
          style="@StyleValue">
         <FluentInputLabel ForId="@Id" Label="@Label" AriaLabel="@GetAriaLabel()" ChildContent="@LabelTemplate" />
-        <FluentKeyCode Anchor="@Id" OnKeyDown="@KeyDownHandlerAsync" Only="@CatchOnly" StopPropagation="true" PreventDefault="true" />
+        <FluentKeyCode Anchor="@Id" OnKeyDown="@KeyDownHandlerAsync" Only="@CatchOnly" StopPropagation="true" PreventDefaultOnly="@PreventOnly" />
 
         <FluentTextField role="combobox"
                          @ref="@Element"

--- a/src/Core/Components/List/FluentAutocomplete.razor.cs
+++ b/src/Core/Components/List/FluentAutocomplete.razor.cs
@@ -214,6 +214,7 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
     }
 
     private static readonly KeyCode[] CatchOnly = new[] { KeyCode.Escape, KeyCode.Enter, KeyCode.Backspace, KeyCode.Down, KeyCode.Up };
+    private static readonly KeyCode[] PreventOnly = CatchOnly.Except(new[] { KeyCode.Backspace }).ToArray();
 
     /// <summary />
     protected async Task KeyDownHandlerAsync(FluentKeyCodeEventArgs e)


### PR DESCRIPTION
# [FluentAutocomplete] Fix Backspace usage

To fix the issue #1524: Can't remove more than one letter at once in FluentAutocomplete, 
we added `FluentKeyCode.PreventDefaultOnly` property and updated the Autocomplete code.


## Before
![Backspace-before](https://github.com/microsoft/fluentui-blazor/assets/8350694/ad50cb62-0d1d-4e64-a06b-40c2d57c6185)

## After
![Autocomplete-After](https://github.com/microsoft/fluentui-blazor/assets/8350694/a041f00c-bc6f-4d22-864c-35c180457441)


