### PR TITLE
[Menu] Add Threshold attributes

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -454,72 +454,6 @@
             If this app is outside of visible app bar area.
             </summary>
         </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAnchor.Download">
-            <summary>
-            Prompts the user to save the linked URL. See <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a">a element</see> for more information.
-            </summary>
-        </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAnchor.Href">
-            <summary>
-            Gets or sets the URL the hyperlink references. See <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a">a element</see> for more information.
-            Use Target parameter to specify where.
-            </summary>
-        </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAnchor.Hreflang">
-            <summary>
-            Hints at the language of the referenced resource. See <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a">a element</see> for more information.
-            </summary>
-        </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAnchor.Ping">
-            <summary>
-            See <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a">a element</see> for more information.
-            </summary>
-        </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAnchor.Referrerpolicy">
-            <summary>
-            See <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a">a element</see> for more information.
-            </summary>
-        </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAnchor.Rel">
-            <summary>
-            See <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a">a element</see> for more information.
-            </summary>
-        </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAnchor.Target">
-            <summary>
-            Gets or sets the target attribute that specifies where to open the link, if Href is specified.
-            Possible values: _blank | _self | _parent | _top.
-            </summary>
-        </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAnchor.Type">
-            <summary>
-            See <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a">a element</see> for more information.
-            </summary>
-        </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAnchor.Appearance">
-            <summary>
-            Gets or sets the visual appearance. See <seealso cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentAnchor.Appearance"/>
-            Defaults to <seealso cref="F:Microsoft.FluentUI.AspNetCore.Components.Appearance.Neutral"/>
-            </summary>
-        </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAnchor.IconStart">
-            <summary>
-            Gets or sets the <see cref="T:Microsoft.FluentUI.AspNetCore.Components.Icon"/> displayed at the start of anchor content.
-            </summary>
-        </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAnchor.IconEnd">
-            <summary>
-            Gets or sets the <see cref="T:Microsoft.FluentUI.AspNetCore.Components.Icon"/> displayed at the end of anchor content.
-            </summary>
-        </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAnchor.ChildContent">
-            <summary>
-            Gets or sets the content to be rendered inside the component.
-            </summary>
-        </member>
-        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentAnchor.DisposeAsync">
-            <inheritdoc />
-        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentBadge.Color">
             <summary>
             Gets or sets the color.
@@ -4943,6 +4877,16 @@
             <summary>
             Draw the menu below the component clicked (true) or
             using the mouse coordinates (false).
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentMenu.VerticalThreshold">
+            <summary>
+            Gets or sets how short the space allocated to the default position has to be before the tallest area is selected for layout.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentMenu.HorizontalThreshold">
+            <summary>
+            Gets or sets how narrow the space allocated to the default position has to be before the widest area is selected for layout.
             </summary>
         </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentMenu.OnAfterRenderAsync(System.Boolean)">

--- a/examples/Demo/Shared/Pages/Menu/Examples/SimpleMenuExample.razor
+++ b/examples/Demo/Shared/Pages/Menu/Examples/SimpleMenuExample.razor
@@ -3,7 +3,7 @@
     Open menu
 </FluentButton>
 
-<FluentMenu Anchor="btnOpen1" @bind-Open="open" @onmenuchange=OnMenuChange>
+<FluentMenu Anchor="btnOpen1" @bind-Open="open" @onmenuchange=OnMenuChange VerticalThreshold="170">
     <FluentMenuItem OnClick="@((e) => DemoLogger.WriteLine("Item 1 Clicked"))">
         Menu item 1
     </FluentMenuItem>

--- a/src/Core/Components/Menu/FluentMenu.razor
+++ b/src/Core/Components/Menu/FluentMenu.razor
@@ -7,15 +7,17 @@
         {
             <FluentOverlay @bind-Visible="@Open" OnClose="@CloseAsync" Transparent="true" FullScreen="true" />
             <FluentAnchoredRegion Anchor="@Anchor"
-                HorizontalDefaultPosition="@HorizontalPosition"
-                HorizontalInset="true"
-                HorizontalViewportLock="true"
-                HorizontalThreshold="200"
-                VerticalDefaultPosition="@VerticalPosition.Bottom"
-                Shadow="@ElevationShadow.None"
-                Class="@ClassValue"
-                Style="@StyleValue"
-                @attributes="AdditionalAttributes">
+                                  HorizontalDefaultPosition="@HorizontalPosition"
+                                  VerticalDefaultPosition="@VerticalPosition.Bottom"
+                                  HorizontalInset="true"
+                                  VerticalInset="false"
+                                  HorizontalViewportLock="true"
+                                  HorizontalThreshold="@HorizontalThreshold"
+                                  VerticalThreshold="@VerticalThreshold"
+                                  Shadow="@ElevationShadow.None"
+                                  Class="@ClassValue"
+                                  Style="@StyleValue"
+                                  @attributes="AdditionalAttributes">
                 <fluent-menu @ref=Element id="@Id">
                     @ChildContent
                 </fluent-menu>
@@ -23,7 +25,8 @@
         }
         else
         {
-            if (_contextMenu) {
+            if (_contextMenu)
+            {
                 <FluentOverlay @bind-Visible="@Open" OnClose="@CloseAsync" Transparent="true" FullScreen="true" />
             }
             <fluent-menu @ref=Element

--- a/src/Core/Components/Menu/FluentMenu.razor.cs
+++ b/src/Core/Components/Menu/FluentMenu.razor.cs
@@ -87,6 +87,18 @@ public partial class FluentMenu : FluentComponentBase, IDisposable
     [Parameter]
     public bool Anchored { get; set; } = true;
 
+    /// <summary>
+    /// Gets or sets how short the space allocated to the default position has to be before the tallest area is selected for layout.
+    /// </summary>
+    [Parameter]
+    public int VerticalThreshold { get; set; } = 0;
+
+    /// <summary>
+    /// Gets or sets how narrow the space allocated to the default position has to be before the widest area is selected for layout.
+    /// </summary>
+    [Parameter]
+    public int HorizontalThreshold { get; set; } = 200;
+
     protected override void OnInitialized()
     {
         if (Anchored && string.IsNullOrEmpty(Anchor))


### PR DESCRIPTION
To reply to this issue https://github.com/microsoft/fluentui-blazor/issues/1640, we need to add two attributes: VerticalThreshold and HorizontalThreshold (was already present.
In this way, you can set limit margins to automatically reposition the Menu component.