### PR TITLE
feat(pagination): Adding in Disabled parameter to Pagination component

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -6066,6 +6066,11 @@
             A component that provides a user interface for <see cref="T:Microsoft.FluentUI.AspNetCore.Components.PaginationState"/>.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentPaginator.Disabled">
+            <summary>
+            Disables the pagination buttons
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentPaginator.State">
             <summary>
             Gets or sets the associated <see cref="T:Microsoft.FluentUI.AspNetCore.Components.PaginationState"/>. This parameter is required.

--- a/src/Core/Components/Pagination/FluentPaginator.razor
+++ b/src/Core/Components/Pagination/FluentPaginator.razor
@@ -1,4 +1,4 @@
-@namespace Microsoft.FluentUI.AspNetCore.Components
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 @inherits FluentComponentBase
 <div class="paginator" style="@Style">
     @if (State.TotalItemCount.HasValue)
@@ -14,10 +14,10 @@
             }
         </div>
         <nav role="navigation" class="paginator-nav">
-            <FluentButton @onclick="GoFirstAsync" Disabled="@(!CanGoBack)" title="Go to first page" aria-label="Go to first page">
+            <FluentButton @onclick="GoFirstAsync" Disabled="@(!CanGoBack || Disabled)" title="Go to first page" aria-label="Go to first page">
                 <FluentIcon Value="@(new CoreIcons.Regular.Size20.ChevronDoubleLeft())" Width="20px" />
             </FluentButton>
-            <FluentButton @onclick="GoPreviousAsync" Disabled="@(!CanGoBack)" title="Go to previous page" aria-label="Go to previous page">
+            <FluentButton @onclick="GoPreviousAsync" Disabled="@(!CanGoBack || Disabled)" title="Go to previous page" aria-label="Go to previous page">
                 <FluentIcon Value="@(new CoreIcons.Regular.Size24.ChevronLeft())" Width="20px" />
             </FluentButton>
             <div class="pagination-text">
@@ -31,10 +31,10 @@
                 }
 
             </div>
-            <FluentButton @onclick="GoNextAsync" Disabled="@(!CanGoForwards)" title="Go to next page" aria-label="Go to next page">
+            <FluentButton @onclick="GoNextAsync" Disabled="@(!CanGoForwards || Disabled)" title="Go to next page" aria-label="Go to next page">
                 <FluentIcon Value="@(new CoreIcons.Regular.Size24.ChevronRight())" Width="20px" />
             </FluentButton>
-            <FluentButton @onclick="GoLastAsync" Disabled="@(!CanGoForwards)" title="Go to last page" aria-label="Go to last page">
+            <FluentButton @onclick="GoLastAsync" Disabled="@(!CanGoForwards || Disabled)" title="Go to last page" aria-label="Go to last page">
                 <FluentIcon Value="@(new CoreIcons.Regular.Size20.ChevronDoubleRight())" Width="20px" />
             </FluentButton>
         </nav>

--- a/src/Core/Components/Pagination/FluentPaginator.razor.cs
+++ b/src/Core/Components/Pagination/FluentPaginator.razor.cs
@@ -14,6 +14,12 @@ public partial class FluentPaginator : FluentComponentBase, IDisposable
     public EventCallback<int> CurrentPageIndexChanged { get; set; }
 
     /// <summary>
+    /// Disables the pagination buttons
+    /// </summary>
+    [Parameter]
+    public bool Disabled { get; set; }
+
+    /// <summary>
     /// Gets or sets the associated <see cref="PaginationState"/>. This parameter is required.
     /// </summary>
     [Parameter, EditorRequired]


### PR DESCRIPTION
# feat(pagination): Adding in Disabled parameter to Pagination component

Adding in the ability to disable the pagination buttons on the Pagination control.


## 📖 Description

There are scenarios where a user can click the pagination navigation buttons faster than the navigation can complete (e.g. dynamically loading content).  In these scenarios, it is useful to be able to disable the pagination navigation buttons until the navigation has completed.

This pull request adds to the Pagination component:

* Disabled

### 🎫 Issues

* None

## 👩‍💻 Reviewer Notes

* None

## 📑 Test Plan

No pagination tests exist to update.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new compontent
- [x] I have modified an existing component
- [ ] I have validate [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component 

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->