### PR TITLE
[FluentGrid] Add AdaptiveRendering property

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -3557,6 +3557,9 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentGrid.Module">
             <summary />
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentGrid.CurrentSize">
+            <summary />
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentGrid.Spacing">
             <summary>
             Gets or sets the distance between flexbox items, using a multiple of 4px.
@@ -3566,6 +3569,12 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentGrid.Justify">
             <summary>
             Defines how the browser distributes space between and around content items.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentGrid.AdaptiveRendering">
+            <summary>
+            Gets or sets the adaptive rendering, which not render the HTML code when the item is hidden (true) or only hide the item by CSS (false).
+            Default is false.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentGrid.ChildContent">
@@ -3631,6 +3640,12 @@
             See https://developer.mozilla.org/en-US/docs/Web/CSS/gap
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentGridItem.AdaptiveRendering">
+            <summary>
+            Gets or sets the adaptive rendering, which not render the HTML code when the item is hidden (true) or only hide the item by CSS (false).
+            Default is false.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentGridItem.HiddenWhen">
             <summary>
             Hide the item on the specified sizes (you can combine multiple values: GridItemHidden.Sm | GridItemHidden.Xl).
@@ -3646,6 +3661,12 @@
             <summary />
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentGridItem.HiddenAttribute">
+            <summary />
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentGridItem.RenderChildContent">
+            <summary />
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentGridItem.ConvertToHidden(Microsoft.FluentUI.AspNetCore.Components.GridItemSize)">
             <summary />
         </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentGridItem.GetHiddenAttribute(System.Nullable{Microsoft.FluentUI.AspNetCore.Components.GridItemHidden})">
@@ -6427,6 +6448,13 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.HorizontalThreshold">
             <summary>
             How narrow the space allocated to the default position has to be before the widest area is selected for layout.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.FixedPlacement">
+            <summary>
+            Gets or sets a value indicating whether the region is positioned using css "position: fixed".
+            Otherwise the region uses "position: absolute".
+            Fixed placement allows the region to break out of parent containers.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.Open">

--- a/examples/Demo/Shared/Pages/Grid/Examples/GridDefault.razor
+++ b/examples/Demo/Shared/Pages/Grid/Examples/GridDefault.razor
@@ -10,7 +10,7 @@
     <FluentSlider @bind-Value="@Spacing" Min="0" Max="10" Step="1" Style="max-width: 300px; margin-top: 18px;" />
 </FluentStack>
 
-<FluentGrid Spacing="@Spacing" OnBreakpointEnter="@OnBreakpointEnterHandler" Justify="@Justification" Style="background-color: var(--neutral-layer-3); padding: 4px; ">
+<FluentGrid Spacing="@Spacing" OnBreakpointEnter="@OnBreakpointEnterHandler" AdaptiveRendering="true" Justify="@Justification" Style="background-color: var(--neutral-layer-3); padding: 4px; ">
     <FluentGridItem xs="12">
         <div class="card">
             xs="12"

--- a/examples/Demo/Shared/Pages/Grid/GridPage.razor
+++ b/examples/Demo/Shared/Pages/Grid/GridPage.razor
@@ -55,6 +55,12 @@
     e.g. <code>GridItemHidden.Md | GridItemHidden.Lg</code> will display the element for all screen sizes, except on medium and large devices.
 </p>
 <p>
+    <b>AdaptiveRendering</b> allows you not to generate the HTML code of the <b>FluentGridItem</b> that respects the <code>HiddenWhen</code>.
+    In other words, when <code>AdaptiveRendering=false</code> (default), the content of the <b>FluentGridItem</b> is simply hidden by CSS styles,
+    whereas if <code>AdaptiveRendering=true</code>, the content of the <b>FluentGridItem</b> is not rendered by Blazor.
+    In certain cases where this content is important, it may be more efficient not to generate the HTML code instead of simply hiding it.
+</p>
+<p>
     <FluentDataGrid Items="@AllHiddenValues" GridTemplateColumns="28fr 12fr 12fr 12fr 12fr 12fr 12fr" ItemKey="@(i => new Random().Next())">
         <TemplateColumn Align="Align.Start" Style="align-self: unset;">
             <HeaderCellItemTemplate>GridItemHidden</HeaderCellItemTemplate>

--- a/examples/Demo/Shared/Pages/Grid/GridPage.razor
+++ b/examples/Demo/Shared/Pages/Grid/GridPage.razor
@@ -55,10 +55,11 @@
     e.g. <code>GridItemHidden.Md | GridItemHidden.Lg</code> will display the element for all screen sizes, except on medium and large devices.
 </p>
 <p>
-    <b>AdaptiveRendering</b> allows you not to generate the HTML code of the <b>FluentGridItem</b> that respects the <code>HiddenWhen</code>.
+    <b>AdaptiveRendering</b> allows for not generating HTML code in a <b>FluentGridItem</b> based on the value of the <code>HiddenWhen</code> parameter.
     In other words, when <code>AdaptiveRendering=false</code> (default), the content of the <b>FluentGridItem</b> is simply hidden by CSS styles,
     whereas if <code>AdaptiveRendering=true</code>, the content of the <b>FluentGridItem</b> is not rendered by Blazor.
