### PR TITLE
Fix footer styling. Addresses  #1777

### DIFF
--- a/examples/Demo/Shared/Pages/Footer/Examples/FooterDefault.razor
+++ b/examples/Demo/Shared/Pages/Footer/Examples/FooterDefault.razor
@@ -1,3 +1,5 @@
 ﻿<FluentFooter>
-    Footer text
+    Footer start text
+    <FluentSpacer />
+    Footer end text
 </FluentFooter>

--- a/src/Core/Components/Footer/FluentFooter.razor.css
+++ b/src/Core/Components/Footer/FluentFooter.razor.css
@@ -1,8 +1,7 @@
-﻿.footer {
-    display: grid;
+.footer {
+    display: flex;
     z-index: 10;
-    flex-direction: column;
-    position: relative;
+    flex-direction: row;
     font-family: var(--body-font);
     font-weight: normal;
     font-size: var(--type-ramp-minus-1-font-size);

--- a/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/MainLayout.razor
+++ b/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/MainLayout.razor
@@ -14,12 +14,9 @@
         </FluentBodyContent>
     </FluentStack>
     <FluentFooter>
-        <div class="link1">
-            <a href="https://www.fluentui-blazor.net" target="_blank">Documentation and demos</a>
-        </div>
-        <div class="link2">
-            <a href="https://learn.microsoft.com/en-us/aspnet/core/blazor" target="_blank">About Blazor</a>
-        </div>
+        <a href="https://www.fluentui-blazor.net" target="_blank">Documentation and demos</a>
+        <FluentSpacer />
+        <a href="https://learn.microsoft.com/en-us/aspnet/core/blazor" target="_blank">About Blazor</a>
     </FluentFooter>
 </FluentLayout>
 ##else

--- a/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/wwwroot/app.css
+++ b/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/wwwroot/app.css
@@ -42,16 +42,6 @@ footer {
     padding: 10px 10px;
 }
 
-    footer .link1 {
-        grid-column: 2;
-        justify-self: start;
-    }
-
-    footer .link2 {
-        grid-column: 3;
-        justify-self: end;
-    }
-
     footer a {
         color: var(--neutral-foreground-rest);
         text-decoration: none;

--- a/src/Templates/content/ComponentsWebAssembly-CSharp/Layout/MainLayout.Auth.razor
+++ b/src/Templates/content/ComponentsWebAssembly-CSharp/Layout/MainLayout.Auth.razor
@@ -23,12 +23,9 @@
         </FluentBodyContent>
     </FluentStack>
     <FluentFooter>
-        <div class="link1">
-            <a href="https://www.fluentui-blazor.net" target="_blank">Documentation and demos</a>
-        </div>
-        <div class="link2">
-            <a href="https://learn.microsoft.com/en-us/aspnet/core/blazor" target="_blank">About Blazor</a>
-        </div>
+        <a href="https://www.fluentui-blazor.net" target="_blank">Documentation and demos</a>
+        <FluentSpacer />
+        <a href="https://learn.microsoft.com/en-us/aspnet/core/blazor" target="_blank">About Blazor</a>
     </FluentFooter>
 </FluentLayout>
 ##else

--- a/src/Templates/content/ComponentsWebAssembly-CSharp/Layout/MainLayout.NoAuth.razor
+++ b/src/Templates/content/ComponentsWebAssembly-CSharp/Layout/MainLayout.NoAuth.razor
@@ -21,12 +21,9 @@
         </FluentBodyContent>
     </FluentStack>
     <FluentFooter>
-        <div class="link1">
-            <a href="https://www.fluentui-blazor.net" target="_blank">Documentation and demos</a>
-        </div>
-        <div class="link2">
-            <a href="https://learn.microsoft.com/en-us/aspnet/core/blazor" target="_blank">About Blazor</a>
-        </div>
+        <a href="https://www.fluentui-blazor.net" target="_blank">Documentation and demos</a>
+        <FluentSpacer />
+        <a href="https://learn.microsoft.com/en-us/aspnet/core/blazor" target="_blank">About Blazor</a>
     </FluentFooter>
 </FluentLayout>
 ##else

--- a/src/Templates/content/ComponentsWebAssembly-CSharp/wwwroot/css/app.css
+++ b/src/Templates/content/ComponentsWebAssembly-CSharp/wwwroot/css/app.css
@@ -38,16 +38,6 @@ footer {
     padding: 10px 10px;
 }
 
-    footer .link1 {
-        grid-column: 2;
-        justify-self: start;
-    }
-
-    footer .link2 {
-        grid-column: 3;
-        justify-self: end;
-    }
-
     footer a {
         color: var(--neutral-foreground-rest);
         text-decoration: none;


### PR DESCRIPTION
Footer styling comes with a bad design decission made in the past.  It uses a `display: grid;` together with `flex-direction: column;` which does not make any sense.

We are even overriding it in the demo site ourselves:
![image](https://github.com/microsoft/fluentui-blazor/assets/1761079/96888ecd-b40e-4b54-b9c1-ade9e86d6eb2)

With this change we will change it to more sane defaults. Technically it might be considered a breaking change (albeit a small one for sure) but it be will changed in the next release to:
```
.footer {
    display: flex;
    z-index: 10;
    flex-direction: row;
    font-family: var(--body-font);
    font-weight: normal;
    font-size: var(--type-ramp-minus-1-font-size);
    line-height: var(--type-ramp-minus-1-line-height);
}
```

For the templates this means that a `FluentSpacer` is added to the footer so the texts will still align left an right. It also allows to remove some then redundant CSS for those links from the `app.css` (both Web App and WebAssembly templates