### PR TITLE
[NavMenu] Fix keyboard navigation

### DIFF
--- a/src/Core/Components/NavMenu/FluentNavGroup.razor
+++ b/src/Core/Components/NavMenu/FluentNavGroup.razor
@@ -5,7 +5,7 @@
 
 @if (Owner.Expanded || (HasIcon && (!Owner.CollapsedChildNavigation || SubMenu == null)))
 {
-    <FluentKeyCode Anchor="@Id" OnKeyDown="@HandleExpanderKeyDownAsync" />
+    <FluentKeyCode Anchor="@Id" PreventDefaultOnly="new[] { KeyCode.Enter, KeyCode.Left, KeyCode.Right }" StopPropagation="@true" OnKeyDown="@HandleExpanderKeyDownAsync" />
     <div id="@Id" @ref="@Element" @attributes="AdditionalAttributes" class="@ClassValue" disabled="@Disabled" style="@StyleValue" role="menuitem">
 
         @if (!string.IsNullOrEmpty(Href))
@@ -25,7 +25,7 @@
         }
         else
         {
-            <div class="fluent-nav-link notactive" tabindex="0">
+            <div class="fluent-nav-link notactive" tabindex="@(Disabled ? "-1" : "0")">
                 <div class="positioning-region" @onclick="ToggleExpandedAsync" title="@(Tooltip ?? Title)">
                     <div class="content-region">
                         @_renderContent
@@ -42,7 +42,7 @@
         </FluentCollapsibleRegion>
     </div>
 
-    if (Owner.CollapsedChildNavigation && SubMenu == null)
+    if (!Owner.Expanded && Owner.CollapsedChildNavigation && SubMenu == null)
     {
         <FluentMenu @bind-Open="_open"
                     Anchor="@Id"
@@ -53,27 +53,29 @@
             @ChildContent
         </FluentMenu>
     }
+    else
+    {
+        _open = false;
+    }
 }
 else if (!Owner.Expanded && Owner.CollapsedChildNavigation && SubMenu != null)
 {
-    <div>
-        <FluentMenuItem Disabled="@Disabled" OnClick="OnClickHandlerAsync">
-            <ChildContent>
-                @Title
-                @TitleTemplate
+    <FluentMenuItem Disabled="@Disabled" OnClick="OnClickHandlerAsync">
+        <ChildContent>
+            @Title
+            @TitleTemplate
 
-                @if (Icon is not null)
-                {
-                    <span slot="start">
-                        <FluentIcon Value="@Icon" Width="20px" Color="@IconColor" Class="fluent-nav-icon" />
-                    </span>
-                }
-            </ChildContent>
-            <MenuItems>
-                @ChildContent
-            </MenuItems>
-        </FluentMenuItem>
-    </div>
+            @if (Icon is not null)
+            {
+                <span slot="start">
+                    <FluentIcon Value="@Icon" Width="20px" Color="@IconColor" Class="fluent-nav-icon" />
+                </span>
+            }
+        </ChildContent>
+        <MenuItems>
+            @ChildContent
+        </MenuItems>
+    </FluentMenuItem>
 }
 
 

--- a/src/Core/Components/NavMenu/FluentNavGroup.razor.cs
+++ b/src/Core/Components/NavMenu/FluentNavGroup.razor.cs
@@ -102,7 +102,17 @@ public partial class FluentNavGroup : FluentNavBase
         _renderButton = RenderButton;
     }
 
