### PR TITLE
[AppBar] Allow for omitting Href on AppBarItems and don't show active status when Href is null or not specified

### DIFF
--- a/examples/Demo/Shared/Pages/AppBar/Examples/AppBarClick.razor
+++ b/examples/Demo/Shared/Pages/AppBar/Examples/AppBarClick.razor
@@ -13,8 +13,7 @@
                           IconActive="AppBarIcon(active: true)"
                           Text="AppBar"
                           OnClick="HandleOnClick" />
-        <FluentAppBarItem Href="@(null)"
-                          IconRest="WhatsNewIcon()"
+        <FluentAppBarItem IconRest="WhatsNewIcon()"
                           IconActive="WhatsNewIcon(active: true)"
                           Text="What's New'"
                           OnClick="ShowSuccessAsync" />

--- a/src/Core/Components/AppBar/FluentAppBar.razor
+++ b/src/Core/Components/AppBar/FluentAppBar.razor
@@ -27,7 +27,8 @@
                            HorizontalPosition="HorizontalPosition.End"
                            HorizontalInset="false"
                            VerticalPosition="VerticalPosition.Center"
-                           Style="width: 320px; height: 200px; overflow-y: scroll;">
+                           VerticalThreshold="25"
+                           Style="width: 320px; height: 200px; overflow-y: scroll; margin-top: 35px; ">
                 <Body>
                     @if (PopoverShowSearch)
                     {

--- a/src/Core/Components/AppBar/FluentAppBar.razor.css
+++ b/src/Core/Components/AppBar/FluentAppBar.razor.css
@@ -44,9 +44,17 @@
     right: unset;
 }
 
+::deep .fluent-appbar-item.fluent-appbar-item-local:not(.popover) a.active::before {
+    all: initial;
+}
+
 [dir='rtl'] * ::deep .fluent-appbar-item:not(.popover) a.active::before {
     right: calc(var(--design-unit) * 0.5px);
     left: unset;
+}
+
+[dir='rtl'] * ::deep .fluent-appbar-item.fluent-appbar-item-local:not(.popover) a.active::before {
+    all: initial;
 }
 
 ::deep .fluent-popover-content .fluent-popover-body {

--- a/src/Core/Components/AppBar/FluentAppBarItem.razor.cs
+++ b/src/Core/Components/AppBar/FluentAppBarItem.razor.cs
@@ -78,7 +78,7 @@ public partial class FluentAppBarItem : FluentComponentBase, IDisposable
     public bool? Overflow { get; private set; }
 
     internal string? ClassValue => new CssBuilder("fluent-appbar-item")
-        .AddClass("fluent-appbar-item-local", when: Href == null)
+        .AddClass("fluent-appbar-item-local", when: string.IsNullOrEmpty(Href))
         .AddClass(Class)
         .Build();
 

--- a/src/Core/Components/AppBar/FluentAppBarItem.razor.cs
+++ b/src/Core/Components/AppBar/FluentAppBarItem.razor.cs
@@ -14,8 +14,8 @@ public partial class FluentAppBarItem : FluentComponentBase, IDisposable
     /// <summary>
     /// Gets or sets the URL for this item.
     /// </summary>
-    [Parameter, EditorRequired]
-    public required string Href { get; set; }
+    [Parameter]
+    public string? Href { get; set; }
 
     /// <summary>
     /// Gets or sets how the link should be matched.
@@ -78,6 +78,7 @@ public partial class FluentAppBarItem : FluentComponentBase, IDisposable
     public bool? Overflow { get; private set; }
 
     internal string? ClassValue => new CssBuilder("fluent-appbar-item")
+        .AddClass("fluent-appbar-item-local", when: Href == null)
         .AddClass(Class)
         .Build();
 


### PR DESCRIPTION
Changes for fixing #1974 
We have changed the `Href` parameter on the AppBarItem to allow for `null` valure and make it not-`[EditorRequired]` anymore.

In the AppBarItem we now check if `Href` is null. If so, we'll add a class to the AppBarItem indicating it is a local link. We use `NavLink` internally, so an `a` is still rendered and an `active` class is still added. Based on that local class being added, we will remove the CSS that gets applied for 'active' state (i.e remove the accent colored bar)

![image](https://github.com/microsoft/fluentui-blazor/assets/1761079/64e54c29-d3fc-4213-b679-b1536e8c8226)
