### PR TITLE
Fix DatePicker/Calendar not updating under EditContext

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -2251,11 +2251,6 @@
             Defines the appearance of the <see cref="T:Microsoft.FluentUI.AspNetCore.Components.FluentCalendar"/> component.
             </summary>
         </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentCalendarBase.Value">
-            <summary>
-            Gets or sets the selected date (two-way bindable).
-            </summary>
-        </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentCalendarBase.OnSelectedDateHandlerAsync(System.Nullable{System.DateTime})">
             <summary />
         </member>

--- a/src/Core/Components/DateTime/FluentCalendar.razor.cs
+++ b/src/Core/Components/DateTime/FluentCalendar.razor.cs
@@ -151,7 +151,7 @@ public partial class FluentCalendar : FluentCalendarBase
         if (!isReadOnly)
         {
             var value = Culture.Calendar.ToDateTime(year, month, 1, 0, 0, 0, 0);
-            await SetCurrentValueAsync(value);
+            await OnSelectedDateHandlerAsync(value);
         }
     }
 
@@ -161,7 +161,7 @@ public partial class FluentCalendar : FluentCalendarBase
         if (!isReadOnly)
         {
             var value = Culture.Calendar.ToDateTime(year, 1, 1, 0, 0, 0, 0);
-            await SetCurrentValueAsync(value);
+            await OnSelectedDateHandlerAsync(value);
         }
     }
 

--- a/src/Core/Components/DateTime/FluentCalendar.razor.cs
+++ b/src/Core/Components/DateTime/FluentCalendar.razor.cs
@@ -146,23 +146,23 @@ public partial class FluentCalendar : FluentCalendarBase
     }
 
     /// <summary />
-    private Task OnSelectMonthHandlerAsync(int year, int month, bool isReadOnly)
+    private async Task OnSelectMonthHandlerAsync(int year, int month, bool isReadOnly)
     {
         if (!isReadOnly)
         {
-            Value = Culture.Calendar.ToDateTime(year, month, 1, 0, 0, 0, 0);
+            var value = Culture.Calendar.ToDateTime(year, month, 1, 0, 0, 0, 0);
+            await SetCurrentValueAsync(value);
         }
-        return Task.CompletedTask;
     }
 
     /// <summary />
-    private Task OnSelectYearHandlerAsync(int year, bool isReadOnly)
+    private async Task OnSelectYearHandlerAsync(int year, bool isReadOnly)
     {
         if (!isReadOnly)
         {
-            Value = Culture.Calendar.ToDateTime(year, 1, 1, 0, 0, 0, 0);
+            var value = Culture.Calendar.ToDateTime(year, 1, 1, 0, 0, 0, 0);
+            await SetCurrentValueAsync(value);
         }
-        return Task.CompletedTask;
     }
 
     /// <summary>

--- a/src/Core/Components/DateTime/FluentCalendarBase.cs
+++ b/src/Core/Components/DateTime/FluentCalendarBase.cs
@@ -47,9 +47,22 @@ public abstract class FluentCalendarBase : FluentInputBase<DateTime?>
     /// <summary />
     protected virtual async Task OnSelectedDateHandlerAsync(DateTime? value)
     {
+        if (CheckIfSelectedValueHasChanged && Value == value)
+        {
+            return;
+        }
+
         if (!ReadOnly)
         {
-            await SetCurrentValueAsync(value);
+            Value = value;
+            if (ValueChanged.HasDelegate)
+            {
+                await ValueChanged.InvokeAsync(value);
+            }
+            if (FieldBound)
+            {
+                EditContext?.NotifyFieldChanged(FieldIdentifier);
+            }
         }
     }
 

