### PR TITLE
[Toast Examples] TimeOut setting in milliseconds

### DIFF
--- a/examples/Demo/Shared/Pages/Toast/Examples/ToastConfirmationToasts.razor
+++ b/examples/Demo/Shared/Pages/Toast/Examples/ToastConfirmationToasts.razor
@@ -53,7 +53,7 @@
             With action
         </FluentButton>
 
-        <FluentButton Appearance=Appearance.Neutral @onclick="@(() => ToastService.ShowInfo("Info confirmation custom settings.", 10))">
+        <FluentButton Appearance=Appearance.Neutral @onclick="@(() => ToastService.ShowInfo("Info confirmation custom settings.", timeout: 10000))">
             Custom timeout
         </FluentButton>
 


### PR DESCRIPTION
# [Toast Examples] TimeOut setting in milliseconds

Fix #2023 

The problem comes from an invalid `TimeOut` value defined in the example. You must use `10_000` milliseconds.

```csharp
ToastService.ShowInfo("Info confirmation custom settings.", timeout: 10_000)
```
