### PR TITLE
[Docs] Update KeyCodeGlobalExample.razor.css to fix dark mode visuals

### DIFF
--- a/examples/Demo/Shared/Pages/KeyCode/Examples/KeyCodeGlobalExample.razor.css
+++ b/examples/Demo/Shared/Pages/KeyCode/Examples/KeyCodeGlobalExample.razor.css
@@ -11,6 +11,7 @@
     text-align: center;
     font-weight: bold;
     font-size: 14px;
+    color: black;
     cursor: pointer;
 }
 


### PR DESCRIPTION
The key text was hard to read in dark mode, changed CSS so text looks good in both modes.

# Pull Request

## 📖 Description

Just made text color black so the key text was more readable in both modes.

**Before:**
![image](https://github.com/microsoft/fluentui-blazor/assets/149195750/6840ccc3-37d5-4f9a-98b3-a7b158ad7629)
(Hard to read)
![image](https://github.com/microsoft/fluentui-blazor/assets/149195750/0c739f23-3a3c-425f-baa7-09075557cc8f)

**After:**
![image](https://github.com/microsoft/fluentui-blazor/assets/149195750/1717c87c-a9df-4b71-9f44-a7ec97d52115)
![image](https://github.com/microsoft/fluentui-blazor/assets/149195750/1d3b2cf9-fcd4-40be-b721-75b0b2dc10ea)

### 🎫 Issues

## 👩‍💻 Reviewer Notes

Visually tested. open to other solutions.

## 📑 Test Plan

## ✅ Checklist

### General
- [ ] I have added tests for my changes.
- [X] I have tested my changes.
- [X] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

## ⏭ Next Steps
