### PR TITLE
[FluentKeyCode] Allow content to avoid using the Anchor property

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -4054,9 +4054,24 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentKeyCode.Module">
             <summary />
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentKeyCode.Element">
+            <summary />
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentKeyCode.GlobalDocument">
+            <summary>
+            Gets or sets whether the KeyCode engine is global (using document DOM element) or not (only for <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentKeyCode.Anchor"/> or <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentKeyCode.ChildContent"/>).
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentKeyCode.Anchor">
             <summary>
-            Required. Gets or sets the control identifier associated with the KeyCode engine.
+            Gets or sets the control identifier associated with the KeyCode engine.
+            If not set, the KeyCode will be applied to the FluentKeyCode content: see <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentKeyCode.ChildContent"/>.
+            This attribute is ignored when the <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentKeyCode.ChildContent" /> is used..
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentKeyCode.ChildContent">
+            <summary>
+            Gets or sets the content to be managed by the KeyCode engine.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentKeyCode.OnKeyDown">
@@ -4093,6 +4108,11 @@
             <summary>
             Gets or sets the list of <see cref="T:Microsoft.FluentUI.AspNetCore.Components.KeyCode"/> to tells the user agent that if the event does not get explicitly handled,
             its default action should not be taken as it normally would be.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentKeyCode.AdditionalAttributes">
+            <summary>
+            Gets or sets a collection of additional attributes that will be applied to the created element.
             </summary>
         </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentKeyCode.OnAfterRenderAsync(System.Boolean)">

--- a/examples/Demo/Shared/Pages/KeyCode/Examples/KeyCodeExample.razor
+++ b/examples/Demo/Shared/Pages/KeyCode/Examples/KeyCodeExample.razor
@@ -1,16 +1,16 @@
-﻿<FluentKeyCode Anchor="myCard"  OnKeyDown="@KeyDownHandler" />
-<FluentKeyCode Anchor="myKey" OnKeyDown="@KeyDownHandler" StopPropagation="true" />
-
-<FluentStack>
-    <FluentCard Id="myCard" tabindex="0" Width="300px" Height="140px">
-        Click here and press <span tabindex="0" id="myKey">any key</span> to get the event keycode info.
-    </FluentCard>
+﻿<FluentStack>
+    <FluentKeyCode OnKeyDown="@KeyDownHandler">
+        <FluentCard tabindex="0" Width="300px" Height="140px">
+            Click here and press <FluentKeyCode tabindex="0" OnKeyDown="@KeyDownHandler" StopPropagation="true">any key</FluentKeyCode> to get the event keycode info.
+        </FluentCard>
+    </FluentKeyCode>
 
     <ul>
         <li><span>Value:</span> <code>@LastKeyCode?.Value</code></li>
         <li><span>Key:</span> <code>@LastKeyCode?.Key.ToString()</code></li>
         <li><span>Code:</span> <code>@LastKeyCode?.KeyCode</code></li>
