### PR TITLE
[Pipelines] Add compute-version-variables.ps1 to update the YAML file

### DIFF
--- a/eng/pipelines/build-core-lib.yml
+++ b/eng/pipelines/build-core-lib.yml
@@ -107,101 +107,19 @@ extends:
             artifactName: PackageArtifacts
 
         steps:
+
         # Compute AssemblyVersion and PackageVersion
         # -> Update version.yml
-        - powershell: |
-
-            # Example with FileVersion: "1.2.4" and PackageSuffix: "RC.1"
-            # Build.BuildNumber = 1.2.4.23296.1
-            #                   = $(FileVersion).$(Year:yy)$(DayOfYear).$(Rev:r)
-
-            # Default values
-            $branch = "PR"
-            $package = ""
-
-            # To Test?
-            $toTest = "true"
-
-            # BranchName = dev, main, archive or PR
-            if ("$(Build.SourceBranchName)" -eq "main")
-            {
-                $branch = "main"
-            }
-            elseif ("$(Build.SourceBranchName)" -eq "dev")
-            {
-                $branch = "dev"
-            }
-            elseif ("$(Build.SourceBranch)" -like "refs/heads/archives/*")
-            {
-                $branch = "archive"
-            }
-            else
-            {
-                $branch = "PR"
-            }
-
-            # [1, 2, 4, 23296, 1]
-            $builds = "$(Build.BuildNumber)".Split('.')
-
-            # 1.2.4.23296
-            $assembly = "$($builds[0]).$($builds[1]).$($builds[2]).$($builds[3])"
-
-            # Main or Archive without PackageSuffix: 1.2.4
-            # Main or Archive with    PackageSuffix: 1.2.4-rc.1
-            if ("$branch" -eq "main" -or "$branch" -eq "archive")
-            {
-                # Main without PackageSuffix
-                if ("$(PackageSuffix)" -eq "")
-                {
-                    $package = "$($builds[0]).$($builds[1]).$($builds[2])"
-                }
-
-                # Main with PackageSuffix
-                else
-                {
-                    $package = "$($builds[0]).$($builds[1]).$($builds[2])-$(PackageSuffix)"
-                }
-
-                $toTest = "true"
-            }
-
-            # Dev: 1.2.4-preview-23296-1
-            elseif ("$branch" -eq "dev")
-            {
-                $package = "$($builds[0]).$($builds[1]).$($builds[2])-preview.$($builds[3]).$($builds[4])"
-                $toTest = "true"
-            }
-
-            # Other branches: 1.2.4-preview-23296-1
-            else
-            {
-                $package = "$($builds[0]).$($builds[1]).$($builds[2])-preview.$($builds[3]).$($builds[4])"
-                $toTest = "true"
-            }
-
-            if ("${{ parameters.Tests }}" -eq "")
-            {
-                $toTest = "false"
-            }
-
-            # Set the output variable for use in other tasks.
-            Write-Host "##vso[task.setvariable variable=AssemblyVersion]${assembly}"
-            Write-Host "##vso[task.setvariable variable=PackageVersion]${package}"
-            Write-Host "##vso[task.setvariable variable=ShouldTest]${toTest}"
-          displayName: Compute AssemblyVersion and PackageVersion
-
-        # Display computed variables
-        - script: |
-            echo 🔸 FileVersion            = $(FileVersion)
-            echo 🔸 PackageSuffix          = $(PackageSuffix)
-            echo 🔸 Build.BuildNumber      = $(Build.BuildNumber)
-            echo 🔸 Build.SourceBranch     = $(Build.SourceBranch)
-            echo -----------------------------------------------
-            echo 🔸 AssemblyVersion        = $(AssemblyVersion)
-            echo 🔸 PackageVersion         = $(PackageVersion)
-            echo -----------------------------------------------
-            echo 🔸 ShouldTest             = $(ShouldTest)
-          displayName: Display computed variables
+        - task: PowerShell@2
+          displayName: 'Compute AssemblyVersion and PackageVersion'
+          inputs:
+            targetType: 'filePath'
+            filePath: $(System.DefaultWorkingDirectory)/eng/pipelines/compute-version-variables.ps1
+            arguments: > # Use this to avoid newline characters in multiline string
+              -branchName "$(Build.SourceBranchName)"
+              -buildNumber "$(Build.BuildNumber)"
+              -packageSuffix "$(PackageSuffix)"
+              -testProjects "${{ parameters.Tests }}"
 
         # Install NuGet tools
         - task: NuGetToolInstaller@1

--- a/eng/pipelines/compute-version-variables.ps1
+++ b/eng/pipelines/compute-version-variables.ps1
@@ -9,7 +9,7 @@
 .PARAMETER buildNumber
     The name of the completed build, also known as the run number.
     This value is formatted like "[Major].[Minor].[Revision].[Year:00].[DayOfYear].[BuildRevision]" (e.g. "4.6.1.24123.3")
