### PR TITLE
[FluentPersona] Hide name functionality

### DIFF
--- a/examples/Demo/Shared/Pages/Persona/Examples/PersonaOnlyInitials.razor
+++ b/examples/Demo/Shared/Pages/Persona/Examples/PersonaOnlyInitials.razor
@@ -1,0 +1,22 @@
+﻿<FluentPersona Name="Lydia Bauer"
+               ImageSize="50px"
+               HideName=@hideName
+               @onmouseover="OnMouseOver"
+               @onmouseout="OnMouseOut"
+               Status="PresenceStatus.Busy"
+               StatusSize="PresenceBadgeSize.Small">
+</FluentPersona>
+
+@code {
+    bool hideName = true;
+
+    private void OnMouseOver()
+    {
+        hideName = false;
+    }
+
+    private void OnMouseOut()
+    {
+        hideName = true;
+    }
+}

--- a/examples/Demo/Shared/Pages/Persona/PersonaPage.razor
+++ b/examples/Demo/Shared/Pages/Persona/PersonaPage.razor
@@ -32,6 +32,12 @@
     </Description>
 </DemoSection>
 
+<DemoSection Title="Show only initials" Component="typeof(PersonaOnlyInitials)">
+    <Description>
+        Show only initials for the person when <code>HideName</code> property is set to true or when <code>Name</code> and <code>ChildContent</code> properties are null or empty.
+    </Description>
+</DemoSection>
+
 <DemoSection Title="Dismiss action" Component="typeof(PersonaDismiss)">
     <Description>
         Display a "Dismiss" cross and raise an event.

--- a/src/Core/Components/List/FluentPersona.razor
+++ b/src/Core/Components/List/FluentPersona.razor
@@ -1,7 +1,7 @@
 ﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 @inherits FluentComponentBase
 
-<div id="@Id" class="@ClassValue" style="@StyleValue">
+<div id="@Id" class="@ClassValue" style="@StyleValue" @attributes="@AdditionalAttributes">
     <div class="initials">
         <FluentPresenceBadge Status="@Status" Size="@StatusSize" StatusTitle="@StatusTitle">
             <div style="display: table-cell; vertical-align: middle; @GetImageMinSizeStyle()">
@@ -16,16 +16,19 @@
             </div>
         </FluentPresenceBadge>
     </div>
-    <div class="name">
-        @if (ChildContent is null)
-        {
-            @Name
-        }
-        else
-        {
-            @ChildContent
-        }
-    </div>
+    @if (!HideName && (!string.IsNullOrWhiteSpace(Name) || ChildContent is not null))
+    {
+        <div class="name">
+            @if (ChildContent is null)
+            {
+                @Name
+            }
+            else
+            {
+                @ChildContent
+            }
+        </div>
+    }
     @if (OnDismissClick.HasDelegate)
     {
         <div class="close">

--- a/src/Core/Components/List/FluentPersona.razor.cs
+++ b/src/Core/Components/List/FluentPersona.razor.cs
@@ -31,6 +31,12 @@ public partial class FluentPersona : FluentComponentBase
     public string Name { get; set; } = string.Empty;
 
     /// <summary>
+    /// When true, <see cref="Name"/> will not be rendered.
+    /// </summary>
+    [Parameter]
+    public bool HideName { get; set; }
+
+    /// <summary>
     /// Gets or sets the content to display under the <see cref="Name"/>.
     /// </summary>
     [Parameter]

--- a/tests/Core/List/FluentPersonaTests.FluentPersona_HideName-ChildContentName.verified.html
+++ b/tests/Core/List/FluentPersonaTests.FluentPersona_HideName-ChildContentName.verified.html
@@ -2,7 +2,7 @@
 <div id="xxx" class="fluent-persona" b-n7zog0zvqi="">
   <div class="initials" b-n7zog0zvqi="">
     <div class="fluent-presence-badge" title="" b-1o8tp31nhy="">
-      <div style="display: table-cell; vertical-align: middle; " b-n7zog0zvqi="">--</div>
+      <div style="display: table-cell; vertical-align: middle; " b-n7zog0zvqi="">DV</div>
     </div>
   </div>
 </div>

--- a/tests/Core/List/FluentPersonaTests.FluentPersona_HideName-ChildContentNoName.verified.html
+++ b/tests/Core/List/FluentPersonaTests.FluentPersona_HideName-ChildContentNoName.verified.html
@@ -5,4 +5,5 @@
       <div style="display: table-cell; vertical-align: middle; " b-n7zog0zvqi="">--</div>
     </div>
   </div>
+  <div class="name" b-n7zog0zvqi=""></div>
 </div>

--- a/tests/Core/List/FluentPersonaTests.FluentPersona_HideName-NameNoChildContent.verified.html
+++ b/tests/Core/List/FluentPersonaTests.FluentPersona_HideName-NameNoChildContent.verified.html
@@ -2,7 +2,7 @@
 <div id="xxx" class="fluent-persona" b-n7zog0zvqi="">
   <div class="initials" b-n7zog0zvqi="">
     <div class="fluent-presence-badge" title="" b-1o8tp31nhy="">
-      <div style="display: table-cell; vertical-align: middle; " b-n7zog0zvqi="">--</div>
+      <div style="display: table-cell; vertical-align: middle; " b-n7zog0zvqi="">DV</div>
     </div>
   </div>
 </div>

--- a/tests/Core/List/FluentPersonaTests.FluentPersona_HideName-NoNameNoChildContent.verified.html
+++ b/tests/Core/List/FluentPersonaTests.FluentPersona_HideName-NoNameNoChildContent.verified.html
@@ -5,4 +5,5 @@
       <div style="display: table-cell; vertical-align: middle; " b-n7zog0zvqi="">--</div>
     </div>
   </div>
+  <div class="name" b-n7zog0zvqi=""></div>
 </div>

--- a/tests/Core/List/FluentPersonaTests.cs
+++ b/tests/Core/List/FluentPersonaTests.cs
@@ -48,4 +48,27 @@ public class FluentPersonaTests : TestBase
         // Assert
         cut.Verify(suffix: id);
     }
