### PR TITLE
[DialogService] Add missing classes to avoid Trimming exceptions

### DIFF
--- a/src/Core/Components/Dialog/Services/DialogService.cs
+++ b/src/Core/Components/Dialog/Services/DialogService.cs
@@ -7,6 +7,12 @@ public partial class DialogService : IDialogService
 {
     /// <summary />
     [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(DialogEventArgs))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(MessageBoxContent))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(MessageBox))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(SplashScreenContent))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(FluentSplashScreen))] 
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(DialogParameters))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(DialogParameters<object>))]
     public DialogService()
     {
     }


### PR DESCRIPTION
# [DialogService] Fix missing classes to **Trimming** exceptions

When WASM is published `dotnet publish -c Release`, some classes are not marked as exceptions to avoid a runtime exception.

## Before

When calling this command, the following exception occurred.
```csharp
var dialog = await DialogService.ShowConfirmationAsync("Do you want ...");
```
![image](https://github.com/microsoft/fluentui-blazor/assets/8350694/91b3fda9-c2ad-4eab-816e-50bc46f57726)

## After

No error occurred.
