### PR TITLE
Add LoadingContent parameter to FluentTab

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -6862,6 +6862,11 @@
             Gets or sets the content to be rendered inside the component.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentTab.LoadingContent">
+            <summary>
+            Gets or sets the customized loading content message when using deferred loading.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentTab.Owner">
             <summary>
             Gets or sets the owning FluentTabs component.

--- a/examples/Demo/Shared/Pages/Tabs/Examples/TabsDefault.razor
+++ b/examples/Demo/Shared/Pages/Tabs/Examples/TabsDefault.razor
@@ -25,7 +25,7 @@ If checked, the contents of Tab two and three will be loaded after 1 second of p
         @{
             if (DeferredLoading)
             {
-`                Thread.Sleep(1000);
+                Thread.Sleep(1000);
             }
         }
         Tab three content. This is for testing.

--- a/examples/Demo/Shared/Pages/Tabs/Examples/TabsDefault.razor
+++ b/examples/Demo/Shared/Pages/Tabs/Examples/TabsDefault.razor
@@ -8,6 +8,10 @@ If checked, the contents of Tab two and three will be loaded after 1 second of p
         Tab one content. This is for testing.
     </FluentTab>
     <FluentTab Label="Tab two" Id="tab-2" DeferredLoading="@DeferredLoading">
+        <LoadingContent>
+            <FluentProgressRing />
+        </LoadingContent>
+        <Content>
         @{
             if (DeferredLoading)
             {
@@ -15,12 +19,13 @@ If checked, the contents of Tab two and three will be loaded after 1 second of p
             }
         }
         Tab two content. This is for testing.
+        </Content>
     </FluentTab>
     <FluentTab Label="Tab three" Id="tab-3" DeferredLoading="@DeferredLoading">
         @{
             if (DeferredLoading)
             {
-                Thread.Sleep(1000);
+`                Thread.Sleep(1000);
             }
         }
         Tab three content. This is for testing.

--- a/examples/Demo/Shared/Pages/Tabs/TabsPage.razor
+++ b/examples/Demo/Shared/Pages/Tabs/TabsPage.razor
@@ -1,4 +1,4 @@
-@page "/Tabs"
+﻿@page "/Tabs"
 
 @using FluentUI.Demo.Shared.Pages.Tabs.Examples
 
@@ -11,7 +11,7 @@
 </p>
 
 <p>
-    The default width for the active tab indicator is 20 pixels. If you want to change this, you need to add some rules to your CSS like this:
+    The default width for the active tab indicator is 20 pixels. If you would like to change this, you can add some rules to your CSS like this:
 </p>
 <CodeSnippet Language="css">
     ::deep fluent-tabs::part(activeIndicator) {

--- a/src/Core/Components/Tabs/FluentTab.razor
+++ b/src/Core/Components/Tabs/FluentTab.razor
@@ -1,4 +1,4 @@
-@namespace Microsoft.FluentUI.AspNetCore.Components
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 @inherits FluentComponentBase
 @if (Visible)
 {
@@ -39,7 +39,14 @@
         }
         else
         {
-            <FluentProgress />
+            if (LoadingContent is null)
+            {
+                <FluentProgress />
+            }
+            else
+            {
+                @LoadingContent
+            }
         }
     </fluent-tab-panel>
 }

--- a/src/Core/Components/Tabs/FluentTab.razor.cs
+++ b/src/Core/Components/Tabs/FluentTab.razor.cs
@@ -100,6 +100,12 @@ public partial class FluentTab : FluentComponentBase
     public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
+    /// Gets or sets the customized loading content message when using deferred loading.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? LoadingContent { get; set; }
+
+    /// <summary>
     /// Gets or sets the owning FluentTabs component.
     /// </summary>
     [CascadingParameter]


### PR DESCRIPTION
If not specified, a default `FluentProgress` component will be displayed when `DeferredLoading=true` (this is the same as in currrent situation)