### PR TITLE
Extend GridSort possibilities

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -1241,6 +1241,16 @@
             <param name="expression">An expression defining how a set of <typeparamref name="TGridItem"/> instances are to be sorted.</param>
             <returns>A <see cref="T:Microsoft.FluentUI.AspNetCore.Components.GridSort`1"/> instance representing the specified sorting rule.</returns>
         </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.GridSort`1.ByDescending``1(System.Linq.Expressions.Expression{System.Func{`0,``0}},System.Collections.Generic.IComparer{``0})">
+            <summary>
+            Produces a <see cref="T:Microsoft.FluentUI.AspNetCore.Components.GridSort`1"/> instance that sorts according to the specified <paramref name="expression"/> 
+            using the specified <paramref name="comparer"/>, descending.
+            </summary>
+            <typeparam name="U">The type of the expression's value.</typeparam>
+            <param name="expression">An expression defining how a set of <typeparamref name="TGridItem"/> instances are to be sorted.</param>
+            <param name="comparer">Defines how a items in a set of <typeparamref name="TGridItem"/> instances are to be compared.</param>
+            <returns>A <see cref="T:Microsoft.FluentUI.AspNetCore.Components.GridSort`1"/> instance representing the specified sorting rule.</returns>
+        </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.GridSort`1.ThenAscending``1(System.Linq.Expressions.Expression{System.Func{`0,``0}})">
             <summary>
             Updates a <see cref="T:Microsoft.FluentUI.AspNetCore.Components.GridSort`1"/> instance by appending a further sorting rule.
@@ -1249,12 +1259,64 @@
             <param name="expression">An expression defining how a set of <typeparamref name="TGridItem"/> instances are to be sorted.</param>
             <returns>A <see cref="T:Microsoft.FluentUI.AspNetCore.Components.GridSort`1"/> instance representing the specified sorting rule.</returns>
         </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.GridSort`1.ThenAscending``1(System.Linq.Expressions.Expression{System.Func{`0,``0}},System.Collections.Generic.IComparer{``0})">
+            <summary>
+            Updates a <see cref="T:Microsoft.FluentUI.AspNetCore.Components.GridSort`1"/> instance by appending a further sorting rule.
+            </summary>
+            <typeparam name="U">The type of the expression's value.</typeparam>
+            <param name="expression">An expression defining how a set of <typeparamref name="TGridItem"/> instances are to be sorted.</param>
+            <param name="comparer">Defines how a items in a set of <typeparamref name="TGridItem"/> instances are to be compared.</param>
+            <returns>A <see cref="T:Microsoft.FluentUI.AspNetCore.Components.GridSort`1"/> instance representing the specified sorting rule.</returns>
+        </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.GridSort`1.ThenDescending``1(System.Linq.Expressions.Expression{System.Func{`0,``0}})">
             <summary>
             Updates a <see cref="T:Microsoft.FluentUI.AspNetCore.Components.GridSort`1"/> instance by appending a further sorting rule.
             </summary>
             <typeparam name="U">The type of the expression's value.</typeparam>
             <param name="expression">An expression defining how a set of <typeparamref name="TGridItem"/> instances are to be sorted.</param>