-    private Task ToggleExpandedAsync() => SetExpandedAsync(!Expanded);
+    private Task ToggleExpandedAsync()
+    {
+        if (!Owner.Expanded && Owner.CollapsedChildNavigation)
+        {
+            return SetExpandedAsync(!_open);
+        }
+        else
+        {
+            return SetExpandedAsync(!Expanded);
+        }
+    }
 
     private async Task HandleExpanderKeyDownAsync(FluentKeyCodeEventArgs args)
     {
@@ -112,7 +122,7 @@ public partial class FluentNavGroup : FluentNavBase
         }
         Task handler = args.Key switch
         {
-            KeyCode.Enter => SetExpandedAsync(!Expanded),
+            KeyCode.Enter => ToggleExpandedAsync(),
             KeyCode.Right => SetExpandedAsync(true),
             KeyCode.Left => SetExpandedAsync(false),
             _ => Task.CompletedTask
@@ -122,16 +132,11 @@ public partial class FluentNavGroup : FluentNavBase
 
     private async Task SetExpandedAsync(bool value)
     {
-        if (value == Expanded)
-        {
-            return;
-        }
-
         if (!Owner.Expanded)
         {
             if (Owner.CollapsedChildNavigation)
             {
-                _open = !_open;
+                _open = value;
             }
             else
             {
@@ -140,6 +145,11 @@ public partial class FluentNavGroup : FluentNavBase
         }
         else
         {
+            if (value == Expanded)
+            {
+                return;
+            }
+
             Expanded = value;
 
             if (ExpandedChanged.HasDelegate)

--- a/src/Core/Components/NavMenu/FluentNavGroup.razor.css
+++ b/src/Core/Components/NavMenu/FluentNavGroup.razor.css
@@ -60,3 +60,7 @@
 ::deep .rotate.expand-collapse-button svg {
     transform: rotate(90deg);
 }
+
+:not(.expanded) ::deep .items {
+    display: none;
+} 

--- a/src/Core/Components/NavMenu/FluentNavLink.razor
+++ b/src/Core/Components/NavMenu/FluentNavLink.razor
@@ -35,24 +35,22 @@
 }
 else if (!Owner.Expanded && Owner.CollapsedChildNavigation && SubMenu != null)
 {
-    <div>
-        <FluentMenuItem Disabled="@Disabled" OnClick="OnClickHandlerAsync">
-            <NavLink class="@LinkClassValue"
-                     @attributes="@Attributes"
-                     Match="@Match"
-                     ActiveClass="@ActiveClass"
-                     title="@Tooltip">
-                @ChildContent
-            </NavLink>
+    <FluentMenuItem Disabled="@Disabled" OnClick="OnClickHandlerAsync" @onmenuchange="async ev => await OnClickHandlerAsync(null)">
+        <NavLink class="@LinkClassValue"
+                    @attributes="@Attributes"
+                    Match="@Match"
+                    ActiveClass="@ActiveClass"
+                    title="@Tooltip">
+            @ChildContent
+        </NavLink>
 
-            @if (Icon is not null)
-            {
-                <span slot="start">
-                    <FluentIcon Value="@Icon" Color="@IconColor" Class="fluent-nav-icon" />
-                </span>
-            }
-        </FluentMenuItem>
-    </div>
+        @if (Icon is not null)
+        {
+            <span slot="start">
+                <FluentIcon Value="@Icon" Color="@IconColor" Class="fluent-nav-icon" />
+            </span>
+        }
+    </FluentMenuItem>
 }
 
 @code {

--- a/src/Core/Components/NavMenu/FluentNavMenu.razor
+++ b/src/Core/Components/NavMenu/FluentNavMenu.razor
@@ -8,7 +8,7 @@
     <CascadingValue Value="this" IsFixed="true">
         @if (Collapsible)
         {
-            <FluentKeyCode Anchor="expander" OnKeyDown="@HandleExpandCollapseKeyDownAsync" />
+            <FluentKeyCode Anchor="@($"{@Id}-expander")" OnKeyDown="@HandleExpandCollapseKeyDownAsync" />
             <div id="@($"{@Id}-expander")"
                  aria-label="@Title"
                  aria-expanded="@(Expanded.ToAttributeValue())"

--- a/src/Core/Components/NavMenu/FluentNavMenu.razor.css
+++ b/src/Core/Components/NavMenu/FluentNavMenu.razor.css
@@ -63,6 +63,14 @@
     margin-bottom: 2px;
 }
 
+::deep fluent-menu-item .fluent-nav-link {
+    width: 100%;
+    color: inherit;
+    align-items: center;
+    text-decoration: none;
+    display: flex;
+}
+
 /* level indenting */
 ::deep .fluent-nav-group * .fluent-nav-menu > .fluent-nav-item .content-region {
     padding-inline-start: 24px;

--- a/tests/Core/NavMenu/FluentNavGroupTests.FluentNavGroup_Disabled.verified.html
+++ b/tests/Core/NavMenu/FluentNavGroupTests.FluentNavGroup_Disabled.verified.html
@@ -1,6 +1,6 @@
 
 <div id="xxx" class="fluent-nav-item disabled fluent-nav-group" disabled="" role="menuitem" b-hv9rzieq3w="" blazor:elementreference="xxx">
-  <div class="fluent-nav-link notactive" tabindex="0" b-hv9rzieq3w="">
+  <div class="fluent-nav-link notactive" tabindex="-1" b-hv9rzieq3w="">
     <div class="positioning-region" blazor:onclick="1" blazor:onkeydown="2" title="Group title" b-hv9rzieq3w="">
       <div class="content-region" b-hv9rzieq3w="">
         <span class="fluent-nav-icon" style="min-width: 20px;" b-hv9rzieq3w=""></span>


### PR DESCRIPTION
# Pull Request

## 📖 Description

Based on PR #1730, this PR fixes keyboard navigation in the `FluentNavMenu` component.
The nav menu can be opened and closed with keys again when collapsible.
Disabled `FluentNavMenuGroup`s and `FluentNavMenuItem`s can't be focused using keyboard navigation anymore. 

## 📑 Test Plan

The `FluentNavGroup_Disabled` test was affected by this PR as it seems to have allowed focusing a disabled nav menu group. 

## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new compontent
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component 
