### PR TITLE
Fix adoptedStyleSheets is frozen in earlier versions

### DIFF
--- a/src/Core.Assets/src/SplitPanels.ts
+++ b/src/Core.Assets/src/SplitPanels.ts
@@ -80,7 +80,8 @@ class SplitPanels extends HTMLElement {
       const shadow = this.attachShadow({ mode: "open" });
       const styleSheet = new CSSStyleSheet();
       styleSheet.replaceSync(styleString);
-      shadow.adoptedStyleSheets.push(styleSheet);
+      // shadow.adoptedStyleSheets.push(styleSheet);
+      shadow.adoptedStyleSheets = [...shadow.adoptedStyleSheets, styleSheet];
       shadow.innerHTML = template;
     }
     else {
@@ -279,14 +280,14 @@ class SplitPanels extends HTMLElement {
         this.removeAttribute("no-barhandle");
       } else {
         this.setAttribute("no-barhandle", "");
-        
+
       }
     }
   }
   get barhandle() {
     return this.#barhandle;
   }
- 
+
 }
 
 export { SplitPanels };

--- a/src/Core.Assets/src/index.ts
+++ b/src/Core.Assets/src/index.ts
@@ -52,7 +52,8 @@ body:has(.prevent-scroll) {
 `;
 
 styleSheet.replaceSync(styles);
-document.adoptedStyleSheets.push(styleSheet);
+// document.adoptedStyleSheets.push(styleSheet);
+document.adoptedStyleSheets = [...document.adoptedStyleSheets, styleSheet];
 
 var beforeStartCalled = false;
 var afterStartedCalled = false;


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
`document.adoptedStyleSheets` is frozen in earlier versions. `Array.push` not working.
Such as `Microsoft.AspNetCore.Components.WebView.Maui` `8.0.3`

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new compontent
- [ ] I have modified an existing component
- [ ] I have validate [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component 