### PR TITLE
[Tabs] Prevent error 'An item with the same key has already been added.'

### DIFF
--- a/src/Core/Components/Tabs/FluentTabs.razor.cs
+++ b/src/Core/Components/Tabs/FluentTabs.razor.cs
@@ -167,7 +167,7 @@ public partial class FluentTabs : FluentComponentBase
 
     internal int RegisterTab(FluentTab tab)
     {
-        _tabs.Add(tab.Id!, tab);
+        _ = _tabs.TryAdd(tab.Id!, tab);
         return _tabs.Count - 1;
     }
 


### PR DESCRIPTION
Prevent the error by using `TryAdd` instead of just `Add`