### PR TITLE
[ProfileMenu] 

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -6789,6 +6789,16 @@
             Gets or sets the title to show on hover. If not provided, the status will be used.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentProfileMenu.PopoverClass">
+            <summary>
+            Gets or sets the Class to apply to the Profile Popup.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentProfileMenu.PopoverStyle">
+            <summary>
+            Gets or sets the Style to apply to the Profile Popup.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentProfileMenu.Initials">
             <summary>
             Gets or sets the initials to display if no image is provided.

--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -6769,6 +6769,16 @@
             Using this property will override the <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentProfileMenu.FooterLink" /> property.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentProfileMenu.StartTemplate">
+            <summary>
+            Gets or sets the content to be displayed in the start (left) section of the Profile button.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentProfileMenu.EndTemplate">
+            <summary>
+            Gets or sets the content to be displayed in the end (right) section of the Profile button.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentProfileMenu.Status">
             <summary>
             Gets or sets the status to show. See <see cref="T:Microsoft.FluentUI.AspNetCore.Components.PresenceStatus"/> for options.
@@ -6839,6 +6849,9 @@
             <summary>
             Event raised when the user clicks on the Footer hyperlink (e.g. View account).
             </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentProfileMenu.PersonaId">
+            <summary />
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentProgress.Min">
             <summary>

--- a/examples/Demo/Shared/Pages/ProfileMenu/Examples/ProfileMenuCustomized.razor
+++ b/examples/Demo/Shared/Pages/ProfileMenu/Examples/ProfileMenuCustomized.razor
@@ -1,7 +1,10 @@
 ﻿<FluentStack HorizontalAlignment="@HorizontalAlignment.End"
              VerticalAlignment="@VerticalAlignment.Center"
              Style="height: 48px; background: var(--neutral-layer-4); padding-inline-end: 10px; ">
-    <FluentProfileMenu Initials="BG">
+    <FluentProfileMenu Initials="BG" Style="--fluent-profile-menu-hover: var(--neutral-stroke-focus); padding: 4px;">
+        <StartTemplate>
+            Bill Gates
+        </StartTemplate>
         <HeaderTemplate>
             <FluentLabel Typo="@Typography.Header">Login</FluentLabel>
         </HeaderTemplate>

--- a/examples/Demo/Shared/Pages/ProfileMenu/Examples/ProfileMenuCustomized.razor
+++ b/examples/Demo/Shared/Pages/ProfileMenu/Examples/ProfileMenuCustomized.razor
@@ -1,7 +1,8 @@
 ﻿<FluentStack HorizontalAlignment="@HorizontalAlignment.End"
              VerticalAlignment="@VerticalAlignment.Center"
              Style="height: 48px; background: var(--neutral-layer-4); padding-inline-end: 10px; ">
-    <FluentProfileMenu Initials="BG" Style="--fluent-profile-menu-hover: var(--neutral-stroke-focus); padding: 4px;">
+    <FluentProfileMenu Initials="BG"
+                       Style="--fluent-profile-menu-hover: var(--neutral-stroke-focus); padding: 4px;">
         <StartTemplate>
             Bill Gates
         </StartTemplate>

--- a/examples/Demo/Shared/Pages/ProfileMenu/Examples/ProfileMenuDefault.razor
+++ b/examples/Demo/Shared/Pages/ProfileMenu/Examples/ProfileMenuDefault.razor
@@ -7,5 +7,5 @@
                        Initials="BG"
                        FullName="Bill Gates"
                        EMail="bill.gates@microsoft.com"
-                       Style="min-width: 330px;" />
+                       PopoverStyle="min-width: 330px;" />
 </FluentStack>

--- a/src/Core/Components/ProfileMenu/FluentProfileMenu.razor
+++ b/src/Core/Components/ProfileMenu/FluentProfileMenu.razor
@@ -12,74 +12,74 @@
                    StatusTitle="@StatusTitle"
                    Initials="@Initials"
                    Style="height: inherit;" />
