### PR TITLE
feat: Add global search bar

### DIFF
--- a/examples/Demo/Shared/Infrastructure/ServiceCollectionExtensions.cs
+++ b/examples/Demo/Shared/Infrastructure/ServiceCollectionExtensions.cs
@@ -13,6 +13,7 @@ public static class ServiceCollectionExtensions
     {
         services.AddScoped<CacheStorageAccessor>();
         services.AddHttpClient<IStaticAssetService, HttpBasedStaticAssetService>();
+        services.AddSingleton<DemoNavProvider>();
 
         return services;
     }

--- a/examples/Demo/Shared/Shared/DemoMainLayout.razor
+++ b/examples/Demo/Shared/Shared/DemoMainLayout.razor
@@ -13,7 +13,7 @@
                 <div class="logo" role="presentation" aria-hidden="true" itemprop="logo" itemscope="itemscope">
                     <svg xmlns="http://www.w3.org/2000/svg" width="108" height="23" viewBox="72 72 337 74" preserveAspectRatio="xMidYMin slice">
                         <g data-name="MS-symbol">
-                            <clipPath> 
+                            <clipPath>
                                 <path transform="matrix(1 0 0 -1 0 216)" d="M0 216h482V0H0z"></path>
                             </clipPath>
                             <g clip-path="url(#a)">
@@ -28,6 +28,11 @@
                 </div>
             </a>
             <FluentSpacer />
+
+            <div class="search">
+                <DemoSearch />
+            </div>
+
             <div class="links">
                 <FluentAnchor Appearance="Appearance.Hypertext"
                               Href="http://github.com/microsoft/fluentui-blazor" Target="_blank" Rel="noreferrer noopener"
@@ -51,11 +56,11 @@
 
                         <FluentMessageBarProvider Section="@App.MESSAGES_TOP" />
 
-                       
+
                                 <CascadingValue Value=@OnRefreshTableOfContents>
                                     @Body
                                 </CascadingValue>
-                           
+
                     </article>
                     <aside>
                         <TableOfContents @ref=_toc />

--- a/examples/Demo/Shared/Shared/DemoNavMenu.razor
+++ b/examples/Demo/Shared/Shared/DemoNavMenu.razor
@@ -1,132 +1,14 @@
+@inject DemoNavProvider NavProvider
+
 <div class="navmenu">
     <input type="checkbox" title="Menu expand/collapse toggle" id="navmenu-toggle" class="navmenu-icon" />
     <label for="navmenu-toggle" class="navmenu-icon"><FluentIcon Value="@(new Icons.Regular.Size20.Navigation())" Color="Color.Neutral" /></label>
     <nav class="sitenav" aria-labelledby="main-menu" onclick="document.getElementById('navmenu-toggle').click()">
         <FluentNavMenu Id="main-menu" Title="Main menu">
