### PR TITLE
Fix #1531 by using web components current-value instead of value.

### DIFF
--- a/src/Core/Components/NumberField/FluentNumberField.razor
+++ b/src/Core/Components/NumberField/FluentNumberField.razor
@@ -1,4 +1,4 @@
-@namespace Microsoft.FluentUI.AspNetCore.Components
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 @inherits FluentInputBase<TValue>
 @typeparam TValue where TValue : new()
 @using System.Globalization;
@@ -24,7 +24,7 @@
                      max="@(ReadOnly ? value : Max)"
                      min="@(ReadOnly ? value : Min)"
                      id=@Id
-                     value="@value"
+                     current-value="@value"
                      disabled="@Disabled"
                      name=@Name
                      required="@Required"

--- a/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_AdditionalParameter.verified.html
+++ b/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_AdditionalParameter.verified.html
@@ -1,2 +1,2 @@
 
-<fluent-number-field maxlength="14" minlength="1" size="20" step="1" id="xxx" value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" additional-parameter-name="additional-parameter-value" blazor:elementreference="xxx">100</fluent-number-field>
+<fluent-number-field maxlength="14" minlength="1" size="20" step="1" id="xxx" current-value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" additional-parameter-name="additional-parameter-value" blazor:elementreference="xxx">100</fluent-number-field>

--- a/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_AdditionalParameters.verified.html
+++ b/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_AdditionalParameters.verified.html
@@ -1,2 +1,2 @@
 
-<fluent-number-field maxlength="14" minlength="1" size="20" step="1" id="xxx" value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" additional-parameter1-name="additional-parameter1-value" additional-parameter2-name="additional-parameter2-value" blazor:elementreference="xxx">100</fluent-number-field>
+<fluent-number-field maxlength="14" minlength="1" size="20" step="1" id="xxx" current-value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" additional-parameter1-name="additional-parameter1-value" additional-parameter2-name="additional-parameter2-value" blazor:elementreference="xxx">100</fluent-number-field>

--- a/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_AppearanceParameter-Filled.verified.html
+++ b/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_AppearanceParameter-Filled.verified.html
@@ -1,2 +1,2 @@
 
-<fluent-number-field maxlength="14" minlength="1" size="20" step="1" id="xxx" value="100" appearance="filled" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>
+<fluent-number-field maxlength="14" minlength="1" size="20" step="1" id="xxx" current-value="100" appearance="filled" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>

--- a/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_AppearanceParameter-Outline.verified.html
+++ b/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_AppearanceParameter-Outline.verified.html
@@ -1,2 +1,2 @@
 
-<fluent-number-field maxlength="14" minlength="1" size="20" step="1" id="xxx" value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>
+<fluent-number-field maxlength="14" minlength="1" size="20" step="1" id="xxx" current-value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>

--- a/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_AutoFocusParameter.verified.html
+++ b/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_AutoFocusParameter.verified.html
@@ -1,2 +1,2 @@
 
-<fluent-number-field autofocus="" maxlength="14" minlength="1" size="20" step="1" id="xxx" value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>
+<fluent-number-field autofocus="" maxlength="14" minlength="1" size="20" step="1" id="xxx" current-value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>

--- a/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_ClassParameter.verified.html
+++ b/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_ClassParameter.verified.html
@@ -1,2 +1,2 @@
 
-<fluent-number-field class="additional-css-class" maxlength="14" minlength="1" size="20" step="1" id="xxx" value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>
+<fluent-number-field class="additional-css-class" maxlength="14" minlength="1" size="20" step="1" id="xxx" current-value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>

--- a/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_DataListParameter.verified.html
+++ b/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_DataListParameter.verified.html
@@ -1,2 +1,2 @@
 
-<fluent-number-field list="datalist" maxlength="14" minlength="1" size="20" step="1" id="xxx" value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>
+<fluent-number-field list="datalist" maxlength="14" minlength="1" size="20" step="1" id="xxx" current-value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>

--- a/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_Default.verified.html
+++ b/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_Default.verified.html
@@ -1,2 +1,2 @@
 
-<fluent-number-field maxlength="14" minlength="1" size="20" step="1" id="xxx" value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>
+<fluent-number-field maxlength="14" minlength="1" size="20" step="1" id="xxx" current-value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>

--- a/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_DisabledParameter.verified.html
+++ b/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_DisabledParameter.verified.html
@@ -1,2 +1,2 @@
 
-<fluent-number-field maxlength="14" minlength="1" size="20" step="1" id="xxx" value="100" disabled="" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>
+<fluent-number-field maxlength="14" minlength="1" size="20" step="1" id="xxx" current-value="100" disabled="" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>

--- a/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_HideStepParameter.verified.html
+++ b/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_HideStepParameter.verified.html
@@ -1,2 +1,2 @@
 
-<fluent-number-field hide-step="" maxlength="14" minlength="1" size="20" step="1" id="xxx" value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>
+<fluent-number-field hide-step="" maxlength="14" minlength="1" size="20" step="1" id="xxx" current-value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>

--- a/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_IdParameter.verified.html
+++ b/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_IdParameter.verified.html
@@ -1,2 +1,2 @@
 
-<fluent-number-field maxlength="14" minlength="1" size="20" step="1" id="xxx" value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>
+<fluent-number-field maxlength="14" minlength="1" size="20" step="1" id="xxx" current-value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>

