### PR TITLE
[MenuButton] Add ChildContent so items can be supplied manually

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -5062,6 +5062,12 @@
             Gets or sets the items to show in the menu.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentMenuButton.ChildContent">
+            <summary>
+            Gets or sets the content to be shown in the menu.
+            Should consist of <see cref="T:Microsoft.FluentUI.AspNetCore.Components.FluentMenuItem"/> components.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentMenuButton.OnMenuChanged">
             <summary>
             The callback to invoke when a menu item is chosen.
@@ -6288,7 +6294,7 @@
             <summary>
             Optionally supplies a template for rendering the pagination summary.
             The following values can be included:
-            {your State parameter name}.CurrentPageIndex (zero-basedd, so +1 for the current page number)
+            {your State parameter name}.CurrentPageIndex (zero-based, so +1 for the current page number)
             {your State parameter name}.LastPageIndex (zero-based, so +1 for the total number of pages)
             </summary>
         </member>

--- a/examples/Demo/Shared/Pages/MenuButton/Examples/MenuButtonAccentColor.razor
+++ b/examples/Demo/Shared/Pages/MenuButton/Examples/MenuButtonAccentColor.razor
@@ -1,5 +1,4 @@
-﻿@namespace FluentUI.Demo.Shared
-@inject AccentBaseColor AccentBaseColor
+﻿@inject AccentBaseColor AccentBaseColor
 
 <FluentMenuButton @ref=menubutton Text="Select brand color" Items="@items" OnMenuChanged="HandleOnMenuChanged"></FluentMenuButton>
 

--- a/examples/Demo/Shared/Pages/MenuButton/Examples/MenuButtonAppearance.razor
+++ b/examples/Demo/Shared/Pages/MenuButton/Examples/MenuButtonAppearance.razor
@@ -1,6 +1,4 @@
-﻿@namespace FluentUI.Demo.Shared
-
-<FluentStack Orientation="Orientation.Vertical">
+﻿<FluentStack Orientation="Orientation.Vertical">
     <span>
         Neutral: <FluentMenuButton @ref=menubutton ButtonAppearance="@Appearance.Neutral" Text="Select an item" Items="@items"></FluentMenuButton>
     </span>

--- a/examples/Demo/Shared/Pages/MenuButton/Examples/MenuButtonManual.razor
+++ b/examples/Demo/Shared/Pages/MenuButton/Examples/MenuButtonManual.razor
@@ -1,0 +1,24 @@
+﻿@inject AccentBaseColor AccentBaseColor
+
+<FluentMenuButton @ref=menubuttonm Text="Select brand color" OnMenuChanged="HandleOnMenuChanged">
+    <FluentMenuItem Id="0078D4">Windows</FluentMenuItem>
+    <FluentMenuItem Id="D83B01" Disabled="true">Office</FluentMenuItem>
+    <FluentMenuItem Id="464EB8">Teams</FluentMenuItem>
+    <FluentMenuItem Id="107C10" Disabled="true">Xbox</FluentMenuItem>
+    <FluentMenuItem Id="8661C5">Visual Studio</FluentMenuItem>
+    <FluentMenuItem Id="F2C811" Disabled="true">Power BI</FluentMenuItem>
+    <FluentMenuItem Id="0066FF">Power Automate</FluentMenuItem>
+    <FluentMenuItem Id="742774" Disabled="true">Power Apps</FluentMenuItem>
+    <FluentMenuItem Id="0B556A">Power Virtual Agents</FluentMenuItem>
+
+</FluentMenuButton>
+
+@code {
+    private FluentMenuButton menubuttonm = new();
+
+    private async Task HandleOnMenuChanged(MenuChangeEventArgs args)
+    {
+        await AccentBaseColor.SetValueFor(menubuttonm.Button!.Element, $"#{args.Id}".ToSwatch());
+    }
+
+}

--- a/examples/Demo/Shared/Pages/MenuButton/MenuButtonPage.razor
+++ b/examples/Demo/Shared/Pages/MenuButton/MenuButtonPage.razor
@@ -1,5 +1,7 @@
 ﻿@page "/MenuButton"
 
+@using FluentUI.Demo.Shared.Pages.MenuButton.Examples
+
 <h1>MenuButton</h1>
 
 <p>A menu button is a button with a chevron icon after the text used to trigger a menu.</p>
@@ -7,6 +9,8 @@
 <h2 id="example">Example</h2>
 
 <DemoSection Component="typeof(MenuButtonAccentColor)" Title="MenuButton to select accent color"  />
+
+<DemoSection Component="typeof(MenuButtonManual)" Title="MenuButton with manually supplied items" />
 
 <DemoSection Component="typeof(MenuButtonAppearance)" Title="Different button appearances" />
 

