### PR TITLE
[Docs] Update Highlighter example to use FluentTextField instead of input

### DIFF
--- a/examples/Demo/Shared/Pages/Highlighter/Examples/HighlighterDefault.razor
+++ b/examples/Demo/Shared/Pages/Highlighter/Examples/HighlighterDefault.razor
@@ -1,6 +1,6 @@
 @namespace FluentUI.Demo.Shared
 
-<input type="text" @bind-Value="@Highlight" @bind-Value:event="oninput" />
+<FluentTextField @bind-Value="@Highlight" Immediate="true" />
 <br />
 <br />
 


### PR DESCRIPTION
Replaced input with FluentTextField in Highlighter example.

# Pull Request

## 📖 Description

The input had a white background and I was in dark mode so the non-fluent component stood out. Just replaced with equivalent fluent component.

**Before:**
![image](https://github.com/microsoft/fluentui-blazor/assets/22691956/d7f63959-677f-4465-a895-3011b8e30cae)

**After:**
![image](https://github.com/microsoft/fluentui-blazor/assets/22691956/6adc8444-8259-48e9-bace-38bf73989bd3)

### 🎫 Issues

## 👩‍💻 Reviewer Notes

Visually tested and tested by hand.

## 📑 Test Plan

## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [X] I have tested my changes.
- [X] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

## ⏭ Next Steps
