### PR TITLE
[Docs] Update Progress stroke examples dropdowns

### DIFF
--- a/examples/Demo/Shared/Pages/Progress/Examples/ProgressStrokeExample.razor
+++ b/examples/Demo/Shared/Pages/Progress/Examples/ProgressStrokeExample.razor
@@ -1,8 +1,8 @@
 ﻿<h4>Stroke and Color</h4>
 
-<FluentSelect Label="Width" Items="@(new [] { Microsoft.FluentUI.AspNetCore.Components.ProgressStroke.Small, Microsoft.FluentUI.AspNetCore.Components.ProgressStroke.Normal, Microsoft.FluentUI.AspNetCore.Components.ProgressStroke.Large })" @bind-SelectedOption="@Stroke" Width="60px" />
+<FluentSelect Label="Width" Items="@(new [] { Microsoft.FluentUI.AspNetCore.Components.ProgressStroke.Small, Microsoft.FluentUI.AspNetCore.Components.ProgressStroke.Normal, Microsoft.FluentUI.AspNetCore.Components.ProgressStroke.Large })" @bind-SelectedOption="@Stroke" Width="100px" />
 <FluentCheckbox Label="Indeterminate" @bind-Value="@Indeterminate" />
-<FluentSelect Label="Color" Items="@(Enum.GetValues<OfficeColor>())" @bind-SelectedOption="@Color" Width="100px" Height="200px" />
+<FluentSelect Label="Color" Items="@(Enum.GetValues<OfficeColor>())" @bind-SelectedOption="@Color" Width="120px" Height="200px" />
 <FluentSlider Min="0" Max="100" Step="5" @bind-Value="@Percentage" Style="max-width: 200px; margin: 20px 0px;" Disabled="@Indeterminate" />
 
 <FluentStack Style="margin: 30px;">

--- a/examples/Demo/Shared/Pages/ProgressRing/Examples/ProgressRingStroke.razor
+++ b/examples/Demo/Shared/Pages/ProgressRing/Examples/ProgressRingStroke.razor
@@ -1,8 +1,8 @@
 ﻿<h4>Stroke and Color</h4>
 
-<FluentSelect Label="Width" Items="@(new [] { ProgressStroke.Small, ProgressStroke.Normal, ProgressStroke.Large })" @bind-SelectedOption="@Stroke" Width="160px" />
+<FluentSelect Label="Width" Items="@(new [] { ProgressStroke.Small, ProgressStroke.Normal, ProgressStroke.Large })" @bind-SelectedOption="@Stroke" Width="100px" />
 <FluentCheckbox Label="Indeterminate" @bind-Value="@Indeterminate" />
-<FluentSelect Label="Color" Items="@(Enum.GetValues<OfficeColor>())" @bind-SelectedOption="@Color" Width="160px" Height="200px" />
+<FluentSelect Label="Color" Items="@(Enum.GetValues<OfficeColor>())" @bind-SelectedOption="@Color" Width="120px" Height="200px" />
 <FluentSlider Min="0" Max="100" Step="5" @bind-Value="@Percentage" Style="max-width: 200px; margin: 20px 0px;" Disabled="@Indeterminate" />
 
 <FluentStack Style="margin: 30px;">


### PR DESCRIPTION
Adjusted dropdown widths as values were getting cutoff.

# Pull Request

## 📖 Description

Increased dropdown widths so values would not get cut off, and aligned dropdown width for Progress and Progress ring stroke examples (made them the same).

**Before:**
![image](https://github.com/microsoft/fluentui-blazor/assets/22691956/cb50a68c-c75b-4c3d-94c4-4a99a205d574)
![image](https://github.com/microsoft/fluentui-blazor/assets/22691956/61ed2554-c6e7-4467-ae49-f629ba95eb42)

**After:**
![image](https://github.com/microsoft/fluentui-blazor/assets/22691956/451ce51d-efa9-494c-ab48-472145222d51)
![image](https://github.com/microsoft/fluentui-blazor/assets/22691956/f33b6fea-5a2f-441c-abb6-d5140dc0311d)

### 🎫 Issues

## 👩‍💻 Reviewer Notes

Visually tested.

## 📑 Test Plan

## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [X] I have tested my changes.
- [X] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

## ⏭ Next Steps
