### PR TITLE
[MarkdownSection] Optimize to minimize number of calls to OnContentConverted

### DIFF
--- a/examples/Demo/Shared/Components/MarkdownSection.razor.cs
+++ b/examples/Demo/Shared/Components/MarkdownSection.razor.cs
@@ -8,7 +8,6 @@ namespace FluentUI.Demo.Shared.Components;
 public partial class MarkdownSection : FluentComponentBase
 {
     private string? _content;
-    private bool _raiseContentConverted;
     private IJSObjectReference _jsModule = default!;
 
     [Inject]
@@ -58,28 +57,24 @@ public partial class MarkdownSection : FluentComponentBase
     {
         if (firstRender)
         {
+            // import code for highlighting code blocks
+            _jsModule = await JSRuntime.InvokeAsync<IJSObjectReference>("import",
+                "./_content/FluentUI.Demo.Shared/Components/MarkdownSection.razor.js");
+
+            //
             if (!string.IsNullOrEmpty(FromAsset))
             {
                 InternalContent = await StaticAssetService.GetAsync(FromAsset);
             }
-            // add highlight for any code blocks
-            _jsModule = await JSRuntime.InvokeAsync<IJSObjectReference>("import",
-                "./_content/FluentUI.Demo.Shared/Components/MarkdownSection.razor.js");
+            StateHasChanged();
 
-            await OnContentConverted.InvokeAsync();
-
-            _raiseContentConverted = true;
-        }
-
-        if (_raiseContentConverted)
-        {
-            _raiseContentConverted = false;
+            // notify that content converted from markdown 
             if (OnContentConverted.HasDelegate)
             {
                 await OnContentConverted.InvokeAsync();
-                await _jsModule.InvokeVoidAsync("highlight");
-                await _jsModule.InvokeVoidAsync("addCopyButton");
             }
+            await _jsModule.InvokeVoidAsync("highlight");
+            await _jsModule.InvokeVoidAsync("addCopyButton");
         }
     }
 

--- a/examples/Demo/Shared/Components/MarkdownSection.razor.cs
+++ b/examples/Demo/Shared/Components/MarkdownSection.razor.cs
@@ -39,13 +39,6 @@ public partial class MarkdownSection : FluentComponentBase
         {
             _content = value;
             HtmlContent = ConvertToMarkupString(_content);
-
-            if (OnContentConverted.HasDelegate)
-            {
-                OnContentConverted.InvokeAsync();
-            }
-            _raiseContentConverted = true;
-            StateHasChanged();
         }
     }
 
@@ -72,8 +65,10 @@ public partial class MarkdownSection : FluentComponentBase
             // add highlight for any code blocks
             _jsModule = await JSRuntime.InvokeAsync<IJSObjectReference>("import",
                 "./_content/FluentUI.Demo.Shared/Components/MarkdownSection.razor.js");
-            await _jsModule.InvokeVoidAsync("highlight");
-            await _jsModule.InvokeVoidAsync("addCopyButton");
+
+            await OnContentConverted.InvokeAsync();
+
+            _raiseContentConverted = true;
         }
 
         if (_raiseContentConverted)
@@ -82,8 +77,9 @@ public partial class MarkdownSection : FluentComponentBase
             if (OnContentConverted.HasDelegate)
             {
                 await OnContentConverted.InvokeAsync();
+                await _jsModule.InvokeVoidAsync("highlight");
+                await _jsModule.InvokeVoidAsync("addCopyButton");
             }
-
         }
     }
 

--- a/examples/Demo/Shared/Pages/Design/DesignTokensPage.razor
+++ b/examples/Demo/Shared/Pages/Design/DesignTokensPage.razor
@@ -6,7 +6,7 @@
 
 <MarkdownSection FromAsset="./_content/FluentUI.Demo.Shared/docs/DesignTokens.md" OnContentConverted="RefreshTableOfContents" />
 
-@if (refreshCount > 3)
+@if (refreshCount > 0)
 {
     <OfficeColorTable />
 }
@@ -20,6 +20,6 @@
     private async Task RefreshTableOfContents()
     {
         await OnRefreshTableOfContents.InvokeAsync();
-        refreshCount++; ;
+        refreshCount++;
     }
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

Optimize to minimize number of calls to OnContentConverted.

### 🎫 Issues

- original implementation resulted in 4 invocations of `OnContentConverted` per page containing a `MarkdownSection`

## 👩‍💻 Reviewer Notes


## 📑 Test Plan

## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [X] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new compontent
- [X] I have modified an existing component
- [ ] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component 

## ⏭ Next Steps