-
-    <FluentPopover AnchorId="@PersonaId"
-                   Class="@Class"
-                   Style="@Style"
-                   HorizontalPosition="@HorizontalPosition.Start"
-                   @bind-Open="@PopoverVisible"
-                   @attributes="@AdditionalAttributes">
-        <Header>
-            @if (HeaderTemplate is null && (!string.IsNullOrEmpty(HeaderLabel) || !string.IsNullOrEmpty(HeaderButton)))
-            {
-                <FluentStack VerticalAlignment="@VerticalAlignment.Center">
-                    @if (!string.IsNullOrEmpty(HeaderLabel))
-                    {
-                        <FluentLabel part="header-label">@HeaderLabel</FluentLabel>
-                    }
-                    @if (!string.IsNullOrEmpty(HeaderButton))
-                    {
-                        <FluentSpacer />
-                        <FluentButton part="header-button" Appearance="@Appearance.Stealth" OnClick="@OnHeaderButtonClick">@HeaderButton</FluentButton>
-                    }
-                </FluentStack>
-            }
-            else
-            {
-                @HeaderTemplate
-            }
-        </Header>
-
-        <Body>
-            @if (ChildContent is null)
-            {
-                <FluentStack Style="height: 100%;">
-                    <FluentPersona Image="@Image"
-                                   ImageSize="@ImageSize"
-                                   Initials="@Initials"
-                                   Style="align-items: normal;">
-                        <FluentLabel part="fullname" Typo="@Typography.Header" Style="font-weight: bold;">@FullName</FluentLabel>
-                        <FluentLabel part="email">@EMail</FluentLabel>
-                    </FluentPersona>
-
-                </FluentStack>
-            }
-            else
-            {
-                @ChildContent
-            }
-        </Body>
-
-        <Footer>
-            @if (FooterTemplate is null && !string.IsNullOrEmpty(FooterLink))
-            {
-                <FluentStack VerticalAlignment="@VerticalAlignment.Center">
-                    @if (!string.IsNullOrEmpty(FooterLabel))
-                    {
-                        <FluentLabel part="footer-label">@FooterLabel</FluentLabel>
-                    }
-                    @if (!string.IsNullOrEmpty(FooterLink))
-                    {
-                        <FluentSpacer />
-                        <FluentAnchor part="footer-link" Appearance="@Appearance.Hypertext" Href="#" OnClick="@OnFooterLinkClick">@FooterLink</FluentAnchor>
-                    }
-                </FluentStack>
-            }
-            else
-            {
-                @FooterTemplate
-            }
-        </Footer>
-    </FluentPopover>
     @EndTemplate
 </div>
+
+<FluentPopover AnchorId="@PersonaId"
+               Class="@PopoverClass"
+               Style="@PopoverStyle"
+               HorizontalPosition="@HorizontalPosition.Start"
+               @bind-Open="@PopoverVisible"
+               @attributes="@AdditionalAttributes">
+    <Header>
+        @if (HeaderTemplate is null && (!string.IsNullOrEmpty(HeaderLabel) || !string.IsNullOrEmpty(HeaderButton)))
+        {
+            <FluentStack VerticalAlignment="@VerticalAlignment.Center">
+                @if (!string.IsNullOrEmpty(HeaderLabel))
+                {
+                    <FluentLabel part="header-label">@HeaderLabel</FluentLabel>
+                }
+                @if (!string.IsNullOrEmpty(HeaderButton))
+                {
+                    <FluentSpacer />
+                    <FluentButton part="header-button" Appearance="@Appearance.Stealth" OnClick="@OnHeaderButtonClick">@HeaderButton</FluentButton>
+                }
+            </FluentStack>
+        }
+        else
+        {
+            @HeaderTemplate
+        }
+    </Header>
+
+    <Body>
+        @if (ChildContent is null)
+        {
+            <FluentStack Style="height: 100%;">
+                <FluentPersona Image="@Image"
+                               ImageSize="@ImageSize"
+                               Initials="@Initials"
+                               Style="align-items: normal;">
+                    <FluentLabel part="fullname" Typo="@Typography.Header" Style="font-weight: bold;">@FullName</FluentLabel>
+                    <FluentLabel part="email">@EMail</FluentLabel>
+                </FluentPersona>
+
+            </FluentStack>
+        }
+        else
+        {
+            @ChildContent
+        }
+    </Body>
+
+    <Footer>
+        @if (FooterTemplate is null && !string.IsNullOrEmpty(FooterLink))
+        {
+            <FluentStack VerticalAlignment="@VerticalAlignment.Center">
+                @if (!string.IsNullOrEmpty(FooterLabel))
+                {
+                    <FluentLabel part="footer-label">@FooterLabel</FluentLabel>
+                }
+                @if (!string.IsNullOrEmpty(FooterLink))
+                {
+                    <FluentSpacer />
+                    <FluentAnchor part="footer-link" Appearance="@Appearance.Hypertext" Href="#" OnClick="@OnFooterLinkClick">@FooterLink</FluentAnchor>
+                }
+            </FluentStack>
+        }
+        else
+        {
+            @FooterTemplate
+        }
+    </Footer>
+</FluentPopover>

