### PR TITLE
[FluentDatePicker] Allow to select the existing selected month

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -1969,6 +1969,12 @@
             Gets or sets the Type style for the day (numeric or 2-digits).
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentCalendarBase.CheckIfSelectedValueHasChanged">
+            <summary>
+            Gets or sets the verification to do when the selected value has changed.
+            By default, ValueChanged is called only if the selected value has changed.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentCalendarBase.Value">
             <summary>
             Gets or sets the selected date (two-way bindable).

--- a/src/Core/Components/DateTime/FluentCalendar.razor
+++ b/src/Core/Components/DateTime/FluentCalendar.razor
@@ -135,9 +135,10 @@
 
     @if (_pickerView == CalendarViews.Months)
     {
-        <FluentCalendar  View="CalendarViews.Months"
+        <FluentCalendar View="CalendarViews.Months"
                         Value="@PickerMonth"
                         ValueChanged="@PickerMonthSelectAsync"
+                        CheckIfSelectedValueHasChanged="false"
                         ReadOnly="@ReadOnly"
                         Culture="@Culture"
                         DisabledSelectable="@DisabledSelectable"
@@ -151,6 +152,7 @@
         <FluentCalendar View="CalendarViews.Years"
                         Value="@PickerMonth"
                         ValueChanged="@PickerYearSelectAsync"
+                        CheckIfSelectedValueHasChanged="false"
                         ReadOnly="@ReadOnly"
                         Culture="@Culture"
                         DisabledSelectable="@DisabledSelectable"

--- a/src/Core/Components/DateTime/FluentCalendarBase.cs
+++ b/src/Core/Components/DateTime/FluentCalendarBase.cs
@@ -34,6 +34,13 @@ public abstract class FluentCalendarBase : FluentInputBase<DateTime?>
     public DayFormat? DayFormat { get; set; } = AspNetCore.Components.DayFormat.Numeric;
 
     /// <summary>
+    /// Gets or sets the verification to do when the selected value has changed.
+    /// By default, ValueChanged is called only if the selected value has changed.
+    /// </summary>
+    [Parameter]
+    public bool CheckIfSelectedValueHasChanged { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets the selected date (two-way bindable).
     /// </summary>
     [Parameter]
@@ -46,7 +53,7 @@ public abstract class FluentCalendarBase : FluentInputBase<DateTime?>
 
         set
         {
-            if (_selectedDate == value)
+            if (CheckIfSelectedValueHasChanged && _selectedDate == value)
             {
                 return;
             }

--- a/tests/Core/DateTime/FluentCalendarTests.razor
+++ b/tests/Core/DateTime/FluentCalendarTests.razor
@@ -1,4 +1,4 @@
-@using System.Globalization
+﻿@using System.Globalization
 @using Xunit
 @inherits TestContext
 
@@ -174,5 +174,45 @@
 
         // Assert
         calendar.Verify(suffix: view.GetDescription());
+    }
+
+    [Fact]
+    public void FluentCalendar_TitleClick_SameMonthSelected()
+    {
+        DateTime? value = DateTime.Parse("2022-04-15");
+        var culture = CultureInfo.GetCultureInfo("en-us");
+
+        // Arrange
+        var calendar = Render(@<FluentCalendar Culture="@culture" View="CalendarViews.Days" Value="@value" AnimatePeriodChanges="false" />);
+
+        // Act
+        var title = calendar.Find(".label");
+        title!.Click();
+
+        var april = calendar.Find($"div[value='2022-04']");
+        april!.Click();
+
+        // Assert
+        Assert.Equal("April 2022", calendar.Find(".label").TextContent);
+    }
+
+    [Fact]
+    public void FluentCalendar_TitleClick_SameYearSelected()
+    {
+        DateTime? value = DateTime.Parse("2022-04-15");
+        var culture = CultureInfo.GetCultureInfo("en-us");
+
+        // Arrange
+        var calendar = Render(@<FluentCalendar Culture="@culture" View="CalendarViews.Months" Value="@value" AnimatePeriodChanges="false" />);
+
+        // Act
+        var title = calendar.Find(".label");
+        title!.Click();
+
+        var year2022 = calendar.Find($"div[value='2022']");
+        year2022!.Click();
+
+        // Assert
+        Assert.Equal("2022", calendar.Find(".label").TextContent);
     }
 }


### PR DESCRIPTION
#  [FluentDatePicker] Allow to select the existing selected month

This PR will solve the issue describe here #1406:

1. Use the `FluentCalendar` component with the `View="CalendarViews.Months"`
2. Click on a year to navigate to the list of months.
3. Try clicking on the current year to return to the list of months.

## Before
![Date-Before](https://github.com/microsoft/fluentui-blazor/assets/8350694/bef378cb-5ad9-4fe0-9a82-0ed6c2f81806)

## After
![Date-After](https://github.com/microsoft/fluentui-blazor/assets/8350694/b9616840-c56e-4a3c-aa75-6c76beeeddaf)