-            <FluentNavLink Icon="@(new Icons.Regular.Size20.Home())" Href="/" Match="NavLinkMatch.All">
-                <h3>Home</h3>
-            </FluentNavLink>
-
-            <FluentNavGroup Expanded="true" Gap="10px" Icon="@(new Icons.Regular.Size20.PersonRunning())">
-                <TitleTemplate><h3>Getting Started</h3></TitleTemplate>
-                <ChildContent>
-                    <FluentNavLink Href="/WhatsNew" Icon="@(new Icons.Regular.Size20.Info())">What's new</FluentNavLink>
-                    <FluentNavLink Href="/UpgradeGuide" Icon="@(new Icons.Regular.Size20.ArrowUp())">Upgrade guide</FluentNavLink>
-                    <FluentNavLink Href="/CodeSetup" Icon="@(new Icons.Regular.Size20.DocumentOnePageSparkle())">Code setup</FluentNavLink>
-                    <FluentNavLink Href="/Templates" Icon="@(new Icons.Regular.Size20.Classification())">Project templates</FluentNavLink>
-                    <FluentNavLink Href="/DesignTheme" Icon="@(new Icons.Regular.Size20.DarkTheme())">Themes</FluentNavLink>
-                    <FluentNavLink Href="/DesignTokens" Icon="@(new Icons.Regular.Size20.DesignIdeas())">Design tokens</FluentNavLink>
-                    <FluentNavLink Href="/Reboot" Icon="@(new Icons.Regular.Size20.ArrowReset())">Reboot</FluentNavLink>
-                    <FluentNavLink Href="/IconsAndEmoji" Icon="@(new Icons.Regular.Size20.Symbols())">Icons and Emoji</FluentNavLink>
-                    <FluentNavGroup Title="Services" Gap="10px" Icon="@(new Icons.Regular.Size20.SettingsCogMultiple())">
-                        <FluentNavLink Href="/DialogService" Icon="@(new Icons.Regular.Size20.AppGeneric())">DialogService</FluentNavLink>
-                        <FluentNavLink Href="/MessageService" Icon="@(new Icons.Regular.Size20.WindowHeaderHorizontal())">MessageService</FluentNavLink>
-                        <FluentNavLink Href="/ToastService" Icon="@(new Icons.Regular.Size20.FoodToast())">ToastService</FluentNavLink>
-                    </FluentNavGroup>
-                </ChildContent>
-            </FluentNavGroup>
-
-            <FluentNavGroup Gap="10px" Icon="@(new Icons.Regular.Size20.ContentViewGallery())">
-                <TitleTemplate><h3>Layout</h3></TitleTemplate>
-                <ChildContent>
-                    <FluentNavLink Href="/Header" Icon="@(new Icons.Regular.Size20.DocumentHeader())">Header</FluentNavLink>
-                    <FluentNavLink Href="/Footer" Icon="@(new Icons.Regular.Size20.DocumentFooter())">Footer</FluentNavLink>
-                    <FluentNavLink Href="/BodyContent" Icon="@(new Icons.Regular.Size20.ContentViewGallery())">BodyContent</FluentNavLink>
-                    <FluentNavLink Href="/Grid" Icon="@(new Icons.Regular.Size20.Grid())">Grid</FluentNavLink>
-                    <FluentNavLink Href="/Layout" Icon="@(new Icons.Regular.Size20.SlideLayout())">Layout</FluentNavLink>
-                    <FluentNavLink Href="/MainLayout" Icon="@(new Icons.Regular.Size20.MatchAppLayout())">MainLayout</FluentNavLink>
-                    <FluentNavLink Href="/Spacer" Icon="@(new Icons.Regular.Size20.Spacebar())">Spacer</FluentNavLink>
-                    <FluentNavLink Href="/Splitter" Icon="@(new Icons.Regular.Size20.SplitVertical())">Splitter</FluentNavLink>
-                    <FluentNavLink Href="/Stack" Icon="@(new Icons.Regular.Size20.Stack())">Stack</FluentNavLink>
-                </ChildContent>
-            </FluentNavGroup>
-
-            <FluentNavGroup Gap="10px" Icon="@(new Icons.Regular.Size20.Form())">
-                <TitleTemplate><h3>Form & Inputs</h3></TitleTemplate>
-                <ChildContent>
-                    <FluentNavLink Href="/Forms" Icon="@(new Icons.Regular.Size20.Form())">Overview</FluentNavLink>
-                    <FluentNavLink Href="/Checkbox" Icon="@(new Icons.Regular.Size20.CheckboxChecked())">Checkbox</FluentNavLink>
-                    <FluentNavLink Href="/InputFile" Icon="@(new Icons.Regular.Size20.ArrowUpload())">InputFile</FluentNavLink>
-                    <FluentNavLink Href="/NumberField" Icon="@(new Icons.Regular.Size20.NumberSymbolSquare())">Number Field</FluentNavLink>
-                    <FluentNavLink Href="/Radio" Icon="@(new Icons.Regular.Size20.RadioButton())">Radio</FluentNavLink>
-                    <FluentNavLink Href="/RadioGroup" Icon="@(new Icons.Regular.Size20.RadioButton())">Radio Group</FluentNavLink>
-                    <FluentNavLink Href="/Search" Icon="@(new Icons.Regular.Size20.SearchSquare())">Search</FluentNavLink>
-                    <FluentNavLink Href="/Slider" Icon="@(new Icons.Regular.Size20.Options())">Slider</FluentNavLink>
-                    <FluentNavLink Href="/Switch" Icon="@(new Icons.Regular.Size20.ToggleLeft())">Switch</FluentNavLink>
-                    <FluentNavLink Href="/TextArea" Icon="@(new Icons.Regular.Size20.TextboxMore())">TextArea</FluentNavLink>
-                    <FluentNavLink Href="/TextField" Icon="@(new Icons.Regular.Size20.Textbox())">Text Field</FluentNavLink>
-                    <FluentNavLink Href="/DateTime#fluenttimepicker-class" Icon="@(new Icons.Regular.Size20.Clock())">Time picker</FluentNavLink>
-                </ChildContent>
-            </FluentNavGroup>
-
-            <FluentNavGroup Gap="10px" Icon="@(new Icons.Regular.Size20.PuzzleCubePiece())">
-                <TitleTemplate><h3>Components</h3></TitleTemplate>
-                <ChildContent>
-                    <FluentNavLink Href="/FluentComponentBase" Icon="@(new Icons.Regular.Size20.PuzzleCubePiece())">Overview</FluentNavLink>
-                    <FluentNavLink Href="/Accordion" Icon="@(new Icons.Regular.Size20.TextCollapse())">Accordion</FluentNavLink>
-                    <FluentNavLink Href="/Anchor" Icon="@(new Icons.Regular.Size20.Link())">Anchor</FluentNavLink>
-                    <FluentNavLink Href="/AnchoredRegion" Icon="@(new Icons.Regular.Size20.LinkSquare())">Anchored Region</FluentNavLink>
-                    <FluentNavGroup Expanded="true" Title="Badge" Gap="10px" Icon="@(new Icons.Regular.Size20.Tag())">
-                        <FluentNavLink Href="/Badge" Icon="@(new Icons.Regular.Size20.Badge())">Badge</FluentNavLink>
-                        <FluentNavLink Href="/CounterBadge" Icon="@(new Icons.Regular.Size20.NumberCircle1())">CounterBadge</FluentNavLink>
-                        <FluentNavLink Href="/PresenceBadge" Icon="@(new Icons.Regular.Size20.PresenceAvailable())">PresenceBadge</FluentNavLink>
-                    </FluentNavGroup>
-                    <FluentNavLink Href="/Breadcrumb" Icon="@(new Icons.Regular.Size20.DocumentChevronDouble())">Breadcrumb</FluentNavLink>
-                    <FluentNavLink Href="/Button" Icon="@(new Icons.Regular.Size20.ControlButton())">Button</FluentNavLink>
-                    <FluentNavLink Href="/Card" Icon="@(new Icons.Regular.Size20.ContactCardGroup())">Card</FluentNavLink>
-                    <FluentNavLink Href="/DataGrid" Icon="@(new Icons.Regular.Size20.Grid())">Data grid</FluentNavLink>
-                    <FluentNavLink Href="/DateTime" Icon="@(new Icons.Regular.Size20.CalendarLtr())">Date & Time</FluentNavLink>
-                    <FluentNavLink Href="/Dialog" Icon="@(new Icons.Regular.Size20.AppGeneric())">Dialog</FluentNavLink>
-                    <FluentNavLink Href="/Divider" Icon="@(new Icons.Regular.Size20.DividerShort())">Divider</FluentNavLink>
-                    <FluentNavLink Href="/Drag" Icon="@(new Icons.Regular.Size20.Drag())">Drag and Drop</FluentNavLink>
-                    <FluentNavLink Href="/Emoji" Icon="@(new Icons.Regular.Size20.EmojiSmileSlight())">Emoji</FluentNavLink>
-                    <FluentNavLink Href="/Flipper" Icon="@(new Icons.Regular.Size20.Navigation())">Flipper</FluentNavLink>
-                    <FluentNavLink Href="/Highlighter" Icon="@(new Icons.Regular.Size20.Highlight())">Highlighter</FluentNavLink>
-                    <FluentNavLink Href="/HorizontalScroll" Icon="@(new Icons.Regular.Size20.ArrowForward())">Horizontal Scroll</FluentNavLink>
-                    <FluentNavLink Href="/Icon" Icon="@(new Icons.Regular.Size20.Symbols())">Icon</FluentNavLink>
-                    <FluentNavLink Href="/Label" Icon="@(new Icons.Regular.Size20.DoorTag())">Label</FluentNavLink>
-                    <FluentNavGroup Expanded="true" Title="List" Gap="10px" Icon="@(new Icons.Regular.Size20.List())">
-                        <FluentNavLink Href="/Autocomplete" Icon="@(new Icons.Regular.Size20.ArrowAutofitContent())">Autocomplete</FluentNavLink>
-                        <FluentNavLink Href="/Combobox" Icon="@(new Icons.Regular.Size20.BoxEdit())">Combobox</FluentNavLink>
-                        <FluentNavLink Href="/Listbox" Icon="@(new Icons.Regular.Size20.List())">Listbox</FluentNavLink>
-                        <FluentNavLink Href="/Select" Icon="@(new Icons.Regular.Size20.GroupList())">Select</FluentNavLink>
-                        <FluentNavLink Href="/Option" Icon="@(new Icons.Regular.Size20.MultiselectRtl())">Option</FluentNavLink>
-                    </FluentNavGroup>
-                    <FluentNavLink Href="/Menu" Icon="@(new Icons.Regular.Size20.Navigation())">Menu</FluentNavLink>
-                    <FluentNavLink Href="/MenuButton" Icon="@(new Icons.Regular.Size20.ChevronCircleDown())">MenuButton</FluentNavLink>
-                    <FluentNavLink Href="/MessageBar" Icon="@(new Icons.Regular.Size20.WindowHeaderHorizontal())">MessageBar</FluentNavLink>
-                    <FluentNavLink Href="/MessageBox" Icon="@(new Icons.Regular.Size20.MegaphoneLoud())">MessageBox</FluentNavLink>
-                    <FluentNavLink Href="/NavMenu" Icon="@(new Icons.Regular.Size20.Navigation())">NavMenu</FluentNavLink>
-                    <FluentNavLink Href="/NavMenuTree" Icon="@(new Icons.Regular.Size20.Navigation())">NavMenuTree</FluentNavLink>
-                    <FluentNavLink Href="/Overflow" Icon="@(new Icons.Regular.Size20.MultiselectRtl())">Overflow</FluentNavLink>
-                    <FluentNavLink Href="/Overlay" Icon="@(new Icons.Regular.Size20.CursorHover())">Overlay</FluentNavLink>
-                    <FluentNavLink Href="/Panel" Icon="@(new Icons.Regular.Size20.PanelRight())">Panel</FluentNavLink>
-                    <FluentNavLink Href="/Persona" Icon="@(new Icons.Regular.Size20.PersonAvailable())">Persona</FluentNavLink>
-                    <FluentNavLink Href="/Popover" Icon="@(new Icons.Regular.Size20.TooltipQuote())">Popover</FluentNavLink>
-                    <FluentNavLink Href="/Progress" Icon="@(new Icons.Regular.Size20.SquareHint())">Progress</FluentNavLink>
-                    <FluentNavLink Href="/ProgressRing" Icon="@(new Icons.Regular.Size20.ArrowClockwiseDashes())">Progress Ring</FluentNavLink>
-                    <FluentNavLink Href="/Skeleton" Icon="@(new Icons.Regular.Size20.Shortpick())">Skeleton</FluentNavLink>
-                    <FluentNavLink Href="/SortableList" Icon="@(new Icons.Regular.Size20.ArrowSort())">Sortable List</FluentNavLink>
-                    <FluentNavLink Href="/SplashScreen" Icon="@(new Icons.Regular.Size20.Drop())">SplashScreen</FluentNavLink>
-                    <FluentNavLink Href="/Tabs" Icon="@(new Icons.Regular.Size20.TabDesktop())">Tabs</FluentNavLink>
-                    <FluentNavLink Href="/Toast" Icon="@(new Icons.Regular.Size20.FoodToast())">Toast</FluentNavLink>
-                    <FluentNavLink Href="/Toolbar" Icon="@(new Icons.Regular.Size20.WrenchScrewdriver())">Toolbar</FluentNavLink>
-                    <FluentNavLink Href="/Tooltip" Icon="@(new Icons.Regular.Size20.TooltipQuote())">Tooltip</FluentNavLink>
-                    <FluentNavLink Href="/TreeView" Icon="@(new Icons.Regular.Size20.TextBulletListTree())">Tree View</FluentNavLink>
-                    <FluentNavLink Href="/Wizard" Icon="@(new Icons.Regular.Size20.ArrowStepInRight())">Wizard</FluentNavLink>
-                </ChildContent>
-            </FluentNavGroup>
-
-            <FluentNavGroup Icon="@(new Icons.Regular.Size20.Beaker())" Gap="10px">
-                <TitleTemplate><h3>Incubation lab</h3></TitleTemplate>
-                <ChildContent>
-                    <FluentNavLink Href="/Lab/Overview" Icon="@(new Icons.Regular.Size20.Beaker())">Overview</FluentNavLink>
-                    <FluentNavLink Href="/Lab/MarkdownSection" Icon="@(new Icons.Regular.Size20.ArrowSortDown())">MarkdownSection</FluentNavLink>
-                    <FluentNavLink Href="/Lab/TableOfContents" Icon="@(new Icons.Regular.Size20.DocumentTextLink())">TableOfContents</FluentNavLink>
-                    <FluentNavLink Href="/MultiSplitter" Icon="@(new Icons.Regular.Size20.SplitHorizontal())">Multi Splitter</FluentNavLink>
-                    <FluentNavLink Href="/KeyCode" Icon="@(new Icons.Regular.Size20.Keyboard())">KeyCode</FluentNavLink>
-                </ChildContent>
-            </FluentNavGroup>
+            @foreach(var item in NavProvider.NavMenuItems)
+            {
+                <DemoNavMenuItem Value="item"/>
+            }
         </FluentNavMenu>
     </nav>
 </div>

