### PR TITLE
Avoid padding loading icon on button when no text 

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -886,7 +886,7 @@
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentButton.Name">
             <summary>
-            Gets or sets the name of the element. 
+            Gets or sets the name of the element.
             Allows access by name from the associated form.
             </summary>
         </member>

--- a/src/Core/Components/Button/FluentButton.razor
+++ b/src/Core/Components/Button/FluentButton.razor
@@ -45,7 +45,7 @@ else
             {
                 if (Loading)
                 {
-                    <FluentProgressRing slot="start" Style="@RingStyle(IconStart)" />
+                    <FluentProgressRing slot="@(ChildContent != null ? "start" : null)" Style="@RingStyle(IconStart)" />
                 }
                 else
                 {
@@ -58,7 +58,7 @@ else
             {
                 if (Loading && IconStart == null)
                 {
-                    <FluentProgressRing slot="end" Style="@RingStyle(IconEnd)" />
+                    <FluentProgressRing slot="@(ChildContent != null ? "end" : null)" Style="@RingStyle(IconEnd)" />
                 }
                 else
                 {

--- a/src/Core/Components/Button/FluentButton.razor.cs
+++ b/src/Core/Components/Button/FluentButton.razor.cs
@@ -89,7 +89,7 @@ public partial class FluentButton : FluentComponentBase, IAsyncDisposable
     public bool Disabled { get; set; }
 
     /// <summary>
-    /// Gets or sets the name of the element. 
+    /// Gets or sets the name of the element.
     /// Allows access by name from the associated form.
     /// </summary>
     [Parameter]
@@ -228,7 +228,7 @@ public partial class FluentButton : FluentComponentBase, IAsyncDisposable
 
     private string RingStyle(Icon icon)
     {
-        var size = icon.Width;
+        var size = icon.Width - 4;
         var inverse = Appearance == AspNetCore.Components.Appearance.Accent ? " filter: invert(1);" : string.Empty;
 
         return $"width: {size}px; height: {size}px;{inverse}";


### PR DESCRIPTION
Fix #1707 by:
- If no content, move ProgressRing to content part (like icon) 
- Make Progress ring a bit smaller then icon to not make button bigger in Loading state