### PR TITLE
[Fluent DatePicker] Enhance for month /year selection 

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -1902,6 +1902,11 @@
             </summary>
             <param name="calendar"></param>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.CalendarTitles.DateTimeFormat">
+            <summary>
+            Gets the user defined DateTimeFormat to use for the calendar.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.CalendarTitles.CalendarExtended">
             <summary>
             Gets the CalendarExtended to use for the calendar.
@@ -1953,11 +1958,6 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentCalendar.DaysTemplate">
             <summary>
             Defines the appearance of a Day cell.
-            </summary>
-        </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentCalendar.View">
-            <summary>
-            Defines the appearance of the <see cref="T:Microsoft.FluentUI.AspNetCore.Components.FluentCalendar"/> component.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentCalendar.AnimatePeriodChanges">
@@ -2067,6 +2067,16 @@
             <summary>
             Gets or sets the verification to do when the selected value has changed.
             By default, ValueChanged is called only if the selected value has changed.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentCalendarBase.View">
+            <summary>
+            Defines the appearance of the <see cref="T:Microsoft.FluentUI.AspNetCore.Components.FluentCalendar"/> component.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentCalendarBase.DateTimeFormat">
+            <summary>
+            Defines the appearance of the <see cref="T:Microsoft.FluentUI.AspNetCore.Components.FluentCalendar"/> component.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentCalendarBase.Value">
@@ -6427,6 +6437,13 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.HorizontalThreshold">
             <summary>
             How narrow the space allocated to the default position has to be before the widest area is selected for layout.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.FixedPlacement">
+            <summary>
+            Gets or sets a value indicating whether the region is positioned using css "position: fixed".
+            Otherwise the region uses "position: absolute".
+            Fixed placement allows the region to break out of parent containers.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.Open">

--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -1902,11 +1902,6 @@
             </summary>
             <param name="calendar"></param>
         </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.CalendarTitles.DateTimeFormat">
-            <summary>
-            Gets the user defined DateTimeFormat to use for the calendar.
-            </summary>
-        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.CalendarTitles.CalendarExtended">
             <summary>
             Gets the CalendarExtended to use for the calendar.
@@ -2070,11 +2065,6 @@
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentCalendarBase.View">
-            <summary>
-            Defines the appearance of the <see cref="T:Microsoft.FluentUI.AspNetCore.Components.FluentCalendar"/> component.
-            </summary>
-        </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentCalendarBase.DateTimeFormat">
             <summary>
             Defines the appearance of the <see cref="T:Microsoft.FluentUI.AspNetCore.Components.FluentCalendar"/> component.
             </summary>