--- a/examples/Demo/Shared/Shared/DemoNavMenuItem.razor
+++ b/examples/Demo/Shared/Shared/DemoNavMenuItem.razor
@@ -1,0 +1,33 @@
+﻿@using NavLink = FluentUI.Demo.Shared.NavLink
+
+@switch(Value)
+{
+    case NavGroup group:
+        <FluentNavGroup Expanded="@group.Expanded" Gap="@group.Gap" Icon="@group.Icon">
+            <TitleTemplate>
+                <h3>@group.Title</h3></TitleTemplate>
+            <ChildContent>
+                @foreach(var item in group.Children)
+                {
+                    <DemoNavMenuItem Value="item" />
+                }
+            </ChildContent>
+        </FluentNavGroup>
+        break;
+    case NavLink:
+        <FluentNavLink Icon="@Value.Icon" Href="@Value.Href" Match="@Value.Match">
+            @if (Value.Match is NavLinkMatch.All)
+            {
+                <h3>@Value.Title</h3>
+            }
+            else
+            {
+                @Value.Title
+            }
+        </FluentNavLink>
+        break;
+}
+
+@code {
+    [Parameter, EditorRequired] public required NavItem Value { get; set; }
+}

--- a/examples/Demo/Shared/Shared/DemoNavMenuItem.razor
+++ b/examples/Demo/Shared/Shared/DemoNavMenuItem.razor
@@ -29,5 +29,6 @@
 }
 
 @code {
-    [Parameter, EditorRequired] public required NavItem Value { get; set; }
+    [Parameter, EditorRequired]
+    public required NavItem Value { get; set; }
 }

