### PR TITLE
[FluentSlider] Fixes thumb redraw issues (Fix for #1836)

### DIFF
--- a/src/Core/Components/Slider/FluentSlider.razor.js
+++ b/src/Core/Components/Slider/FluentSlider.razor.js
@@ -1,6 +1,9 @@
 export function updateSlider(ref) {
     // incoming reference is to the fluent-slider web component
 
+    // fixes issue where you can't reset value programmatically
+    ref.value = ref.attributes['value'].value;
+
     // fixes issue where the value indicator is not redrawn when either the min or max is changed
     ref.setThumbPositionForOrientation(ref.direction);
 }

--- a/src/Core/Components/Slider/FluentSlider.razor.js
+++ b/src/Core/Components/Slider/FluentSlider.razor.js
@@ -1,0 +1,6 @@
+export function updateSlider(ref) {
+    // incoming reference is to the fluent-slider web component
+
+    // fixes issue where the value indicator is not redrawn when either the min or max is changed
+    ref.setThumbPositionForOrientation(ref.direction);
+}


### PR DESCRIPTION
# Pull Request

## 📖 Description

[FluentSlider] Fixes thumb redraw issues (Fix for #1836)

### 🎫 Issues

- thumb not being redrawn when min or max is changed as per #1836 
- unable to programmtically change thumb value

## 👩‍💻 Reviewer Notes

Part of this fix is dependent on the implementation of the underlying [fast slider](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-foundation/src/slider/slider.ts) component. It calls the `setThumbPositionForOrientation` function which is marked as private.

https://github.com/microsoft/fast/blob/5b2b801208a86c1d342feff49961f5c490ad247e/packages/web-components/fast-foundation/src/slider/slider.ts#L338-L355

## 📑 Test Plan

## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [X] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new compontent
- [X] I have modified an existing component
- [ ] I have validate [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component 