-    In certain cases where this content is important, it may be more efficient not to generate the HTML code instead of simply hiding it.
+    This allows for fine-grained control over when HTML is generated or not, for example in a case where rendering the grid item takes
+    a lot of time or leads to a lot of data being transferred.
 </p>
 <p>
     <FluentDataGrid Items="@AllHiddenValues" GridTemplateColumns="28fr 12fr 12fr 12fr 12fr 12fr 12fr" ItemKey="@(i => new Random().Next())">

--- a/src/Core/Components/Grid/FluentGrid.razor
+++ b/src/Core/Components/Grid/FluentGrid.razor
@@ -1,8 +1,10 @@
 ﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 @inherits FluentComponentBase
 
-<div class="@ClassValue" style="@StyleValue" @attributes="AdditionalAttributes">
-    <div id="@GetId()" class="fluent-grid" style="@($"justify-content: {Justify.ToAttributeValue()};")" spacing="@Spacing">
-        @ChildContent
+<CascadingValue IsFixed Value="this">
+    <div class="@ClassValue" style="@StyleValue" @attributes="AdditionalAttributes">
+        <div id="@GetId()" class="fluent-grid" style="@($"justify-content: {Justify.ToAttributeValue()};")" spacing="@Spacing">
+            @ChildContent
+        </div>
     </div>
-</div>
+</CascadingValue>