--- a/examples/Demo/Shared/Shared/DemoNavProvider.cs
+++ b/examples/Demo/Shared/Shared/DemoNavProvider.cs
@@ -1,0 +1,563 @@
+﻿// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Components.Routing;
+using Microsoft.FluentUI.AspNetCore.Components;
+
+namespace FluentUI.Demo.Shared;
+
+public class DemoNavProvider
+{
+    public IReadOnlyList<NavItem> NavMenuItems { get; init; }
+
+    public IReadOnlyList<NavItem> FlattenedMenuItems { get; init; }
+
+    public DemoNavProvider()
+    {
+        NavMenuItems =
+        [
+            new NavLink(
+                href: "/",
+                match: NavLinkMatch.All,
+                icon: new Icons.Regular.Size20.Home(),
+                title: "Home"
+            ),
+
+            new NavGroup(
+                icon: new Icons.Regular.Size20.PersonRunning(),
+                title: "Getting Started",
+                expanded: true,
+                gap: "10px",
+                children:
+                [
+                    new NavLink(
+                        href: "/WhatsNew",
+                        icon: new Icons.Regular.Size20.Info(),
+                        title: "What's new"
+                    ),
+
+                    new NavLink(
+                        href: "/UpgradeGuide",
+                        icon: new Icons.Regular.Size20.ArrowUp(),
+                        title: "Upgrade guide"
+                    ),
+
+                    new NavLink(
+                        href: "/CodeSetup",
+                        icon: new Icons.Regular.Size20.DocumentOnePageSparkle(),
+                        title: "Code setup"
+                    ),
+
+                    new NavLink(
+                        href: "/Templates",
+                        icon: new Icons.Regular.Size20.Classification(),
+                        title: "Project templates"
+                    ),
+
+                    new NavLink(
+                        href: "/DesignTheme",
+                        icon: new Icons.Regular.Size20.DarkTheme(),
+                        title: "Themes"
+                    ),
+
+                    new NavLink(
+                        href: "/DesignTokens",
+                        icon: new Icons.Regular.Size20.DesignIdeas(),
+                        title: "Design tokens"
+                    ),
+
+                    new NavLink(
+                        href: "/Reboot",
+                        icon: new Icons.Regular.Size20.ArrowReset(),
+                        title: "Reboot"
+                    ),
+
+                    new NavLink(
+                        href: "/IconsAndEmoji",
+                        icon: new Icons.Regular.Size20.Symbols(),
+                        title: "Icons and Emoji"
+                    ),
+
+                    new NavGroup(
+                        icon: new Icons.Regular.Size20.SettingsCogMultiple(),
+                        title: "Services",
+                        expanded: false,
+                        gap: "10px",
+                        children:
+                        [
+                            new NavLink(
+                                href: "/DialogService",
+                                icon: new Icons.Regular.Size20.AppGeneric(),
+                                title: "DialogService"
+                            ),
+
+                            new NavLink(
+                                href: "/MessageService",
+                                icon: new Icons.Regular.Size20.WindowHeaderHorizontal(),
+                                title: "MessageService"
+                            ),
+
+                            new NavLink(
+                                href: "/ToastService",
+                                icon: new Icons.Regular.Size20.FoodToast(),
+                                title: "ToastService"
+                            )
+                        ]
+                    )
+                ]
+            ),
+            new NavGroup(
+                icon: new Icons.Regular.Size20.ContentViewGallery(),
+                title: "Layout",
+                expanded: false,
+                gap: "10px",
+                children:
+                [
+                    new NavLink(
+                        href: "/Header",
+                        icon: new Icons.Regular.Size20.DocumentHeader(),
+                        title: "Header"
+                    ),
+                    new NavLink(
+                        href: "/Footer",
+                        icon: new Icons.Regular.Size20.DocumentFooter(),
+                        title: "Footer"
+                    ),
+                    new NavLink(
+                        href: "/BodyContent",
+                        icon: new Icons.Regular.Size20.ContentViewGallery(),
+                        title: "BodyContent"
+                    ),
+                    new NavLink(
+                        href: "/Grid",
+                        icon: new Icons.Regular.Size20.Grid(),
+                        title: "Grid"
+                    ),
+                    new NavLink(
+                        href: "/Layout",
+                        icon: new Icons.Regular.Size20.SlideLayout(),
+                        title: "Layout"
+                    ),
+                    new NavLink(
+                        href: "/MainLayout",
+                        icon: new Icons.Regular.Size20.MatchAppLayout(),
+                        title: "MainLayout"
+                    ),
+                    new NavLink(
+                        href: "/Spacer",
+                        icon: new Icons.Regular.Size20.Spacebar(),
+                        title: "Spacer"
+                    ),
+                    new NavLink(
+                        href: "/Splitter",
+                        icon: new Icons.Regular.Size20.SplitVertical(),
+                        title: "Splitter"
+                    ),
+                    new NavLink(
+                        href: "/Stack",
+                        icon: new Icons.Regular.Size20.Stack(),
+                        title: "Stack"
+                    )
+                ]),
+            new NavGroup(
+                icon: new Icons.Regular.Size20.Form(),
+                title: "Form & Inputs",
+                expanded: false,
+                gap: "10px",
+                children:
+                [
+                    new NavLink(
+                        href: "/Forms",
+                        icon: new Icons.Regular.Size20.Form(),
+                        title: "Overview"
+                    ),
+                    new NavLink(
+                        href: "/Checkbox",
+                        icon: new Icons.Regular.Size20.CheckboxChecked(),
+                        title: "Checkbox"
+                    ),
+                    new NavLink(
+                        href: "/InputFile",
+                        icon: new Icons.Regular.Size20.ArrowUpload(),
+                        title: "InputFile"
+                    ),
+                    new NavLink(
+                        href: "/NumberField",
+                        icon: new Icons.Regular.Size20.NumberSymbolSquare(),
+                        title: "Number Field"
+                    ),
+                    new NavLink(
+                        href: "/Radio",
+                        icon: new Icons.Regular.Size20.RadioButton(),
+                        title: "Radio"
+                    ),
+                    new NavLink(
+                        href: "/RadioGroup",
+                        icon: new Icons.Regular.Size20.RadioButton(),
+                        title: "Radio Group"
+                    ),
+                    new NavLink(
+                        href: "/Search",
+                        icon: new Icons.Regular.Size20.SearchSquare(),
+                        title: "Search"
+                    ),
+                    new NavLink(
+                        href: "/Slider",
+                        icon: new Icons.Regular.Size20.Options(),
+                        title: "Slider"
+                    ),
+                    new NavLink(
+                        href: "/Switch",
+                        icon: new Icons.Regular.Size20.ToggleLeft(),
+                        title: "Switch"
+                    ),
+                    new NavLink(
+                        href: "/TextArea",
+                        icon: new Icons.Regular.Size20.TextboxMore(),
+                        title: "TextArea"
+                    ),
+                    new NavLink(
+                        href: "/TextField",
+                        icon: new Icons.Regular.Size20.Textbox(),
+                        title: "Text Field"
+                    ),
+                    new NavLink(
+                        href: "/DateTime#fluenttimepicker-class",
+                        icon: new Icons.Regular.Size20.Clock(),
+                        title: "Time picker"
+                    )
+                ]
+            ),
+
+            new NavGroup(
+                icon: new Icons.Regular.Size20.PuzzleCubePiece(),
+                title: "Components",
+                expanded: false,
+                gap: "10px",
+                children:
+                [
+                    new NavLink(
+                        href: "/FluentComponentBase",
+                        icon: new Icons.Regular.Size20.PuzzleCubePiece(),
+                        title: "Overview"
+                    ),
+                    new NavLink(
+                        href: "/Accordion",
+                        icon: new Icons.Regular.Size20.TextCollapse(),
+                        title: "Accordion"
+                    ),
+                    new NavLink(
+                        href: "/Anchor",
+                        icon: new Icons.Regular.Size20.Link(),
+                        title: "Anchor"
+                    ),
+                    new NavLink(
+                        href: "/AnchoredRegion",
+                        icon: new Icons.Regular.Size20.LinkSquare(),
+                        title: "Anchored Region"
+                    ),
+                    new NavGroup(
+                        title: "Badge",
+                        expanded: true,
+                        gap: "10px",
+                        icon: new Icons.Regular.Size20.Tag(),
+                        children:
+                        [
+                            new NavLink(
+                                href: "/Badge",
+                                icon: new Icons.Regular.Size20.Badge(),
+                                title: "Badge"
+                            ),
+                            new NavLink(
+                                href: "/CounterBadge",
+                                icon: new Icons.Regular.Size20.NumberCircle1(),
+                                title: "CounterBadge"
+                            ),
+                            new NavLink(
+                                href: "/PresenceBadge",
+                                icon: new Icons.Regular.Size20.PresenceAvailable(),
+                                title: "PresenceBadge"
+                            )
+                        ]
+                    ),
+                    new NavLink(
+                        href: "/Breadcrumb",
+                        icon: new Icons.Regular.Size20.DocumentChevronDouble(),
+                        title: "Breadcrumb"
+                    ),
+                    new NavLink(
+                        href: "/Button",
+                        icon: new Icons.Regular.Size20.ControlButton(),
+                        title: "Button"
+                    ),
+                    new NavLink(
+                        href: "/Card",
+                        icon: new Icons.Regular.Size20.ContactCardGroup(),
+                        title: "Card"
+                    ),
+                    new NavLink(
+                        href: "/DataGrid",
+                        icon: new Icons.Regular.Size20.Grid(),
+                        title: "Data grid"
+                    ),
+                    new NavLink(
+                        href: "/DateTime",
+                        icon: new Icons.Regular.Size20.CalendarLtr(),
+                        title: "Date & Time"
+                    ),
+                    new NavLink(
+                        href: "/Dialog",
+                        icon: new Icons.Regular.Size20.AppGeneric(),
+                        title: "Dialog"
+                    ),
+                    new NavLink(
+                        href: "/Divider",
+                        icon: new Icons.Regular.Size20.DividerShort(),
+                        title: "Divider"
+                    ),
+                    new NavLink(
+                        href: "/Drag",
+                        icon: new Icons.Regular.Size20.Drag(),
+                        title: "Drag and Drop"
+                    ),
+                    new NavLink(
+                        href: "/Emoji",
+                        icon: new Icons.Regular.Size20.EmojiSmileSlight(),
+                        title: "Emoji"
+                    ),
+                    new NavLink(
+                        href: "/Flipper",
+                        icon: new Icons.Regular.Size20.Navigation(),
+                        title: "Flipper"
+                    ),
+                    new NavLink(
+                        href: "/Highlighter",
+                        icon: new Icons.Regular.Size20.Highlight(),
+                        title: "Highlighter"
+                    ),
+                    new NavLink(
+                        href: "/HorizontalScroll",
+                        icon: new Icons.Regular.Size20.ArrowForward(),
+                        title: "Horizontal Scroll"
+                    ),
+                    new NavLink(
+                        href: "/Icon",
+                        icon: new Icons.Regular.Size20.Symbols(),
+                        title: "Icon"
+                    ),
+                    new NavLink(
+                        href: "/Label",
+                        icon: new Icons.Regular.Size20.DoorTag(),
+                        title: "Label"
+                    ),
+                    new NavGroup(
+                        title: "List",
+                        expanded: true,
+                        gap: "10px",
+                        icon: new Icons.Regular.Size20.List(),
+                        children:
+                        [
+                            new NavLink(
+                                href: "/Autocomplete",
+                                icon: new Icons.Regular.Size20.ArrowAutofitContent(),
+                                title: "Autocomplete"
+                            ),
+                            new NavLink(
+                                href: "/Combobox",
+                                icon: new Icons.Regular.Size20.BoxEdit(),
+                                title: "Combobox"
+                            ),
+                            new NavLink(
+                                href: "/Listbox",
+                                icon: new Icons.Regular.Size20.List(),
+                                title: "Listbox"
+                            ),
+                            new NavLink(
+                                href: "/Select",
+                                icon: new Icons.Regular.Size20.GroupList(),
+                                title: "Select"
+                            ),
+                            new NavLink(
+                                href: "/Option",
+                                icon: new Icons.Regular.Size20.MultiselectRtl(),
+                                title: "Option"
+                            )
+                        ]
+                    ),
+                    new NavLink(
+                        href: "/Menu",
+                        icon: new Icons.Regular.Size20.Navigation(),
+                        title: "Menu"
+                    ),
+                    new NavLink(
+                        href: "/MenuButton",
+                        icon: new Icons.Regular.Size20.ChevronCircleDown(),
+                        title: "MenuButton"
+                    ),
+                    new NavLink(
+                        href: "/MessageBar",
+                        icon: new Icons.Regular.Size20.WindowHeaderHorizontal(),
+                        title: "MessageBar"
+                    ),
+                    new NavLink(
+                        href: "/MessageBox",
+                        icon: new Icons.Regular.Size20.MegaphoneLoud(),
+                        title: "MessageBox"
+                    ),
+                    new NavLink(
+                        href: "/NavMenu",
+                        icon: new Icons.Regular.Size20.Navigation(),
+                        title: "NavMenu"
+                    ),
+                    new NavLink(
+                        href: "/NavMenuTree",
+                        icon: new Icons.Regular.Size20.Navigation(),
+                        title: "NavMenuTree"
+                    ),
+                    new NavLink(
+                        href: "/Overflow",
+                        icon: new Icons.Regular.Size20.MultiselectRtl(),
+                        title: "Overflow"
+                    ),
+                    new NavLink(
+                        href: "/Overlay",
+                        icon: new Icons.Regular.Size20.CursorHover(),
+                        title: "Overlay"
+                    ),
+                    new NavLink(
+                        href: "/Panel",
+                        icon: new Icons.Regular.Size20.PanelRight(),
+                        title: "Panel"
+                    ),
+                    new NavLink(
+                        href: "/Persona",
+                        icon: new Icons.Regular.Size20.PersonAvailable(),
+                        title: "Persona"
+                    ),
+                    new NavLink(
+                        href: "/Popover",
+                        icon: new Icons.Regular.Size20.TooltipQuote(),
+                        title: "Popover"
+                    ),
+                    new NavLink(
+                        href: "/Progress",
+                        icon: new Icons.Regular.Size20.SquareHint(),
+                        title: "Progress"
+                    ),
+                    new NavLink(
+                        href: "/ProgressRing",
+                        icon: new Icons.Regular.Size20.ArrowClockwiseDashes(),
+                        title: "Progress Ring"
+                    ),
+                    new NavLink(
+                        href: "/Skeleton",
+                        icon: new Icons.Regular.Size20.Shortpick(),
+                        title: "Skeleton"
+                    ),
+                    new NavLink(
+                        href: "/SortableList",
+                        icon: new Icons.Regular.Size20.ArrowSort(),
+                        title: "Sortable List"
+                    ),
+                    new NavLink(
+                        href: "/SplashScreen",
+                        icon: new Icons.Regular.Size20.Drop(),
+                        title: "SplashScreen"
+                    ),
+                    new NavLink(
+                        href: "/Tabs",
+                        icon: new Icons.Regular.Size20.TabDesktop(),
+                        title: "Tabs"
+                    ),
+                    new NavLink(
+                        href: "/Toast",
+                        icon: new Icons.Regular.Size20.FoodToast(),
+                        title: "Toast"
+                    ),
+                    new NavLink(
+                        href: "/Toolbar",
+                        icon: new Icons.Regular.Size20.WrenchScrewdriver(),
+                        title: "Toolbar"
+                    ),
+                    new NavLink(
+                        href: "/Tooltip",
+                        icon: new Icons.Regular.Size20.TooltipQuote(),
+                        title: "Tooltip"
+                    ),
+                    new NavLink(
+                        href: "/TreeView",
+                        icon: new Icons.Regular.Size20.TextBulletListTree(),
+                        title: "Tree View"
+                    ),
+                    new NavLink(
+                        href: "/new Icons.Regular.Size20.ArrowStepInRight()",
+                        icon: new Icons.Regular.Size20.TextBulletListTree(),
+                        title: "Wizard"
+                    )
+                ]),
+
+
+            new NavGroup(
+                icon: new Icons.Regular.Size20.Beaker(),
+                title: "Incubation lab",
+                expanded: false,
+                gap: "10px",
+                children:
+                [
+                    new NavLink(
+                        href: "/Lab/Overview",
+                        icon: new Icons.Regular.Size20.Beaker(),
+                        title: "Overview"
+                    ),
+
+                    new NavLink(
+                        href: "/Lab/MarkdownSection",
+                        icon: new Icons.Regular.Size20.ArrowSortDown(),
+                        title: "MarkdownSection"
+                    ),
+
+                    new NavLink(
+                        href: "/Lab/TableOfContents",
+                        icon: new Icons.Regular.Size20.DocumentTextLink(),
+                        title: "TableOfContents"
+                    ),
+
+                    new NavLink(
+                        href: "/MultiSplitter",
+                        icon: new Icons.Regular.Size20.SplitHorizontal(),
+                        title: "Multi Splitter"
+                    ),
+
+                    new NavLink(
+                        href: "/KeyCode",
+                        icon: new Icons.Regular.Size20.Keyboard(),
+                        title: "KeyCode"
+                    )
+                ]
+            )
+        ];
+
+        FlattenedMenuItems = GetFlattenedMenuItems(NavMenuItems)
+            .ToList()
+            .AsReadOnly();
+    }
+
+    private static IEnumerable<NavItem> GetFlattenedMenuItems(IEnumerable<NavItem> items)
+    {
+        foreach (var item in items)
+        {
+            yield return item;
+
+            if (item is not NavGroup group || !group.Children.Any())
+            {
+                continue;
+            }
+
+            foreach (var flattenedMenuItem in GetFlattenedMenuItems(group.Children))
+            {
+                yield return flattenedMenuItem;
+            }
+        }
+    }
+}