+            <returns>A <see cref="T:Microsoft.FluentUI.AspNetCore.Components.GridSort`1"/> instance representing the specified sorting rule.</returns>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.GridSort`1.ThenDescending``1(System.Linq.Expressions.Expression{System.Func{`0,``0}},System.Collections.Generic.IComparer{``0})">
+            <summary>
+            Updates a <see cref="T:Microsoft.FluentUI.AspNetCore.Components.GridSort`1"/> instance by appending a further sorting rule.
+            </summary>
+            <typeparam name="U">The type of the expression's value.</typeparam>
+            <param name="expression">An expression defining how a set of <typeparamref name="TGridItem"/> instances are to be sorted.</param>
+            <param name="comparer">Defines how a items in a set of <typeparamref name="TGridItem"/> instances are to be compared.</param>
+            <returns>A <see cref="T:Microsoft.FluentUI.AspNetCore.Components.GridSort`1"/> instance representing the specified sorting rule.</returns>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.GridSort`1.ThenAlwaysAscending``1(System.Linq.Expressions.Expression{System.Func{`0,``0}})">
+            <summary>
+            Updates a <see cref="T:Microsoft.FluentUI.AspNetCore.Components.GridSort`1"/> instance by appending a further sorting rule.
+            </summary>
+            <typeparam name="U">The type of the expression's value.</typeparam>
+            <param name="expression">An expression defining how a set of <typeparamref name="TGridItem"/> instances are to be sorted.</param>
+            <returns>A <see cref="T:Microsoft.FluentUI.AspNetCore.Components.GridSort`1"/> instance representing the specified sorting rule.</returns>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.GridSort`1.ThenAlwaysAscending``1(System.Linq.Expressions.Expression{System.Func{`0,``0}},System.Collections.Generic.IComparer{``0})">
+            <summary>
+            Updates a <see cref="T:Microsoft.FluentUI.AspNetCore.Components.GridSort`1"/> instance by appending a further sorting rule.
+            </summary>
+            <typeparam name="U">The type of the expression's value.</typeparam>
+            <param name="expression">An expression defining how a set of <typeparamref name="TGridItem"/> instances are to be sorted.</param>
+            <param name="comparer">Defines how a items in a set of <typeparamref name="TGridItem"/> instances are to be compared.</param>
+            <returns>A <see cref="T:Microsoft.FluentUI.AspNetCore.Components.GridSort`1"/> instance representing the specified sorting rule.</returns>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.GridSort`1.ThenAlwaysDescending``1(System.Linq.Expressions.Expression{System.Func{`0,``0}})">
+            <summary>
+            Updates a <see cref="T:Microsoft.FluentUI.AspNetCore.Components.GridSort`1"/> instance by appending a further sorting rule.
+            </summary>
+            <typeparam name="U">The type of the expression's value.</typeparam>
+            <param name="expression">An expression defining how a set of <typeparamref name="TGridItem"/> instances are to be sorted.</param>
+            <returns>A <see cref="T:Microsoft.FluentUI.AspNetCore.Components.GridSort`1"/> instance representing the specified sorting rule.</returns>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.GridSort`1.ThenAlwaysDescending``1(System.Linq.Expressions.Expression{System.Func{`0,``0}},System.Collections.Generic.IComparer{``0})">
+            <summary>
+            Updates a <see cref="T:Microsoft.FluentUI.AspNetCore.Components.GridSort`1"/> instance by appending a further sorting rule.
+            </summary>
+            <typeparam name="U">The type of the expression's value.</typeparam>
+            <param name="expression">An expression defining how a set of <typeparamref name="TGridItem"/> instances are to be sorted.</param>
+            <param name="comparer">Defines how a items in a set of <typeparamref name="TGridItem"/> instances are to be compared.</param>
             <returns>A <see cref="T:Microsoft.FluentUI.AspNetCore.Components.GridSort`1"/> instance representing the specified sorting rule.</returns>
         </member>
         <member name="T:Microsoft.FluentUI.AspNetCore.Components.PropertyColumn`2">

--- a/examples/Demo/Shared/Pages/DataGrid/DataGridPage.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/DataGridPage.razor
@@ -65,6 +65,14 @@
     </Description>
 </DemoSection>
 
+<DemoSection Title="SortBy Rank" Component="@typeof(DataGridRankSort)">
+    <Description>
+        <p>
+            Here is an example that demonstrates the rank sort.
+        </p>
+    </Description>
+</DemoSection>
+
 
 <DemoSection Title="Remote data" Component="@typeof(DataGridRemoteData)">
     <Description>

--- a/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridRankSort.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridRankSort.razor
@@ -1,0 +1,43 @@
+﻿<FluentDataGrid Items="@_gridData" ResizableColumns=true GridTemplateColumns="0.5fr 0.5fr">
+    <PropertyColumn Sortable="true" Property="x => x.Number" Title="Number" />
+
+    <TemplateColumn Sortable="true" SortBy="groupRank" Title="Group">
+        @context.Group
+    </TemplateColumn>
+
+</FluentDataGrid>
+
+<p>Keep numbers always sorted ascending inside the group when sorting by group</p>
+<FluentDataGrid Items="@_gridData" ResizableColumns=true GridTemplateColumns="0.5fr 0.5fr">
+    <PropertyColumn Sortable="true" Property="x => x.Number" Title="Number" />
+
+    <TemplateColumn Sortable="true" SortBy="groupRankNumberAlwaysAscending" Title="Group">
+        @context.Group
+    </TemplateColumn>
+
+</FluentDataGrid>
+
+
+
+@code {
+    GridSort<GridRow> groupRank = GridSort<GridRow>
+            .ByAscending(x => x.Group)
+            .ThenAscending(x => x.Number);
+
+    GridSort<GridRow> groupRankNumberAlwaysAscending = GridSort<GridRow>
+        .ByAscending(x => x.Group)
+        .ThenAlwaysAscending(x => x.Number);
+
+    private static readonly IQueryable<GridRow> _gridData = new GridRow[] {
+        new(2, "B"),
+        new(1, "A"),
+        new(4, "B"),
+        new(3, "A")
+    }.AsQueryable();
+
+    public class GridRow(int number, string group)
+    {
+        public int Number { get; } = number;
+        public string Group { get; } = group;
+    }
+}

