### PR TITLE
Fix #1596 (very long title, see description)

### DIFF
--- a/src/Core/Components/DataGrid/FluentDataGrid.razor
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor
@@ -133,7 +133,7 @@
             else
                 col.ShowSortIcon = false;
 
-            <FluentDataGridCell GridColumn=@(colIndex+1) CellType=DataGridCellType.ColumnHeader Class="@("column-header " + @ColumnHeaderClass(col))" Style="@col.Style" aria-sort="@AriaSortValue(col)" @key="@col" scope="col" TGridItem="TGridItem">
+            <FluentDataGridCell GridColumn=@(colIndex+1) CellType=DataGridCellType.ColumnHeader Class="@("column-header " + @ColumnHeaderClass(col) + (ResizableColumns ? " resizable" : ""))" Style="@col.Style" aria-sort="@AriaSortValue(col)" @key="@col" scope="col" TGridItem="TGridItem">
                 @col.HeaderContent
                 @if (col == _displayOptionsForColumn)
                 {

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -284,6 +284,10 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     {
         _collectingColumns = false;
         _manualGrid = _columns.Count == 0;
+        if (ResizableColumns)
+        {
+            _ = Module?.InvokeVoidAsync("enableColumnResizing", _gridReference).AsTask();
+        }
     }
 
     /// <summary>

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.js
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.js
@@ -86,13 +86,13 @@ export function checkColumnOptionsPosition(gridElement) {
     }
 }
 
-function enableColumnResizing(gridElement) {
+export function enableColumnResizing(gridElement) {
     const columns = [];
     let min = 50;
     let headerBeingResized;
     let resizeHandle;
 
-    gridElement.querySelectorAll('.column-header').forEach(header => {
+    gridElement.querySelectorAll('.column-header.resizable').forEach(header => {
         columns.push({ header });
         const onPointerMove = (e) => requestAnimationFrame(() => {
             //console.log(`onPointerMove${headerBeingResized ? '' : ' [not resizing]'}`);
@@ -115,7 +115,11 @@ function enableColumnResizing(gridElement) {
             // Set initial sizes
             columns.forEach((column) => {
                 if (column.size === undefined) {
-                    column.size = column.header.clientWidth + 'px';
+                    if (column.header.clientWidth === undefined || column.header.clientWidth === 0) {
+                        column.size = '50px';
+                    } else {
+                        column.size = column.header.clientWidth + 'px';
+                    }
                 }
             });
 

--- a/src/Core/Components/Pagination/PaginationState.cs
+++ b/src/Core/Components/Pagination/PaginationState.cs
@@ -65,13 +65,11 @@ public class PaginationState
         {
             // If the number of items has reduced such that the current page index is no longer valid, move
             // automatically to the final valid page index and trigger a further data load.
-            return SetCurrentPageIndexAsync(LastPageIndex.Value);
+            SetCurrentPageIndexAsync(LastPageIndex.Value);
         }
-        else
-        {
-            // Under normal circumstances, we just want any associated pagination UI to update
-            TotalItemCountChanged?.Invoke(this, TotalItemCount);
-            return TotalItemCountChangedSubscribable.InvokeCallbacksAsync(this);
-        }
+
+        // Under normal circumstances, we just want any associated pagination UI to update
+        TotalItemCountChanged?.Invoke(this, TotalItemCount);
+        return TotalItemCountChangedSubscribable.InvokeCallbacksAsync(this);
     }
 }


### PR DESCRIPTION
Fix #1596: Pagination state is not updating in the UI when filtering returns less pages of results than the current page index using a FluentDataGrid with ItemsProvider in FluentPaginator
- Add .resizable class to header cell when ResizableColumns is true
- Call enableColumnResizing when finished collecting columns
- Make enableColumnResizing callable from c# side
- Change SetTotalItemsCount to do both SetCurrentPageIndexAsync (if criteria met) and do regular work