### PR TITLE
[FluentPersona] Manage the empty Name

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -444,11 +444,6 @@
             Gets or sets the tooltip to show when the item is hovered.
             </summary>
         </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAppBarItem.ForceLoad">
-            <summary>
-            If true, force browser to redirect outside component router-space.
-            </summary>
-        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAppBarItem.ChildContent">
             <summary>
              Gets or sets the content to be shown.
@@ -4572,6 +4567,11 @@
             <summary>
             Gets or sets the <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentPersona.Status"/> size to use.
             Default is ExtraSmall.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentPersona.OnClick">
+            <summary>
+            Gets or sets the event raised when the user clicks on this Persona.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentPersona.OnDismissClick">

--- a/examples/Demo/Shared/Pages/Persona/Examples/PersonaNoImage.razor
+++ b/examples/Demo/Shared/Pages/Persona/Examples/PersonaNoImage.razor
@@ -1,5 +1,11 @@
-﻿<FluentPersona Name="Lydia Bauer"
-               ImageSize="50px"
-               Status="PresenceStatus.Busy"
-               StatusSize="PresenceBadgeSize.Small">
-</FluentPersona>
+﻿<FluentStack>
+    <FluentPersona Name="Lydia Bauer"
+                   ImageSize="50px"
+                   Status="PresenceStatus.Busy"
+                   StatusSize="PresenceBadgeSize.Small">
+    </FluentPersona>
+
+    <FluentPersona Initials="LB"
+                   ImageSize="50px">
+    </FluentPersona>
+</FluentStack>

--- a/src/Core/Components/List/FluentPersona.razor
+++ b/src/Core/Components/List/FluentPersona.razor
@@ -1,8 +1,8 @@
 ﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 @inherits FluentComponentBase
 
-<div id="@Id" class="@ClassValue" style="@StyleValue">
-    <div class="initials">
+<div id="@Id" class="@ClassValue" style="@StyleValue" @attributes="@AdditionalAttributes">
+    <div class="initials" @onclick="@OnClick" style="@(OnClick.HasDelegate ? $"cursor: pointer;" : null)">
         <FluentPresenceBadge Status="@Status" Size="@StatusSize" StatusTitle="@StatusTitle">
             <div style="display: table-cell; vertical-align: middle; @GetImageMinSizeStyle()">
                 @if (string.IsNullOrEmpty(Image))
@@ -16,16 +16,19 @@
             </div>
         </FluentPresenceBadge>
     </div>
-    <div class="name">
-        @if (ChildContent is null)
-        {
-            @Name
-        }
-        else
-        {
-            @ChildContent
-        }
-    </div>
+    @if (ChildContent is not null || !String.IsNullOrEmpty(Name))
+    {
+        <div class="name" @onclick="@OnClick" style="@(OnClick.HasDelegate ? $"cursor: pointer;" : null)">
+            @if (ChildContent is null)
+            {
+                @Name
+            }
+            else
+            {
+                @ChildContent
+            }
+        </div>
+    }
     @if (OnDismissClick.HasDelegate)
     {
         <div class="close">

--- a/src/Core/Components/List/FluentPersona.razor.cs
+++ b/src/Core/Components/List/FluentPersona.razor.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.FluentUI.AspNetCore.Components.Utilities;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
@@ -68,6 +69,12 @@ public partial class FluentPersona : FluentComponentBase
     public PresenceBadgeSize StatusSize { get; set; } = PresenceBadgeSize.ExtraSmall;
 
     /// <summary>
+    /// Gets or sets the event raised when the user clicks on this Persona.
+    /// </summary>
+    [Parameter]
+    public EventCallback<MouseEventArgs> OnClick { get; set; }
+
+    /// <summary>
     /// Gets or sets the event raised when the user clicks on the dismiss button.
     /// </summary>
     [Parameter]
@@ -82,11 +89,16 @@ public partial class FluentPersona : FluentComponentBase
     /// <summary />
     private string GetDefaultInitials()
     {
+        if (string.IsNullOrEmpty(Name))
+        {
+            return string.Empty;
+        }
+
         var parts = Name.ToUpper().Split(' ', StringSplitOptions.RemoveEmptyEntries);
         return parts == null
                 || parts.Length == 0
                 || (parts.Length == 1 && parts[0] == string.Empty)
-            ? "--"
+            ? string.Empty
             : parts.Length > 1
             ? $"{parts[0][0]}{parts[1][0]}"
             : $"{parts[0][0]}";

--- a/src/Core/Components/List/FluentPersona.razor.css
+++ b/src/Core/Components/List/FluentPersona.razor.css
@@ -1,6 +1,5 @@
 .fluent-persona {
     display: flex;
-    height: 100%;
     width: fit-content;
     border-radius: 999px;
     align-items: center;

--- a/tests/Core/List/FluentPersonaTests.FluentPersona_Initials-NoName.verified.html
+++ b/tests/Core/List/FluentPersonaTests.FluentPersona_Initials-NoName.verified.html
@@ -2,8 +2,7 @@
 <div id="xxx" class="fluent-persona" b-t78kyg8ike="">
   <div class="initials" b-t78kyg8ike="">
     <div class="fluent-presence-badge" title="" b-3h6zxwsqc2="">
-      <div style="display: table-cell; vertical-align: middle; " b-t78kyg8ike="">--</div>
+      <div style="display: table-cell; vertical-align: middle; " b-t78kyg8ike=""></div>
     </div>
   </div>
-  <div class="name" b-t78kyg8ike=""></div>
 </div>


### PR DESCRIPTION
# [FluentPersona] Manage the empty Name

Manage the empty `Name=""` to display a **Persona** without other properties.

- Adding `@attributes`. 
- Adding `OnClick` event.
- Adding `String.IsNullOrEmpty(Name)` to not generate the code if content of name is empty.

## Examples

![image](https://github.com/microsoft/fluentui-blazor/assets/8350694/5b961906-a3fa-4342-87ca-446c21143355)

```xml
<FluentPersona Name="Lydia Bauer"
               ImageSize="50px"
               Status="PresenceStatus.Busy"
               StatusSize="PresenceBadgeSize.Small">
</FluentPersona>

<FluentPersona Initials="LB" ImageSize="50px" />

<FluentPersona ImageSize="50px" />
```

## Unit Tests

Unit tests updated and verified.