### PR TITLE
[FluentSplashScreen] Add WaitingMilliseconds and UpdateLabels

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -2753,9 +2753,10 @@
             Can be a URL or a base64 encoded string or an SVG.
             </summary>
         </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.SplashScreenContent.WaitingMilliseconds">
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.SplashScreenContent.DisplayTime">
             <summary>
-            Gets or sets the delay to wait before to close the dialog.
+            Gets or sets the delay to wait before to close the dialog (in milliseconds).
+            Default is 4000 milliseconds.
             </summary>
         </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.SplashScreenContent.UpdateLabels(System.String,System.Nullable{Microsoft.AspNetCore.Components.MarkupString})">

--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -2753,6 +2753,23 @@
             Can be a URL or a base64 encoded string or an SVG.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.SplashScreenContent.WaitingMilliseconds">
+            <summary>
+            Gets or sets the delay to wait before to close the dialog.
+            </summary>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.SplashScreenContent.UpdateLabels(System.String,System.Nullable{Microsoft.AspNetCore.Components.MarkupString})">
+            <summary>
+            Updates the labels of the splash screen.
+            </summary>
+            <param name="loadingText"></param>
+            <param name="message"></param>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.SplashScreenContent.RefreshProperties">
+            <summary>
+            Action with StateHasChanged assigned in FluentSplashScreen.razor.cs
+            </summary>
+        </member>
         <member name="T:Microsoft.FluentUI.AspNetCore.Components.DialogResult">
             <summary />
         </member>