--- a/src/Core/Components/ProfileMenu/FluentProfileMenu.razor
+++ b/src/Core/Components/ProfileMenu/FluentProfileMenu.razor
@@ -1,18 +1,19 @@
 ﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 @inherits FluentComponentBase
 
-<div class="fluent-profile-menu" top-corner="@TopCorner">
-    <FluentPersona Id="@Id"
+<div id="@Id" class="@ClassValue" style="@StyleValue" top-corner="@TopCorner"
+     @onclick="@(e => PopoverVisible = !PopoverVisible)">
+    @StartTemplate
+    <FluentPersona Id="@PersonaId"
                    Image="@Image"
                    Name="@FullName"
                    ImageSize="@ButtonSize"
                    Status="@Status"
                    StatusTitle="@StatusTitle"
                    Initials="@Initials"
-                   Style="height: inherit;"
-                   OnClick="@(e => PopoverVisible = !PopoverVisible)" />
+                   Style="height: inherit;" />
 
-    <FluentPopover AnchorId="@Id"
+    <FluentPopover AnchorId="@PersonaId"
                    Class="@Class"
                    Style="@Style"
                    HorizontalPosition="@HorizontalPosition.Start"
@@ -80,4 +81,5 @@
             }
         </Footer>
     </FluentPopover>
+    @EndTemplate
 </div>

--- a/src/Core/Components/ProfileMenu/FluentProfileMenu.razor.cs
+++ b/src/Core/Components/ProfileMenu/FluentProfileMenu.razor.cs
@@ -75,6 +75,18 @@ public partial class FluentProfileMenu : FluentComponentBase
     public string? StatusTitle { get; set; }
 
     /// <summary>
+    /// Gets or sets the Class to apply to the Profile Popup.
+    /// </summary>
+    [Parameter]
+    public virtual string? PopoverClass { get; set; } = null;
+
+    /// <summary>
+    /// Gets or sets the Style to apply to the Profile Popup.
+    /// </summary>
+    [Parameter]
+    public virtual string? PopoverStyle { get; set; } = null;
+
+    /// <summary>
     /// Gets or sets the initials to display if no image is provided.
     /// By default, the first letters of the <see cref="FullName"/> is used.
     /// </summary>

--- a/src/Core/Components/ProfileMenu/FluentProfileMenu.razor.cs
+++ b/src/Core/Components/ProfileMenu/FluentProfileMenu.razor.cs
@@ -3,6 +3,7 @@
 // ------------------------------------------------------------------------
 
 using Microsoft.AspNetCore.Components;
+using Microsoft.FluentUI.AspNetCore.Components.Utilities;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
@@ -12,6 +13,13 @@ public partial class FluentProfileMenu : FluentComponentBase
     {
         Id = Identifier.NewId();
     }
+
+    protected string? ClassValue => new CssBuilder(Class)
+        .AddClass("fluent-profile-menu")
+        .Build();
+
+    protected string? StyleValue => new StyleBuilder(Style)
+        .Build();
 
     private bool PopoverVisible { get; set; } = false;
 
@@ -41,6 +49,18 @@ public partial class FluentProfileMenu : FluentComponentBase
     /// </summary>
     [Parameter]
     public RenderFragment? FooterTemplate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the content to be displayed in the start (left) section of the Profile button.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? StartTemplate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the content to be displayed in the end (right) section of the Profile button.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? EndTemplate { get; set; }
 
     /// <summary>
     /// Gets or sets the status to show. See <see cref="PresenceStatus"/> for options.
@@ -126,4 +146,7 @@ public partial class FluentProfileMenu : FluentComponentBase
     /// </summary>
     [Parameter]
     public EventCallback OnFooterLinkClick { get; set; }
