### PR TITLE
[DataGrid] Add SortBy parameter support for PropertyColumn

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -1137,7 +1137,8 @@
              Gets or sets a value indicating whether the data should be sortable by this column.
             
              The default value may vary according to the column type (for example, a <see cref="T:Microsoft.FluentUI.AspNetCore.Components.TemplateColumn`1" />
-             is sortable by default if any <see cref="P:Microsoft.FluentUI.AspNetCore.Components.TemplateColumn`1.SortBy" /> parameter is specified).
+             or <see cref="T:Microsoft.FluentUI.AspNetCore.Components.PropertyColumn`2" /> is sortable by default if any<see cref="P:Microsoft.FluentUI.AspNetCore.Components.TemplateColumn`1.SortBy" />
+             or <see cref="P:Microsoft.FluentUI.AspNetCore.Components.PropertyColumn`2.SortBy" /> parameter is specified).
              </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.ColumnBase`1.Filtered">
@@ -6976,6 +6977,12 @@
             <summary>
             Gets or sets the content to be rendered inside the component.
             </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentSlider`1.JSRuntime">
+            <summary />
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentSlider`1.Module">
+            <summary />
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentSlider`1.Min">
             <summary>

--- a/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridRankSort.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridRankSort.razor
@@ -9,11 +9,9 @@
 
 <p>Keep numbers always sorted ascending inside the group when sorting by group</p>
 <FluentDataGrid Items="@_gridData" ResizableColumns=true GridTemplateColumns="0.5fr 0.5fr">
-    <PropertyColumn Sortable="true" Property="x => x.Number" Title="Number" />
 
-    <TemplateColumn Sortable="true" SortBy="groupRankNumberAlwaysAscending" Title="Group">
-        @context.Group
-    </TemplateColumn>
+    <PropertyColumn Sortable="true" Property="x => x.Number" Title="Number" />
+    <PropertyColumn Property="x => x.Group" SortBy="groupRankNumberAlwaysAscending" Title="Group" />
 
 </FluentDataGrid>
 

--- a/src/Core/Components/DataGrid/Columns/ColumnBase.razor.cs
+++ b/src/Core/Components/DataGrid/Columns/ColumnBase.razor.cs
@@ -67,7 +67,8 @@ public abstract partial class ColumnBase<TGridItem>
     /// Gets or sets a value indicating whether the data should be sortable by this column.
     ///
     /// The default value may vary according to the column type (for example, a <see cref="TemplateColumn{TGridItem}" />
-    /// is sortable by default if any <see cref="TemplateColumn{TGridItem}.SortBy" /> parameter is specified).
+    /// or <see cref="PropertyColumn{TGridItem, TProp}" /> is sortable by default if any<see cref="TemplateColumn{TGridItem}.SortBy" />
+    /// or <see cref="PropertyColumn{TGridItem, TProp}.SortBy" /> parameter is specified).
     /// </summary>
     [Parameter] public bool? Sortable { get; set; }
 

--- a/src/Core/Components/DataGrid/Columns/PropertyColumn.cs
+++ b/src/Core/Components/DataGrid/Columns/PropertyColumn.cs
@@ -18,6 +18,7 @@ public class PropertyColumn<TGridItem, TProp> : ColumnBase<TGridItem>, IBindable
     private Func<TGridItem, string?>? _cellTextFunc;
     private Func<TGridItem, string?>? _cellTooltipTextFunc;
     private GridSort<TGridItem>? _sortBuilder;
+    private GridSort<TGridItem>? _customSortBy;
 
     public PropertyInfo? PropertyInfo { get; private set; }
 
@@ -40,10 +41,10 @@ public class PropertyColumn<TGridItem, TProp> : ColumnBase<TGridItem>, IBindable
     /// </summary>
     [Parameter] public IComparer<TProp>? Comparer { get; set; } = null;
 
-    public override GridSort<TGridItem>? SortBy
+    [Parameter] public override GridSort<TGridItem>? SortBy
     {
-        get => _sortBuilder;
-        set => throw new NotSupportedException($"PropertyColumn generates this member internally. For custom sorting rules, see '{typeof(TemplateColumn<TGridItem>)}'.");
+        get => _customSortBy ?? _sortBuilder;
+        set => _customSortBy = value;
     }
 
     /// <inheritdoc />
@@ -103,4 +104,7 @@ public class PropertyColumn<TGridItem, TProp> : ColumnBase<TGridItem>, IBindable
 
     protected internal override string? RawCellContent(TGridItem item)
         => _cellTooltipTextFunc?.Invoke(item);
+
+    protected override bool IsSortableByDefault()
+        => SortBy is not null;
 }

--- a/src/Core/Components/DataGrid/Columns/PropertyColumn.cs
+++ b/src/Core/Components/DataGrid/Columns/PropertyColumn.cs
@@ -106,5 +106,5 @@ public class PropertyColumn<TGridItem, TProp> : ColumnBase<TGridItem>, IBindable
         => _cellTooltipTextFunc?.Invoke(item);
 
     protected override bool IsSortableByDefault()
-        => SortBy is not null;
+        => _customSortBy is not null;
 }


### PR DESCRIPTION
As mentioned here #1860, the PropertyColumn does not support the SortBy parameter although it is listed in the documentation.
This PR keeps the default behaviour of the PropertyColumn by providing a default sorting configuration but additionally adds the possibility to set a custom SortBy implementation.