### PR TITLE
[DataGrid] Change column width when using generated value 

### DIFF
--- a/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridCustomPaging.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridCustomPaging.razor
@@ -1,7 +1,7 @@
 ﻿@inject DataSource Data
 
-<div class="grid">
-    <FluentDataGrid Items="@itemsQueryable" Pagination="@pagination">
+<div class="grid" style="width: 100%; overflow-x:auto;">
+    <FluentDataGrid Items="@itemsQueryable" Pagination="@pagination"  Style="width: 1000px;">
         <PropertyColumn Property="@(c => c.Name)" Sortable="true" Class="country-name" />
         <PropertyColumn Property="@(c => c.Medals.Gold)" Sortable="true" Align="Align.End" />
         <PropertyColumn Property="@(c => c.Medals.Silver)" Sortable="true" Align="Align.End" />

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -321,7 +321,7 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
 
         if (string.IsNullOrWhiteSpace(_internalGridTemplateColumns) && _columns.Any(x => !string.IsNullOrWhiteSpace(x.Width)))
         {
-            _internalGridTemplateColumns = string.Join(" ", _columns.Select(x => x.Width ?? "auto"));
+            _internalGridTemplateColumns = string.Join(" ", _columns.Select(x => x.Width ?? "1fr"));
         }
 
         if (ResizableColumns)


### PR DESCRIPTION
Fix #1954 and change custom paging example to show scrollable grid on a smaller screen.

With the new `Width` parameter, the grid-template-colums value gets genareted based on what widths are supplied. In case nothingis pecified we used `auto`. This can lead to undesired effects where column cells have different widths per row (for the same column) With this PR we change the default value to `1fr`