--- a/examples/Demo/Shared/Pages/DateTimes/Examples/DatePickerDefault.razor
+++ b/examples/Demo/Shared/Pages/DateTimes/Examples/DatePickerDefault.razor
@@ -1,7 +1,17 @@
-﻿<FluentDatePicker Label="Meeting date" @bind-Value="@SelectedValue" ReadOnly />
-<FluentDatePicker AriaLabel="To" @bind-Value="@SelectedValue" />
-<FluentDatePicker AriaLabel="To" @bind-Value="@SelectedValue" View="CalendarViews.Months" DateTimeFormat="yyyy MMMM" />
-<FluentDatePicker AriaLabel="To" @bind-Value="@SelectedValue" View="CalendarViews.Years" DateTimeFormat="yyyy" />
+﻿<div style="display: flex; flex-direction:row;  ">
+    <div style="margin-right: 10px;">
+        <FluentDatePicker Label="Meeting date" @bind-Value="@SelectedValue" ReadOnly />
+    </div>
+    <div style="margin-right: 10px;">
+        <FluentDatePicker Label="Days view" AriaLabel="To" @bind-Value="@SelectedValue" />
+    </div>
+    <div style="margin-right: 10px;">
+        <FluentDatePicker Label="Months view" AriaLabel="To" @bind-Value="@SelectedValue" View="CalendarViews.Months" DateTimeFormat="yyyy MMMM" />
+    </div>
+    <div>
+        <FluentDatePicker Label="Years view" AriaLabel="To" @bind-Value="@SelectedValue" View="CalendarViews.Years" DateTimeFormat="yyyy-01-01 - yyyy-12-31" />
+    </div>
+</div>
 <p>Selected Date: @(SelectedValue?.ToString("yyyy-MM-dd"))</p>
 @code
 {

--- a/examples/Demo/Shared/Pages/DateTimes/Examples/DatePickerDefault.razor
+++ b/examples/Demo/Shared/Pages/DateTimes/Examples/DatePickerDefault.razor
@@ -6,10 +6,10 @@
         <FluentDatePicker Label="Days view" AriaLabel="To" @bind-Value="@SelectedValue" />
     </div>
     <div style="margin-right: 10px;">
-        <FluentDatePicker Label="Months view" AriaLabel="To" @bind-Value="@SelectedValue" View="CalendarViews.Months" DateTimeFormat="yyyy MMMM" />
+        <FluentDatePicker Label="Months view" AriaLabel="To" @bind-Value="@SelectedValue" View="CalendarViews.Months" />
     </div>
     <div>
-        <FluentDatePicker Label="Years view" AriaLabel="To" @bind-Value="@SelectedValue" View="CalendarViews.Years" DateTimeFormat="yyyy-01-01 - yyyy-12-31" />
+        <FluentDatePicker Label="Years view" AriaLabel="To" @bind-Value="@SelectedValue" View="CalendarViews.Years" />
     </div>
 </div>
 <p>Selected Date: @(SelectedValue?.ToString("yyyy-MM-dd"))</p>

--- a/examples/Demo/Shared/Pages/DateTimes/Examples/DatePickerDefault.razor
+++ b/examples/Demo/Shared/Pages/DateTimes/Examples/DatePickerDefault.razor
@@ -1,5 +1,7 @@
 ﻿<FluentDatePicker Label="Meeting date" @bind-Value="@SelectedValue" ReadOnly />
 <FluentDatePicker AriaLabel="To" @bind-Value="@SelectedValue" />
+<FluentDatePicker AriaLabel="To" @bind-Value="@SelectedValue" View="CalendarViews.Months" DateTimeFormat="yyyy MMMM" />
+<FluentDatePicker AriaLabel="To" @bind-Value="@SelectedValue" View="CalendarViews.Years" DateTimeFormat="yyyy" />
 <p>Selected Date: @(SelectedValue?.ToString("yyyy-MM-dd"))</p>
 @code
 {

--- a/src/Core/Components/DateTime/CalendarTitles.cs
+++ b/src/Core/Components/DateTime/CalendarTitles.cs
@@ -1,4 +1,3 @@
-using Microsoft.VisualBasic;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
@@ -15,15 +14,8 @@ internal class CalendarTitles
         _calendar = calendar;
         CalendarExtended = new CalendarExtended(calendar.Culture, calendar.PickerMonth);
         View = calendar.View;
-        DateTimeFormat = calendar.DateTimeFormat;
     }
     
-    /// <summary>
-    /// Gets the user defined DateTimeFormat to use for the calendar.
-    /// </summary>
-
-    public string? DateTimeFormat { get; set; }
-
     /// <summary>
     /// Gets the CalendarExtended to use for the calendar.
     /// </summary>

--- a/src/Core/Components/DateTime/CalendarTitles.cs
+++ b/src/Core/Components/DateTime/CalendarTitles.cs
@@ -1,3 +1,5 @@
+using Microsoft.VisualBasic;
+
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 internal class CalendarTitles
@@ -13,7 +15,14 @@ internal class CalendarTitles
         _calendar = calendar;
         CalendarExtended = new CalendarExtended(calendar.Culture, calendar.PickerMonth);
         View = calendar.View;
+        DateTimeFormat = calendar.DateTimeFormat;
     }
+    
+    /// <summary>
+    /// Gets the user defined DateTimeFormat to use for the calendar.
+    /// </summary>
+
+    public string? DateTimeFormat { get; set; }
 
     /// <summary>
     /// Gets the CalendarExtended to use for the calendar.

--- a/src/Core/Components/DateTime/CalendarTitles.cs
+++ b/src/Core/Components/DateTime/CalendarTitles.cs
@@ -15,7 +15,7 @@ internal class CalendarTitles
         CalendarExtended = new CalendarExtended(calendar.Culture, calendar.PickerMonth);
         View = calendar.View;
     }
-    
+
     /// <summary>
     /// Gets the CalendarExtended to use for the calendar.
     /// </summary>

--- a/src/Core/Components/DateTime/FluentCalendar.razor.cs
+++ b/src/Core/Components/DateTime/FluentCalendar.razor.cs
@@ -74,12 +74,6 @@ public partial class FluentCalendar : FluentCalendarBase
     public RenderFragment<FluentCalendarDay>? DaysTemplate { get; set; }
 
     /// <summary>
