### PR TITLE
[Demo & docs] Clears demo site cache on startup if new version

### DIFF
--- a/examples/Demo/Shared/Infrastructure/AppVersionService.cs
+++ b/examples/Demo/Shared/Infrastructure/AppVersionService.cs
@@ -1,0 +1,35 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using System.Reflection;
+
+namespace FluentUI.Demo.Shared.Infrastructure;
+internal class AppVersionService : IAppVersionService
+{
+    public string Version
+    {
+        get => GetVersionFromAssembly();
+    }
+
+    static public string GetVersionFromAssembly()
+    {
+        string strVersion = default!;
+        var versionAttribute = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+        if (versionAttribute != null)
+        {
+            var version = versionAttribute.InformationalVersion;
+            var plusIndex = version.IndexOf('+');
+            if (plusIndex >= 0 && plusIndex + 9 < version.Length)
+            {
+                strVersion = version[..(plusIndex + 9)];
+            }
+            else
+            {
+                strVersion = version;
+            }
+        }
+
+        return strVersion;
+    }
+}

--- a/examples/Demo/Shared/Infrastructure/CacheStorageAccessor.cs
+++ b/examples/Demo/Shared/Infrastructure/CacheStorageAccessor.cs
@@ -4,6 +4,8 @@ using Microsoft.JSInterop;
 namespace FluentUI.Demo.Shared;
 public class CacheStorageAccessor(IJSRuntime js) : JSModule(js, "./_content/FluentUI.Demo.Shared/js/CacheStorageAccessor.js")
 {
+    private bool Initialized = false;
+
     public async ValueTask PutAsync(HttpRequestMessage requestMessage, HttpResponseMessage responseMessage)
     {
         var requestMethod = requestMessage.Method.Method;
@@ -26,6 +28,12 @@ public class CacheStorageAccessor(IJSRuntime js) : JSModule(js, "./_content/Flue
 
     public async ValueTask<string> GetAsync(HttpRequestMessage requestMessage)
     {
+        if (!Initialized)
+        {
+            await RemoveAllAsync();
+            Initialized = true;
+        }
+
         var requestMethod = requestMessage.Method.Method;
         var requestBody = await GetRequestBodyAsync(requestMessage);
         var result = await InvokeAsync<string>("get", requestMessage.RequestUri!, requestMethod, requestBody);

--- a/examples/Demo/Shared/Infrastructure/HttpBasedStaticAssetService.cs
+++ b/examples/Demo/Shared/Infrastructure/HttpBasedStaticAssetService.cs
@@ -12,7 +12,6 @@ public class HttpBasedStaticAssetService : IStaticAssetService
         _httpClient = httpClient;
         _httpClient.BaseAddress ??= new Uri(navigationManager.BaseUri);
         _cacheStorageAccessor = cacheStorageAccessor;
-
     }
 
     public async Task<string?> GetAsync(string assetUrl, bool useCache = true)

--- a/examples/Demo/Shared/Infrastructure/IAppVersionService.cs
+++ b/examples/Demo/Shared/Infrastructure/IAppVersionService.cs
@@ -1,0 +1,10 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+namespace FluentUI.Demo.Shared.Infrastructure;
+
+public interface IAppVersionService
+{
+    string Version { get; }
+}

--- a/examples/Demo/Shared/Infrastructure/ServiceCollectionExtensions.cs
+++ b/examples/Demo/Shared/Infrastructure/ServiceCollectionExtensions.cs
@@ -12,7 +12,7 @@ public static class ServiceCollectionExtensions
     /// <param name="configuration">Library configuration</param>
     public static IServiceCollection AddFluentUIDemoClientServices(this IServiceCollection services)
     {
-        services.AddScoped<CacheStorageAccessor>();
+        services.AddSingleton<CacheStorageAccessor>();
         services.AddHttpClient<IStaticAssetService, HttpBasedStaticAssetService>();
         services.AddSingleton<DemoNavProvider>();
 

--- a/examples/Demo/Shared/Infrastructure/ServiceCollectionExtensions.cs
+++ b/examples/Demo/Shared/Infrastructure/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ public static class ServiceCollectionExtensions
     /// <param name="configuration">Library configuration</param>
     public static IServiceCollection AddFluentUIDemoClientServices(this IServiceCollection services)
     {
+        services.AddSingleton<IAppVersionService, AppVersionService>();
         services.AddSingleton<CacheStorageAccessor>();
         services.AddHttpClient<IStaticAssetService, HttpBasedStaticAssetService>();
         services.AddSingleton<DemoNavProvider>();
@@ -26,6 +27,7 @@ public static class ServiceCollectionExtensions
     /// <param name="configuration">Library configuration</param>
     public static IServiceCollection AddFluentUIDemoServerServices(this IServiceCollection services)
     {
+        services.AddScoped<IAppVersionService, AppVersionService>();
         services.AddScoped<CacheStorageAccessor>();
         services.AddHttpClient<IStaticAssetService, ServerStaticAssetService>();
         services.AddSingleton<DemoNavProvider>();

--- a/examples/Demo/Shared/Shared/DemoMainLayout.razor.cs
+++ b/examples/Demo/Shared/Shared/DemoMainLayout.razor.cs
@@ -1,5 +1,5 @@
-using System.Reflection;
 using FluentUI.Demo.Shared.Components;
+using FluentUI.Demo.Shared.Infrastructure;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.JSInterop;
@@ -26,20 +26,7 @@ public partial class DemoMainLayout
 
     protected override void OnInitialized()
     {
-        var versionAttribute = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>();
-        if (versionAttribute != null)
-        {
-            var version = versionAttribute.InformationalVersion;
-            var plusIndex = version.IndexOf('+');
-            if (plusIndex >= 0 && plusIndex + 9 < version.Length)
-            {
-                _version = version[..(plusIndex + 9)];
-            }
-            else
-            {
-                _version = version;
-            }
-        }
+        _version = AppVersionService.GetVersionFromAssembly();
 
         _prevUri = NavigationManager.Uri;
         NavigationManager.LocationChanged += LocationChanged;


### PR DESCRIPTION
# Pull Request

## 📖 Description

Clears the browser cache when the demo site is started. 

### 🎫 Issues

Old versions of the markdown are retained between sessions. So when a new version of the site is released, new markdown content will not be downloaded if an older version is cached.

For example, the WhatsNew page continues to render previous version.

## 👩‍💻 Reviewer Notes

I've made the CacheStorageAccessor a singleton and provided a flag to check if the cache has been previously cleared.

I would have preferred being to _tag_ the cache but was not sure if the extra effort was necessary. That way, the cache would only be cleared if there is a new version or build.  Thoughts?

## 📑 Test Plan

## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps
