### PR TITLE
[FluentAutocomplete] Add `ImmediateDelay` parameter

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -4822,6 +4822,11 @@
             Gets or sets the maximum height of the field to adjust its height in relation to selected elements.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.ImmediateDelay">
+            <summary>
+            Gets or sets the delay, in milliseconds, before to raise the <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.OnOptionsSearch"/> event.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.ListStyleValue">
             <summary />
         </member>

--- a/examples/Demo/Shared/Pages/List/Autocomplete/AutocompletePage.razor
+++ b/examples/Demo/Shared/Pages/List/Autocomplete/AutocompletePage.razor
@@ -12,7 +12,14 @@
 
 <DemoSection Title="Customized options" Component="@typeof(AutocompleteCustomized)" />
 
-<DemoSection Title="Many Items" Component="@typeof(AutocompleteManyItems)" />
+<DemoSection Title="Many Items" Component="@typeof(AutocompleteManyItems)">
+    <Description>
+        <p>
+            This example shows how you can use <code>ImmediateDelay</code> to control the delay between the user input and the search for options. A value of 0 means no delay
+        </p>
+    </Description>
+</DemoSection>
+
 
 <DemoSection Title="FluentPersona" Component="@typeof(AutocompletePersona)" />
 
@@ -24,10 +31,12 @@
 
 <h2>Accessibility</h2>
 
-This component is compatible with accessibility rules.<br/>
+This component is compatible with accessibility rules.
+<br />
 Except this <a href="https://accessibilityinsights.io/info-examples/web/aria-valid-attr-value/" target="_blank">Invalid ARIA attribute value: aria-controls="[id]-popup"</a> when the list is expanded (will be solved later).
 <br />
-You can customize these 3 messages to be read by screen readers<br/>
+You can customize these 3 messages to be read by screen readers
+<br />
 <ul>
     <li><code>FluentAutocomplete.AccessibilitySelected = "Selected {0}"</code> List of selected items.</li>
     <li><code>FluentAutocomplete.AccessibilityNotFound = "No items found"</code> When the search criteria returns an empty list.</li>

--- a/examples/Demo/Shared/Pages/List/Autocomplete/Examples/AutocompleteManyItems.razor
+++ b/examples/Demo/Shared/Pages/List/Autocomplete/Examples/AutocompleteManyItems.razor
@@ -1,17 +1,35 @@
 ﻿@using System.Globalization
 @inject DataSource Data
 
-<FluentAutocomplete TOption="CultureInfo"
-                    AutoComplete="off"
-                    Label="Select Culture"
-                    Width="250px"
-                    OnOptionsSearch="OnSearch"
-                    Placeholder="Select countries"
-                    MaximumOptionsSearch="int.MaxValue"
-                    MaximumSelectedOptions="2"
-                    Virtualize="true"
-                    OptionText="@(item => $"{item.DisplayName} - {item.Name}")"
-                    @bind-SelectedOptions="@SelectedCultures" />
+<FluentStack Orientation="Orientation.Vertical" VerticalGap="10">
+
+    @* Immediate Delay *@
+    <FluentNumberField @bind-Value="_immediateDelay"
+                       TValue="int"
+                       Label="Immediate Delay"
+                       Placeholder="Delay"
+                       Min="0"
+                       Max="2000"
+                       Step="100" />
+
+    
+    <FluentAutocomplete TOption="CultureInfo"
+                        ImmediateDelay="_immediateDelay"
+                        AutoComplete="off"
+                        Label="Select Culture"
+                        Width="250px"
+                        OnOptionsSearch="OnSearch"
+                        Placeholder="Select countries"
+                        MaximumOptionsSearch="int.MaxValue"
+                        MaximumSelectedOptions="2"
+                        Virtualize="true"
+                        OptionText="@(item => $"{item.DisplayName} - {item.Name}")"
+                        @bind-SelectedOptions="@SelectedCultures" />
+
+</FluentStack>
+
+
+
 
 <p>
     <b>Selected</b>: @(String.Join(" - ", SelectedCultures.Select(i => i.Name)))
@@ -19,6 +37,8 @@
 
 @code
 {
+    private int _immediateDelay;
+
     IEnumerable<CultureInfo> SelectedCultures = Array.Empty<CultureInfo>();
     CultureInfo[] Cultures = CultureInfo.GetCultures(CultureTypes.AllCultures);
 

--- a/src/Core/Components/List/FluentAutocomplete.razor
+++ b/src/Core/Components/List/FluentAutocomplete.razor
@@ -25,7 +25,8 @@
                          @oninput="@InputHandlerAsync"
                          @onfocusout="@(e => { IsReachedMaxItems = false; })"
                          autofocus="@Autofocus"
-                         Style="@ComponentWidth">
+                         Style="@ComponentWidth"
+                         >
             @* Selected Items *@
             @if (this.SelectedOptions?.Any() == true)
             {

--- a/src/Core/Components/List/FluentAutocomplete.razor.cs
+++ b/src/Core/Components/List/FluentAutocomplete.razor.cs
@@ -16,6 +16,7 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
 
     public new FluentTextField? Element { get; set; } = default!;
     private Virtualize<TOption>? VirtualizationContainer { get; set; }
+    private readonly Debouncer _debouncer = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FluentAutocomplete{TOption}"/> class.
@@ -207,6 +208,12 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
     [Parameter]
     public string? MaxAutoHeight { get; set; }
 
+    /// <summary>
+    /// Gets or sets the delay, in milliseconds, before to raise the <see cref="OnOptionsSearch"/> event.
+    /// </summary>
+    [Parameter]
+    public int ImmediateDelay { get; set; } = 0;
+
     /// <summary />
     private string? ListStyleValue => new StyleBuilder()
         .AddStyle("width", Width, when: !string.IsNullOrEmpty(Width))
@@ -254,6 +261,8 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
     /// <summary />
     protected async Task InputHandlerAsync(ChangeEventArgs e)
     {
+
+
         ValueText = e.Value?.ToString() ?? string.Empty;
         await ValueTextChanged.InvokeAsync(ValueText);
 
@@ -272,7 +281,14 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
             Text = ValueText,
         };
 
-        await OnOptionsSearch.InvokeAsync(args);
+        if (ImmediateDelay > 0)
+        {
+           await _debouncer.DebounceAsync(ImmediateDelay, () => InvokeAsync(() => OnOptionsSearch.InvokeAsync(args)));
+        }
+        else
+        {
+            await OnOptionsSearch.InvokeAsync(args);
+        }
 
         Items = args.Items?.Take(MaximumOptionsSearch);
 

--- a/src/Core/Components/List/FluentAutocomplete.razor.cs
+++ b/src/Core/Components/List/FluentAutocomplete.razor.cs
@@ -261,8 +261,6 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
     /// <summary />
     protected async Task InputHandlerAsync(ChangeEventArgs e)
     {
-
-
         ValueText = e.Value?.ToString() ?? string.Empty;
         await ValueTextChanged.InvokeAsync(ValueText);
 


### PR DESCRIPTION
Fix #1951 
Add an `ImmediateDelay parameter. Idea was to pass this parameter through to the internal TextField but this proved not to be necessary. Kept the same name though for consistency.
An `Immediate` parameter has not been added because the default behavior on the internal text filed is already to respond to oninput (onchange is not implemented in this component)