--- a/examples/Demo/Shared/Pages/MenuButton/MenuButtonPage.razor
+++ b/examples/Demo/Shared/Pages/MenuButton/MenuButtonPage.razor
@@ -4,13 +4,20 @@
 
 <h1>MenuButton</h1>
 
-<p>A menu button is a button with a chevron icon after the text used to trigger a menu.</p>
+<p>A menu button is a button with a chevron icon after the text used to trigger a menu. Menu items can be supplied by both
+   an <code>Items</code> parameter as well as manually as the <code>ChildContent</code> (at the same time).
+</p>
 
 <h2 id="example">Example</h2>
 
 <DemoSection Component="typeof(MenuButtonAccentColor)" Title="MenuButton to select accent color"  />
 
-<DemoSection Component="typeof(MenuButtonManual)" Title="MenuButton with manually supplied items" />
+<DemoSection Component="typeof(MenuButtonManual)" Title="MenuButton with manually supplied items">
+    <Description>
+        Besides using the <code>Items</code> parameter, you can also directly enter <code>FluentMenuItem</code>s manually. This way you can
+        use all that component's parameters and, for example, disable certain items.
+    </Description>
+</DemoSection>
 
 <DemoSection Component="typeof(MenuButtonAppearance)" Title="Different button appearances" />
 

--- a/src/Core/Components/MenuButton/FluentMenuButton.razor
+++ b/src/Core/Components/MenuButton/FluentMenuButton.razor
@@ -9,16 +9,10 @@
     </FluentButton>
     <FluentOverlay @bind-Visible="@_visible" Transparent="true" FullScreen="true" />
     <FluentMenu @ref="Menu" Anchor="@_buttonId" aria-labelledby="button" Style="@MenuStyleValue" @bind-Open=@_visible @onmenuchange=OnMenuChangeAsync>
-        @if (Items is not null)
+        @foreach (KeyValuePair<string, string> item in Items)
         {
-            @foreach (KeyValuePair<string, string> item in Items)
-            {
-                <FluentMenuItem Id="@item.Key">@item.Value</FluentMenuItem>
-            }
+            <FluentMenuItem Id="@item.Key">@item.Value</FluentMenuItem>
         }
-        else
-        {
-            @ChildContent
-        }
+        @ChildContent
     </FluentMenu>
 </div>

--- a/src/Core/Components/MenuButton/FluentMenuButton.razor
+++ b/src/Core/Components/MenuButton/FluentMenuButton.razor
@@ -9,9 +9,16 @@
     </FluentButton>
     <FluentOverlay @bind-Visible="@_visible" Transparent="true" FullScreen="true" />
     <FluentMenu @ref="Menu" Anchor="@_buttonId" aria-labelledby="button" Style="@MenuStyleValue" @bind-Open=@_visible @onmenuchange=OnMenuChangeAsync>
-        @foreach (KeyValuePair<string, string> item in Items)
+        @if (Items is not null)
         {
-            <FluentMenuItem Id="@item.Key">@item.Value</FluentMenuItem>
+            @foreach (KeyValuePair<string, string> item in Items)
+            {
+                <FluentMenuItem Id="@item.Key">@item.Value</FluentMenuItem>
+            }
+        }
+        else
+        {
+            @ChildContent
         }
     </FluentMenu>
 </div>

--- a/src/Core/Components/MenuButton/FluentMenuButton.razor.cs
+++ b/src/Core/Components/MenuButton/FluentMenuButton.razor.cs
@@ -54,7 +54,14 @@ public partial class FluentMenuButton : FluentComponentBase
     /// Gets or sets the items to show in the menu.
     /// </summary>
     [Parameter]
-    public Dictionary<string, string> Items { get; set; } = [];
+    public Dictionary<string, string>? Items { get; set; }
+
+    /// <summary>
+    /// Gets or sets the content to be shown in the menu.
+    /// Should consist of <see cref="FluentMenuItem"/> components.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
     /// The callback to invoke when a menu item is chosen.

--- a/src/Core/Components/MenuButton/FluentMenuButton.razor.cs
+++ b/src/Core/Components/MenuButton/FluentMenuButton.razor.cs
@@ -54,7 +54,7 @@ public partial class FluentMenuButton : FluentComponentBase
     /// Gets or sets the items to show in the menu.
     /// </summary>
     [Parameter]
-    public Dictionary<string, string>? Items { get; set; }
+    public Dictionary<string, string> Items { get; set; } = [];
 
     /// <summary>
     /// Gets or sets the content to be shown in the menu.


### PR DESCRIPTION
Based on issue #1847 I've added a `ChildContent` parameter to MenuButton. This allows for manually supplying the `FluentMenuItem` children and thereby use all it's parameters (like Disabled)

An example has been added 

![image](https://github.com/microsoft/fluentui-blazor/assets/1761079/fac8df74-2c55-4546-98db-2c796fa05d1b)

