### PR TITLE
FluentMenu fixes

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -4706,7 +4706,7 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentMenu.Trigger">
             <summary>
             Gets or sets the automatic trigger. See <seealso cref="T:Microsoft.FluentUI.AspNetCore.Components.MouseButton"/>
-            Possible values are None (default), Left, Middle, Right, Back, Forward 
+            Possible values are None (default), Left, Middle, Right, Back, Forward
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentMenu.Open">

--- a/examples/Demo/Shared/Pages/Menu/Examples/MenuNested.razor
+++ b/examples/Demo/Shared/Pages/Menu/Examples/MenuNested.razor
@@ -14,7 +14,7 @@
             <FluentMenuItem>Menu item 2.3</FluentMenuItem>
         </MenuItems>
     </FluentMenuItem>
-    <FluentMenuItem Label="Mneu item 3">
+    <FluentMenuItem Label="Menu item 3">
         <MenuItems>
             <FluentMenuItem>Menu item 3.1</FluentMenuItem>
             <FluentMenuItem>Menu item 3.2</FluentMenuItem>

--- a/src/Core/Components/Menu/FluentMenu.razor
+++ b/src/Core/Components/Menu/FluentMenu.razor
@@ -1,4 +1,4 @@
-@namespace Microsoft.FluentUI.AspNetCore.Components
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 @inherits FluentComponentBase
 <CascadingValue Value="this" IsFixed="true">
     @if (Open)
@@ -23,6 +23,9 @@
         }
         else
         {
+            if (_contextMenu) {
+                <FluentOverlay @bind-Visible="@Open" OnClose="@CloseAsync" Transparent="true" FullScreen="true" />
+            }
             <fluent-menu @ref=Element
                          id="@Id"
                          class="@ClassValue"

--- a/src/Core/Components/Menu/FluentMenu.razor.cs
+++ b/src/Core/Components/Menu/FluentMenu.razor.cs
@@ -21,6 +21,7 @@ public partial class FluentMenu : FluentComponentBase, IDisposable
     internal string? StyleValue => new StyleBuilder(Style)
         .AddStyle("min-width: max-content")
         .AddStyle("width", Width, () => !string.IsNullOrEmpty(Width))
+        .AddStyle("border-radius: calc(var(--layer-corner-radius) * 1px)")
 
         // For Anchored == false
         .AddStyle("z-index", $"{ZIndex.Menu}", () => !Anchored)
@@ -43,7 +44,7 @@ public partial class FluentMenu : FluentComponentBase, IDisposable
 
     /// <summary>
     /// Gets or sets the automatic trigger. See <seealso cref="MouseButton"/>
-    /// Possible values are None (default), Left, Middle, Right, Back, Forward 
+    /// Possible values are None (default), Left, Middle, Right, Back, Forward
     /// </summary>
     [Parameter]
     public MouseButton Trigger { get; set; } = MouseButton.None;

--- a/src/Core/Components/Menu/FluentMenu.razor.cs
+++ b/src/Core/Components/Menu/FluentMenu.razor.cs
@@ -10,6 +10,7 @@ public partial class FluentMenu : FluentComponentBase, IDisposable
 {
     private DotNetObjectReference<FluentMenu>? _dotNetHelper = null;
     private Point _clickedPoint = default;
+    private bool _contextMenu = false;
     private readonly Dictionary<string, FluentMenuItem> items = [];
     private IJSObjectReference _jsModule = default!;
 
@@ -118,6 +119,7 @@ public partial class FluentMenu : FluentComponentBase, IDisposable
                     // Add RightClick event
                     if (Trigger == MouseButton.Right)
                     {
+                        _contextMenu = true;
                         await _jsModule.InvokeVoidAsync("addEventRightClick", Anchor, _dotNetHelper);
                     }
                 }


### PR DESCRIPTION
- Fix visual inconsistency with the FluentMenu by adding a border radius to the anchored region surrounding the menu
- Fix context menu cannot be closed without selecting a menu option by adding an overlay