### PR TITLE
[FluentInputBase] Use `Debouncer` instead of `PeriodicTimer` for debouncing `ValueChanged` handler with `ImmediateDelay`.

### DIFF
--- a/examples/Demo/Shared/Pages/Search/Examples/SearchImmediate.razor
+++ b/examples/Demo/Shared/Pages/Search/Examples/SearchImmediate.razor
@@ -1,0 +1,110 @@
+﻿@using System.Timers;
+
+<FluentStack Orientation="Orientation.Vertical" VerticalGap="10">
+
+    @* Immediate Delay *@
+    <FluentNumberField @bind-Value="_immediateDelay"
+                       TValue="int"
+                       Label="Immediate Delay"
+                       Placeholder="Delay"
+                       Min="0"
+                       Max="2000"
+                       Step="100" />
+
+    @* Search Box *@
+    <FluentSearch @bind-Value="_searchValue"
+                  @bind-Value:after="OnSearch"
+                  Immediate
+                  ImmediateDelay="_immediateDelay"
+                  Placeholder="Search for name" />
+
+    @* Search Results *@
+    <p>You searched for: @_searchValue</p>
+    <FluentListbox aria-label="search results"
+                   TOption="string"
+                   Items=@_searchResults                   
+                   SelectedOptionChanged="@(e => _searchValue = (e != _defaultResultsText ? e : string.Empty))" />
+</FluentStack>
+
+@code {
+    private string? _searchValue;
+    private int _immediateDelay;
+
+    private const string _defaultResultsText = "No results";
+    private List<string> _searchResults = DefaultResults();
+
+    private static List<string> DefaultResults() => new() { _defaultResultsText };
+
+    private void OnSearch()
+    {
+        if (!string.IsNullOrWhiteSpace(_searchValue))
+        {
+            // You can also call an API here if the list is not local.
+            var results = searchData
+                .Where(str => str.Contains(_searchValue, StringComparison.OrdinalIgnoreCase))
+                .Select(str => str)
+                .ToList();
+
+            _searchResults = results.Any() ? results : DefaultResults();
+        }
+        else
+        {
+            _searchResults = DefaultResults();
+        }
+    }
+
+    //This component is made for a lot of data. You can copy and paste a list with 6000 entries here https://sharetext.me/vfknowohwl"
+    private List<string> searchData = new()
+    {
+        "Alabama",
+        "Alaska",
+        "Arizona",
+        "Arkansas",
+        "California",
+        "Colorado",
+        "Connecticut",
+        "Delaware",
+        "Florida",
+        "Georgia",
+        "Hawaii",
+        "Idaho",
+        "Illinois",
+        "Indiana",
+        "Iowa",
+        "Kansas",
+        "Kentucky",
+        "Louisiana",
+        "Maine",
+        "Maryland",
+        "Massachussets",
+        "Michigain",
+        "Minnesota",
+        "Mississippi",
+        "Missouri",
+        "Montana",
+        "Nebraska",
+        "Nevada",
+        "New Hampshire",
+        "New Jersey",
+        "New Mexico",
+        "New York",
+        "North Carolina",
+        "North Dakota",
+        "Ohio",
+        "Oklahoma",
+        "Oregon",
+        "Pennsylvania",
+        "Rhode Island",
+        "South Carolina",
+        "South Dakota",
+        "Texas",
+        "Tennessee",
+        "Utah",
+        "Vermont",
+        "Virginia",
+        "Washington",
+        "Wisconsin",
+        "West Virginia",
+        "Wyoming"
+    };
+}

--- a/examples/Demo/Shared/Pages/Search/Examples/SearchImmediate.razor
+++ b/examples/Demo/Shared/Pages/Search/Examples/SearchImmediate.razor
@@ -1,6 +1,4 @@
-﻿@using System.Timers;
-
-<FluentStack Orientation="Orientation.Vertical" VerticalGap="10">
+﻿<FluentStack Orientation="Orientation.Vertical" VerticalGap="10">
 
     @* Immediate Delay *@
     <FluentNumberField @bind-Value="_immediateDelay"
@@ -14,7 +12,7 @@
     @* Search Box *@
     <FluentSearch @bind-Value="_searchValue"
                   @bind-Value:after="OnSearch"
-                  Immediate
+                  Immediate="true"
                   ImmediateDelay="_immediateDelay"
                   Placeholder="Search for name" />
 

--- a/examples/Demo/Shared/Pages/Search/SearchPage.razor
+++ b/examples/Demo/Shared/Pages/Search/SearchPage.razor
@@ -23,6 +23,8 @@
 
 <DemoSection Title="Interactive with debounce" Component="@typeof(SearchInteractiveWithDebounce)"></DemoSection>
 
+<DemoSection Title="Immediate (with and without debounce)" Component="@typeof(SearchImmediate)"></DemoSection>
+
 <DemoSection Title="States" Component="@typeof(SearchStates)"></DemoSection>
 
 <DemoSection Title="Icons" Component="@typeof(SearchIcons)"></DemoSection>

