### PR TITLE
[Input] NotifyFieldChanged is called twice for all FluentInputBase derived components

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -6288,7 +6288,7 @@
             <summary>
             Optionally supplies a template for rendering the pagination summary.
             The following values can be included:
-            {your State parameter name}.CurrentPageIndex (zero-basedd, so +1 for the current page number)
+            {your State parameter name}.CurrentPageIndex (zero-based, so +1 for the current page number)
             {your State parameter name}.LastPageIndex (zero-based, so +1 for the total number of pages)
             </summary>
         </member>

--- a/src/Core/Components/Base/FluentInputBaseHandlers.cs
+++ b/src/Core/Components/Base/FluentInputBaseHandlers.cs
@@ -27,11 +27,13 @@ public partial class FluentInputBase<TValue>
     /// <returns></returns>
     protected virtual async Task ChangeHandlerAsync(ChangeEventArgs e)
     {
+        var _notifyCalled = false;
         var isValid = TryParseValueFromString(e.Value?.ToString(), out TValue? result, out var validationErrorMessage);
 
         if (isValid)
         {
             await SetCurrentValueAsync(result ?? default);
+            _notifyCalled = true;
         }
         else
         {
@@ -43,7 +45,7 @@ public partial class FluentInputBase<TValue>
                 _parsingValidationMessages.Add(FieldIdentifier, validationErrorMessage ?? "Unknown parsing error");
             }
         }
-        if (FieldBound)
+        if (FieldBound && !_notifyCalled)
         {
             CascadedEditContext?.NotifyFieldChanged(FieldIdentifier);
         }


### PR DESCRIPTION
Fix #1830 by adding a check to see if NotifyFieldChanged has already been called.

```
protected virtual async Task ChangeHandlerAsync(ChangeEventArgs e)
{
    var _notifyCalled = false; //<--👈added
    var isValid = TryParseValueFromString(e.Value?.ToString(), out TValue? result, out var validationErrorMessage);

    if (isValid)
    {
        await SetCurrentValueAsync(result ?? default);
        _notifyCalled = true; //<--👈added
    }
    else
    {
        if (FieldBound && CascadedEditContext != null)
        {
            _parsingValidationMessages ??= new ValidationMessageStore(CascadedEditContext);

            _parsingValidationMessages.Clear();
            _parsingValidationMessages.Add(FieldIdentifier, validationErrorMessage ?? "Unknown parsing error");
        }
    }
    if (FieldBound && !_notifyCalled)  //<--👈changed
    {
        CascadedEditContext?.NotifyFieldChanged(FieldIdentifier);
    }
}
```