--- a/examples/Demo/Shared/Shared/DemoNavProvider.cs
+++ b/examples/Demo/Shared/Shared/DemoNavProvider.cs
@@ -497,7 +497,6 @@ public class DemoNavProvider
                     )
                 ]),
 
-
             new NavGroup(
                 icon: new Icons.Regular.Size20.Beaker(),
                 title: "Incubation lab",

--- a/examples/Demo/Shared/Shared/DemoSearch.razor
+++ b/examples/Demo/Shared/Shared/DemoSearch.razor
@@ -1,8 +1,4 @@
-﻿@using System.Diagnostics
-@inject DemoNavProvider NavProvider
-@inject NavigationManager NavigationManager
-
-<FluentSearch @bind-Value="@_searchValue"
+﻿<FluentSearch @bind-Value="@_searchValue"
               Immediate
               @bind-Value:after="HandleSearchInput"
               Id="demo-search"

--- a/examples/Demo/Shared/Shared/DemoSearch.razor
+++ b/examples/Demo/Shared/Shared/DemoSearch.razor
@@ -4,7 +4,7 @@
 
 <FluentSearch @bind-Value="@_searchValue"
               Immediate
-              @bind-Value:after=HandleSearchInput
+              @bind-Value:after="HandleSearchInput"
               Id="demo-search"
               Placeholder="Search everything..."/>
 
@@ -25,58 +25,4 @@
             </FluentMenuItem>
         }
     </FluentMenu>