--- a/src/Core/Components/DateTime/FluentCalendarBase.cs
+++ b/src/Core/Components/DateTime/FluentCalendarBase.cs
@@ -5,8 +5,6 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 
 public abstract class FluentCalendarBase : FluentInputBase<DateTime?>
 {
-    private DateTime? _selectedDate = null;
-
     /// <summary>
     /// Gets or sets the culture of the component.
     /// By default <see cref="CultureInfo.CurrentCulture"/> to display using the OS culture.
@@ -46,46 +44,13 @@ public abstract class FluentCalendarBase : FluentInputBase<DateTime?>
     [Parameter]
     public virtual CalendarViews View { get; set; } = CalendarViews.Days;
 
-    /// <summary>
-    /// Gets or sets the selected date (two-way bindable).
-    /// </summary>
-    [Parameter]
-    public override DateTime? Value
-    {
-        get
-        {
-            return _selectedDate;
-        }
-
-        set
-        {
-            if (CheckIfSelectedValueHasChanged && _selectedDate == value)
-            {
-                return;
-            }
-
-            _selectedDate = value;
-
-            if (ValueChanged.HasDelegate)
-            {
-                ValueChanged.InvokeAsync(value);
-            }
-            if (FieldBound)
-            {
-                EditContext?.NotifyFieldChanged(FieldIdentifier);
-            }
-        }
-    }
-
     /// <summary />
-    protected virtual Task OnSelectedDateHandlerAsync(DateTime? value)
+    protected virtual async Task OnSelectedDateHandlerAsync(DateTime? value)
     {
         if (!ReadOnly)
         {
-            Value = value;
+            await SetCurrentValueAsync(value);
         }
-
-        return Task.CompletedTask;
     }
 
     /// <summary />

--- a/src/Core/Components/DateTime/FluentDatePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor.cs
@@ -7,8 +7,7 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 
 public partial class FluentDatePicker : FluentCalendarBase
 {
-    public static string CalendarIcon =
-        "<svg slot=\"end\" width=\"20\" height=\"20\" viewBox=\"0 0 24 24\" fill=\"var(--neutral-fill-strong-focus)\" xmlns=\"http://www.w3.org/2000/svg\"><path d=\"M17.75 3C19.55 3 21 4.46 21 6.25v11.5c0 1.8-1.46 3.25-3.25 3.25H6.25A3.25 3.25 0 013 17.75V6.25C3 4.45 4.46 3 6.25 3h11.5zm1.75 5.5h-15v9.25c0 .97.78 1.75 1.75 1.75h11.5c.97 0 1.75-.78 1.75-1.75V8.5zm-11.75 6a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zm4.25 0a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zm-4.25-4a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zm4.25 0a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zm4.25 0a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zm1.5-6H6.25c-.97 0-1.75.78-1.75 1.75V7h15v-.75c0-.97-.78-1.75-1.75-1.75z\"/>";
+    public static string CalendarIcon = "<svg slot=\"end\" width=\"20\" height=\"20\" viewBox=\"0 0 24 24\" fill=\"var(--neutral-fill-strong-focus)\" xmlns=\"http://www.w3.org/2000/svg\"><path d=\"M17.75 3C19.55 3 21 4.46 21 6.25v11.5c0 1.8-1.46 3.25-3.25 3.25H6.25A3.25 3.25 0 013 17.75V6.25C3 4.45 4.46 3 6.25 3h11.5zm1.75 5.5h-15v9.25c0 .97.78 1.75 1.75 1.75h11.5c.97 0 1.75-.78 1.75-1.75V8.5zm-11.75 6a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zm4.25 0a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zm-4.25-4a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zm4.25 0a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zm4.25 0a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zm1.5-6H6.25c-.97 0-1.75.78-1.75 1.75V7h15v-.75c0-.97-.78-1.75-1.75-1.75z\"/>";
 
     /// <summary />
     public FluentDatePicker()

--- a/src/Core/Components/DateTime/FluentDatePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor.cs
@@ -7,7 +7,8 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 
 public partial class FluentDatePicker : FluentCalendarBase
 {
-    public static string CalendarIcon = "<svg slot=\"end\" width=\"20\" height=\"20\" viewBox=\"0 0 24 24\" fill=\"var(--neutral-fill-strong-focus)\" xmlns=\"http://www.w3.org/2000/svg\"><path d=\"M17.75 3C19.55 3 21 4.46 21 6.25v11.5c0 1.8-1.46 3.25-3.25 3.25H6.25A3.25 3.25 0 013 17.75V6.25C3 4.45 4.46 3 6.25 3h11.5zm1.75 5.5h-15v9.25c0 .97.78 1.75 1.75 1.75h11.5c.97 0 1.75-.78 1.75-1.75V8.5zm-11.75 6a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zm4.25 0a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zm-4.25-4a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zm4.25 0a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zm4.25 0a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zm1.5-6H6.25c-.97 0-1.75.78-1.75 1.75V7h15v-.75c0-.97-.78-1.75-1.75-1.75z\"/>";
+    public static string CalendarIcon =
+        "<svg slot=\"end\" width=\"20\" height=\"20\" viewBox=\"0 0 24 24\" fill=\"var(--neutral-fill-strong-focus)\" xmlns=\"http://www.w3.org/2000/svg\"><path d=\"M17.75 3C19.55 3 21 4.46 21 6.25v11.5c0 1.8-1.46 3.25-3.25 3.25H6.25A3.25 3.25 0 013 17.75V6.25C3 4.45 4.46 3 6.25 3h11.5zm1.75 5.5h-15v9.25c0 .97.78 1.75 1.75 1.75h11.5c.97 0 1.75-.78 1.75-1.75V8.5zm-11.75 6a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zm4.25 0a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zm-4.25-4a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zm4.25 0a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zm4.25 0a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zm1.5-6H6.25c-.97 0-1.75.78-1.75 1.75V7h15v-.75c0-.97-.78-1.75-1.75-1.75z\"/>";
 
     /// <summary />
     public FluentDatePicker()
@@ -32,8 +33,7 @@ public partial class FluentDatePicker : FluentCalendarBase
     [Parameter]
     public virtual FluentInputAppearance Appearance { get; set; } = FluentInputAppearance.Outline;
 
-    [Parameter]
-    public EventCallback<bool> OnCalendarOpen { get; set; }
+    [Parameter] public EventCallback<bool> OnCalendarOpen { get; set; }
 
     public bool Opened { get; set; } = false;
 
@@ -44,7 +44,6 @@ public partial class FluentDatePicker : FluentCalendarBase
             CalendarViews.Years => "yyyy",
             CalendarViews.Months => Culture.DateTimeFormat.YearMonthPattern,
             _ => Culture.DateTimeFormat.ShortDatePattern
-
         }, Culture);
     }
 
