### PR TITLE
[FluentTooltip] Add the HideTooltipOnCursorLeave property

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -7461,6 +7461,13 @@
             Gets the default tooltip options.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentTooltip.CloseTooltipOnCursorLeave">
+            <summary>
+            Gets or sets the value indicating whether the library should close the tooltip if the cursor leaves the anchor and the tooltip.
+            By default, the tooltip closes if the cursor leaves the anchor, but not the tooltip itself.
+            You can configure this behavior globally using the <see cref="P:Microsoft.FluentUI.AspNetCore.Components.LibraryConfiguration.CloseTooltipOnCursorLeave"/> property.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentTooltip.UseTooltipService">
             <summary>
             Use ITooltipService to create the tooltip, if this service was injected.
@@ -12658,6 +12665,17 @@
             <summary>
             Gets or sets a value indicating whether the library should use the TooltipServiceProvider.
             If set to true, add the FluentTooltipProvider component at end of the MainLayout.razor page.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.LibraryConfiguration.RequiredLabel">
+            <summary>
+            Gets or sets the required label for the form fields.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.LibraryConfiguration.CloseTooltipOnCursorLeave">
+            <summary>
+            Gets or sets the value indicating whether the library should close the tooltip if the cursor leaves the anchor and the tooltip.
+            By default, the tooltip closes if the cursor leaves the anchor, but not the tooltip itself.
             </summary>
         </member>
         <member name="T:Microsoft.FluentUI.AspNetCore.Components.Resources.TimeAgoResource">

--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -7479,11 +7479,11 @@
             Gets the default tooltip options.
             </summary>
         </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentTooltip.CloseTooltipOnCursorLeave">
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentTooltip.HideTooltipOnCursorLeave">
             <summary>
             Gets or sets the value indicating whether the library should close the tooltip if the cursor leaves the anchor and the tooltip.
             By default, the tooltip closes if the cursor leaves the anchor, but not the tooltip itself.
-            You can configure this behavior globally using the <see cref="P:Microsoft.FluentUI.AspNetCore.Components.LibraryConfiguration.CloseTooltipOnCursorLeave"/> property.
+            You can configure this behavior globally using the <see cref="P:Microsoft.FluentUI.AspNetCore.Components.LibraryConfiguration.HideTooltipOnCursorLeave"/> property.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentTooltip.UseTooltipService">
@@ -12690,7 +12690,7 @@
             Gets or sets the required label for the form fields.
             </summary>
         </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.LibraryConfiguration.CloseTooltipOnCursorLeave">
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.LibraryConfiguration.HideTooltipOnCursorLeave">
             <summary>
             Gets or sets the value indicating whether the library should close the tooltip if the cursor leaves the anchor and the tooltip.
             By default, the tooltip closes if the cursor leaves the anchor, but not the tooltip itself.

--- a/examples/Demo/Shared/Pages/Tooltip/Examples/TooltipDelay.razor
+++ b/examples/Demo/Shared/Pages/Tooltip/Examples/TooltipDelay.razor
@@ -1,10 +1,10 @@
 ﻿<FluentStack>
     <FluentButton Id="delay1" Appearance=Appearance.Accent>Tooltip at the start</FluentButton>
-    <FluentTooltip Anchor="delay1" CloseTooltipOnCursorLeave="true" Position=TooltipPosition.Start Delay=100>I'm helping (very quick)!</FluentTooltip>
+    <FluentTooltip Anchor="delay1" HideTooltipOnCursorLeave="true" Position=TooltipPosition.Start Delay=100>I'm helping (very quick)!</FluentTooltip>
 
     <FluentButton Id="delay2" Appearance=Appearance.Accent>Tooltip at the top</FluentButton>
-    <FluentTooltip Anchor="delay2" CloseTooltipOnCursorLeave="true" Position=TooltipPosition.Top Delay=200>I'm helping (quick)!</FluentTooltip>
+    <FluentTooltip Anchor="delay2" HideTooltipOnCursorLeave="true" Position=TooltipPosition.Top Delay=200>I'm helping (quick)!</FluentTooltip>
 
     <FluentButton Id="delay3" Appearance=Appearance.Accent>Tooltip at the end</FluentButton>
-    <FluentTooltip Anchor="delay3" CloseTooltipOnCursorLeave="true" Position=TooltipPosition.End Delay=600>I'm helping (slow)!</FluentTooltip>
+    <FluentTooltip Anchor="delay3" HideTooltipOnCursorLeave="true" Position=TooltipPosition.End Delay=600>I'm helping (slow)!</FluentTooltip>
 </FluentStack>