-}
-
-@code {
-    string? _searchValue = string.Empty;
-
-    private bool _visible;
-
-    private void HandleOnClose()
-    {
-        _searchResults = null;
-        _visible = false;
-        InvokeAsync(StateHasChanged);
-    }
-
-    List<string>? _searchResults = DefaultResults();
-    static List<string>? DefaultResults() => null;
-
-    void HandleSearchInput()
-    {
-        if (string.IsNullOrWhiteSpace(_searchValue))
-        {
-            _searchResults = DefaultResults();
-            _searchValue = string.Empty;
-        }
-        else
-        {
-            var searchTerm = _searchValue.ToLower();
-
-            if (searchTerm.Length > 0)
-            {
-                var temp = NavProvider.FlattenedMenuItems
-                    .Where(x => x.Href != null) // Ignore Group headers
-                    .Where(x => x.Title.ToLower().Contains(searchTerm))
-                    .Select(x => x.Title)
-                    .ToList();
-
-                _searchResults = temp.Any()
-                    ? temp
-                    : DefaultResults();
-            }
-        }
-
-        _visible = _searchResults is not null;
-    }
-
-    private void HandleSearchClicked(NavItem item)
-    {
-        _searchValue = string.Empty;
-        _searchResults = DefaultResults();
-        _visible = false;
-        InvokeAsync(StateHasChanged);
-
-        NavigationManager.NavigateTo(item.Href ?? throw new UnreachableException("Item has no href"));
-    }
 }