-    /// Defines the appearance of the <see cref="FluentCalendar"/> component.
-    /// </summary>
-    [Parameter]
-    public CalendarViews View { get; set; } = CalendarViews.Days;
-
-    /// <summary>
     /// Gets ot sets if the calendar items are animated during a period change.
     /// By default, the animation is enabled for Months views, but disabled for Days and Years view.
     /// </summary>

--- a/src/Core/Components/DateTime/FluentCalendarBase.cs
+++ b/src/Core/Components/DateTime/FluentCalendarBase.cs
@@ -47,12 +47,6 @@ public abstract class FluentCalendarBase : FluentInputBase<DateTime?>
     public virtual CalendarViews View { get; set; } = CalendarViews.Days;
 
     /// <summary>
-    /// Defines the appearance of the <see cref="FluentCalendar"/> component.
-    /// </summary>
-    [Parameter]
-    public virtual string? DateTimeFormat { get; set; } = null;
-    
-    /// <summary>
     /// Gets or sets the selected date (two-way bindable).
     /// </summary>
     [Parameter]

--- a/src/Core/Components/DateTime/FluentCalendarBase.cs
+++ b/src/Core/Components/DateTime/FluentCalendarBase.cs
@@ -41,6 +41,18 @@ public abstract class FluentCalendarBase : FluentInputBase<DateTime?>
     public bool CheckIfSelectedValueHasChanged { get; set; } = true;
 
     /// <summary>
+    /// Defines the appearance of the <see cref="FluentCalendar"/> component.
+    /// </summary>
+    [Parameter]
+    public virtual CalendarViews View { get; set; } = CalendarViews.Days;
+
+    /// <summary>
+    /// Defines the appearance of the <see cref="FluentCalendar"/> component.
+    /// </summary>
+    [Parameter]
+    public virtual string? DateTimeFormat { get; set; } = null;
+    
+    /// <summary>
     /// Gets or sets the selected date (two-way bindable).
     /// </summary>
     [Parameter]

