### PR TITLE
[Doc] Adds office color table to Design Tokens page

### DIFF
--- a/examples/Demo/Shared/Pages/Design/DesignTokensPage.razor
+++ b/examples/Demo/Shared/Pages/Design/DesignTokensPage.razor
@@ -5,9 +5,9 @@
 <h1>Design Tokens</h1>
 
 <MarkdownSection FromAsset="./_content/FluentUI.Demo.Shared/docs/DesignTokens.md" OnContentConverted="RefreshTableOfContents" />
+<OfficeColorTable />
 
 @code {
-
     [CascadingParameter]
     public EventCallback OnRefreshTableOfContents { get; set; }
 

--- a/examples/Demo/Shared/Pages/Design/DesignTokensPage.razor
+++ b/examples/Demo/Shared/Pages/Design/DesignTokensPage.razor
@@ -5,14 +5,21 @@
 <h1>Design Tokens</h1>
 
 <MarkdownSection FromAsset="./_content/FluentUI.Demo.Shared/docs/DesignTokens.md" OnContentConverted="RefreshTableOfContents" />
-<OfficeColorTable />
+
+@if (refreshCount > 3)
+{
+    <OfficeColorTable />
+}
 
 @code {
     [CascadingParameter]
     public EventCallback OnRefreshTableOfContents { get; set; }
 
+    private int refreshCount = 0;
+
     private async Task RefreshTableOfContents()
     {
         await OnRefreshTableOfContents.InvokeAsync();
+        refreshCount++; ;
     }
 }

--- a/examples/Demo/Shared/Pages/Design/OfficeColorTable.razor
+++ b/examples/Demo/Shared/Pages/Design/OfficeColorTable.razor
@@ -1,0 +1,50 @@
+﻿<style>
+    th, td {
+        border: solid gray 1px;
+        padding: 0 5px;
+    }
+</style>
+<div>
+    <table>
+        <thead>
+            <tr>
+                <th>Product</th>
+                <th>AccentBaseColor</th>
+            </tr>
+        </thead>
+        <tbody>
+            @{
+                var allColors = OfficeColorUtilities.AllColors;
+                @foreach (var color in allColors)
+                {
+                    <tr>
+                        <td>
+                            <FluentLabel>@color</FluentLabel>
+                        </td>
+                        <td>
+                            <FluentStack>
+                                <FluentIcon Value="@(new Icons.Filled.Size20.RectangleLandscape())"
+                                            Color="Color.Custom"
+                                            CustomColor="@GetCustomColor(color)" />
+                                <FluentLabel>@GetCustomColor(color)</FluentLabel>
+                            </FluentStack>
+                        </td>
+                    </tr>
+                }
+            }
+        </tbody>
+    </table>
+
+</div>
+
+@code {
+    private static string? GetCustomColor(OfficeColor? color)
+    {
+        return color switch
+        {
+            OfficeColor.Default => "#036ac4",
+            _ => color.ToAttributeValue(),
+        };
+
+    }
+}

--- a/examples/Demo/Shared/Pages/Design/OfficeColorTable.razor
+++ b/examples/Demo/Shared/Pages/Design/OfficeColorTable.razor
@@ -4,6 +4,7 @@
         padding: 0 5px;
     }
 </style>
+
 <div>
     <table>
         <thead>
@@ -14,8 +15,7 @@
         </thead>
         <tbody>
             @{
-                var allColors = OfficeColorUtilities.AllColors;
-                @foreach (var color in allColors)
+                @foreach (var color in OfficeColorUtilities.AllColors)
                 {
                     <tr>
                         <td>
@@ -34,7 +34,6 @@
             }
         </tbody>
     </table>
-
 </div>
 
 @code {
@@ -45,6 +44,5 @@
             OfficeColor.Default => "#036ac4",
             _ => color.ToAttributeValue(),
         };
-
     }
 }

--- a/examples/Demo/Shared/wwwroot/docs/DesignTokens.md
+++ b/examples/Demo/Shared/wwwroot/docs/DesignTokens.md
@@ -337,3 +337,14 @@ To make this work, a link needs to be created between the Design Token component
 ## Colors for integration with specific Microsoft products
 If you are configuring the components for integration into a specific Microsoft product, the following table provides `AccentBaseColor` values you can use. 
 *The library offers an `OfficeColor` enumeration which contains the specific accent colors for 17 different Office applications.*
+
+Product | AccentBaseColor
+------- | ---------------
+| Office | #D83B01 |
+| Word | #185ABD |
+| Excel | #107C41 |
+| PowerPoint | #C43E1C |
+| Teams | #6264A7 |
+| OneNote | #7719AA |
+| SharePoint | #03787C |
+| Stream | #BC1948 |

--- a/examples/Demo/Shared/wwwroot/docs/DesignTokens.md
+++ b/examples/Demo/Shared/wwwroot/docs/DesignTokens.md
@@ -336,4 +336,4 @@ To make this work, a link needs to be created between the Design Token component
 
 ## Colors for integration with specific Microsoft products
 If you are configuring the components for integration into a specific Microsoft product, the following table provides `AccentBaseColor` values you can use. 
-*The library offers an `OfficeColor` enumeration which contains the specific accent colors for 25 different Office applications.*
+*The specific accent colors for many Office applications are offered in the `OfficeColor` enumeration.*

--- a/examples/Demo/Shared/wwwroot/docs/DesignTokens.md
+++ b/examples/Demo/Shared/wwwroot/docs/DesignTokens.md
@@ -336,15 +336,4 @@ To make this work, a link needs to be created between the Design Token component
 
 ## Colors for integration with specific Microsoft products
 If you are configuring the components for integration into a specific Microsoft product, the following table provides `AccentBaseColor` values you can use. 
-*The library offers an `OfficeColor` enumeration which contains the specific accent colors for 17 different Office applications.*
-
-Product | AccentBaseColor
-------- | ---------------
-| Office | #D83B01 |
-| Word | #185ABD |
-| Excel | #107C41 |
-| PowerPoint | #C43E1C |
-| Teams | #6264A7 |
-| OneNote | #7719AA |
-| SharePoint | #03787C |
-| Stream | #BC1948 |
+*The library offers an `OfficeColor` enumeration which contains the specific accent colors for 25 different Office applications.*


### PR DESCRIPTION
# Pull Request

## 📖 Description

A table at the end of  the [design tokens](https://www.fluentui-blazor.net/DesignTokens) page appears to have been accidentally deleted. 

[Edit] [See comment](https://github.com/microsoft/fluentui-blazor/pull/2073#discussion_r1605828137) Original delete intentional.

[Edit] Added new table based on review comments
<img width="783" alt="image" src="https://github.com/microsoft/fluentui-blazor/assets/23250332/491456ad-9f3d-44d4-9d70-d28a6394de99">


### 🎫 Issues

- missing table?

## 👩‍💻 Reviewer Notes

- Was the table deletion intentional? If so, the text above it should be changed.
- The text above the table also mentions _accent colors for 17 different Office applications_. I find it confusing and am unsure what it is trying to convey to the reader. 

## 📑 Test Plan

## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [X] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