--- a/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_Label.verified.html
+++ b/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_Label.verified.html
@@ -1,4 +1,4 @@
 
 <label for="xxx" class="fluent-input-label" b-hum22yrq17="">My label
 </label>
-<fluent-number-field maxlength="14" minlength="1" size="20" step="1" id="xxx" value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>
+<fluent-number-field maxlength="14" minlength="1" size="20" step="1" id="xxx" current-value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>

--- a/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_LabelTemplate.verified.html
+++ b/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_LabelTemplate.verified.html
@@ -2,4 +2,4 @@
 <label for="xxx" class="fluent-input-label" b-hum22yrq17="">
   <h1>My label</h1>
 </label>
-<fluent-number-field maxlength="14" minlength="1" size="20" step="1" id="xxx" value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>
+<fluent-number-field maxlength="14" minlength="1" size="20" step="1" id="xxx" current-value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>

--- a/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_MaxLengthParameter.verified.html
+++ b/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_MaxLengthParameter.verified.html
@@ -1,2 +1,2 @@
 
-<fluent-number-field maxlength="10" minlength="1" size="20" step="1" id="xxx" value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>
+<fluent-number-field maxlength="10" minlength="1" size="20" step="1" id="xxx" current-value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>

--- a/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_MaxParameter.verified.html
+++ b/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_MaxParameter.verified.html
@@ -1,2 +1,2 @@
 
-<fluent-number-field maxlength="14" minlength="1" size="20" step="1" max="2147483647" id="xxx" value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>
+<fluent-number-field maxlength="14" minlength="1" size="20" step="1" max="2147483647" id="xxx" current-value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>

--- a/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_MinLengthParameter.verified.html
+++ b/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_MinLengthParameter.verified.html
@@ -1,2 +1,2 @@
 
-<fluent-number-field maxlength="14" minlength="3" size="20" step="1" id="xxx" value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>
+<fluent-number-field maxlength="14" minlength="3" size="20" step="1" id="xxx" current-value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>

--- a/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_MinParameter.verified.html
+++ b/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_MinParameter.verified.html
@@ -1,2 +1,2 @@
 
-<fluent-number-field maxlength="14" minlength="1" size="20" step="1" min="-2147483648" id="xxx" value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>
+<fluent-number-field maxlength="14" minlength="1" size="20" step="1" min="-2147483648" id="xxx" current-value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>

--- a/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_NameParameter.verified.html
+++ b/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_NameParameter.verified.html
@@ -1,2 +1,2 @@
 
-<fluent-number-field maxlength="14" minlength="1" size="20" step="1" id="xxx" value="100" name="xxx" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>
+<fluent-number-field maxlength="14" minlength="1" size="20" step="1" id="xxx" current-value="100" name="xxx" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>

--- a/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_PlaceholderParameter.verified.html
+++ b/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_PlaceholderParameter.verified.html
@@ -1,2 +1,2 @@
 
-<fluent-number-field placeholder="placeholder-value" maxlength="14" minlength="1" size="20" step="1" id="xxx" value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>
+<fluent-number-field placeholder="placeholder-value" maxlength="14" minlength="1" size="20" step="1" id="xxx" current-value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>

--- a/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_ReadOnlyParameter.verified.html
+++ b/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_ReadOnlyParameter.verified.html
@@ -1,2 +1,2 @@
 
-<fluent-number-field readonly="" maxlength="14" minlength="1" size="20" step="1" max="100" min="100" id="xxx" value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>
+<fluent-number-field readonly="" maxlength="14" minlength="1" size="20" step="1" max="100" min="100" id="xxx" current-value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>

--- a/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_RequiredParameter.verified.html
+++ b/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_RequiredParameter.verified.html
@@ -1,2 +1,2 @@
 
-<fluent-number-field maxlength="14" minlength="1" size="20" step="1" id="xxx" value="100" required="" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>
+<fluent-number-field maxlength="14" minlength="1" size="20" step="1" id="xxx" current-value="100" required="" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>

--- a/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_SizeParameter.verified.html
+++ b/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_SizeParameter.verified.html
@@ -1,2 +1,2 @@
 
-<fluent-number-field maxlength="14" minlength="1" size="3" step="1" id="xxx" value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>
+<fluent-number-field maxlength="14" minlength="1" size="3" step="1" id="xxx" current-value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>

--- a/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_StepParameter.verified.html
+++ b/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_StepParameter.verified.html
@@ -1,2 +1,2 @@
 
-<fluent-number-field maxlength="14" minlength="1" size="20" step="3" id="xxx" value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>
+<fluent-number-field maxlength="14" minlength="1" size="20" step="3" id="xxx" current-value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>

--- a/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_StyleParameter.verified.html
+++ b/tests/Core/NumberField/FluentNumberFieldTests.FluentNumberField_StyleParameter.verified.html
@@ -1,2 +1,2 @@
 
-<fluent-number-field style="background-color: red;" maxlength="14" minlength="1" size="20" step="1" id="xxx" value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>
+<fluent-number-field style="background-color: red;" maxlength="14" minlength="1" size="20" step="1" id="xxx" current-value="100" appearance="outline" blazor:onchange="1" blazor:oninput="2" blazor:elementreference="xxx">100</fluent-number-field>


### PR DESCRIPTION
- Fix #1531 by using web components current-value instead of value. Confirmed this is correct by looking at Fluent UI web component and FAST Explorer markup (both show no `value` attribute being used.
- Also updated verified files for tests