### PR TITLE
[ProfileMenu] Remove ProfileMenu from demo site header and change examples

### DIFF
--- a/examples/Demo/Shared/Pages/ProfileMenu/Examples/ProfileMenuCustomized.razor
+++ b/examples/Demo/Shared/Pages/ProfileMenu/Examples/ProfileMenuCustomized.razor
@@ -1,6 +1,6 @@
-﻿<FluentStack HorizontalAlignment="@HorizontalAlignment.Center"
+﻿<FluentStack HorizontalAlignment="@HorizontalAlignment.End"
              VerticalAlignment="@VerticalAlignment.Center"
-             Style="height: 48px; background: var(--neutral-layer-4);">
+             Style="height: 48px; background: var(--neutral-layer-4); padding-inline-end: 10px; ">
     <FluentProfileMenu Initials="BG">
         <HeaderTemplate>
             <FluentLabel Typo="@Typography.Header">Login</FluentLabel>

--- a/examples/Demo/Shared/Pages/ProfileMenu/Examples/ProfileMenuDefault.razor
+++ b/examples/Demo/Shared/Pages/ProfileMenu/Examples/ProfileMenuDefault.razor
@@ -1,6 +1,6 @@
-﻿<FluentStack HorizontalAlignment="@HorizontalAlignment.Center"
+﻿<FluentStack HorizontalAlignment="@HorizontalAlignment.End"
              VerticalAlignment="@VerticalAlignment.Center"
-             Style="height: 48px; background: var(--neutral-layer-4);">
+             Style="height: 48px; background: var(--neutral-layer-4); padding-inline-end: 10px; ">
     <FluentProfileMenu Image="@DataSource.SamplePicture"
                        Status="@PresenceStatus.Available"
                        HeaderLabel="Microsoft"

--- a/examples/Demo/Shared/Shared/DemoMainLayout.razor
+++ b/examples/Demo/Shared/Shared/DemoMainLayout.razor
@@ -47,18 +47,7 @@
                 <SiteSettings />
             </div>
 
-             <div class="profile">
-                <FluentProfileMenu Image="@DataSource.ImageFaces[3]"
-                                   Status="@PresenceStatus.Available"
-                                   TopCorner="true"
-                                   Initials="OS"
-                                   FullName="Olivia Smith"
-                                   EMail="sam@my-company.com"
-                                   Style="min-width: 330px;">
-                                   <HeaderTemplate><FluentLabel Typo="Typography.Body">My Company Corp</FluentLabel></HeaderTemplate>
-                                   <FooterTemplate></FooterTemplate>
-                </FluentProfileMenu>
-            </div>
+            
         </FluentHeader>
 
         <FluentStack Class="body-stack" Orientation="Orientation.Horizontal" Width="100%" HorizontalGap="0">

--- a/examples/Demo/Shared/wwwroot/css/site.css
+++ b/examples/Demo/Shared/wwwroot/css/site.css
@@ -35,14 +35,9 @@ body {
     }
 
     .siteheader .settings {
+        padding-right: 6px;
         display: flex;
         align-items: center;
-        margin-left: 0;
-        margin-right: 10px;
-    }
-
-    .siteheader .profile {
-        padding-right: 16px;
         margin-left: 0;
         margin-right: 10px;
     }


### PR DESCRIPTION
This PR removes the ProfileMenu for the demo site header because it gives the impression that your are logged in with someone elses account. 
It also changes the samples to show the profile image/initials at the end of the container so the menu can be seen in full on a small screen device as well.

![image](https://github.com/microsoft/fluentui-blazor/assets/1761079/9a10602b-d835-4904-b0b4-c2b952470268)