--- a/examples/Demo/Shared/Pages/Tooltip/Examples/TooltipDelay.razor
+++ b/examples/Demo/Shared/Pages/Tooltip/Examples/TooltipDelay.razor
@@ -1,10 +1,10 @@
 ﻿<FluentStack>
     <FluentButton Id="delay1" Appearance=Appearance.Accent>Tooltip at the start</FluentButton>
-    <FluentTooltip Anchor="delay1" Position=TooltipPosition.Start Delay=100>I'm helping (very quick)!</FluentTooltip>
+    <FluentTooltip Anchor="delay1" CloseTooltipOnCursorLeave="true" Position=TooltipPosition.Start Delay=100>I'm helping (very quick)!</FluentTooltip>
 
     <FluentButton Id="delay2" Appearance=Appearance.Accent>Tooltip at the top</FluentButton>
-    <FluentTooltip Anchor="delay2" Position=TooltipPosition.Top Delay=200>I'm helping (quick)!</FluentTooltip>
+    <FluentTooltip Anchor="delay2" CloseTooltipOnCursorLeave="true" Position=TooltipPosition.Top Delay=200>I'm helping (quick)!</FluentTooltip>
 
     <FluentButton Id="delay3" Appearance=Appearance.Accent>Tooltip at the end</FluentButton>
-    <FluentTooltip Anchor="delay3" Position=TooltipPosition.End Delay=600>I'm helping (slow)!</FluentTooltip>
+    <FluentTooltip Anchor="delay3" CloseTooltipOnCursorLeave="true" Position=TooltipPosition.End Delay=600>I'm helping (slow)!</FluentTooltip>
 </FluentStack>

--- a/examples/Demo/Shared/Pages/Tooltip/TooltipPage.razor
+++ b/examples/Demo/Shared/Pages/Tooltip/TooltipPage.razor
@@ -59,7 +59,7 @@ and will be written at the end of the HTML page to support the different z-index
     <Description>
         Hover one of the buttons to have a tooltip appear on hover at the position mentioned. <br/>
         Unlike the other tooltip examples, these contain the <code>HideTooltipOnCursorLeave</code> attribute.
-        which closes the tooltip even when the user hovers over it.
+        which hides the tooltip when the cursor leaves (i.e. not hovering) its anchor (even when the cursor hovers the tooltip itself).
     </Description>
 </DemoSection>
 

--- a/examples/Demo/Shared/Pages/Tooltip/TooltipPage.razor
+++ b/examples/Demo/Shared/Pages/Tooltip/TooltipPage.razor
@@ -58,7 +58,7 @@ and will be written at the end of the HTML page to support the different z-index
 <DemoSection Title="Different delays" Component="@typeof(TooltipDelay)">
     <Description>
         Hover one of the buttons to have a tooltip appear on hover at the position mentioned. <br/>
-        Unlike the other tooltip examples, these contain the <code>CloseTooltipOnCursorLeave</code> attribute.
+        Unlike the other tooltip examples, these contain the <code>HideTooltipOnCursorLeave</code> attribute.
         which closes the tooltip even when the user hovers over it.
     </Description>
 </DemoSection>

--- a/examples/Demo/Shared/Pages/Tooltip/TooltipPage.razor
+++ b/examples/Demo/Shared/Pages/Tooltip/TooltipPage.razor
@@ -1,4 +1,4 @@
-@page "/Tooltip"
+﻿@page "/Tooltip"
 
 @using FluentUI.Demo.Shared.Pages.Tooltip.Examples
 
@@ -56,7 +56,11 @@ and will be written at the end of the HTML page to support the different z-index
 </DemoSection>
 
 <DemoSection Title="Different delays" Component="@typeof(TooltipDelay)">
-    <Description>Hover one of the buttons to have a tooltip appear on hover at the position mentioned.</Description>
+    <Description>
+        Hover one of the buttons to have a tooltip appear on hover at the position mentioned. <br/>
+        Unlike the other tooltip examples, these contain the <code>CloseTooltipOnCursorLeave</code> attribute.
+        which closes the tooltip even when the user hovers over it.
+    </Description>
 </DemoSection>
 
 <DemoSection Title="Always visible" Component="@typeof(TooltipVisible)" />