-    Please, use $((Build.BuildNumber)
+    Please, use $(Build.BuildNumber)
 
 .PARAMETER packageSuffix
     Suffix to add to the computed version. Example "Preview", "RC.1", ...
@@ -22,6 +22,20 @@
 
 .EXAMPLE
     $> .\compute-version-variables -branchName "dev" -buildNumber "4.6.1.24123.3" -packageSuffix "Preview"
+
+.EXAMPLE
+    # Compute AssemblyVersion and PackageVersion
+    # -> Update version.yml
+    - task: PowerShell@2
+      displayName: 'Compute AssemblyVersion and PackageVersion'
+      inputs:
+          targetType: 'filePath'
+          filePath: $(System.DefaultWorkingDirectory)/eng/pipelines/compute-version-variables.ps1
+          arguments: > # Use this to avoid newline characters in multiline string
+          -branchName "$(Build.SourceBranchName)"
+          -buildNumber "$(Build.BuildNumber)"
+          -packageSuffix "$(PackageSuffix)"
+          -testProjects "${{ parameters.Tests }}"
 
 #>
 

--- a/eng/pipelines/compute-version-variables.ps1
+++ b/eng/pipelines/compute-version-variables.ps1
@@ -1,0 +1,114 @@
+<#
+.DESCRIPTION
+    XXX
+
+.PARAMETER branchName
+    The branch of the trigger repo for which the build has been queued.
+    Please, use $(Build.SourceBranchName)
+
+.PARAMETER buildNumber
+    The name of the completed build, also known as the run number.
+    This value is formatted like "[Major].[Minor].[Revision].[Year:00].[DayOfYear].[BuildRevision]" (e.g. "4.6.1.24123.3")
+    Please, use $((Build.BuildNumber)
+
+.PARAMETER packageSuffix
+    Suffix to add to the computed version. Example "Preview", "RC.1", ...
+    This suffix overrides the one calculated for dev our main branches.
+    Default is "".
+
+.PARAMETER testProjects
+    Projects to tests, to define the variable "ShouldTest".
+    Not empty, ShouldTest will be "true".
+
+.EXAMPLE
+    $> .\compute-version-variables -branchName "dev" -buildNumber "4.6.1.24123.3" -packageSuffix "Preview"
+
+#>
+
+param (
+    [Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()][string]$branchName,
+    [Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()][string]$buildNumber,
+    [string]$packageSuffix,
+    [string]$testProjects
+)
+
+Write-Host "Compute AssemblyVersion and PackageVersion."
+
+# Default values
+$branch = "PR"
+$package = ""
+
+# To Test?
+$toTest = "true"
+
+# BranchName = dev, main, archive or PR
+if ($branchName -eq "main") {
+    $branch = "main"
+}
+elseif ($branchName -eq "dev") {
+    $branch = "dev"
+}
+# elseif ("$(Build.SourceBranch)" -like "refs/heads/archives/*")
+elseif ($branchName -like "*/archives/*") {
+    $branch = "archive"
+}
+else {
+    $branch = "PR"
+}
+
+# [1, 2, 4, 23296, 1]
+$builds = $buildNumber.Split('.')
+
+# 1.2.4
+$fileVersion = "$($builds[0]).$($builds[1]).$($builds[2])"
+
+# 1.2.4.23296
+$assembly = "$($builds[0]).$($builds[1]).$($builds[2]).$($builds[3])"
+
+# Main or Archive without PackageSuffix: 1.2.4
+# Main or Archive with    PackageSuffix: 1.2.4-rc.1
+if ($branch -eq "main" -or $branch -eq "archive") {
+    # Main without PackageSuffix
+    if ($packageSuffix -eq "") {
+        $package = "$($builds[0]).$($builds[1]).$($builds[2])"
+    }
+
+    # Main with PackageSuffix
+    else {
+        $package = "$($builds[0]).$($builds[1]).$($builds[2])-$packageSuffix"
+    }
+
+    $toTest = "true"
+}
+
+# Dev: 1.2.4-preview-23296-1
+elseif ($branch -eq "dev") {
+    $package = "$($builds[0]).$($builds[1]).$($builds[2])-preview.$($builds[3]).$($builds[4])"
+    $toTest = "true"
+}
+
+# Other branches: 1.2.4-preview-23296-1
+else {
+    $package = "$($builds[0]).$($builds[1]).$($builds[2])-preview.$($builds[3]).$($builds[4])"
+    $toTest = "true"
+}
+
+if ($testProjects -eq "") {
+    $toTest = "false"
+}
+
+# Set the output variable for use in other tasks.
+Write-Host "##vso[task.setvariable variable=AssemblyVersion]$assembly"
+Write-Host "##vso[task.setvariable variable=PackageVersion]$package"
+Write-Host "##vso[task.setvariable variable=ShouldTest]$toTest"
+
+# Display computed versions
+Write-Host "----------------------------------------------- "
+Write-Host " -  Branch                 = $branch "
+Write-Host " -  BuildNumber            = $buildNumber "
+Write-Host " -  PackageSuffix          = $packageSuffix "
+Write-Host "----------------------------------------------- "
+Write-Host " -> AssemblyVersion        = $assembly "
+Write-Host " -> PackageVersion         = $package "
+Write-Host " -> ShouldTest             = $toTest "
+Write-Host "----------------------------------------------- "

--- a/eng/pipelines/compute-version-variables.ps1
+++ b/eng/pipelines/compute-version-variables.ps1
@@ -1,6 +1,6 @@
 <#
 .DESCRIPTION
-    XXX
+    Compute AssemblyVersion and PackageVersion
 
 .PARAMETER branchName
     The branch of the trigger repo for which the build has been queued.
@@ -47,6 +47,7 @@ param (
 )
 
 Write-Host "Compute AssemblyVersion and PackageVersion."
+Write-Host ""
 
 # Default values
 $branch = "PR"
@@ -117,6 +118,7 @@ Write-Host "##vso[task.setvariable variable=PackageVersion]$package"
 Write-Host "##vso[task.setvariable variable=ShouldTest]$toTest"
 
 # Display computed versions
+Write-Host ""
 Write-Host "----------------------------------------------- "
 Write-Host " -  Branch                 = $branch "
 Write-Host " -  BuildNumber            = $buildNumber "


### PR DESCRIPTION
# [Pipelines] Add `compute-version-variables.ps1` to update the YAML file

Adding a script `compute-version-variables.ps1` to compute **AssemblyVersion** and **PackageVersion**.

## Examples.

### For a PR

➡️ `.\compute-version-variables -branchName "users\dvoituron\stuff" -buildNumber "4.6.1.24123.3"`

```
Compute AssemblyVersion and PackageVersion.

##vso[task.setvariable variable=AssemblyVersion]4.6.1.24123
##vso[task.setvariable variable=PackageVersion]4.6.1-preview.24123.3
##vso[task.setvariable variable=ShouldTest]false

-----------------------------------------------
 -  Branch                 = PR
 -  BuildNumber            = 4.6.1.24123.3
 -  PackageSuffix          =
-----------------------------------------------
 -> AssemblyVersion        = 4.6.1.24123
 -> PackageVersion         = 4.6.1-preview.24123.3
 -> ShouldTest             = false
-----------------------------------------------
```

### For **dev** branch

➡️`.\compute-version-variables -branchName "dev" -buildNumber "4.6.1.24123.3"`

```
Compute AssemblyVersion and PackageVersion.

##vso[task.setvariable variable=AssemblyVersion]4.6.1.24123
##vso[task.setvariable variable=PackageVersion]4.6.1-preview.24123.3
##vso[task.setvariable variable=ShouldTest]false

-----------------------------------------------
 -  Branch                 = dev
 -  BuildNumber            = 4.6.1.24123.3
 -  PackageSuffix          =
-----------------------------------------------
 -> AssemblyVersion        = 4.6.1.24123
 -> PackageVersion         = 4.6.1-preview.24123.3
 -> ShouldTest             = false
-----------------------------------------------
```

### For **main** branch

➡️`.\compute-version-variables -branchName "main" -buildNumber "4.6.1.24123.3"`

```
Compute AssemblyVersion and PackageVersion.

##vso[task.setvariable variable=AssemblyVersion]4.6.1.24123
##vso[task.setvariable variable=PackageVersion]4.6.1
##vso[task.setvariable variable=ShouldTest]false

-----------------------------------------------
 -  Branch                 = main
 -  BuildNumber            = 4.6.1.24123.3
 -  PackageSuffix          =
-----------------------------------------------
 -> AssemblyVersion        = 4.6.1.24123
 -> PackageVersion         = 4.6.1
 -> ShouldTest             = false
-----------------------------------------------
```

### With Tests

➡️`.\compute-version-variables -branchName "dev" -buildNumber "4.6.1.24123.3" -testProjects "..."`

```
Compute AssemblyVersion and PackageVersion.

##vso[task.setvariable variable=AssemblyVersion]4.6.1.24123
##vso[task.setvariable variable=PackageVersion]4.6.1-preview.24123.3
##vso[task.setvariable variable=ShouldTest]true

-----------------------------------------------
 -  Branch                 = dev
 -  BuildNumber            = 4.6.1.24123.3
 -  PackageSuffix          =
-----------------------------------------------
 -> AssemblyVersion        = 4.6.1.24123
 -> PackageVersion         = 4.6.1-preview.24123.3
 -> ShouldTest             = true
-----------------------------------------------
```

# Summary

![image](https://github.com/microsoft/fluentui-blazor/assets/8350694/bf20b2c6-079b-4690-b720-add950cdf1f3)
