### PR TITLE
Virtualization for FluentAutocomplete

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -4301,7 +4301,6 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.MaximumOptionsSearch">
             <summary>
             Gets or sets the number of maximum options (items) returned by <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.OnOptionsSearch"/>.
-            If the value is smaller than 0, all search results are shown.
             Default value is 9.
             </summary>
         </member>
@@ -4366,8 +4365,7 @@
              If you use <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.Virtualize"/>, you should supply a value for <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.ItemSize"/> and must
              ensure that every row renders with the same constant height.
             
-             Generally it's preferable not to use <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.Virtualize"/> if the amount of data being rendered
-             is small or if you are using pagination.
+             Generally it's preferable not to use <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.Virtualize"/> if the amount of data being rendered is small.
              </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.ItemSize">

--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -4301,6 +4301,7 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.MaximumOptionsSearch">
             <summary>
             Gets or sets the number of maximum options (items) returned by <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.OnOptionsSearch"/>.
+            If the value is smaller than 0, all search results are shown.
             Default value is 9.
             </summary>
         </member>

--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -4357,6 +4357,26 @@
             Gets or sets whether the dropdown is shown when there are no items.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.Virtualize">
+             <summary>
+             If true, the options list will be rendered with virtualization. This is normally used in conjunction with
+             scrolling and causes the option list to fetch and render only the data around the current scroll viewport.
+             This can greatly improve the performance when scrolling through large data sets.
+            
+             If you use <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.Virtualize"/>, you should supply a value for <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.ItemSize"/> and must
+             ensure that every row renders with the same constant height.
+            
+             Generally it's preferable not to use <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.Virtualize"/> if the amount of data being rendered
+             is small or if you are using pagination.
+             </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.ItemSize">
+            <summary>
+            This is applicable only when using <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.Virtualize"/>. It defines an expected height in pixels for
+            each row, allowing the virtualization mechanism to fetch the correct number of items to match the display
+            size and to ensure accurate scrolling.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.ListStyleValue">
             <summary />
         </member>

--- a/examples/Demo/Shared/Pages/List/Autocomplete/AutocompletePage.razor
+++ b/examples/Demo/Shared/Pages/List/Autocomplete/AutocompletePage.razor
@@ -1,4 +1,4 @@
-@page "/Autocomplete"
+﻿@page "/Autocomplete"
 
 @using FluentUI.Demo.Shared.Pages.List.Autocomplete.Examples
 
@@ -9,6 +9,8 @@
 <DemoSection Title="Default" Component="@typeof(AutocompleteDefault)" />
 
 <DemoSection Title="Customized options" Component="@typeof(AutocompleteCustomized)" />
+
+<DemoSection Title="Many Items" Component="@typeof(AutocompleteManyItems)" />
 
 <DemoSection Title="FluentPersona" Component="@typeof(AutocompletePersona)" />
 

--- a/examples/Demo/Shared/Pages/List/Autocomplete/Examples/AutocompleteManyItems.razor
+++ b/examples/Demo/Shared/Pages/List/Autocomplete/Examples/AutocompleteManyItems.razor
@@ -7,7 +7,7 @@
                     Width="250px"
                     OnOptionsSearch="OnSearch"
                     Placeholder="Select countries"
-                    MaximumOptionsSearch="-1"
+                    MaximumOptionsSearch="int.MaxValue"
                     MaximumSelectedOptions="2"
                     Virtualize="true"
                     OptionText="@(item => $"{item.DisplayName} - {item.Name}")"

--- a/examples/Demo/Shared/Pages/List/Autocomplete/Examples/AutocompleteManyItems.razor
+++ b/examples/Demo/Shared/Pages/List/Autocomplete/Examples/AutocompleteManyItems.razor
@@ -9,6 +9,7 @@
                     Placeholder="Select countries"
                     MaximumOptionsSearch="-1"
                     MaximumSelectedOptions="2"
+                    Virtualize="true"
                     OptionText="@(item => $"{item.DisplayName} - {item.Name}")"
                     @bind-SelectedOptions="@SelectedCultures" />
 

