### PR TITLE
[FluentTabs] Not using ClassValue and StyleValue when rendering

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -7628,7 +7628,7 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentTabs.ClassValue">
             <summary />
         </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentTabs.StyleValues">
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentTabs.StyleValue">
             <summary />
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentTabs.StyleMoreValues">

--- a/src/Core/Components/Tabs/FluentTabs.razor
+++ b/src/Core/Components/Tabs/FluentTabs.razor
@@ -1,10 +1,10 @@
-@namespace Microsoft.FluentUI.AspNetCore.Components
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 @inherits FluentComponentBase
 <CascadingValue Value="this" IsFixed="true">
     <fluent-tabs @ref=Element
                  id="@Id"
-                 class="@Class"
-                 style="@Style"
+                 class="@ClassValue"
+                 style="@StyleValue"
                  orientation=@Orientation.ToAttributeValue()
                  activeid=@ActiveTabId
                  activeindicator="@(ShowActiveIndicator.ToString().ToLower())"

--- a/src/Core/Components/Tabs/FluentTabs.razor.cs
+++ b/src/Core/Components/Tabs/FluentTabs.razor.cs
@@ -23,7 +23,7 @@ public partial class FluentTabs : FluentComponentBase
         .Build();
 
     /// <summary />
-    protected string? StyleValues => new StyleBuilder(Style)
+    protected string? StyleValue => new StyleBuilder(Style)
         .AddStyle("padding", "6px", () => Size == TabSize.Small)
         .AddStyle("padding", "12px 10px", () => Size == TabSize.Small)
         .AddStyle("padding", "16px 10px", () => Size == TabSize.Small)


### PR DESCRIPTION
Tiny PR. Title says it all.

Probably never been caught before because we don't have good unit tests fo this one yet...