+
+    [Theory]
+    [InlineData("NameNoChildContent", "Denis Voituron", null)]
+    [InlineData("ChildContentNoName", "", null)]
+    [InlineData("ChildContentName", "Denis Voituron", "Denis Voituron")]
+    [InlineData("NoNameNoChildContent", "", null)]
+    public void FluentPersona_HideName(string id, string name, string? childContent)
+    {
+        // Arrange
+        var cut = TestContext.RenderComponent<FluentPersona>(parameters =>
+        {
+            parameters.Add(p => p.Id, "myComponent");
+            parameters.Add(p => p.Name, name);
+            parameters.Add(p => p.HideName, !string.IsNullOrWhiteSpace(name) || childContent is not null);
+            parameters.Add(p => p.ChildContent, context =>
+            {
+                context.AddContent(0, childContent);
+            });
+        });
+
+        // Assert
+        cut.Verify(suffix: id);
+    }
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description
Changes involve the addition of a new feature that allows only the initials of a person to be rendered. This is achieved through the introduction of a new `HideName` property in the `FluentPersona` class. Additionally, the `FluentPersona.razor` file has been updated to accommodate this new feature, as well as not rendering `<div class="name">` when both `ChildContent` and `Name` properties are null. Changes also include additional attributes to be passed to the `div` element in order for events to work (e.g. `@onmouseover`). 

### 🎫 Issues
`FluentPersona` component renders `<div class="name">` even if both `Name` and `ChildContent` properties are empty. 

![fluent-ui-persona-initials-noname-bug-html](https://github.com/microsoft/fluentui-blazor/assets/24671023/39c5432a-bb70-46a8-9a3f-ab8fcbbb4d41)

Which results in the element taking additional empty space within the container. 

![fluent-ui-persona-initials-noname-bug](https://github.com/microsoft/fluentui-blazor/assets/24671023/3f47d52e-8754-45c8-8267-4b93c1902ab2)

This can cause problems when using `FluentPersona` component as a button or when trying to align it with other elements.

Additionally `FluentPersona` component does not have the ability to use events like `@onmouseover`.

## 👩‍💻 Reviewer Notes
1. A new demo section titled "Show only initials" has been added to the `PersonaPage.razor` file. This section describes a new feature where only the initials of a person are shown when the `HideName` property is set to true or when the `Name` and `ChildContent` properties are not set.

![fluent-ui-persona-initials-noname-fix](https://github.com/microsoft/fluentui-blazor/assets/24671023/c5a6bf36-6c9c-41f0-823b-2c43f77fadc9)

![fluent-ui-persona-initials-noname-fix-html](https://github.com/microsoft/fluentui-blazor/assets/24671023/8f772063-4b70-4c26-b936-c9c728c34811)

2. The `div` tag in the `FluentPersona.razor` file has been updated to include `@attributes="@AdditionalAttributes"`. This allows for additional attributes to be passed to the `div` element.

3. The `name` div in the `FluentPersona.razor` file has been updated to only display if the `HideName` property is false and either the `Name` property is not null or whitespace, or the `ChildContent` property is not null.

4. A new property `HideName` has been added to the `FluentPersona` class in the `FluentPersona.razor.cs` file. This property is a boolean that determines whether the name should be displayed or not.

## 📑 Test Plan
`FluentPersonaTests` has been updated to accommodate these new changes.  

## ✅ Checklist

### General
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new compontent
- [x] I have modified an existing component
- [x] I have validate [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component 