--- a/src/Core/Components/Tooltip/FluentTooltip.razor.cs
+++ b/src/Core/Components/Tooltip/FluentTooltip.razor.cs
@@ -41,10 +41,10 @@ public partial class FluentTooltip : FluentComponentBase, IDisposable
     /// <summary>
     /// Gets or sets the value indicating whether the library should close the tooltip if the cursor leaves the anchor and the tooltip.
     /// By default, the tooltip closes if the cursor leaves the anchor, but not the tooltip itself.
-    /// You can configure this behavior globally using the <see cref="LibraryConfiguration.CloseTooltipOnCursorLeave"/> property.
+    /// You can configure this behavior globally using the <see cref="LibraryConfiguration.HideTooltipOnCursorLeave"/> property.
     /// </summary>
     [Parameter]
-    public bool? CloseTooltipOnCursorLeave { get; set; }
+    public bool? HideTooltipOnCursorLeave { get; set; }
 
     /// <summary>
     /// Use ITooltipService to create the tooltip, if this service was injected.
@@ -135,7 +135,7 @@ public partial class FluentTooltip : FluentComponentBase, IDisposable
     /// <summary />
     protected override void OnInitialized()
     {
-        CloseTooltipOnCursorLeave = CloseTooltipOnCursorLeave ?? LibraryConfiguration?.CloseTooltipOnCursorLeave;
+        HideTooltipOnCursorLeave = HideTooltipOnCursorLeave ?? LibraryConfiguration?.HideTooltipOnCursorLeave;
         _tooltipService = ServiceProvider?.GetService<ITooltipService>();
 
         if (TooltipService != null && UseTooltipService)
@@ -156,7 +156,7 @@ public partial class FluentTooltip : FluentComponentBase, IDisposable
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (firstRender && !string.IsNullOrEmpty(Anchor) && CloseTooltipOnCursorLeave == true)
+        if (firstRender && !string.IsNullOrEmpty(Anchor) && HideTooltipOnCursorLeave == true)
         {
             JSModule ??= await JSRuntime.InvokeAsync<IJSObjectReference>("import", JAVASCRIPT_FILE);
             await JSModule.InvokeVoidAsync("tooltipHideOnCursorLeave", Anchor);

--- a/src/Core/Components/Tooltip/FluentTooltip.razor.cs
+++ b/src/Core/Components/Tooltip/FluentTooltip.razor.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.FluentUI.AspNetCore.Components.Components.Tooltip;
+using Microsoft.JSInterop;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
@@ -8,6 +9,15 @@ public partial class FluentTooltip : FluentComponentBase, IDisposable
 {
     private readonly Guid _guid = Guid.NewGuid();
     private ITooltipService? _tooltipService = null;
+    private const string JAVASCRIPT_FILE = "./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Tooltip/FluentTooltip.razor.js";
+
+    private IJSObjectReference? JSModule { get; set; }
+
+    [Inject]
+    private IJSRuntime JSRuntime { get; set; } = default!;
+
+    [Inject]
+    private LibraryConfiguration? LibraryConfiguration { get; set; }
 
     /// <summary>
     /// Gets or sets a reference to the list of registered services.
@@ -27,6 +37,14 @@ public partial class FluentTooltip : FluentComponentBase, IDisposable
     /// Gets the default tooltip options.
     /// </summary>
     protected virtual TooltipGlobalOptions? GlobalOptions => TooltipService?.GlobalOptions;
+
+    /// <summary>
+    /// Gets or sets the value indicating whether the library should close the tooltip if the cursor leaves the anchor and the tooltip.
+    /// By default, the tooltip closes if the cursor leaves the anchor, but not the tooltip itself.
+    /// You can configure this behavior globally using the <see cref="LibraryConfiguration.CloseTooltipOnCursorLeave"/> property.
+    /// </summary>
+    [Parameter]
+    public bool? CloseTooltipOnCursorLeave { get; set; }
 
     /// <summary>
     /// Use ITooltipService to create the tooltip, if this service was injected.
@@ -117,6 +135,7 @@ public partial class FluentTooltip : FluentComponentBase, IDisposable
     /// <summary />
     protected override void OnInitialized()
     {
+        CloseTooltipOnCursorLeave = CloseTooltipOnCursorLeave ?? LibraryConfiguration?.CloseTooltipOnCursorLeave;
         _tooltipService = ServiceProvider?.GetService<ITooltipService>();
 
         if (TooltipService != null && UseTooltipService)
@@ -132,6 +151,15 @@ public partial class FluentTooltip : FluentComponentBase, IDisposable
                 OnDismissed = OnDismissed,
                 Visible = Visible,
             });
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender && !string.IsNullOrEmpty(Anchor) && CloseTooltipOnCursorLeave == true)
+        {
+            JSModule ??= await JSRuntime.InvokeAsync<IJSObjectReference>("import", JAVASCRIPT_FILE);
+            await JSModule.InvokeVoidAsync("tooltipHideOnCursorLeave", Anchor);
         }
     }
 