--- a/src/Core/Components/DateTime/FluentDatePicker.razor
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor
@@ -2,7 +2,7 @@
 @inherits FluentCalendarBase
 
 @code {
-    private string FormatAccardingToView()
+    private string PlaceholderAccordingToView()
     => View switch
     {
         CalendarViews.Years => "yyyy",
@@ -24,7 +24,7 @@
                  ReadOnly="@ReadOnly"
                  Disabled="@Disabled"
                  Required="@Required"
-                 Placeholder="@(Placeholder ?? FormatAccardingToView())"
+                 Placeholder="@(Placeholder ?? PlaceholderAccordingToView())"
                  Name="@Name"
                  @attributes="@AdditionalAttributes">
     @((MarkupString)CalendarIcon)

--- a/src/Core/Components/DateTime/FluentDatePicker.razor
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor
@@ -1,16 +1,6 @@
 ﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 @inherits FluentCalendarBase
 
-@code {
-    private string PlaceholderAccordingToView()
-    => View switch
-    {
-        CalendarViews.Years => "yyyy",
-        CalendarViews.Months => Culture.DateTimeFormat.YearMonthPattern,
-        _ => Culture.DateTimeFormat.ShortDatePattern
-    };
-}
-
 <FluentInputLabel ForId="@Id" Label="@Label" AriaLabel="@AriaLabel" ChildContent="@LabelTemplate" Required="@Required" />
 <FluentTextField Id="@Id"
                  Embedded="true"

--- a/src/Core/Components/DateTime/FluentDatePicker.razor
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor
@@ -14,7 +14,7 @@
                  ReadOnly="@ReadOnly"
                  Disabled="@Disabled"
                  Required="@Required"
-                 Placeholder="@(Placeholder ?? Culture.DateTimeFormat.ShortDatePattern)"
+                 Placeholder="@(Placeholder ?? DateTimeFormat ?? Culture.DateTimeFormat.ShortDatePattern)"
                  Name="@Name"
                  @attributes="@AdditionalAttributes">
     @((MarkupString)CalendarIcon)

--- a/src/Core/Components/DateTime/FluentDatePicker.razor
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor
@@ -1,6 +1,16 @@
 ﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 @inherits FluentCalendarBase
 
+@code {
+    private string FormatAccardingToView()
+    => View switch
+    {
+        CalendarViews.Years => "yyyy",
+        CalendarViews.Months => Culture.DateTimeFormat.YearMonthPattern,
+        _ => Culture.DateTimeFormat.ShortDatePattern
+    };
+}
+
 <FluentInputLabel ForId="@Id" Label="@Label" AriaLabel="@AriaLabel" ChildContent="@LabelTemplate" Required="@Required" />
 <FluentTextField Id="@Id"
                  Embedded="true"
@@ -10,11 +20,11 @@
                  Autofocus="@Autofocus"
                  Appearance="@Appearance"
                  @bind-Value="@CurrentValueAsString"
-                 @onclick="@OnCalendarOpenHandlerAsync" 
+                 @onclick="@OnCalendarOpenHandlerAsync"
                  ReadOnly="@ReadOnly"
                  Disabled="@Disabled"
                  Required="@Required"
-                 Placeholder="@(Placeholder ?? DateTimeFormat ?? Culture.DateTimeFormat.ShortDatePattern)"
+                 Placeholder="@(Placeholder ?? FormatAccardingToView())"
                  Name="@Name"
                  @attributes="@AdditionalAttributes">
     @((MarkupString)CalendarIcon)
@@ -32,7 +42,6 @@
                           Style="@($"z-index: {ZIndex.DatePickerPopup}; border-radius: calc(var(--control-corner-radius) * 1px); padding: 12px;")">
         <FluentCalendar Culture="@Culture"
                         View="@View"
-                        DateTimeFormat="@DateTimeFormat"
                         DayFormat="@DayFormat"
                         DisabledDateFunc="@DisabledDateFunc"
                         DisabledSelectable="@DisabledSelectable"

--- a/src/Core/Components/DateTime/FluentDatePicker.razor
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor
@@ -1,4 +1,4 @@
-@namespace Microsoft.FluentUI.AspNetCore.Components
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 @inherits FluentCalendarBase
 
 <FluentInputLabel ForId="@Id" Label="@Label" AriaLabel="@AriaLabel" ChildContent="@LabelTemplate" Required="@Required" />
@@ -31,6 +31,8 @@
                           Class="fluent-datepicker-popup"
                           Style="@($"z-index: {ZIndex.DatePickerPopup}; border-radius: calc(var(--control-corner-radius) * 1px); padding: 12px;")">
         <FluentCalendar Culture="@Culture"
+                        View="@View"
+                        DateTimeFormat="@DateTimeFormat"
                         DayFormat="@DayFormat"
                         DisabledDateFunc="@DisabledDateFunc"
                         DisabledSelectable="@DisabledSelectable"

--- a/src/Core/Components/DateTime/FluentDatePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;

--- a/src/Core/Components/DateTime/FluentDatePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor.cs
@@ -39,7 +39,7 @@ public partial class FluentDatePicker : FluentCalendarBase
 
     protected override string? FormatValueAsString(DateTime? value)
     {
-        return Value?.ToString(Culture.DateTimeFormat.ShortDatePattern, Culture);
+        return Value?.ToString(DateTimeFormat ?? Culture.DateTimeFormat.ShortDatePattern, Culture);
     }
 
     protected Task OnCalendarOpenHandlerAsync(MouseEventArgs e)

--- a/src/Core/Components/DateTime/FluentDatePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.FluentUI.AspNetCore.Components.Utilities;

--- a/src/Core/Components/DateTime/FluentDatePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor.cs
@@ -83,9 +83,9 @@ public partial class FluentDatePicker : FluentCalendarBase
 
     protected override bool TryParseValueFromString(string? value, out DateTime? result, [NotNullWhen(false)] out string? validationErrorMessage)
     {
-        if (Regex.IsMatch(value ?? "", @"^\d{4}$"))
+        if (View == CalendarViews.Years && int.TryParse(value, out var year))
         {
-            value = new DateTime(Convert.ToInt32(value), 1, 1).ToString(Culture.DateTimeFormat.ShortDatePattern);
+            value = new DateTime(year, 1, 1).ToString(Culture.DateTimeFormat.ShortDatePattern);
         }
 
         BindConverter.TryConvertTo(value, Culture, out result);
@@ -93,4 +93,12 @@ public partial class FluentDatePicker : FluentCalendarBase
         validationErrorMessage = null;
         return true;
     }
+
+    private string PlaceholderAccordingToView()
+        => View switch
+        {
+            CalendarViews.Years => "yyyy",
+            CalendarViews.Months => Culture.DateTimeFormat.YearMonthPattern,
+            _ => Culture.DateTimeFormat.ShortDatePattern
+        };
 }

--- a/src/Core/Components/DateTime/FluentDatePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -85,12 +86,11 @@ public partial class FluentDatePicker : FluentCalendarBase
     {
         if (Regex.IsMatch(value ?? "", @"^\d{4}$"))
         {
-            result = new DateTime(Convert.ToInt32(value), 1, 1);
+            value = new DateTime(Convert.ToInt32(value), 1, 1).ToString(Culture.DateTimeFormat.ShortDatePattern);
         }
-        else
-        {
-            BindConverter.TryConvertTo(value, Culture, out result);
-        }
+
+        BindConverter.TryConvertTo(value, Culture, out result);
+
         validationErrorMessage = null;
         return true;
     }

--- a/src/Core/Components/DateTime/FluentDatePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.FluentUI.AspNetCore.Components.Utilities;
@@ -39,7 +40,13 @@ public partial class FluentDatePicker : FluentCalendarBase
 
     protected override string? FormatValueAsString(DateTime? value)
     {
-        return Value?.ToString(DateTimeFormat ?? Culture.DateTimeFormat.ShortDatePattern, Culture);
+        return Value?.ToString(View switch
+        {
+            CalendarViews.Years => "yyyy",
+            CalendarViews.Months => Culture.DateTimeFormat.YearMonthPattern,
+            _ => Culture.DateTimeFormat.ShortDatePattern
+
+        }, Culture);
     }
 
     protected Task OnCalendarOpenHandlerAsync(MouseEventArgs e)
@@ -76,7 +83,14 @@ public partial class FluentDatePicker : FluentCalendarBase
 
     protected override bool TryParseValueFromString(string? value, out DateTime? result, [NotNullWhen(false)] out string? validationErrorMessage)
     {
-        BindConverter.TryConvertTo(value, Culture, out result);
+        if (Regex.IsMatch(value ?? "", @"^\d{4}$"))
+        {
+            result = new DateTime(Convert.ToInt32(value), 1, 1);
+        }
+        else
+        {
+            BindConverter.TryConvertTo(value, Culture, out result);
+        }
         validationErrorMessage = null;
         return true;
     }

--- a/src/Core/Components/List/ListComponentBase.razor.cs
+++ b/src/Core/Components/List/ListComponentBase.razor.cs
@@ -444,15 +444,8 @@ public abstract partial class ListComponentBase<TOption> : FluentComponentBase, 
             {
                 return OptionDisabled(item);
             }
-            else
-            {
-                return Disabled;
-            }
         }