--- a/src/Core/Components/DataGrid/Columns/GridSort.cs
+++ b/src/Core/Components/DataGrid/Columns/GridSort.cs
@@ -60,6 +60,18 @@ public sealed class GridSort<TGridItem>
             (expression, false));
 
     /// <summary>
+    /// Produces a <see cref="GridSort{T}"/> instance that sorts according to the specified <paramref name="expression"/> 
+    /// using the specified <paramref name="comparer"/>, descending.
+    /// </summary>
+    /// <typeparam name="U">The type of the expression's value.</typeparam>
+    /// <param name="expression">An expression defining how a set of <typeparamref name="TGridItem"/> instances are to be sorted.</param>
+    /// <param name="comparer">Defines how a items in a set of <typeparamref name="TGridItem"/> instances are to be compared.</param>
+    /// <returns>A <see cref="GridSort{T}"/> instance representing the specified sorting rule.</returns>
+    public static GridSort<TGridItem> ByDescending<U>(Expression<Func<TGridItem, U>> expression, IComparer<U> comparer)
+        => new((queryable, asc) => asc ? queryable.OrderByDescending(expression, comparer) : queryable.OrderBy(expression, comparer),
+            (expression, false));
+
+    /// <summary>
     /// Updates a <see cref="GridSort{T}"/> instance by appending a further sorting rule.
     /// </summary>
     /// <typeparam name="U">The type of the expression's value.</typeparam>
@@ -67,13 +79,25 @@ public sealed class GridSort<TGridItem>
     /// <returns>A <see cref="GridSort{T}"/> instance representing the specified sorting rule.</returns>
     public GridSort<TGridItem> ThenAscending<U>(Expression<Func<TGridItem, U>> expression)
     {
-        _then ??= [];
-        _thenExpressions ??= [];
-        _then.Add((queryable, asc) => asc ? queryable.ThenBy(expression) : queryable.ThenByDescending(expression));
-        _thenExpressions.Add((expression, true));
-        _cachedPropertyListAscending = null;
-        _cachedPropertyListDescending = null;
-        return this;
+        return AddThenExpression(
+            (queryable, asc) => asc ? queryable.ThenBy(expression) : queryable.ThenByDescending(expression),
+            (expression, true)
+        );
+    }
+
+    /// <summary>
+    /// Updates a <see cref="GridSort{T}"/> instance by appending a further sorting rule.
+    /// </summary>
+    /// <typeparam name="U">The type of the expression's value.</typeparam>
+    /// <param name="expression">An expression defining how a set of <typeparamref name="TGridItem"/> instances are to be sorted.</param>
+    /// <param name="comparer">Defines how a items in a set of <typeparamref name="TGridItem"/> instances are to be compared.</param>
+    /// <returns>A <see cref="GridSort{T}"/> instance representing the specified sorting rule.</returns>
+    public GridSort<TGridItem> ThenAscending<U>(Expression<Func<TGridItem, U>> expression, IComparer<U> comparer)
+    {
+        return AddThenExpression(
+            (queryable, asc) => asc ? queryable.ThenBy(expression, comparer) : queryable.ThenByDescending(expression, comparer),
+            (expression, true)
+        );
     }
 
     /// <summary>
