### PR TITLE
Fix documentation error.

### DIFF
--- a/examples/Demo/Shared/Pages/Wizard/WizardPage.razor
+++ b/examples/Demo/Shared/Pages/Wizard/WizardPage.razor
@@ -55,14 +55,14 @@
 <DemoSection Title="Edit Form" Component="@typeof(WizardEditForms)">
     <Description>
         <blockquote>
-            <b>note</b>: In order for the Wizard component to automatically validate your EditForms, you must place the following component inside your EditForm:
+            <b>note</b>: In order for the Wizard component to automatically validate your EditForms, you must use the 'FluentEditForm' component instead of the 'EditForm' component:
         </blockquote>
 
         <CodeSnippet>
 &lt;FluentWizardStep>
-    &lt;EditForm>
-        &lt;FluentWizardStepFormValidator />
-    &lt;/EditForm>
+    &lt;FluentEditForm>
+        &lt;DataAnnotationsValidator />
+    &lt;/FluentEditForm>
 &lt;/FluentWizardStep>
         </CodeSnippet>
     </Description>


### PR DESCRIPTION
Looks like I forgot to update the documentation when we changed the architecture and introduced the `FluentEditForm` component for validating an edit form in the `FluentWizardComponent`.  See #1663 