--- a/src/Core/Components/Tooltip/FluentTooltip.razor.js
+++ b/src/Core/Components/Tooltip/FluentTooltip.razor.js
@@ -1,0 +1,21 @@
+export function tooltipHideOnCursorLeave(anchorId) {
+    const srcElement = document.getElementById(anchorId);
+    const tooltipSelector = `fluent-tooltip[anchor="${anchorId}"]:not([visible])`;
+
+    if (!!srcElement) {
+        srcElement.addEventListener("mouseleave", function (event) {
+            const tooltip = document.querySelector(tooltipSelector);
+            if (!!tooltip) {
+                tooltip.style.display = "none";
+            }
+        });
+
+        srcElement.addEventListener("mouseenter", function (event) {
+            const tooltip = document.querySelector(tooltipSelector);
+            if (!!tooltip) {
+                tooltip.style.display = null;
+            }
+        });
+
+    }
+}

--- a/src/Core/Infrastructure/LibraryConfiguration.cs
+++ b/src/Core/Infrastructure/LibraryConfiguration.cs
@@ -27,7 +27,7 @@ public class LibraryConfiguration
     /// Gets or sets the value indicating whether the library should close the tooltip if the cursor leaves the anchor and the tooltip.
     /// By default, the tooltip closes if the cursor leaves the anchor, but not the tooltip itself.
     /// </summary>
-    public bool CloseTooltipOnCursorLeave { get; set; } = false;
+    public bool HideTooltipOnCursorLeave { get; set; } = false;
 
     public LibraryConfiguration()
     {

--- a/src/Core/Infrastructure/LibraryConfiguration.cs
+++ b/src/Core/Infrastructure/LibraryConfiguration.cs
@@ -15,10 +15,19 @@ public class LibraryConfiguration
     /// </summary>
     public bool UseTooltipServiceProvider { get; set; } = true;
 
+    /// <summary>
+    /// Gets or sets the required label for the form fields.
+    /// </summary>
     public MarkupString RequiredLabel { get; set; } = (MarkupString)
         """
         <span aria-label="required" aria-hidden="true" style="padding-inline-start: calc(var(--design-unit) * 1px); color: var(--error); pointer-events: none;">*</span>
         """;
+
+    /// <summary>
+    /// Gets or sets the value indicating whether the library should close the tooltip if the cursor leaves the anchor and the tooltip.
+    /// By default, the tooltip closes if the cursor leaves the anchor, but not the tooltip itself.
+    /// </summary>
+    public bool CloseTooltipOnCursorLeave { get; set; } = false;
 
     public LibraryConfiguration()
     {

--- a/tests/Core/Tooltip/FluentTooltipTests.cs
+++ b/tests/Core/Tooltip/FluentTooltipTests.cs
@@ -1,9 +1,19 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.FluentUI.AspNetCore.Components.Tests.Tooltip;
 
 public class FluentTooltipTests : TestBase
 {
+    [Inject]
+    private LibraryConfiguration LibraryConfiguration { get; set; } = new LibraryConfiguration();
+
+    public FluentTooltipTests()
+    {
+        TestContext.Services.AddSingleton(LibraryConfiguration);
+    }
+
     [Fact]
     public void FluentTooltip_Default()
     {


### PR DESCRIPTION
# [FluentTooltip] Add the HideTooltipOnCursorLeave property

Following request #1564, we have added a `HideTooltipOnCursorLeave` attribute to **FluentTooltip** components and also for global configuration. 

```csharp
builder.Services.AddFluentUIComponents(configuration =>
{
    configuration.HideTooltipOnCursorLeave = true;
});
```

This allows you to keep the default behavior
![Tooltip-Before](https://github.com/microsoft/fluentui-blazor/assets/8350694/5e81c939-e1e4-494f-93cd-c8ac5ad18844)

But also to activate a new behavior.
![Tooltip-After](https://github.com/microsoft/fluentui-blazor/assets/8350694/d5cc52f1-7ae0-423e-a87c-9d9892ac3da4)