-        else
-        {
-            return null;
-        }
+        return null;
     }
 
     /// <summary />

--- a/tests/Core/DateTime/FluentDatePickerTests.cs
+++ b/tests/Core/DateTime/FluentDatePickerTests.cs
@@ -131,6 +131,47 @@ public class FluentDatePickerTests : TestBase
     }
 
     [Fact]
+    public void FluentDatePicker_MonthsViewGetCorrectPlaceholder()
+    {
+        // Arrange
+        using var ctx = new TestContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+        ctx.Services.AddSingleton(LibraryConfiguration);
+
+        // Act
+        var picker = ctx.RenderComponent<FluentDatePicker>(parameters =>
+        {
+            parameters.Add(p => p.Culture, CultureInfo.GetCultureInfo("en-US"));
+            parameters.Add(p => p.View, CalendarViews.Months);
+        });
+        var textfield = picker.Find("fluent-text-field");
+
+        // Assert
+        Assert.Equal("MMMM yyyy", textfield.Attributes["placeholder"].Value);
+    }
+
+    [Fact]
+    public void FluentDatePicker_YearsViewGetCorrectPlaceholder()
+    {
+        // Arrange
+        using var ctx = new TestContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+        ctx.Services.AddSingleton(LibraryConfiguration);
+
+        // Act
+        var picker = ctx.RenderComponent<FluentDatePicker>(parameters =>
+        {
+            parameters.Add(p => p.Culture, CultureInfo.GetCultureInfo("en-US"));
+            parameters.Add(p => p.View, CalendarViews.Years);
+        });
+        var textfield = picker.Find("fluent-text-field");
+        
+        // Assert
+        Assert.Equal("yyyy", textfield.Attributes["placeholder"].Value);
+    }
+
+
+    [Fact]
     public void FluentCalendar_DisabledDate()
     {
 


### PR DESCRIPTION
Enhancement for selecting a different view, month or year, and a custom DateTimeFormat


# Pull Request

## 📖 Description

FluentDatePicker is missing the possibility to select view like month or year which is available in FluentCalendar. 

### 🎫 Issues

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

Create a FluentDatePicker, set view to desired choice of Month or Year. Possibility to add custom DateTimeFormat 

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/main/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new compontent
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component 

## ⏭ Next Steps
