### PR TITLE
[FluentSelect] Allow value to be set when component is disabled

### DIFF
--- a/src/Core/Components/List/ListComponentBase.razor.cs
+++ b/src/Core/Components/List/ListComponentBase.razor.cs
@@ -444,15 +444,8 @@ public abstract partial class ListComponentBase<TOption> : FluentComponentBase, 
             {
                 return OptionDisabled(item);
             }
-            else
-            {
-                return Disabled;
-            }
         }
-        else
-        {
-            return null;
-        }
+        return null;
     }
 
     /// <summary />


### PR DESCRIPTION
Fix #1703 by only returning a value from `GetOptionDisabled` if an actual lambda is supplied. In previous situation the value of `Disabled` (from the Select itself) would be returned which effectively disabled every option if Disabled was set to true and thereby making them not setable