### PR TITLE
MenuButton changes and additions

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -4689,6 +4689,46 @@
             Gets or sets the content to be rendered inside the component.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentMenuButton.Button">
+            <summary>
+            Gets or sets a reference to the button.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentMenuButton.ButtonAppearance">
+            <summary>
+            Gets or sets the button appearance.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentMenuButton.Menu">
+            <summary>
+            Gets or sets a reference to the menu.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentMenuButton.Text">
+            <summary>
+            Gets or sets the texts shown on th button.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentMenuButton.ButtonStyle">
+            <summary>
+            Gets or sets the button style.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentMenuButton.MenuStyle">
+            <summary>
+            Gets or sets the menu style.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentMenuButton.Items">
+            <summary>
+            Gets or sets the items to show in the menu.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentMenuButton.OnMenuChanged">
+            <summary>
+            The callback to invoke when a menu item is chosen.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentMenu.ClassValue">
             <summary />
         </member>

--- a/examples/Demo/Shared/Pages/Lab/IssueTester.razor
+++ b/examples/Demo/Shared/Pages/Lab/IssueTester.razor
@@ -1,1 +1,29 @@
 ﻿@page "/IssueTester"
+@inject AccentBaseColor AccentBaseColor
+
+<FluentMenuButton Id="anchor" @ref=menubutton Text="Select brand color" Items="@items" OnMenuChanged="HandleOnMenuChanged"></FluentMenuButton>
+
+
+@code {
+    private FluentMenuButton menubutton = new();
+
+    private Dictionary<string, string> items = new Dictionary<string, string>()
+    {
+        {"0078D4","Windows"},
+        {"D83B01","Office"},
+        {"464EB8","Teams"},
+        {"107C10","Xbox"},
+        {"8661C5","Visual Studio"},
+        {"F2C811","Power BI"},
+        {"0066FF","Power Automate"},
+        {"742774","Power Apps"},
+        {"0B556A","Power Virtual Agents"}
+    };
+
+    private async Task HandleOnMenuChanged(MenuChangeEventArgs args)
+    {
+
+        await AccentBaseColor.SetValueFor(menubutton.Button!.Element, $"#{args.Id}".ToSwatch());
+    }
+
+}

--- a/examples/Demo/Shared/Pages/MenuButton/Examples/MenuButtonAccentColor.razor
+++ b/examples/Demo/Shared/Pages/MenuButton/Examples/MenuButtonAccentColor.razor
@@ -21,7 +21,6 @@
 
     private async Task HandleOnMenuChanged(MenuChangeEventArgs args)
     {
-
         await AccentBaseColor.SetValueFor(menubutton.Button!.Element, $"#{args.Id}".ToSwatch());
     }
 

--- a/examples/Demo/Shared/Pages/MenuButton/Examples/MenuButtonAppearance.razor
+++ b/examples/Demo/Shared/Pages/MenuButton/Examples/MenuButtonAppearance.razor
@@ -1,0 +1,27 @@
+﻿@namespace FluentUI.Demo.Shared
+
+<FluentStack Orientation="Orientation.Vertical">
+    <span>
+        Neutral: <FluentMenuButton @ref=menubutton ButtonAppearance="@Appearance.Neutral" Text="Select an item" Items="@items"></FluentMenuButton>
+    </span>
+    <span>
+        Lightweight: <FluentMenuButton @ref=menubutton ButtonAppearance="@Appearance.Lightweight" Text="Select an item" Items="@items"></FluentMenuButton>
+    </span>
+    <span>
+        Outline: <FluentMenuButton @ref=menubutton ButtonAppearance="@Appearance.Outline" Text="Select an item" Items="@items"></FluentMenuButton>
+    </span>
+    <span>
+        Stealth: <FluentMenuButton @ref=menubutton ButtonAppearance="@Appearance.Stealth" Text="Select an item" Items="@items"></FluentMenuButton>
+    </span>
+</FluentStack>
+@code {
+
+    private FluentMenuButton menubutton = new();
+    private Dictionary<string, string> items = new Dictionary<string, string>()
+    {
+        {"1","Item 1"},
+        {"2","Item 2"},
+        {"3","Item 3"},
+        {"4","Item 4"},
+    };
+}

--- a/examples/Demo/Shared/Pages/MenuButton/MenuButtonPage.razor
+++ b/examples/Demo/Shared/Pages/MenuButton/MenuButtonPage.razor
@@ -7,3 +7,5 @@
 <h2 id="example">Example</h2>
 
 <DemoSection Component="typeof(MenuButtonAccentColor)" Title="MenuButton to select accent color"  />
+
+<DemoSection Component="typeof(MenuButtonAppearance)" Title="Different button appearances" />

