### PR TITLE
[FluentDataGrid] Add column Width parameter

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -1340,11 +1340,11 @@
              </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.PropertyColumn`2.Comparer">
-            <summary>
-            Optionally specifies how to compare values in this column when sorting.
+             <summary>
+             Optionally specifies how to compare values in this column when sorting.
             
-            Using this requires the <typeparamref name="TProp"/> type to implement <see cref="T:System.IComparable`1"/>.
-            </summary>
+             Using this requires the <typeparamref name="TProp"/> type to implement <see cref="T:System.IComparable`1"/>.
+             </summary>
         </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.PropertyColumn`2.OnParametersSet">
             <inheritdoc />

--- a/examples/Demo/Shared/Pages/DataGrid/DataGridPage.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/DataGridPage.razor
@@ -25,7 +25,7 @@
 <p>
     You can use the <kbd>Arrow</kbd> keys to navigate through a DataGrid. When a header cell is focused and the column is sortable, you can use the <kbd>Tab</kbd> key to select the sort button.
     Pressing the <kbd>Enter</kbd> key will toggle the sorting direction. Pressing <kbd>Ctrl+Enter</kbd> removes the column sorting and restores the default/start situation with regards to sorting.
-    <em>You cannot not remove the default grid sorting with this key combination.</em>
+    <em>You cannot remove the default grid sorting with this key combination.</em>
 </p>
 <p>
     When a header cell is focused and the column allows setting options, you can use the <kbd>Tab</kbd> key to select the options button.
@@ -153,6 +153,10 @@
     <Description>
         <p>
             You can make columns appear conditionally using normal Razor logic such as <code>@@if</code>. Example:
+        </p>
+        <p>
+            Also, in this example the columns's Width parameter is being set instead of specifying all widths for all
+            columns in the <code>GridTemplateColumn</code> parameter.
         </p>
     </Description>
 </DemoSection>

--- a/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridDynamicColumns.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridDynamicColumns.razor
@@ -7,17 +7,21 @@
 </p>
 
 
-    <FluentDataGrid Items="@Data.People" GridTemplateColumns="0.5fr 1fr 1fr" style="width: 500px;">
-        <PropertyColumn Title="ID" Property="@(c => c.PersonId)" Sortable="true" />
+    <FluentDataGrid Items="@Data.People" Style="width: 500px;">
+        <PropertyColumn Title="ID" Property="@(c => c.PersonId)" Sortable="true" Width="100px" />
         @if (showName)
         {
-            <TemplateColumn Title="Name">
+            <TemplateColumn Title="Name" Width="200px">
                 <strong>@context.LastName</strong>, @context.FirstName
             </TemplateColumn>
         }
         @if (showBirthDate)
         {
-            <PropertyColumn Title="Birth date" Property="@(c => c.BirthDate)" Format="yyyy-MM-dd" Sortable="true" />
+            <PropertyColumn Title="Birth date"
+                            Property="@(c => c.BirthDate)"
+                            Format="yyyy-MM-dd"
+                            Sortable="true"
+                            Width="200px"/>
         }
     </FluentDataGrid>
 

--- a/src/Core/Components/DataGrid/Columns/ColumnBase.razor.cs
+++ b/src/Core/Components/DataGrid/Columns/ColumnBase.razor.cs
@@ -101,6 +101,13 @@ public abstract partial class ColumnBase<TGridItem>
     [Parameter] public RenderFragment<PlaceholderContext>? PlaceholderTemplate { get; set; }
 
     /// <summary>
+    /// Gets or sets the width of the column.
+    /// Use either this or the <see cref="FluentDataGrid{TGridItem}"/> GridTemplateColumns parameter but not both.
+    /// Needs to be a valid CSS width value like '100px', '10%' or '0.5fr'.
+    /// </summary>
+    [Parameter] public string? Width { get; set; }
+
+    /// <summary>
     /// Gets a reference to the enclosing <see cref="FluentDataGrid{TGridItem}" />.
     /// </summary>
     public FluentDataGrid<TGridItem> Grid => InternalGridContext.Grid;

--- a/src/Core/Components/DataGrid/Columns/PropertyColumn.cs
+++ b/src/Core/Components/DataGrid/Columns/PropertyColumn.cs
@@ -36,7 +36,7 @@ public class PropertyColumn<TGridItem, TProp> : ColumnBase<TGridItem>, IBindable
 
     /// <summary>
     /// Optionally specifies how to compare values in this column when sorting.
-    /// 
+    ///
     /// Using this requires the <typeparamref name="TProp"/> type to implement <see cref="IComparable{T}"/>.
     /// </summary>
     [Parameter] public IComparer<TProp>? Comparer { get; set; } = null;

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor
@@ -15,7 +15,7 @@
         <fluent-data-grid @ref=_gridReference
                           no-tabbing=@NoTabbing
                           generate-header="none"
-                          grid-template-columns=@GridTemplateColumns
+                          grid-template-columns=@_internalGridTemplateColumns
                           class="@GridClass()"
                           style="@Style"
                           aria-rowcount="@(_ariaBodyRowCount + 1)"
@@ -91,7 +91,7 @@
         var rowClass = RowClass?.Invoke(item) ?? null;
         var rowStyle = RowStyle?.Invoke(item) ?? null;
         Loading = false;
-        <FluentDataGridRow @key="@(ItemKey(item))" GridTemplateColumns=@GridTemplateColumns aria-rowindex="@rowIndex" Class="@rowClass" Style="@rowStyle" TGridItem="TGridItem" Item="@item">
+        <FluentDataGridRow @key="@(ItemKey(item))" GridTemplateColumns=@_internalGridTemplateColumns aria-rowindex="@rowIndex" Class="@rowClass" Style="@rowStyle" TGridItem="TGridItem" Item="@item">
             @for (var colIndex = 0; colIndex < _columns.Count; colIndex++)
             {
                 var col = _columns[colIndex];


### PR DESCRIPTION
Based on #1901. You can now do:

```
 <FluentDataGrid Items="@Data.People" Style="width: 500px;">
     <PropertyColumn Title="ID" Property="@(c => c.PersonId)" Sortable="true" Width="100px" />
     @if (showName)
     {
         <TemplateColumn Title="Name" Width="200px">
             <strong>@context.LastName</strong>, @context.FirstName
         </TemplateColumn>
     }
     @if (showBirthDate)
     {
         <PropertyColumn Title="Birth date"
                         Property="@(c => c.BirthDate)"
                         Format="yyyy-MM-dd"
                         Sortable="true"
                         Width="200px"/>
     }
 </FluentDataGrid>
```
instead of using `GridTemplateColumns`