+
+    /// <summary />
+    private string PersonaId => $"{Id}-persona";
 }

--- a/src/Core/Components/ProfileMenu/FluentProfileMenu.razor.css
+++ b/src/Core/Components/ProfileMenu/FluentProfileMenu.razor.css
@@ -1,5 +1,14 @@
 .fluent-profile-menu {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 4px;
+    cursor: pointer;
 }
+
+    .fluent-profile-menu:hover {
+        background-color: var(--fluent-profile-menu-hover);
+    }
 
     .fluent-profile-menu ::deep > .fluent-persona > .name {
         display: none;

--- a/tests/Core/ProfileMenu/FluentProfileMenuTests.FluentProfileMenu_Customized.verified.razor.html
+++ b/tests/Core/ProfileMenu/FluentProfileMenuTests.FluentProfileMenu_Customized.verified.razor.html
@@ -1,24 +1,24 @@
 
-<div class="fluent-profile-menu" b-rsm9d6pikk="">
+<div id="xxx" class="fluent-profile-menu" blazor:onclick="1" b-rsm9d6pikk="">
   <div id="xxx" class="fluent-persona" style="height: inherit;" position="end" b-n7zog0zvqi="">
-    <div class="initials" blazor:onclick="1" style="cursor: pointer;" b-n7zog0zvqi="">
+    <div class="initials" b-n7zog0zvqi="">
       <div class="fluent-presence-badge" title="" b-1o8tp31nhy="">
         <div style="display: table-cell; vertical-align: middle; width: 32px; min-width: 32px; height: 32px; min-height: 32px;" b-n7zog0zvqi="">DV</div>
       </div>
     </div>
   </div>
-  <div class="fluent-overlay" style="cursor: auto; position: fixed; z-index: 9900;" blazor:onclick="2" blazor:oncontextmenu="3" blazor:oncontextmenu:preventdefault="" b-xkrr7evqik="">
-    <div style="display: flex; align-items:center; justify-content: center; width: 100%; height: 100%" b-xkrr7evqik=""></div>
-  </div>
-  <fluent-anchored-region anchor="xxx" horizontal-positioning-mode="dynamic" horizontal-default-position="start" horizontal-inset="" horizontal-threshold="0" horizontal-scaling="content" vertical-positioning-mode="dynamic" vertical-default-position="bottom" vertical-threshold="0" vertical-scaling="content" auto-update-mode="auto" style="z-index: 9999;" b-2ov9fhztky="" blazor:elementreference="xxx">
-    <div style="z-index: 9999; background-color: var(--neutral-layer-floating); box-shadow: var(--elevation-shadow-flyout);" b-2ov9fhztky="">
-      <div class="stack-vertical" style="align-items: start; justify-content: start; column-gap: 10px; row-gap: 10px; width: 100%;" b-0nr62qx0mz="">
-        <div class="fluent-popover-content" b-qp3z8ghd2d="">
-          <div part="header" b-qp3z8ghd2d="">Header</div>
-          <div part="body" b-qp3z8ghd2d="">Body</div>
-          <div part="footer" b-qp3z8ghd2d="">Footer</div>
-        </div>
+</div>
+<div class="fluent-overlay" style="cursor: auto; position: fixed; z-index: 9900;" blazor:onclick="2" blazor:oncontextmenu="3" blazor:oncontextmenu:preventdefault="" b-xkrr7evqik="">
+  <div style="display: flex; align-items:center; justify-content: center; width: 100%; height: 100%" b-xkrr7evqik=""></div>
+</div>
+<fluent-anchored-region id="xxx" anchor="xxx" horizontal-positioning-mode="dynamic" horizontal-default-position="start" horizontal-inset="" horizontal-threshold="0" horizontal-scaling="content" vertical-positioning-mode="dynamic" vertical-default-position="bottom" vertical-threshold="0" vertical-scaling="content" auto-update-mode="auto" style="z-index: 9999;" b-2ov9fhztky="" blazor:elementreference="xxx">
+  <div style="z-index: 9999; background-color: var(--neutral-layer-floating); box-shadow: var(--elevation-shadow-flyout);" b-2ov9fhztky="">
+    <div class="stack-vertical" style="align-items: start; justify-content: start; column-gap: 10px; row-gap: 10px; width: 100%;" b-0nr62qx0mz="">
+      <div class="fluent-popover-content" b-qp3z8ghd2d="">
+        <div part="header" b-qp3z8ghd2d="">Header</div>
+        <div part="body" b-qp3z8ghd2d="">Body</div>
+        <div part="footer" b-qp3z8ghd2d="">Footer</div>
       </div>
     </div>
-  </fluent-anchored-region>
-</div>
+  </div>
+</fluent-anchored-region>

--- a/tests/Core/ProfileMenu/FluentProfileMenuTests.FluentProfileMenu_Default.verified.razor.html
+++ b/tests/Core/ProfileMenu/FluentProfileMenuTests.FluentProfileMenu_Default.verified.razor.html
@@ -1,59 +1,59 @@
 
-<div class="fluent-profile-menu" b-rsm9d6pikk="">
+<div id="xxx" class="fluent-profile-menu" blazor:onclick="1" b-rsm9d6pikk="">
   <div id="xxx" class="fluent-persona" style="height: inherit;" position="end" b-n7zog0zvqi="">
-    <div class="initials" blazor:onclick="1" style="cursor: pointer;" b-n7zog0zvqi="">
+    <div class="initials" b-n7zog0zvqi="">
       <div class="fluent-presence-badge" title="I'm available" b-1o8tp31nhy="">
         <div style="display: table-cell; vertical-align: middle; width: 20px; min-width: 20px; height: 20px; min-height: 20px;" b-n7zog0zvqi="">
           <img src="iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=" alt="Bill Gates" title="Bill Gates" style="max-width: 20px; max-height: 20px;" b-n7zog0zvqi="">
         </div>
-        <svg class="status" style="width: 12px; fill: var(--presence-available);" focusable="false" viewBox="0 0 24 24" aria-hidden="true" blazor:onclick="3">
+        <svg class="status" style="width: 12px; fill: var(--presence-available);" focusable="false" viewBox="0 0 24 24" aria-hidden="true" blazor:onkeydown="2" blazor:onclick="3">
           <title>I'm available</title>
           <path d="M12 24a12 12 0 1 0 0-24 12 12 0 0 0 0 24Zm5.06-13.44-5.5 5.5a1.5 1.5 0 0 1-2.12 0l-2-2a1.5 1.5 0 0 1 2.12-2.12l.94.94 4.44-4.44a1.5 1.5 0 0 1 2.12 2.12Z"></path>
         </svg>
       </div>
     </div>
-    <div class="name" blazor:onclick="2" style="cursor: pointer;" b-n7zog0zvqi="">Bill Gates</div>
+    <div class="name" b-n7zog0zvqi="">Bill Gates</div>
   </div>
-  <div class="fluent-overlay" style="cursor: auto; position: fixed; z-index: 9900;" blazor:onclick="4" blazor:oncontextmenu="5" blazor:oncontextmenu:preventdefault="" b-xkrr7evqik="">
-    <div style="display: flex; align-items:center; justify-content: center; width: 100%; height: 100%" b-xkrr7evqik=""></div>
-  </div>
-  <fluent-anchored-region anchor="xxx" horizontal-positioning-mode="dynamic" horizontal-default-position="start" horizontal-inset="" horizontal-threshold="0" horizontal-scaling="content" vertical-positioning-mode="dynamic" vertical-default-position="bottom" vertical-threshold="0" vertical-scaling="content" auto-update-mode="auto" style="z-index: 9999;" b-2ov9fhztky="" blazor:elementreference="xxx">
-    <div style="z-index: 9999; background-color: var(--neutral-layer-floating); box-shadow: var(--elevation-shadow-flyout);" b-2ov9fhztky="">
-      <div class="stack-vertical" style="align-items: start; justify-content: start; column-gap: 10px; row-gap: 10px; width: 100%;" b-0nr62qx0mz="">
-        <div class="fluent-popover-content" b-qp3z8ghd2d="">
-          <div part="header" b-qp3z8ghd2d="">
-            <div class="stack-horizontal" style="justify-content: start; align-items: center; column-gap: 10px; row-gap: 10px; width: 100%;" b-0nr62qx0mz="">
-              <p part="header-label" typo="body" class="fluent-typography" b-1nnnfjehkp="">Microsoft</p>
-              <div style="flex-grow: 1;"></div>
-              <fluent-button type="button" appearance="stealth" blazor:onclick="6" part="header-button" b-x1200685t0="" blazor:elementreference="xxx">Sign out</fluent-button>
-            </div>
+</div>
+<div class="fluent-overlay" style="cursor: auto; position: fixed; z-index: 9900;" blazor:onclick="4" blazor:oncontextmenu="5" blazor:oncontextmenu:preventdefault="" b-xkrr7evqik="">
+  <div style="display: flex; align-items:center; justify-content: center; width: 100%; height: 100%" b-xkrr7evqik=""></div>
+</div>
+<fluent-anchored-region id="xxx" anchor="xxx" horizontal-positioning-mode="dynamic" horizontal-default-position="start" horizontal-inset="" horizontal-threshold="0" horizontal-scaling="content" vertical-positioning-mode="dynamic" vertical-default-position="bottom" vertical-threshold="0" vertical-scaling="content" auto-update-mode="auto" style="z-index: 9999;" b-2ov9fhztky="" blazor:elementreference="xxx">
+  <div style="z-index: 9999; background-color: var(--neutral-layer-floating); box-shadow: var(--elevation-shadow-flyout);" b-2ov9fhztky="">
+    <div class="stack-vertical" style="align-items: start; justify-content: start; column-gap: 10px; row-gap: 10px; width: 100%;" b-0nr62qx0mz="">
+      <div class="fluent-popover-content" b-qp3z8ghd2d="">
+        <div part="header" b-qp3z8ghd2d="">
+          <div class="stack-horizontal" style="justify-content: start; align-items: center; column-gap: 10px; row-gap: 10px; width: 100%;" b-0nr62qx0mz="">
+            <p part="header-label" typo="body" class="fluent-typography" b-1nnnfjehkp="">Microsoft</p>
+            <div style="flex-grow: 1;"></div>
+            <fluent-button type="button" appearance="stealth" blazor:onclick="6" part="header-button" b-x1200685t0="" blazor:elementreference="xxx">Sign out</fluent-button>
           </div>
-          <div part="body" b-qp3z8ghd2d="">
-            <div class="stack-horizontal" style="justify-content: start; align-items: start; column-gap: 10px; row-gap: 10px; width: 100%; height: 100%;" b-0nr62qx0mz="">
-              <div class="fluent-persona" style="align-items: normal;" position="end" b-n7zog0zvqi="">
-                <div class="initials" b-n7zog0zvqi="">
-                  <div class="fluent-presence-badge" title="" b-1o8tp31nhy="">
-                    <div style="display: table-cell; vertical-align: middle; width: 48px; min-width: 48px; height: 48px; min-height: 48px;" b-n7zog0zvqi="">
-                      <img src="iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=" alt="" title="" style="max-width: 48px; max-height: 48px;" b-n7zog0zvqi="">
-                    </div>
+        </div>
+        <div part="body" b-qp3z8ghd2d="">
+          <div class="stack-horizontal" style="justify-content: start; align-items: start; column-gap: 10px; row-gap: 10px; width: 100%; height: 100%;" b-0nr62qx0mz="">
+            <div class="fluent-persona" style="align-items: normal;" position="end" b-n7zog0zvqi="">
+              <div class="initials" b-n7zog0zvqi="">
+                <div class="fluent-presence-badge" title="" b-1o8tp31nhy="">
+                  <div style="display: table-cell; vertical-align: middle; width: 48px; min-width: 48px; height: 48px; min-height: 48px;" b-n7zog0zvqi="">
+                    <img src="iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=" alt="" title="" style="max-width: 48px; max-height: 48px;" b-n7zog0zvqi="">
                   </div>
                 </div>
-                <div class="name" b-n7zog0zvqi="">
-                  <h5 part="fullname" typo="header" class="fluent-typography" style="font-weight: bold;" b-1nnnfjehkp="">Bill Gates</h5>
-                  <p part="email" typo="body" class="fluent-typography" b-1nnnfjehkp="">bill.gates@microsoft.com</p>
-                </div>
+              </div>
+              <div class="name" b-n7zog0zvqi="">
+                <h5 part="fullname" typo="header" class="fluent-typography" style="font-weight: bold;" b-1nnnfjehkp="">Bill Gates</h5>
+                <p part="email" typo="body" class="fluent-typography" b-1nnnfjehkp="">bill.gates@microsoft.com</p>
               </div>
             </div>
           </div>
-          <div part="footer" b-qp3z8ghd2d="">
-            <div class="stack-horizontal" style="justify-content: start; align-items: center; column-gap: 10px; row-gap: 10px; width: 100%;" b-0nr62qx0mz="">
-              <p part="footer-label" typo="body" class="fluent-typography" b-1nnnfjehkp="">v 3.14</p>
-              <div style="flex-grow: 1;"></div>
-              <fluent-anchor href="#" appearance="hypertext" blazor:onclick="7" blazor:onclick:preventdefault="" part="footer-link" blazor:elementreference="xxx">View account</fluent-anchor>
-            </div>
+        </div>
+        <div part="footer" b-qp3z8ghd2d="">
+          <div class="stack-horizontal" style="justify-content: start; align-items: center; column-gap: 10px; row-gap: 10px; width: 100%;" b-0nr62qx0mz="">
+            <p part="footer-label" typo="body" class="fluent-typography" b-1nnnfjehkp="">v 3.14</p>
+            <div style="flex-grow: 1;"></div>
+            <fluent-anchor href="#" appearance="hypertext" blazor:onclick="7" blazor:onclick:preventdefault="" part="footer-link" blazor:elementreference="xxx">View account</fluent-anchor>
           </div>
         </div>
       </div>
     </div>
-  </fluent-anchored-region>
-</div>
+  </div>
+</fluent-anchored-region>

--- a/tests/Core/ProfileMenu/FluentProfileMenuTests.FluentProfileMenu_StartEndTemplate.verified.razor.html
+++ b/tests/Core/ProfileMenu/FluentProfileMenuTests.FluentProfileMenu_StartEndTemplate.verified.razor.html
@@ -1,0 +1,12 @@
+
+<div id="xxx" class="fluent-profile-menu" blazor:onclick="1" b-rsm9d6pikk="">Before
+  <div id="xxx" class="fluent-persona" style="height: inherit;" position="end" b-n7zog0zvqi="">
+    <div class="initials" b-n7zog0zvqi="">
+      <div class="fluent-presence-badge" title="" b-1o8tp31nhy="">
+        <div style="display: table-cell; vertical-align: middle; width: 32px; min-width: 32px; height: 32px; min-height: 32px;" b-n7zog0zvqi="">
+          <img src="iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=" style="max-width: 32px; max-height: 32px;" b-n7zog0zvqi="">
+        </div>
+      </div>
+    </div>
+  </div>
+  After</div>

--- a/tests/Core/ProfileMenu/FluentProfileMenuTests.razor
+++ b/tests/Core/ProfileMenu/FluentProfileMenuTests.razor
@@ -50,9 +50,9 @@
     );
 
         // Open the Popover