--- a/src/Core/Components/Base/FluentInputBase.cs
+++ b/src/Core/Components/Base/FluentInputBase.cs
@@ -155,7 +155,8 @@ public abstract partial class FluentInputBase<TValue> : FluentComponentBase, IDi
         Value = value;
         if (ValueChanged.HasDelegate)
         {
-            await ValueChanged.InvokeAsync(value);
+            // Thread Safety: Force `ValueChanged` to be re-associated with the Dispatcher, prior to invokation.
+            await InvokeAsync(async () => await ValueChanged.InvokeAsync(value));
         }
         if (FieldBound)
         {
@@ -450,7 +451,7 @@ public abstract partial class FluentInputBase<TValue> : FluentComponentBase, IDi
             EditContext.OnValidationStateChanged -= _validationStateChangedHandler;
         }
 
-        _timerCancellationTokenSource.Dispose();
+        _debouncer.Dispose();
 
         Dispose(disposing: true);
     }

--- a/src/Core/Components/Base/FluentInputBaseHandlers.cs
+++ b/src/Core/Components/Base/FluentInputBaseHandlers.cs
@@ -1,12 +1,12 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.FluentUI.AspNetCore.Components.Utilities;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 public partial class FluentInputBase<TValue>
 {
-    private PeriodicTimer? _timerForImmediate;
-    private CancellationTokenSource _timerCancellationTokenSource = new();
+    private readonly Debouncer _debouncer = new();
 
     /// <summary>
     /// Change the content of this input field when the user write text (based on 'OnInput' HTML event).
@@ -58,48 +58,17 @@ public partial class FluentInputBase<TValue>
     /// <returns></returns>
     protected virtual async Task InputHandlerAsync(ChangeEventArgs e) // TODO: To update in all Input fields 
     {
-        if (Immediate)
+        if (!Immediate)
         {
-            // Raise ChangeHandler after a delay
-            if (ImmediateDelay > 0)
-            {
-                _timerForImmediate = GetNewPeriodicTimer(ImmediateDelay);
-
-                while (await _timerForImmediate.WaitForNextTickAsync(_timerCancellationTokenSource.Token))
-                {
-                    await ChangeHandlerAsync(e);
-                    _timerCancellationTokenSource.Cancel();
-                }
-            }
-            // Raise ChangeHandler immediately
-            else
-            {
-                // Cancel a potential existing object
-                _timerForImmediate?.Dispose();
-                _timerForImmediate = null;
-
-                await ChangeHandlerAsync(e);
-            }
+            return;
         }
-
-        // Cancel the previous Timer (if existing)
-        // And create a new Timer with a new CancellationToken
-        PeriodicTimer GetNewPeriodicTimer(int delay)
+        if (ImmediateDelay > 0)
         {
-            _timerCancellationTokenSource.Cancel();
-
-            if (_timerForImmediate is not null)
-            {
-                _timerForImmediate.Dispose();
-                _timerForImmediate = null;
-            }
-
-            _timerForImmediate = new PeriodicTimer(TimeSpan.FromMilliseconds(delay));
-
-            _timerCancellationTokenSource.Dispose();
-            _timerCancellationTokenSource = new CancellationTokenSource();
-
-            return _timerForImmediate;
+            await _debouncer.DebounceAsync(ImmediateDelay, async () => await ChangeHandlerAsync(e));
+        }
+        else
+        {
+            await ChangeHandlerAsync(e);
         }
     }
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

This pull request applies the use of the internal [`Debouncer`](https://github.com/microsoft/fluentui-blazor/blob/dev/src/Core/Utilities/Debouncer.cs) instead of the `PeriodicTimer` to debounce values. A live demonstration has also been added to the `FluentSearch` page to show how `Immediate` can be used, as opposed to the `oninput` method.

### 🎫 Issues

#2030: Using the `FluentSearch` input box, but likely any debounce with `ImmediateDelay`, you can reliably force it to throw an exception, by firing the debounce while the `PeriodicTimer` is resetting itself. The exception shows that the `CancellationToken` used to reset the timer is set to cancelled, as the timer tries to tick.

## 👩‍💻 Reviewer Notes

The only code-flow change I've had to make is to push the invocation of the `ValueChanged` handler back to the Dispatcher, within `FluentInputBase.cs`. This is a thread safety precaution, as the use of the Debouncer takes the invocation of UI state changes off-thread.

## 📑 Test Plan

Because this is an implementation swap, any unit tests that cover the debouncing process will still pass, as intended. No further coverage necessary. Systems tests added by way of a working live example.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://www.fast.design/docs/community/contributor-guide) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component 

## ⏭ Next Steps

It would be nice to expose the [`Debouncer`](https://github.com/microsoft/fluentui-blazor/blob/dev/src/Core/Utilities/Debouncer.cs) as public, and promote its use as a simple and effective debouncer, for most situations.