--- a/examples/Demo/Shared/Pages/SplashScreen/Examples/DialogSplashScreenDefault.razor.cs
+++ b/examples/Demo/Shared/Pages/SplashScreen/Examples/DialogSplashScreenDefault.razor.cs
@@ -9,11 +9,12 @@ public partial class DialogSplashScreenDefault
 
     private async Task OpenSplashDefaultAsync()
     {
-        DemoLogger.WriteLine($"Open default splashscreen for 4 seconds");
+        DemoLogger.WriteLine($"Open default SplashScreen for 4 seconds");
         DialogParameters<SplashScreenContent> parameters = new()
         {
             Content = new()
             {
+                WaitingMilliseconds = 0,    // See Task.Delay below
                 Title = "Core components",
                 SubTitle = "Microsoft Fluent UI Blazor library",
                 LoadingText = "Loading...",
@@ -24,13 +25,25 @@ public partial class DialogSplashScreenDefault
             Height = "480px",
         };
         _dialog = await DialogService.ShowSplashScreenAsync(parameters);
+
+        var splashScreen = (SplashScreenContent)_dialog.Instance.Content;
+
+        // Simulate a first task
+        await Task.Delay(2000);
+
+        // Update the splash screen content and simulate a second task
+        splashScreen.UpdateLabels(loadingText: "Second task...");
+        await Task.Delay(2000);
+
+        await _dialog.CloseAsync();
+
         DialogResult result = await _dialog.Result;
         await HandleDefaultSplashAsync(result);
     }
 
     private void OpenSplashDefault()
     {
-        DemoLogger.WriteLine($"Open default splashscreen for 4 seconds");
+        DemoLogger.WriteLine($"Open default SplashScreen for 4 seconds");
         DialogParameters<SplashScreenContent> parameters = new()
         {
             Content = new()

--- a/examples/Demo/Shared/Pages/SplashScreen/Examples/DialogSplashScreenDefault.razor.cs
+++ b/examples/Demo/Shared/Pages/SplashScreen/Examples/DialogSplashScreenDefault.razor.cs
@@ -14,7 +14,7 @@ public partial class DialogSplashScreenDefault
         {
             Content = new()
             {
-                WaitingMilliseconds = 0,    // See Task.Delay below
+                DisplayTime = 0,    // See Task.Delay below
                 Title = "Core components",
                 SubTitle = "Microsoft Fluent UI Blazor library",
                 LoadingText = "Loading...",

--- a/src/Core/Components/Dialog/ContentComponents/FluentSplashScreen.razor.cs
+++ b/src/Core/Components/Dialog/ContentComponents/FluentSplashScreen.razor.cs
@@ -29,12 +29,17 @@ public partial class FluentSplashScreen : IDialogContentComponent<SplashScreenCo
     [CascadingParameter]
     public FluentDialog Dialog { get; set; } = default!;
 
+    protected override void OnInitialized()
+    {
+        Content.RefreshProperties = () => StateHasChanged();
+    }
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (firstRender)
+        if (firstRender && Content.WaitingMilliseconds > 0)
         {
             // Simulation of loading process
-            await Task.Delay(4000);
+            await Task.Delay(Content.WaitingMilliseconds);
 
             // Close the dialog
             await Dialog.CloseAsync();

--- a/src/Core/Components/Dialog/ContentComponents/FluentSplashScreen.razor.cs
+++ b/src/Core/Components/Dialog/ContentComponents/FluentSplashScreen.razor.cs
@@ -36,10 +36,10 @@ public partial class FluentSplashScreen : IDialogContentComponent<SplashScreenCo
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (firstRender && Content.WaitingMilliseconds > 0)
+        if (firstRender && Content.DisplayTime > 0)
         {
             // Simulation of loading process
-            await Task.Delay(Content.WaitingMilliseconds);
+            await Task.Delay(Content.DisplayTime);
 
             // Close the dialog
             await Dialog.CloseAsync();

--- a/src/Core/Components/Dialog/Parameters/SplashScreenContent.cs
+++ b/src/Core/Components/Dialog/Parameters/SplashScreenContent.cs
@@ -36,9 +36,10 @@ public class SplashScreenContent
     public string? Logo { get; set; }
 
     /// <summary>
-    /// Gets or sets the delay to wait before to close the dialog.
+    /// Gets or sets the delay to wait before to close the dialog (in milliseconds).
+    /// Default is 4000 milliseconds.
     /// </summary>
-    public int WaitingMilliseconds { get; set; } = 4000;
+    public int DisplayTime { get; set; } = 4000;
 
     /// <summary>
     /// Updates the labels of the splash screen.

--- a/src/Core/Components/Dialog/Parameters/SplashScreenContent.cs
+++ b/src/Core/Components/Dialog/Parameters/SplashScreenContent.cs
@@ -34,4 +34,37 @@ public class SplashScreenContent
     /// Can be a URL or a base64 encoded string or an SVG.
     /// </summary>
     public string? Logo { get; set; }
+
+    /// <summary>
+    /// Gets or sets the delay to wait before to close the dialog.
+    /// </summary>
+    public int WaitingMilliseconds { get; set; } = 4000;
+
+    /// <summary>
+    /// Updates the labels of the splash screen.
+    /// </summary>
+    /// <param name="loadingText"></param>
+    /// <param name="message"></param>
+    public void UpdateLabels(string? loadingText = null, MarkupString? message = null)
+    {
+        if (loadingText != null)
+        {
+            LoadingText = loadingText;
+        }
+
+        if (message != null)
+        {
+            Message = message;
+        }
+
+        if (RefreshProperties != null)
+        {
+            RefreshProperties();
+        }
+    }
+
+    /// <summary>
+    /// Action with StateHasChanged assigned in FluentSplashScreen.razor.cs
+    /// </summary>
+    internal Action? RefreshProperties { get; set; }
 }


### PR DESCRIPTION
# [FluentSplashScreen] Add WaitingMilliseconds and UpdateLabels

Adding two new properties to allow SplashScreen customization during the loading process:

- `SplashScreenContent.DisplayTime`: Gets or sets the delay to wait before to close the dialog. Default is 4000 milliseconds.
- `SplashScreenContent.UpdateLabels(loadingText, message)`: Updates the labels of the splash screen.

## Example

```csharp
DialogParameters<SplashScreenContent> parameters = new()
{
    Content = new()
    {
        DisplayTime = 0,    // // <============== See Task.Delay below
        Title = "Core components",
        SubTitle = "Microsoft Fluent UI Blazor library",
        LoadingText = "Loading...",
        Message = (MarkupString)"some <i>extra</i> text <strong>here</strong>",
    }
};
_dialog = await DialogService.ShowSplashScreenAsync(parameters);

var splashScreen = (SplashScreenContent)_dialog.Instance.Content;

// Simulate a first task
await Task.Delay(2000);

// Update the splash screen content and simulate a second task
splashScreen.UpdateLabels(loadingText: "Second task...");   // <==============
await Task.Delay(2000);

await _dialog.CloseAsync();
```

To solve #1566