### PR TITLE
Adding expanded value to Accordion custom event handler

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -196,6 +196,11 @@
             Gets or sets a value indicating whether the item is expanded or collapsed.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAccordionItem.ExpandedChanged">
+            <summary>
+            Gets or sets a callback for when the expanded state changes.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAccordionItem.HeadingLevel">
             <summary>
             Gets or sets the <see href="https://www.w3.org/TR/wai-aria-1.1/#aria-level">level</see> of the heading element.

--- a/examples/Demo/Shared/Pages/Accordion/AccordionPage.razor
+++ b/examples/Demo/Shared/Pages/Accordion/AccordionPage.razor
@@ -1,4 +1,4 @@
-@page "/Accordion"
+﻿@page "/Accordion"
 
 @using FluentUI.Demo.Shared.Pages.Accordion.Examples
 
@@ -22,6 +22,8 @@
 </DemoSection>
 
 <DemoSection Title="Accordion with single expand mode" Component="@typeof(AccordionSingleExpand)"></DemoSection>
+
+<DemoSection Title="Control from code" Component="@typeof(AccordionControlItem)"></DemoSection>
 
 <h2 id="documentation">Documentation</h2>
 

--- a/examples/Demo/Shared/Pages/Accordion/Examples/AccordionControlItem.razor
+++ b/examples/Demo/Shared/Pages/Accordion/Examples/AccordionControlItem.razor
@@ -1,0 +1,32 @@
+﻿<FluentAccordion>
+    <FluentAccordionItem Heading="@($"Just an item (status: {(accordionOpen!.Value ? "open" : "closed")})")" @bind-Expanded="@accordionOpen">
+        This accordion item can programatically be opened and closed. Use the buttons below to manipulate the state
+    </FluentAccordionItem>
+</FluentAccordion>
+
+<FluentButton OnClick="OpenAccordion">Open</FluentButton>
+<FluentButton OnClick="CloseAccordion">Close</FluentButton>
+<FluentButton OnClick="ToggleAccordion">Toggle</FluentButton>
+
+
+
+
+@code
+{
+    private bool? accordionOpen = false;
+
+    private void OpenAccordion()
+    {
+        accordionOpen = true;
+    }
+
+    private void CloseAccordion()
+    {
+        accordionOpen = false;
+    }
+
+    private void ToggleAccordion()
+    {
+        accordionOpen = !accordionOpen;
+    }
+}

--- a/src/Core.Assets/src/index.ts
+++ b/src/Core.Assets/src/index.ts
@@ -143,6 +143,7 @@ export function afterStarted(blazor: Blazor, mode: string) {
       if (event.target!.localName == 'fluent-accordion-item') {
         return {
           activeId: event.target!.id,
+          expanded: event.target!._expanded
         }
       };
       return null;

--- a/src/Core/Components/Accordion/FluentAccordionItem.razor
+++ b/src/Core/Components/Accordion/FluentAccordionItem.razor
@@ -1,4 +1,4 @@
-@namespace Microsoft.FluentUI.AspNetCore.Components
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 @inherits FluentComponentBase
 <fluent-accordion-item @ref=Element
                        id="@Id"
@@ -6,6 +6,7 @@
                        style="@Style"
                        heading-level=@HeadingLevel
                        expanded="@Expanded"
+                       @onaccordionchange="HandleOnAccordionItemChangedAsync"
                        @attributes="AdditionalAttributes">
     @if (Heading is not null)
     {

--- a/src/Core/Components/Accordion/FluentAccordionItem.razor.cs
+++ b/src/Core/Components/Accordion/FluentAccordionItem.razor.cs
@@ -33,6 +33,12 @@ public partial class FluentAccordionItem : FluentComponentBase, IDisposable
     public bool? Expanded { get; set; }
 
     /// <summary>
+    /// Gets or sets a callback for when the expanded state changes.
+    /// </summary>
+    [Parameter]
+    public EventCallback<bool?> ExpandedChanged { get; set; }
+
+    /// <summary>
     /// Gets or sets the <see href="https://www.w3.org/TR/wai-aria-1.1/#aria-level">level</see> of the heading element.
     /// Possible values: 1 | 2 | 3 | 4 | 5 | 6
     /// </summary>
@@ -53,6 +59,19 @@ public partial class FluentAccordionItem : FluentComponentBase, IDisposable
     protected override void OnInitialized()
     {
         Owner?.Register(this);
+    }
+
+    private async Task HandleOnAccordionItemChangedAsync(AccordionChangeEventArgs args)
+    {
+        if (args is not null)
+        {
+            var id = args.ActiveId;
+            if (id is not null && Id == id)
+            {
+
+                await ExpandedChanged.InvokeAsync(args.Expanded);
+            }
+        }
     }
 
     public void Dispose() => Owner?.Unregister(this);

--- a/src/Core/Events/AccordionChangeEventArgs.cs
+++ b/src/Core/Events/AccordionChangeEventArgs.cs
@@ -3,4 +3,6 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 public class AccordionChangeEventArgs : EventArgs
 {
     public string? ActiveId { get; set; }
+    public bool? Expanded { get; set; }
+
 }


### PR DESCRIPTION
- Fixes #1678 
- The AccordionItem `Expanded` parameter is now 2-way bindable

- Add example:

![AccordionItem](https://github.com/microsoft/fluentui-blazor/assets/1761079/4028a295-dbae-4606-9284-222d7ab87972)
