### PR TITLE
[MarddownSection] Adds border around code snippets

### DIFF
--- a/examples/Demo/Shared/Components/MarkdownSection.razor.css
+++ b/examples/Demo/Shared/Components/MarkdownSection.razor.css
@@ -8,7 +8,7 @@
     border-width: 1px;
 }
 
-.snippet {
+::deep .snippet {
     margin-bottom: 0.5rem;
     border: calc(var(--stroke-width) * 1px) solid var(--neutral-stroke-rest);
     border-radius: calc(var(--control-corner-radius) * 1px);


### PR DESCRIPTION
# Pull Request

## 📖 Description

Adds border around code snippets in markdown document.

#### Before

<img width="773" alt="image" src="https://github.com/microsoft/fluentui-blazor/assets/23250332/4329e193-060a-4a22-800d-8057de85e266">

#### After
<img width="774" alt="image" src="https://github.com/microsoft/fluentui-blazor/assets/23250332/4425d07b-1aee-48ab-b0e1-dfe1ebfe8062">

### 🎫 Issues

There were no borders around code snippets in the markdown document. So appearance was inconsistent with that rendering generated by the `DemoSection` component.

## 👩‍💻 Reviewer Notes

Change is purely aesthetic.

## 📑 Test Plan

## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [X] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new compontent
- [X] I have modified an existing component
- [X] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component 

## ⏭ Next Steps