-        var button = cut.Find(".initials");
+        var button = cut.Find(".fluent-profile-menu");
         button.Click();
-
+        
         // sign out
         var signOut = cut.Find("fluent-button");
         signOut.Click();
@@ -82,6 +82,20 @@
         // Open the Popover
         var button = cut.Find(".initials");
         button.Click();
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentProfileMenu_StartEndTemplate()
+    {
+        // Arrange && Act
+        var cut = Render(
+            @<FluentProfileMenu Image="@SamplePicture">
+                <StartTemplate>Before</StartTemplate>
+                <EndTemplate>After</EndTemplate>
+            </FluentProfileMenu>);
 
         // Assert
         cut.Verify();


### PR DESCRIPTION
# [ProfileMenu] 

Add `StartTemplate` and `EndTemplate` properties to have the possibility to write custom code before/after the button.
The CSS variable `--fluent-profile-menu-hover` can be used to defined the hover background color (overridable).

```xml
<FluentProfileMenu Initials="BG" Style="--fluent-profile-menu-hover: var(--neutral-stroke-focus); padding: 4px;">
    <StartTemplate>
        Bill Gates
    </StartTemplate>
   ...
</FluentProfileMenu>
```

![peek](https://github.com/microsoft/fluentui-blazor/assets/8350694/e8e1149f-d13f-426d-957c-a1267edb317e)

## Unit Tests

Updated