--- a/src/Core/Components/Grid/FluentGrid.razor.cs
+++ b/src/Core/Components/Grid/FluentGrid.razor.cs
@@ -16,7 +16,7 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 public partial class FluentGrid : FluentComponentBase, IAsyncDisposable
 {
     private const string JAVASCRIPT_FILE = "./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Grid/FluentGrid.razor.js";
-    private DotNetObjectReference<FluentGrid>? _dotNetHelper = null;
+    private DotNetObjectReference<FluentGrid>? _dotNetHelper = null;    
 
     public FluentGrid()
     {
@@ -30,6 +30,9 @@ public partial class FluentGrid : FluentComponentBase, IAsyncDisposable
     /// <summary />
     private IJSObjectReference? Module { get; set; }
 
+    /// <summary />
+    internal GridItemSize? CurrentSize { get; private set; }
+
     /// <summary>
     /// Gets or sets the distance between flexbox items, using a multiple of 4px.
     /// Only values from 0 to 10 are possible.
@@ -42,6 +45,13 @@ public partial class FluentGrid : FluentComponentBase, IAsyncDisposable
     /// </summary>
     [Parameter]
     public JustifyContent Justify { get; set; } = JustifyContent.FlexStart;
+
+    /// <summary>
+    /// Gets or sets the adaptive rendering, which not render the HTML code when the item is hidden (true) or only hide the item by CSS (false).
+    /// Default is false.
+    /// </summary>
+    [Parameter]
+    public bool AdaptiveRendering { get; set; } = false;
 
     /// <summary>
     /// Gets or sets the child content of component.
@@ -76,9 +86,12 @@ public partial class FluentGrid : FluentComponentBase, IAsyncDisposable
     [JSInvokable]
     public async Task FluentGrid_MediaChangedAsync(string size)
     {
+        bool valid = Enum.TryParse<GridItemSize>(size, ignoreCase: true, out var sizeEnum);
+        CurrentSize = valid ? sizeEnum : null;
+
         if (OnBreakpointEnter.HasDelegate)
         {
-            if (Enum.TryParse<GridItemSize>(size, ignoreCase: true, out var sizeEnum))
+            if (valid)
             {
                 await OnBreakpointEnter.InvokeAsync(sizeEnum);
             }

--- a/src/Core/Components/Grid/FluentGridItem.razor
+++ b/src/Core/Components/Grid/FluentGridItem.razor
@@ -2,5 +2,8 @@
 @inherits FluentComponentBase
 
 <div class="@ClassValue" style="@StyleValue" xs="@(NoBreakpointsDefined() ? 0 : xs)" sm=@sm md=@md lg=@lg xl=@xl xxl=@xxl hidden-when="@HiddenAttribute" @attributes="AdditionalAttributes">
-    @ChildContent
+    @if (RenderChildContent())
+    {
+        @ChildContent
+    }
 </div>

--- a/src/Core/Components/Grid/FluentGridItem.razor.cs
+++ b/src/Core/Components/Grid/FluentGridItem.razor.cs
@@ -57,6 +57,9 @@ public partial class FluentGridItem : FluentComponentBase
 #pragma warning restore SA1300
 #pragma warning restore IDE1006
 
+    [CascadingParameter]
+    internal FluentGrid? Grid { get; set; }
+
     /// <summary>
     /// Defines how the browser distributes space between and around content items.
     /// </summary>
@@ -69,6 +72,13 @@ public partial class FluentGridItem : FluentComponentBase
     /// </summary>
     [Parameter]
     public string? Gap { get; set; }
+
+    /// <summary>
+    /// Gets or sets the adaptive rendering, which not render the HTML code when the item is hidden (true) or only hide the item by CSS (false).
+    /// Default is false.
+    /// </summary>
+    [Parameter]
+    public bool? AdaptiveRendering { get; set; }
 
     /// <summary>
     /// Hide the item on the specified sizes (you can combine multiple values: GridItemHidden.Sm | GridItemHidden.Xl).
@@ -106,6 +116,39 @@ public partial class FluentGridItem : FluentComponentBase
         get
         {
             return GetHiddenAttribute(HiddenWhen);
+        }
+    }
+
+    /// <summary />
+    private bool RenderChildContent()
+    {
+        if (Grid != null && Grid.CurrentSize != null && HiddenWhen != null && (Grid.AdaptiveRendering == true || AdaptiveRendering == true))
+        {
+            return !HiddenWhen.Value.HasFlag(ConvertToHidden(Grid.CurrentSize.Value));
+        }
+
+        return true;
+    }
+
+    /// <summary />
+    private GridItemHidden ConvertToHidden(GridItemSize size)
+    {
+        switch (size)
+        {
+            case GridItemSize.Xs:
+                return GridItemHidden.Xs;
+            case GridItemSize.Sm:
+                return GridItemHidden.Sm;
+            case GridItemSize.Md:
+                return GridItemHidden.Md;
+            case GridItemSize.Lg:
+                return GridItemHidden.Lg;
+            case GridItemSize.Xl:
+                return GridItemHidden.Xl;
+            case GridItemSize.Xxl:
+                return GridItemHidden.Xxl;
+            default:
+                return GridItemHidden.None;
         }
     }
 

--- a/tests/Core/Grid/FluentGridTests.razor
+++ b/tests/Core/Grid/FluentGridTests.razor
@@ -1,4 +1,4 @@
-@using Xunit;
+﻿@using Xunit;
 @inherits TestContext
 @code
 {
@@ -79,6 +79,7 @@
         //Assert
         cut.Verify();
     }
+
     #pragma warning disable xUnit1025 
     [Theory]
     [InlineData(GridItemHidden.Xs, "xs")]
@@ -113,4 +114,44 @@
         Assert.Equal(assert, hiddenAttribute);
     }
     #pragma warning restore xUnit1025
+
+    [Fact]
+    public async void FluentGrid_Grid_AdaptiveRendering()
+    {
+        // Arrange && Act
+        var cut = Render(
+    @<FluentGrid AdaptiveRendering="true">
+        <FluentGridItem HiddenWhen="GridItemHidden.XsAndUp">Cell 1</FluentGridItem>
+        <FluentGridItem HiddenWhen="GridItemHidden.XxlAndUp">Cell 2</FluentGridItem>
+    </FluentGrid>
+    );
+
+        // Simulate screen size Medium
+        var grid = cut.FindComponent<FluentGrid>();
+        await grid.Instance.FluentGrid_MediaChangedAsync("md");
+        grid.Render();
+
+        //Assert
+        Assert.DoesNotContain("Cell 1", cut.Markup);
+    }
+
+    [Fact]
+    public async void FluentGrid_GridItem_AdaptiveRendering()
+    {
+        // Arrange && Act
+        var cut = Render(
+    @<FluentGrid>
+        <FluentGridItem AdaptiveRendering="true" HiddenWhen="GridItemHidden.XsAndUp">Cell 1</FluentGridItem>
+        <FluentGridItem HiddenWhen="GridItemHidden.XxlAndUp">Cell 2</FluentGridItem>
+    </FluentGrid>
+    );
+
+        // Simulate screen size Medium
+        var grid = cut.FindComponent<FluentGrid>();
+        await grid.Instance.FluentGrid_MediaChangedAsync("md");
+        grid.Render();
+
+        //Assert
+        Assert.DoesNotContain("Cell 1", cut.Markup);
+    }
 }


### PR DESCRIPTION
# [FluentGrid] Add AdaptiveRendering property

**AdaptiveRendering** allows you not to generate the HTML code of the **FluentGridItem** that respects the `HiddenWhen`. In other words, when `AdaptiveRendering=false` (default), the content of the **FluentGridItem** is simply hidden by CSS styles, whereas if `AdaptiveRendering=true`, the content of the **FluentGridItem** is not rendered by Blazor. In certain cases where this content is important, it may be more efficient not to generate the HTML code instead of simply hiding it.

```xml
<FluentGrid AdaptiveRendering="true">
   ...
</FluentGrid> 
```

![peek_1](https://github.com/microsoft/fluentui-blazor/assets/8350694/c8d37d7c-811b-4121-9990-0b3b6514754a)