--- a/examples/Demo/Shared/Pages/MenuButton/MenuButtonPage.razor
+++ b/examples/Demo/Shared/Pages/MenuButton/MenuButtonPage.razor
@@ -9,3 +9,7 @@
 <DemoSection Component="typeof(MenuButtonAccentColor)" Title="MenuButton to select accent color"  />
 
 <DemoSection Component="typeof(MenuButtonAppearance)" Title="Different button appearances" />
+
+<h2 id="documentation">Documentation</h2>
+
+<ApiDocumentation Component="typeof(FluentMenuButton)" />

--- a/src/Core/Components/MenuButton/FluentMenuButton.razor
+++ b/src/Core/Components/MenuButton/FluentMenuButton.razor
@@ -3,11 +3,12 @@
 @inherits FluentComponentBase
 
 <div class="fluent-menubutton-container">
-    <FluentButton @ref="Button" Appearance="Appearance.Accent" Style=@ButtonStyle aria-haspopup="true" aria-expanded="@_visible" @onclick=ToggleMenu @onkeydown=OnKeyDown>
+    <FluentButton @ref="Button" Appearance="@ButtonAppearance" Style=@ButtonStyle aria-haspopup="true" aria-expanded="@_visible" @onclick=ToggleMenu @onkeydown=OnKeyDown>
         @Text
-        <FluentIcon Value="@(new CoreIcons.Regular.Size24.ChevronDown())" Slot="end" Color="@Color.Fill" />
+        <FluentIcon Value="@(new CoreIcons.Regular.Size24.ChevronDown())" Slot="end" Color="@_iconColor" />
     </FluentButton>
-    <FluentMenu @ref="Menu" aria-labelledby="button" Style="@MenuStyle" @bind-Open=@_visible @onmenuchange=OnMenuChangeAsync>
+    <FluentOverlay @bind-Visible="@_visible" Transparent="true" FullScreen="true" />
+    <FluentMenu @ref="Menu" aria-labelledby="button" Style="@MenuStyleValue" @bind-Open=@_visible @onmenuchange=OnMenuChangeAsync>
         @foreach (KeyValuePair<string, string> item in Items)
         {
             <FluentMenuItem Id="@item.Key">@item.Value</FluentMenuItem>

--- a/src/Core/Components/MenuButton/FluentMenuButton.razor.cs
+++ b/src/Core/Components/MenuButton/FluentMenuButton.razor.cs
@@ -1,33 +1,70 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.FluentUI.AspNetCore.Components.Utilities;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 public partial class FluentMenuButton : FluentComponentBase
 {
     private bool _visible;
+    private Color _iconColor = Color.Fill;
 
+    protected string? MenuStyleValue => new StyleBuilder(MenuStyle)
+        .AddStyle("position", "relative")
+        .Build();
+
+    /// <summary>
+    /// Gets or sets a reference to the button.
+    /// </summary>
     [Parameter]
     public FluentButton? Button { get; set; }
 
+    /// <summary>
+    /// Gets or sets the button appearance.
+    /// </summary>
+    [Parameter]
+    public Appearance ButtonAppearance { get; set; } = Appearance.Accent;
+
+    /// <summary>
+    /// Gets or sets a reference to the menu.
+    /// </summary>
     [Parameter]
     public FluentMenu? Menu { get; set; }
 
+    /// <summary>
+    /// Gets or sets the texts shown on th button.
+    /// </summary>
     [Parameter]
     public string? Text { get; set; }
 
+    /// <summary>
+    /// Gets or sets the button style.
+    /// </summary>
     [Parameter]
     public string? ButtonStyle { get; set; }
 
+    /// <summary>
+    /// Gets or sets the menu style.
+    /// </summary>
     [Parameter]
     public string? MenuStyle { get; set; }
 
+    /// <summary>
+    /// Gets or sets the items to show in the menu.
+    /// </summary>
     [Parameter]
     public Dictionary<string, string> Items { get; set; } = [];
 
+    /// <summary>
+    /// The callback to invoke when a menu item is chosen.
+    /// </summary>
     [Parameter]
-
     public EventCallback<MenuChangeEventArgs> OnMenuChanged { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        _iconColor = ButtonAppearance == Appearance.Accent ? Color.Fill : Color.FillInverse;
+    }
 
     private void ToggleMenu()
     {


### PR DESCRIPTION
This PR fixes #1593 and #1594 by:
- adding a FluentOverlay so clicking outside the menu closes it
- Adding a `ButtonAppearance` parameter to make changing the button appearance possible

An example has been added to the deom to show this.
Example of the ovverlay:
![issue-#1594](https://github.com/microsoft/fluentui-blazor/assets/1761079/600f4257-4f1c-419b-bce0-c4f93aec529b)

Also, source comments have been added and a documentation section is added to the menu button page.
