### PR TITLE
[FluentCard] Add MinimalStyle property

### DIFF
--- a/examples/Demo/Shared/Pages/Card/CardPage.razor
+++ b/examples/Demo/Shared/Pages/Card/CardPage.razor
@@ -1,4 +1,4 @@
-@page "/Card"
+﻿@page "/Card"
 
 @using FluentUI.Demo.Shared.Pages.Card.Examples
 
@@ -22,6 +22,20 @@
     </Description>
 </DemoSection>
 
+<DemoSection Title="Minimal Style" Component="@typeof(CardMinimalStyle)">
+    <Description>
+        <p>
+            By default the <b>FluentCard</b> component is a visual container and design system provider. Cards are snapshots of content that are typically used in a group to present collections of related information.
+            Thus, by design, the <b>FluentCard</b> component includes all the styles required for a good representation of the other components included in it.
+            This adds a large number of styles such as <code>justify-content; align-items; gap; width;</code> and over <b>80 CSS variables</b>.
+            The code generated can therefore become very important, especially if you use this component several times, for example in a list or during a <code>foreach</code>.
+        </p>
+        <p>
+            To avoid this, you can use the <code>MinimalStyle</code> property. This will remove all the default styles from the <b>FluentCard</b> component.
+            This will allow you to use the <b>FluentCard</b> component as a simple container without any style, except the styles to draw the <code>box-shadow</code> (and some minimal styles).
+        </p>
+    </Description>
+</DemoSection>
 
 <h2 id="documentation">Documentation</h2>
 

--- a/examples/Demo/Shared/Pages/Card/Examples/CardMinimalStyle.razor
+++ b/examples/Demo/Shared/Pages/Card/Examples/CardMinimalStyle.razor
@@ -1,0 +1,6 @@
+﻿<FluentCard MinimalStyle="true">
+    <p>Just some content in a card (with a button that does not do anything).</p>
+
+    <FluentButton Appearance="Appearance.Accent">Hello</FluentButton>
+    <p>No Width or Height has been specified.</p>
+</FluentCard>

--- a/src/Core/Components/Card/FluentCard.razor
+++ b/src/Core/Components/Card/FluentCard.razor
@@ -1,9 +1,23 @@
-@namespace Microsoft.FluentUI.AspNetCore.Components
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 @inherits FluentComponentBase
-<fluent-card @ref=Element 
-             id="@Id"
-             class=@Class
-             style="@StyleValue"
-             @attributes="AdditionalAttributes">
-    @ChildContent
-</fluent-card>
+
+@if (MinimalStyle)
+{
+    <div @ref=Element
+         id="@Id"
+         class="@ClassValue"
+         style="@StyleValue"
+         @attributes="AdditionalAttributes">
+        @ChildContent
+    </div>
+}
+else
+{
+    <fluent-card @ref=Element
+                 id="@Id"
+                 class="@ClassValue"
+                 style="@StyleValue"
+                 @attributes="AdditionalAttributes">
+        @ChildContent
+    </fluent-card>
+}

--- a/src/Core/Components/Card/FluentCard.razor.cs
+++ b/src/Core/Components/Card/FluentCard.razor.cs
@@ -8,8 +8,12 @@ public partial class FluentCard
     protected string? StyleValue => new StyleBuilder(Style)
         .AddStyle("--card-width", Width, !string.IsNullOrEmpty(Width))
         .AddStyle("--card-height", Height, !string.IsNullOrEmpty(Height))
-        .AddStyle("content-visibility", "visible", !AreaRestricted)
-        .AddStyle("contain", "style", !AreaRestricted)
+        .AddStyle("content-visibility", "visible", !AreaRestricted && !MinimalStyle)
+        .AddStyle("contain", "style", !AreaRestricted && !MinimalStyle)
+        .Build();
+
+    protected string? ClassValue => new CssBuilder(Class)
+        .AddClass("fluent-card-minimal-style", when: MinimalStyle)
         .Build();
 
     /// <summary>
@@ -30,6 +34,9 @@ public partial class FluentCard
     /// </summary>  
     [Parameter]
     public string? Height { get; set; }
+
+    [Parameter]
+    public bool MinimalStyle { get; set; } = false;
 
     /// <summary>
     /// Gets or sets the content to be rendered inside the component.

