### PR TITLE
[MarkdownSection] fixes border not showing in markdown tables

### DIFF
--- a/examples/Demo/Shared/Components/MarkdownSection.razor
+++ b/examples/Demo/Shared/Components/MarkdownSection.razor
@@ -1,8 +1,6 @@
 ﻿@using Markdig
 @inherits FluentComponentBase
 
-@HtmlContent
-
-
-
-
+<div>
+    @HtmlContent
+</div>

--- a/examples/Demo/Shared/Components/MarkdownSection.razor.css
+++ b/examples/Demo/Shared/Components/MarkdownSection.razor.css
@@ -1,0 +1,9 @@
+::deep th {
+    padding: 0 5px 0 5px;
+    border-width: 1px;
+}
+
+::deep td {
+    padding: 0 5px 0 5px;
+    border-width: 1px;
+}


### PR DESCRIPTION
# Pull Request

## 📖 Description

Fixes issue where markdown tables are not showing borders.

[Design tokens page](https://www.fluentui-blazor.net/DesignTokens) on demo site shows

![image](https://github.com/microsoft/fluentui-blazor/assets/23250332/b887ea1b-c1c1-4c70-a42e-fdb8c6bb3b9e)

### 🎫 Issues

Default styling does not provide borders

## 👩‍💻 Reviewer Notes

How are the aesthetics - border width and padding?
![image](https://github.com/microsoft/fluentui-blazor/assets/23250332/a80e141e-dbe2-4d97-9b43-f53ec4ee04f9)

## 📑 Test Plan

## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [X] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new compontent
- [X] I have modified an existing component
- [ ] I have validate [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component 

## ⏭ Next Steps