-        <li><span>Meta:</span>
+        <li>
+            <span>Meta:</span>
             @if (LastKeyCode?.ShiftKey == true)
             {
                 <FluentIcon Value="@(new Icons.Filled.Size20.KeyboardShift())" />

--- a/src/Core/Components/KeyCode/FluentKeyCode.razor
+++ b/src/Core/Components/KeyCode/FluentKeyCode.razor
@@ -1,1 +1,8 @@
-@namespace Microsoft.FluentUI.AspNetCore.Components
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components
+
+@if (ChildContent is not null)
+{
+    <span @ref="@Element" @attributes="@AdditionalAttributes">
+        @ChildContent
+    </span>
+}

--- a/src/Core/Components/KeyCode/FluentKeyCode.razor.cs
+++ b/src/Core/Components/KeyCode/FluentKeyCode.razor.cs
@@ -20,12 +20,28 @@ public partial class FluentKeyCode
     /// <summary />
     private IJSObjectReference? Module { get; set; }
 
+    /// <summary />
+    private ElementReference Element { get; set; }
+
     /// <summary>
-    /// Required. Gets or sets the control identifier associated with the KeyCode engine.
+    /// Gets or sets whether the KeyCode engine is global (using document DOM element) or not (only for <see cref="Anchor"/> or <see cref="ChildContent"/>).
     /// </summary>
     [Parameter]
-    [EditorRequired]
+    public bool GlobalDocument { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets the control identifier associated with the KeyCode engine.
+    /// If not set, the KeyCode will be applied to the FluentKeyCode content: see <see cref="ChildContent"/>.
+    /// This attribute is ignored when the <see cref="ChildContent" /> is used..
+    /// </summary>
+    [Parameter]
     public string Anchor { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the content to be managed by the KeyCode engine.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
     /// Event triggered when a KeyDown event is raised.
@@ -70,15 +86,26 @@ public partial class FluentKeyCode
     [Parameter]
     public KeyCode[] PreventDefaultOnly { get; set; } = Array.Empty<KeyCode>();
 
+    /// <summary>
+    /// Gets or sets a collection of additional attributes that will be applied to the created element.
+    /// </summary>
+    [Parameter(CaptureUnmatchedValues = true)]
+    public virtual IReadOnlyDictionary<string, object>? AdditionalAttributes { get; set; }
+
     /// <summary />
     protected async override Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
         {
+            if (ChildContent is null && string.IsNullOrEmpty(Anchor) && !GlobalDocument)
+            {
+                throw new ArgumentNullException(Anchor, $"The {nameof(Anchor)} parameter must be set to the ID of an element. Or the {nameof(ChildContent)} must be set to apply the KeyCode engine to this content.");
+            }
+
             Module ??= await JSRuntime.InvokeAsync<IJSObjectReference>("import", JAVASCRIPT_FILE);
             _dotNetHelper = DotNetObjectReference.Create(this);
 
-            await Module.InvokeVoidAsync("RegisterKeyCode", Anchor, Only, IgnoreModifier ? Ignore.Union(_Modifiers) : Ignore, StopPropagation, PreventDefault, PreventDefaultOnly, _dotNetHelper);
+            await Module.InvokeVoidAsync("RegisterKeyCode", GlobalDocument, Anchor, ChildContent is null ? null : Element, Only, IgnoreModifier ? Ignore.Union(_Modifiers) : Ignore, StopPropagation, PreventDefault, PreventDefaultOnly, _dotNetHelper);
         }
     }
 

--- a/src/Core/Components/KeyCode/FluentKeyCode.razor.js
+++ b/src/Core/Components/KeyCode/FluentKeyCode.razor.js
@@ -1,5 +1,8 @@
-export function RegisterKeyCode(id, onlyCodes, excludeCodes, stopPropagation, preventDefault, preventDefaultOnly, dotNetHelper) {
-    const element = id == "#document#" ? document : document.getElementById(id);
+export function RegisterKeyCode(globalDocument, id, elementRef, onlyCodes, excludeCodes, stopPropagation, preventDefault, preventDefaultOnly, dotNetHelper) {
+    const element = globalDocument
+        ? document
+        : elementRef == null ? document.getElementById(id) : elementRef;
+
     if (!!element) {
         element.addEventListener('keydown', function (e) {
             const keyCode = e.which || e.keyCode || e.charCode;

--- a/src/Core/Components/KeyCode/FluentKeyCodeProvider.razor
+++ b/src/Core/Components/KeyCode/FluentKeyCodeProvider.razor
@@ -1,3 +1,3 @@
 ﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 
-<FluentKeyCode Anchor="#document#" OnKeyDown="@KeyDownHandler" PreventDefault="@PreventDefault" />
+<FluentKeyCode GlobalDocument="true" OnKeyDown="@KeyDownHandler" PreventDefault="@PreventDefault" />

--- a/tests/Core/KeyCodeProvider/FluentKeyCodeTests.razor
+++ b/tests/Core/KeyCodeProvider/FluentKeyCodeTests.razor
@@ -26,6 +26,29 @@
     }
 
     [Fact]
+    public async Task FluentKeyCode_ChildContent()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        FluentKeyCodeEventArgs pressed = new();
+
+        // Arrange && Act
+        var cut = Render(@<FluentKeyCode OnKeyDown="@(e => pressed = e)">Hello World</FluentKeyCode>);
+
+        await cut.FindComponent<FluentKeyCode>().Instance.OnKeyDownRaisedAsync(65, "A", false, false, false, false, 0, "myZone");
+
+        // Assert
+        Assert.Equal(65, pressed.KeyCode);
+        Assert.Equal(KeyCode.KeyA, pressed.Key);
+        Assert.Equal("A", pressed.Value);
+
+        Assert.False(pressed.CtrlKey);
+        Assert.False(pressed.ShiftKey);
+        Assert.False(pressed.AltKey);
+        Assert.False(pressed.MetaKey);
+    }
+
+    [Fact]
     public async Task FluentKeyCode_CtrlShiftAltMeta()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
@@ -133,6 +156,25 @@
         keycodeService.Clear();
         Assert.Empty(keycodeService.Listeners);
 
+    }
+
+    [Fact]
+    public async Task FluentKeyCode_AnchorOrChildContent_Required()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        FluentKeyCodeEventArgs pressed = new();
+
+        // Arrange && Act
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+        {
+            var cut = Render(@<FluentKeyCode OnKeyDown="@(e => pressed = e)"></FluentKeyCode>        );
+        });
+
+        Assert.Equal("The Anchor parameter must be set to the ID of an element. Or the ChildContent must be set to apply the KeyCode engine to this content.", exception.Message);
+
+        // To avoid warning on "async Task"
+        await Task.CompletedTask;
     }
 
     private class MyKeyCodeListener : IKeyCodeListener


### PR DESCRIPTION
# [FluentKeyCode] Allow content to avoid using the Anchor property

Adding a `ChildContent` property and a ´ElementReference` to apply the KeyCode engine to the **FluentKeyCode** content.

If the `ChildContent` is filled, the `Anchor` attribute is no longer used (and is ignored).
A new `GlobalDocument` property defines the component as global to the page, using the DOM object `document`.

Example:
```xml
<FluentKeyCode OnKeyDown="@KeyDownHandler">
   Hello World
</FluentKeyCode>
```

The HTML result will be:
```html
<span>Hello World</span>
```

## Breaking changes
No

## Unit Tests

Updated