--- a/src/Core/Components/Card/FluentCard.razor.css
+++ b/src/Core/Components/Card/FluentCard.razor.css
@@ -5,6 +5,7 @@ fluent-card ::deep {
 .fluent-card-minimal-style ::deep {
     height: var(--card-height, 100%);
     width: var(--card-width, 100%);
+    contain: content;
     background: var(--fill-color);
     color: var(--neutral-foreground-rest);
     border: calc(var(--stroke-width)* 1px) solid var(--neutral-stroke-layer-rest);

--- a/src/Core/Components/Card/FluentCard.razor.css
+++ b/src/Core/Components/Card/FluentCard.razor.css
@@ -1,3 +1,14 @@
 fluent-card ::deep {
     padding: calc(var(--design-unit) * 5px);
 }
+
+.fluent-card-minimal-style ::deep {
+    height: var(--card-height, 100%);
+    width: var(--card-width, 100%);
+    background: var(--fill-color);
+    color: var(--neutral-foreground-rest);
+    border: calc(var(--stroke-width)* 1px) solid var(--neutral-stroke-layer-rest);
+    border-radius: calc(var(--layer-corner-radius)* 1px);
+    box-shadow: var(--elevation-shadow-card-rest);
+    padding: calc(var(--design-unit)* 5px);
+}

--- a/tests/Core/Card/FluentCardTests.FluentCard_MinimalStyle.verified.html
+++ b/tests/Core/Card/FluentCardTests.FluentCard_MinimalStyle.verified.html
@@ -1,0 +1,2 @@
+
+<div id="xxx" class="fluent-card-minimal-style" style="--card-width: 400px; --card-height: 400px;" b-6epdlk0xtt="" blazor:elementreference="xxx">ChildContent</div>

--- a/tests/Core/Card/FluentCardTests.cs
+++ b/tests/Core/Card/FluentCardTests.cs
@@ -160,4 +160,21 @@ public class FluentCardTests : TestBase
         // Assert
         cut.Verify();
     }
+
+    [Fact]
+    public void FluentCard_MinimalStyle()
+    {
+        // Arrange && Act
+        var cut = TestContext.RenderComponent<FluentCard>(parameters =>
+        {
+            parameters.Add(p => p.MinimalStyle, true);
+            parameters.Add(p => p.Id, "customId");
+            parameters.Add(p => p.Width, "400px");
+            parameters.Add(p => p.Height, "400px");
+            parameters.AddChildContent("ChildContent");
+        });
+
+        // Assert
+        cut.Verify();
+    }
 }


### PR DESCRIPTION
# [FluentCard] Add MinimalStyle property

By default the **FluentCard** component is a visual container and design system provider. Cards are snapshots of content that are typically used in a group to present collections of related information. Thus, by design, the **FluentCard** component includes all the styles required for a good representation of the other components included in it. This adds a large number of styles such as `justify-content; align-items; gap; width;` and **over 80 CSS variables**. The code generated can therefore become very important, especially if you use this component several times, for example in a list or during a foreach.

To avoid this, you can use the **MinimalStyle** property. This will remove all the default styles from the **FluentCard** component. This will allow you to use the **FluentCard** component as a simple container without any style, except the styles to draw the box-shadow (and some minimal styles).

## Example

```xml
<FluentCard MinimalStyle="true">
    <p>Just some content in a card (with a button that does not do anything).</p>

    <FluentButton Appearance="Appearance.Accent">Hello</FluentButton>
    <p>No Width or Height has been specified.</p>
</FluentCard>
```
![image](https://github.com/microsoft/fluentui-blazor/assets/8350694/980fe786-29b4-4c91-91c2-e00354072229)

## Code generated

```html
<div class="fluent-card-minimal-style">
  <p>Just some content in a card (with a button that does not do anything).</p>
  <fluent-button type="button" appearance="accent" class="accent">Hello</fluent-button>
  <p>No Width or Height has been specified.</p>
</div>
```

## Default `FluentCard` code generated

![image](https://github.com/microsoft/fluentui-blazor/assets/8350694/57c0a046-0de9-45d6-8f55-2b85845943a5)