--- a/examples/Demo/Shared/Pages/List/Autocomplete/Examples/AutocompleteManyItems.razor
+++ b/examples/Demo/Shared/Pages/List/Autocomplete/Examples/AutocompleteManyItems.razor
@@ -1,0 +1,30 @@
+﻿@using System.Globalization
+@inject DataSource Data
+
+<FluentAutocomplete TOption="CultureInfo"
+                    AutoComplete="off"
+                    Label="Select Culture"
+                    Width="250px"
+                    OnOptionsSearch="OnSearch"
+                    Placeholder="Select countries"
+                    MaximumOptionsSearch="-1"
+                    MaximumSelectedOptions="2"
+                    OptionText="@(item => $"{item.DisplayName} - {item.Name}")"
+                    @bind-SelectedOptions="@SelectedCultures" />
+
+<p>
+    <b>Selected</b>: @(String.Join(" - ", SelectedCultures.Select(i => i.Name)))
+</p>
+
+@code
+{
+    IEnumerable<CultureInfo> SelectedCultures = Array.Empty<CultureInfo>();
+    CultureInfo[] Cultures = CultureInfo.GetCultures(CultureTypes.AllCultures);
+
+    private void OnSearch(OptionsSearchEventArgs<CultureInfo> e)
+    {
+        e.Items = Cultures.Where(culture =>
+            culture.Name.Contains(e.Text, StringComparison.OrdinalIgnoreCase) ||
+            culture.DisplayName.Contains(e.Text, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/src/Core/Components/List/FluentAutocomplete.razor
+++ b/src/Core/Components/List/FluentAutocomplete.razor
@@ -113,26 +113,19 @@
                     @if (Items != null)
                     {
                         var selectableItem = GetOptionValue(SelectableItem);
-                        foreach (TOption item in Items)
+
+                        @if (Virtualize)
                         {
-                            var value = GetOptionValue(item);
-                            <FluentOption TOption="TOption"
-                                          Value="@value"
-                                          Style="@OptionStyle"
-                                          Class="@OptionClass"
-                                          Selected="@GetOptionSelected(item)"
-                                          Disabled="@(GetOptionDisabled(item) ?? false)"
-                                          OnSelect="@OnSelectCallback(item)"
-                                          selectable="@(value == selectableItem)">
-                                @if (OptionTemplate == null)
-                                {
-                                    @GetOptionText(item)
-                                }
-                                else
-                                {
-                                    @OptionTemplate(item)
-                                }
-                            </FluentOption>
+                            <Virtualize ItemsProvider="LoadFilteredItemsAsync" @ref="VirtualizationContainer" ItemSize="ItemSize">
+                                @RenderOption((context, selectableItem))
+                            </Virtualize>
+                        }
+                        else
+                        {
+                            foreach (TOption item in Items)
+                            {
+                                @RenderOption((item, selectableItem))
+                            }
                         }
                     }
                 </div>
@@ -159,3 +152,28 @@
         }
     </div>
 </CascadingValue>
+
+@code {
+    private RenderFragment<(TOption Item, string? SelectableItem)> RenderOption => context => __builder =>
+    {
+        var optionValue = GetOptionValue(context.Item);
+        <FluentOption TOption="TOption"
+                      @key="@context.Item"
+                      Value="@optionValue"
+                      Style="@OptionStyle"
+                      Class="@OptionClass"
+                      Selected="@GetOptionSelected(context.Item)"
+                      Disabled="@(GetOptionDisabled(context.Item) ?? false)"
+                      OnSelect="@OnSelectCallback(context.Item)"
+                      selectable="@(optionValue == context.SelectableItem)">
+            @if (OptionTemplate == null)
+            {
+                @GetOptionText(context.Item)
+            }
+            else
+            {
+                @OptionTemplate(context.Item)
+            }
+        </FluentOption>
+    };
+}

--- a/src/Core/Components/List/FluentAutocomplete.razor.cs
+++ b/src/Core/Components/List/FluentAutocomplete.razor.cs
@@ -112,7 +112,6 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
 
     /// <summary>
     /// Gets or sets the number of maximum options (items) returned by <see cref="OnOptionsSearch"/>.
-    /// If the value is smaller than 0, all search results are shown.
     /// Default value is 9.
     /// </summary>
     [Parameter]
@@ -188,8 +187,7 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
     /// If you use <see cref="Virtualize"/>, you should supply a value for <see cref="ItemSize"/> and must
     /// ensure that every row renders with the same constant height.
     ///
-    /// Generally it's preferable not to use <see cref="Virtualize"/> if the amount of data being rendered
-    /// is small or if you are using pagination.
+    /// Generally it's preferable not to use <see cref="Virtualize"/> if the amount of data being rendered is small.
     /// </summary>
     [Parameter] public bool Virtualize { get; set; }
 
@@ -267,14 +265,7 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
 
         await OnOptionsSearch.InvokeAsync(args);
 
-        if (MaximumOptionsSearch < 0)
-        {
-            Items = args.Items;
-        }
-        else
-        {
-            Items = args.Items?.Take(MaximumOptionsSearch);
-        }
+        Items = args.Items?.Take(MaximumOptionsSearch);
 
         SelectableItem = Items != null
             ? Items.FirstOrDefault()

--- a/src/Core/Components/List/FluentAutocomplete.razor.cs
+++ b/src/Core/Components/List/FluentAutocomplete.razor.cs
@@ -110,6 +110,7 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
 
     /// <summary>
     /// Gets or sets the number of maximum options (items) returned by <see cref="OnOptionsSearch"/>.
+    /// If the value is smaller than 0, all search results are shown.
     /// Default value is 9.
     /// </summary>
     [Parameter]
@@ -244,7 +245,15 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
 
         await OnOptionsSearch.InvokeAsync(args);
 
-        Items = args.Items?.Take(MaximumOptionsSearch);
+        if (MaximumOptionsSearch < 0)
+        {
+            Items = args.Items;
+        }
+        else
+        {
+            Items = args.Items?.Take(MaximumOptionsSearch);
+        }
+
         SelectableItem = Items != null
             ? Items.FirstOrDefault()
             : default;

--- a/src/Core/Components/List/FluentAutocomplete.razor.cs
+++ b/src/Core/Components/List/FluentAutocomplete.razor.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web.Virtualization;
 using Microsoft.FluentUI.AspNetCore.Components.Utilities;
 using Microsoft.JSInterop;
 
@@ -13,6 +14,7 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
     internal const string JAVASCRIPT_FILE = "./_content/Microsoft.FluentUI.AspNetCore.Components/Components/List/FluentAutocomplete.razor.js";
 
     public new FluentTextField? Element { get; set; } = default!;
+    private Virtualize<TOption>? VirtualizationContainer { get; set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FluentAutocomplete{TOption}"/> class.
@@ -178,6 +180,26 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
     [Parameter]
     public bool ShowOverlayOnEmptyResults { get; set; } = true;
 
+    /// <summary>
+    /// If true, the options list will be rendered with virtualization. This is normally used in conjunction with
+    /// scrolling and causes the option list to fetch and render only the data around the current scroll viewport.
+    /// This can greatly improve the performance when scrolling through large data sets.
+    ///
+    /// If you use <see cref="Virtualize"/>, you should supply a value for <see cref="ItemSize"/> and must
+    /// ensure that every row renders with the same constant height.
+    ///
+    /// Generally it's preferable not to use <see cref="Virtualize"/> if the amount of data being rendered
+    /// is small or if you are using pagination.
+    /// </summary>
+    [Parameter] public bool Virtualize { get; set; }
+
+    /// <summary>
+    /// This is applicable only when using <see cref="Virtualize"/>. It defines an expected height in pixels for
+    /// each row, allowing the virtualization mechanism to fetch the correct number of items to match the display
+    /// size and to ensure accurate scrolling.
+    /// </summary>
+    [Parameter] public float ItemSize { get; set; } = 50;
+
     /// <summary />
     private string? ListStyleValue => new StyleBuilder()
         .AddStyle("width", Width, when: !string.IsNullOrEmpty(Width))
@@ -257,6 +279,27 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
         SelectableItem = Items != null
             ? Items.FirstOrDefault()
             : default;
+
+        if (VirtualizationContainer != null)
+        {
+            await VirtualizationContainer.RefreshDataAsync();
+        }
+    }
+
+    private ValueTask<ItemsProviderResult<TOption>> LoadFilteredItemsAsync(ItemsProviderRequest request)
+    {
+        if (Items is null)
+        {
+            return ValueTask.FromResult(
+                new ItemsProviderResult<TOption>(
+                    Array.Empty<TOption>(),
+                    0));
+        }
+
+        return ValueTask.FromResult(
+            new ItemsProviderResult<TOption>(
+                Items.Skip(request.StartIndex).Take(request.Count),
+                Items.Count()));
     }
 
     private static readonly KeyCode[] CatchOnly = new[] { KeyCode.Escape, KeyCode.Enter, KeyCode.Backspace, KeyCode.Down, KeyCode.Up };


### PR DESCRIPTION
This PR implements the virtualization feature for FluentAutocomplete discussed here #1638 

For me the implementation works fine and greatly improves the initial rendering performance and the reactivity when a search is done on that list. The improvement can be checked by changing the Virtualize Parameter in the Autocomplete with Many Items Demo example.

Additionally, if the MaximumOptionsSearch is set to a value smaller than 0, it is disabled. With this change the OnOptionsSearch implementer can decide on their own how many items should be displayed. E.g. when a search text is active the displayed items can be reduced to n results. But when e.g. no Search text is active all items can be shown by default.
This is a breaking change:
Before: MaximumOptionsSearch < 0 --> empty list is rendered
After: MaximumOptionsSearch < 0 --> all items are rendered