@@ -63,24 +62,19 @@ public partial class FluentDatePicker : FluentCalendarBase
         return Task.CompletedTask;
     }
 
-    protected Task OnSelectedDateAsync(DateTime? value)
+    protected async Task OnSelectedDateAsync(DateTime? value)
     {
         Opened = false;
 
-        if (Value != null && Value?.TimeOfDay != TimeSpan.Zero)
-        {
-            DateTime currentValue = value ?? DateTime.MinValue;
-            Value = currentValue.Date + Value?.TimeOfDay;
-        }
-        else
-        {
-            Value = value;
-        }
+        var updatedValue = Value?.TimeOfDay != TimeSpan.Zero
+            ? (value ?? DateTime.MinValue).Date + Value?.TimeOfDay
+            : value;
 
-        return Task.CompletedTask;
+        await SetCurrentValueAsync(updatedValue);
     }
 
-    protected override bool TryParseValueFromString(string? value, out DateTime? result, [NotNullWhen(false)] out string? validationErrorMessage)
+    protected override bool TryParseValueFromString(string? value, out DateTime? result,
+        [NotNullWhen(false)] out string? validationErrorMessage)
     {
         if (View == CalendarViews.Years && int.TryParse(value, out var year))
         {

--- a/src/Core/Components/DateTime/FluentDatePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor.cs
@@ -32,7 +32,8 @@ public partial class FluentDatePicker : FluentCalendarBase
     [Parameter]
     public virtual FluentInputAppearance Appearance { get; set; } = FluentInputAppearance.Outline;
 
-    [Parameter] public EventCallback<bool> OnCalendarOpen { get; set; }
+    [Parameter]
+    public EventCallback<bool> OnCalendarOpen { get; set; }
 
     public bool Opened { get; set; } = false;
 
@@ -72,8 +73,7 @@ public partial class FluentDatePicker : FluentCalendarBase
         await SetCurrentValueAsync(updatedValue);
     }
 
-    protected override bool TryParseValueFromString(string? value, out DateTime? result,
-        [NotNullWhen(false)] out string? validationErrorMessage)
+    protected override bool TryParseValueFromString(string? value, out DateTime? result, [NotNullWhen(false)] out string? validationErrorMessage)
     {
         if (View == CalendarViews.Years && int.TryParse(value, out var year))
         {

--- a/src/Core/Components/DateTime/FluentDatePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor.cs
@@ -70,7 +70,7 @@ public partial class FluentDatePicker : FluentCalendarBase
             ? (value ?? DateTime.MinValue).Date + Value?.TimeOfDay
             : value;
 
-        await SetCurrentValueAsync(updatedValue);
+        await OnSelectedDateHandlerAsync(updatedValue);
     }
 
     protected override bool TryParseValueFromString(string? value, out DateTime? result, [NotNullWhen(false)] out string? validationErrorMessage)


### PR DESCRIPTION
# Pull Request

## 📖 Description

When using a FluentDatePicker or FluentCalender inside an EditContext, there are issues with selecting a new value in the Year-view of the calendar. My diagnosis suggests that this comes down to a race condition-like issue between invoking ValueChanged and also notifying the EditContext about changes which will propagate the "old" value to the component through the parameters being updated.

The changes I propose changes the approach for updating value of the FluentCalendar (and thus FluentDatePicker) by utilizing `SetCurrentValueAsync` available on `FluentInputBase`. This approach is similar to other components where `SetCurrentValueAsync` is called as part of `ChangeHandlerAsync`.

The changes proposed fixes the issue.

### 🎫 Issues

https://github.com/microsoft/fluentui-blazor/issues/2046

## 👩‍💻 Reviewer Notes


## 📑 Test Plan

I tested all the DatePicker/Calendar examples in the sample project.


## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fluentui-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new compontent
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component 

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
