### PR TITLE
fix: allow FluentCombobox to be cleared from code

### DIFF
--- a/src/Core/Components/List/FluentCombobox.razor.cs
+++ b/src/Core/Components/List/FluentCombobox.razor.cs
@@ -85,11 +85,10 @@ public partial class FluentCombobox<TOption> : ListComponentBase<TOption> where 
                 // If Items is null, we don't know if the selected option is in the list of items, so we just set it
                 _currentSelectedOption = newSelectedOption;
             }
-            if (_currentSelectedOption is not null)
-            {
-                // An option was selected from the list, so set the value to that
-                Value = GetOptionValue(_currentSelectedOption);
-            }
+
+            // Sync Value from selected option.
+            // If it is null, we set it to the default value so the attribute is not deleted & the webcomponents don't throw an exception
+            Value = GetOptionValue(_currentSelectedOption) ?? string.Empty;
             await ValueChanged.InvokeAsync(Value);
         }
 


### PR DESCRIPTION
# Pull Request

## 📖 Description
in #1485 it was made possible to set the selected value from code by implementing the OnParameterAsync for the FluentCombobox, however there was a small bug that prevented it from being cleared by code, and when null was set it would just revert back to the previous selection. 
this fix allows it to be cleared by code when needed 
Our use case was when we were clearing the form after a submit or pressing the reset button (which set the form to a new instance)

### 🎫 Issues
#1485 

## 👩‍💻 Reviewer Notes

this can be tested by adding these buttons to `ComboboxWithOptionTemplate.razor` : 
```
<FluentButton OnClick=@(() => {Person = null!; StateHasChanged();})>Reset</FluentButton>
<FluentButton OnClick=@(() => {Person = Data.People.Last(); StateHasChanged();})>Set</FluentButton> 
```

my test scenario was : 
* select person
* select different person
* click set button
* select a different person
* click reset button
* select a different person

## 📑 Test Plan
N/A afaik

if unit tests are needed to be added, i can look into this, but i couldn't find any combobox unit tests by the looks of it.
it might be better to see if they can be added imo

## ✅ Checklist

### General

- [x] I have tested my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
- [ ] I have added tests for my changes.
- [ ] I have updated the project documentation to reflect my changes.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [x] I have modified an existing component
- [x] I have validate [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component 
- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new compontent

## ⏭ Next Steps
N/A