### PR TITLE
[FluentAutocomplete] Add IconDismiss adn IconSearch

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -4238,6 +4238,16 @@
             Gets or sets the title and Aria-Label for the Scroll to next button.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.IconDismiss">
+            <summary>
+            Gets or sets the icon used for the Clear button. By default: Dismiss icon.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.IconSearch">
+            <summary>
+            Gets or sets the icon used for the Search button. By default: Search icon.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.ListStyleValue">
             <summary />
         </member>

--- a/src/Core/Components/List/FluentAutocomplete.razor
+++ b/src/Core/Components/List/FluentAutocomplete.razor
@@ -68,21 +68,27 @@
             {
                 if (this.SelectedOptions?.Any() == true || !string.IsNullOrEmpty(_valueText))
                 {
-                    <FluentIcon Value="@(new CoreIcons.Regular.Size16.Dismiss())"
-                                Width="12px"
-                                Style="cursor: pointer;"
-                                Slot="end"
-                                Title="Clear"
-                                OnClick="@OnClearAsync" />
+                    if (IconDismiss != null)
+                    {
+                        <FluentIcon Value="@IconDismiss"
+                                    Width="12px"
+                                    Style="cursor: pointer;"
+                                    Slot="end"
+                                    Title="Clear"
+                                    OnClick="@OnClearAsync" />
+                    }
                 }
                 else
                 {
-                    <FluentIcon Value="@(new CoreIcons.Regular.Size16.Search())"
-                                Width="16px"
-                                Style="cursor: pointer;"
-                                Slot="end"
-                                Title="Search"
-                                OnClick="@OnDropDownExpandedAsync" />
+                    if (IconSearch != null)
+                    {
+                        <FluentIcon Value="@IconSearch"
+                                    Width="16px"
+                                    Style="cursor: pointer;"
+                                    Slot="end"
+                                    Title="Search"
+                                    OnClick="@OnDropDownExpandedAsync" />
+                    }
                 }
             }
         </FluentTextField>

--- a/src/Core/Components/List/FluentAutocomplete.razor.cs
+++ b/src/Core/Components/List/FluentAutocomplete.razor.cs
@@ -143,6 +143,18 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
     [Parameter]
     public string TitleScrollToNext { get; set; } = "Next";
 
+    /// <summary>
+    /// Gets or sets the icon used for the Clear button. By default: Dismiss icon.
+    /// </summary>
+    [Parameter]
+    public Icon? IconDismiss { get; set; } = new CoreIcons.Regular.Size16.Dismiss();
+
+    /// <summary>
+    /// Gets or sets the icon used for the Search button. By default: Search icon.
+    /// </summary>
+    [Parameter]
+    public Icon? IconSearch { get; set; } = new CoreIcons.Regular.Size16.Search();
+
     /// <summary />
     private string? ListStyleValue => new StyleBuilder()
         .AddStyle("width", Width, when: !string.IsNullOrEmpty(Width))


### PR DESCRIPTION
# [FluentAutocomplete] Add `IconDismiss` adn `IconSearch`

Following this discussion #1563, we added 2 new attributes to the Autocomplete component.

## IconDismiss

![image](https://github.com/microsoft/fluentui-blazor/assets/8350694/a2a84750-022f-4522-9dc1-6761ce428dc1)

## IconSearch

![image](https://github.com/microsoft/fluentui-blazor/assets/8350694/b52bb3d4-8781-4a91-9aaf-144b3440df0c)