--- a/examples/Demo/Shared/Shared/DemoSearch.razor
+++ b/examples/Demo/Shared/Shared/DemoSearch.razor
@@ -1,0 +1,82 @@
+﻿@using System.Diagnostics
+@inject DemoNavProvider NavProvider
+@inject NavigationManager NavigationManager
+
+<FluentSearch @bind-Value="@_searchValue"
+              Immediate
+              @bind-Value:after=HandleSearchInput
+              Id="demo-search"
+              Placeholder="Search everything..."/>
+
+@if (_searchResults is not null)
+{
+    <FluentMenu Anchor="demo-search"
+                HorizontalPosition="HorizontalPosition.Right"
+                @bind-Open="_visible">
+        @foreach (var searchResult in _searchResults)
+        {
+            var item = NavProvider.FlattenedMenuItems.First(x => x.Title == searchResult);
+
+            <FluentMenuItem OnClick="@(() => HandleSearchClicked(item))">
+                <span slot="start">
+                    <FluentIcon Value="@(item.Icon)" Class="search-result-icon" Color="Color.Neutral" Slot="start"/>
+                </span>
+                @item.Title
+            </FluentMenuItem>
+        }
+    </FluentMenu>
+}
+
+@code {
+    string? _searchValue = string.Empty;
+
+    private bool _visible;
+
+    private void HandleOnClose()
+    {
+        _searchResults = null;
+        _visible = false;
+        InvokeAsync(StateHasChanged);
+    }
+
+    List<string>? _searchResults = DefaultResults();
+    static List<string>? DefaultResults() => null;
+
+    void HandleSearchInput()
+    {
+        if (string.IsNullOrWhiteSpace(_searchValue))
+        {
+            _searchResults = DefaultResults();
+            _searchValue = string.Empty;
+        }
+        else
+        {
+            var searchTerm = _searchValue.ToLower();
+
+            if (searchTerm.Length > 0)
+            {
+                var temp = NavProvider.FlattenedMenuItems
+                    .Where(x => x.Href != null) // Ignore Group headers
+                    .Where(x => x.Title.ToLower().Contains(searchTerm))
+                    .Select(x => x.Title)
+                    .ToList();
+
+                _searchResults = temp.Any()
+                    ? temp
+                    : DefaultResults();
+            }
+        }
+
+        _visible = _searchResults is not null;
+    }
+
+    private void HandleSearchClicked(NavItem item)
+    {
+        _searchValue = string.Empty;
+        _searchResults = DefaultResults();
+        _visible = false;
+        InvokeAsync(StateHasChanged);
+
+        NavigationManager.NavigateTo(item.Href ?? throw new UnreachableException("Item has no href"));
+    }
+}

--- a/examples/Demo/Shared/Shared/DemoSearch.razor.cs
+++ b/examples/Demo/Shared/Shared/DemoSearch.razor.cs
@@ -3,11 +3,15 @@
 // ------------------------------------------------------------------------
 
 using System.Diagnostics;