@@ -84,12 +108,91 @@ public sealed class GridSort<TGridItem>
     /// <returns>A <see cref="GridSort{T}"/> instance representing the specified sorting rule.</returns>
     public GridSort<TGridItem> ThenDescending<U>(Expression<Func<TGridItem, U>> expression)
     {
+        return AddThenExpression(
+            (queryable, asc) => asc ? queryable.ThenByDescending(expression) : queryable.ThenBy(expression),
+            (expression, false));
+    }
+
+    /// <summary>
+    /// Updates a <see cref="GridSort{T}"/> instance by appending a further sorting rule.
+    /// </summary>
+    /// <typeparam name="U">The type of the expression's value.</typeparam>
+    /// <param name="expression">An expression defining how a set of <typeparamref name="TGridItem"/> instances are to be sorted.</param>
+    /// <param name="comparer">Defines how a items in a set of <typeparamref name="TGridItem"/> instances are to be compared.</param>
+    /// <returns>A <see cref="GridSort{T}"/> instance representing the specified sorting rule.</returns>
+    public GridSort<TGridItem> ThenDescending<U>(Expression<Func<TGridItem, U>> expression, IComparer<U> comparer)
+    {
+        return AddThenExpression(
+            (queryable, asc) => asc ? queryable.ThenByDescending(expression, comparer) : queryable.ThenBy(expression, comparer),
+            (expression, false)
+        );
+    }
+
+    /// <summary>
+    /// Updates a <see cref="GridSort{T}"/> instance by appending a further sorting rule.
+    /// </summary>
+    /// <typeparam name="U">The type of the expression's value.</typeparam>
+    /// <param name="expression">An expression defining how a set of <typeparamref name="TGridItem"/> instances are to be sorted.</param>
+    /// <returns>A <see cref="GridSort{T}"/> instance representing the specified sorting rule.</returns>
+    public GridSort<TGridItem> ThenAlwaysAscending<U>(Expression<Func<TGridItem, U>> expression)
+    {
+        return AddThenExpression(
+            (queryable, _) => queryable.ThenBy(expression),
+            (expression, true));
+    }
+
+    /// <summary>
+    /// Updates a <see cref="GridSort{T}"/> instance by appending a further sorting rule.
+    /// </summary>
+    /// <typeparam name="U">The type of the expression's value.</typeparam>
+    /// <param name="expression">An expression defining how a set of <typeparamref name="TGridItem"/> instances are to be sorted.</param>
+    /// <param name="comparer">Defines how a items in a set of <typeparamref name="TGridItem"/> instances are to be compared.</param>
+    /// <returns>A <see cref="GridSort{T}"/> instance representing the specified sorting rule.</returns>
+    public GridSort<TGridItem> ThenAlwaysAscending<U>(Expression<Func<TGridItem, U>> expression, IComparer<U> comparer)
+    {
+        return AddThenExpression(
+            (queryable, _) => queryable.ThenBy(expression, comparer),
+            (expression, true)
+        );
+    }
+
+    /// <summary>
+    /// Updates a <see cref="GridSort{T}"/> instance by appending a further sorting rule.
+    /// </summary>
+    /// <typeparam name="U">The type of the expression's value.</typeparam>
+    /// <param name="expression">An expression defining how a set of <typeparamref name="TGridItem"/> instances are to be sorted.</param>
+    /// <returns>A <see cref="GridSort{T}"/> instance representing the specified sorting rule.</returns>
+    public GridSort<TGridItem> ThenAlwaysDescending<U>(Expression<Func<TGridItem, U>> expression)
+    {
+        return AddThenExpression(
+            (queryable, _) => queryable.ThenByDescending(expression),
+            (expression, false));
+    }
+
+    /// <summary>
+    /// Updates a <see cref="GridSort{T}"/> instance by appending a further sorting rule.
+    /// </summary>
+    /// <typeparam name="U">The type of the expression's value.</typeparam>
+    /// <param name="expression">An expression defining how a set of <typeparamref name="TGridItem"/> instances are to be sorted.</param>
+    /// <param name="comparer">Defines how a items in a set of <typeparamref name="TGridItem"/> instances are to be compared.</param>
+    /// <returns>A <see cref="GridSort{T}"/> instance representing the specified sorting rule.</returns>
+    public GridSort<TGridItem> ThenAlwaysDescending<U>(Expression<Func<TGridItem, U>> expression, IComparer<U> comparer)
+    {
+        return AddThenExpression(
+            (queryable, _) => queryable.ThenByDescending(expression, comparer),
+            (expression, false)
+        );
+    }
+
+    private GridSort<TGridItem> AddThenExpression(Func<IOrderedQueryable<TGridItem>, bool, IOrderedQueryable<TGridItem>> thenSortExpression, (LambdaExpression, bool) thenExpression)
+    {
         _then ??= [];
         _thenExpressions ??= [];
-        _then.Add((queryable, asc) => asc ? queryable.ThenByDescending(expression) : queryable.ThenBy(expression));
-        _thenExpressions.Add((expression, false));
+        _then.Add(thenSortExpression);
+        _thenExpressions.Add(thenExpression);
         _cachedPropertyListAscending = null;
         _cachedPropertyListDescending = null;
+
         return this;
     }
 

