### PR TITLE
[FluentWizard] Fix the Wizard bullet number style

### DIFF
--- a/src/Core/Components/Wizard/FluentWizardStep.razor.css
+++ b/src/Core/Components/Wizard/FluentWizardStep.razor.css
@@ -69,10 +69,11 @@
 
 /* Icon Number */
 .fluent-wizard > ol > li .fluent-wizard-icon-number {
-    margin-top: calc(var(--fluent-wizard-circle-size) * -1 - 3px);
+    margin-top: calc(var(--fluent-wizard-circle-size) * -1 - 4px);
     font-size: small;
     color: var(--accent-fill-rest);
     text-align: center;
+    align-content: center;
 }
 
 .fluent-wizard[position="top"] > ol > li .fluent-wizard-icon-number {


### PR DESCRIPTION
# [FluentWizard] Fix the Wizard bullet number style

This PR fixes the `.fluent-wizard-icon-number` style to center the **Bullet Number** when no default style (Reboot) styles are defined.

## Before

![image](https://github.com/microsoft/fluentui-blazor/assets/8350694/1ed7d523-1340-4953-bf53-1f135c882565)


## After

![image](https://github.com/microsoft/fluentui-blazor/assets/8350694/a150baef-e584-4a6a-8dbb-fe073098731f)