+using Microsoft.AspNetCore.Components;
 
 namespace FluentUI.Demo.Shared.Shared;
 
 public partial class DemoSearch
 {
+    [Inject] protected DemoNavProvider NavProvider { get; set; } = default!;
+    [Inject] protected NavigationManager NavigationManager { get; set; } = default!;
+
     private string? _searchValue = string.Empty;
 
     private bool _visible;

--- a/examples/Demo/Shared/Shared/DemoSearch.razor.cs
+++ b/examples/Demo/Shared/Shared/DemoSearch.razor.cs
@@ -1,0 +1,56 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using System.Diagnostics;
+
+namespace FluentUI.Demo.Shared.Shared;
+
+public partial class DemoSearch
+{
+    private string? _searchValue = string.Empty;
+
+    private bool _visible;
+
+    private List<string>? _searchResults = DefaultResults();
+    private static List<string>? DefaultResults() => null;
+
+    private void HandleSearchInput()
+    {
+        if (string.IsNullOrWhiteSpace(_searchValue))
+        {
+            _searchResults = DefaultResults();
+            _searchValue = string.Empty;
+        }
+        else
+        {
+            var searchTerm = _searchValue.ToLower();
+
+            if (searchTerm.Length > 0)
+            {
+                _searchResults = NavProvider.FlattenedMenuItems
+                    .Where(x => x.Href != null) // Ignore Group headers
+                    .Where(x => x.Title.Contains(searchTerm, StringComparison.OrdinalIgnoreCase))
+                    .Select(x => x.Title)
+                    .ToList();
+
+                if (_searchResults.Count == 0)
+                {
+                    _searchResults = DefaultResults();
+                }
+            }
+        }
+
+        _visible = _searchResults is not null;
+    }
+
+    private void HandleSearchClicked(NavItem item)
+    {
+        _searchValue = string.Empty;
+        _searchResults = DefaultResults();
+        _visible = false;
+        InvokeAsync(StateHasChanged);
+
+        NavigationManager.NavigateTo(item.Href ?? throw new UnreachableException("Item has no href"));
+    }
+}

--- a/examples/Demo/Shared/Shared/DemoSearch.razor.cs
+++ b/examples/Demo/Shared/Shared/DemoSearch.razor.cs
@@ -9,8 +9,11 @@ namespace FluentUI.Demo.Shared.Shared;
 
 public partial class DemoSearch
 {
-    [Inject] protected DemoNavProvider NavProvider { get; set; } = default!;
-    [Inject] protected NavigationManager NavigationManager { get; set; } = default!;
+    [Inject]
+    protected DemoNavProvider NavProvider { get; set; } = default!;
+    
+    [Inject]
+    protected NavigationManager NavigationManager { get; set; } = default!;
 
     private string? _searchValue = string.Empty;
 

--- a/examples/Demo/Shared/Shared/NavItem.cs
+++ b/examples/Demo/Shared/Shared/NavItem.cs
@@ -1,0 +1,44 @@
+﻿// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Components.Routing;
+using Microsoft.FluentUI.AspNetCore.Components;
+
+namespace FluentUI.Demo.Shared;
+
+public abstract record NavItem
+{
+    public string Title { get; init; } = string.Empty;
+    public string? Href { get; init; }
+    public NavLinkMatch Match { get; init; } = NavLinkMatch.Prefix;
+    public Icon Icon { get; init; } = new Icons.Regular.Size20.Document();
+}
+
+public record NavLink : NavItem
+{
+    public NavLink(string? href, Icon icon, string title, NavLinkMatch match = NavLinkMatch.Prefix)
+    {
+        Href = href;
+        Icon = icon;
+        Title = title;
+        Match = match;
+    }
+}
+
+public record NavGroup : NavItem
+{
+    public bool Expanded { get; init; }
+    public string Gap { get; init; }
+    public IReadOnlyList<NavItem> Children { get; }
+
+    public NavGroup(Icon icon, string title, bool expanded, string gap, List<NavItem> children)
+    {
+        Href = null;
+        Icon = icon;
+        Title = title;
+        Expanded = expanded;
+        Gap = gap;
+        Children = children.AsReadOnly();
+    }
+}

--- a/examples/Demo/Shared/wwwroot/css/site.css
+++ b/examples/Demo/Shared/wwwroot/css/site.css
@@ -17,6 +17,12 @@ body {
         grid-column: 1;
     }
 
+    .siteheader .search {
+        display: flex;
+        align-items: center;
+        padding-right: 20px;
+    }
+
     .siteheader .links {
         padding-right: 10px;
         display: flex;
@@ -42,8 +48,17 @@ body {
     margin-right: 0;
 }
 
+[dir="rtl"] .siteheader .search {
+    padding-left: 20px;
+    padding-right: 0;
+}
+
 [dir="rtl"] .siteheader .links {
     padding-left: 10px;
+}
+
+.search-result-icon {
+    vertical-align: middle;
 }
 
 .body-stack {
@@ -260,6 +275,10 @@ code {
         justify-content: flex-start;
     }
 
+        .siteheader .search {
+            display: none;
+        }
+
         .siteheader .logo {
             width: 160px;
             height: 23px;
@@ -272,10 +291,10 @@ code {
     }
 
     nav.sitenav {
-        
+
         width: 100%;
         height: calc(100dvh - 50px);
-        
+
     }
 
     .navmenu {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

from

![image](https://github.com/microsoft/fluentui-blazor/assets/10430890/fd390d7e-c4a1-456f-b5c9-db69616dbaca)

to

![image](https://github.com/microsoft/fluentui-blazor/assets/10430890/97d8547d-ae9c-4516-a754-a7be08ef4a63)

Example when typing valid content:

![image](https://github.com/microsoft/fluentui-blazor/assets/10430890/d3ae68a3-1afa-49b3-8310-0af133625f6b)

Note: Hides on mobile - future work could make it nice & responsive. Probably an Icon only button that pops up a fullscreen overlay

![image](https://github.com/microsoft/fluentui-blazor/assets/10430890/8eae4f5e-9d30-47e6-87d2-9d0affca8a44)


<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

Fixes #1578 

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

Manually test the nav menu looks the same (I tested each item 1 by 1 & saw no difference).
Test that the search bar behaves as a nice UX.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

~~- [ ] I have added tests for my changes.~~
Not done - No tests in Demo site
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.