--- a/tests/Core/DataGrid/GridSortTests.cs
+++ b/tests/Core/DataGrid/GridSortTests.cs
@@ -1,0 +1,101 @@
+using FluentAssertions;
+using Xunit;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Tests.DataGrid;
+
+public class GridSortTests : TestBase
+{
+    private static readonly GridRow[] _gridData = [
+        new(2, "B"),
+        new(1, "A"),
+        new(4, "B"),
+        new(3, "A")
+    ];
+
+#pragma warning disable CA1861 // Avoid constant arrays as arguments
+
+    [Theory]
+    [InlineData(true, new int[] { 1, 2, 3, 4 })]
+    [InlineData(false, new int[] { 4, 3, 2, 1 })]
+    public void GridSortTests_SortBy_Number(bool ascending, IList<int> expected)
+    {
+        var sort = GridSort<GridRow>.ByAscending(x => x.Number);
+        var ordered = sort.Apply(_gridData.AsQueryable(), ascending);
+
+        ordered.Select(x => x.Number)
+            .SequenceEqual(expected)
+            .Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(true, new int[] { 1, 3, 2, 4 })]
+    [InlineData(false, new int[] { 4, 2, 3, 1 })]
+    public void GridSortTests_SortBy_GroupThenNumberAscending(bool ascending, IList<int> expected)
+    {
+        var sort = GridSort<GridRow>
+            .ByAscending(x => x.Group)
+            .ThenAscending(x => x.Number);
+
+        var ordered = sort.Apply(_gridData.AsQueryable(), ascending);
+
+        ordered.Select(x => x.Number)
+            .SequenceEqual(expected)
+            .Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(true, new int[] { 3, 1, 4, 2 })]
+    [InlineData(false, new int[] { 2, 4, 1, 3 })]
+    public void GridSortTests_SortBy_GroupThenNumberDescending(bool ascending, IList<int> expected)
+    {
+        var sort = GridSort<GridRow>
+            .ByAscending(x => x.Group)
+            .ThenDescending(x => x.Number);
+
+        var ordered = sort.Apply(_gridData.AsQueryable(), ascending);
+
+        ordered.Select(x => x.Number)
+            .SequenceEqual(expected)
+            .Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(true, new int[] { 1, 3, 2, 4 })]
+    [InlineData(false, new int[] { 2, 4, 1, 3 })]
+    public void GridSortTests_SortBy_GroupThenNumberAlwaysAscending(bool ascending, IList<int> expected)
+    {
+        var sort = GridSort<GridRow>
+            .ByAscending(x => x.Group)
+            .ThenAlwaysAscending(x => x.Number);
+
+        var ordered = sort.Apply(_gridData.AsQueryable(), ascending);
+
+        ordered.Select(x => x.Number)
+            .SequenceEqual(expected)
+            .Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(true, new int[] { 3, 1, 4, 2 })]
+    [InlineData(false, new int[] { 4, 2, 3, 1 })]
+    public void GridSortTests_SortBy_GroupThenNumberAlwaysDescending(bool ascending, IList<int> expected)
+    {
+        var sort = GridSort<GridRow>
+            .ByAscending(x => x.Group)
+            .ThenAlwaysDescending(x => x.Number);
+
+        var ordered = sort.Apply(_gridData.AsQueryable(), ascending);
+
+        ordered.Select(x => x.Number)
+            .SequenceEqual(expected)
+            .Should().BeTrue();
+    }
+
+#pragma warning restore CA1861 // Avoid constant arrays as arguments
+
+    public class GridRow(int number, string group)
+    {
+        public int Number { get; } = number;
+        public string Group { get; } = group;
+    }
+}


### PR DESCRIPTION
This PR extends missing GridSort overloads including an IComparer

1. GridSort<TGridItem> ByDescending<U>(Expression<Func<TGridItem, U>> expression, IComparer<U> comparer)
2. GridSort<TGridItem> ThenAscending<U>(Expression<Func<TGridItem, U>> expression, IComparer<U> comparer)
3. GridSort<TGridItem> ThenDescending<U>(Expression<Func<TGridItem, U>> expression, IComparer<U> comparer)

---

Additionally add methods to sort for a second column that is not affected by the sort direction

1. GridSort<TGridItem> ThenAlwaysAscending<U>(Expression<Func<TGridItem, U>> expression)
2. GridSort<TGridItem> ThenAlwaysAscending<U>(Expression<Func<TGridItem, U>> expression, IComparer<U> comparer)
3. GridSort<TGridItem> ThenAlwaysDescending<U>(Expression<Func<TGridItem, U>> expression)
4. public GridSort<TGridItem> ThenAlwaysDescending<U>(Expression<Func<TGridItem, U>> expression, IComparer<U> comparer)
