### PR TITLE
[ComboBox] bind-SelectedOption is null when using bind-SelectedOption:after 

### DIFF
--- a/src/Core/Components/List/FluentCombobox.razor.cs
+++ b/src/Core/Components/List/FluentCombobox.razor.cs
@@ -103,6 +103,10 @@ public partial class FluentCombobox<TOption> : ListComponentBase<TOption> where 
                 {
                     _currentSelectedOption = newSelectedOption;
                 }
+                else if (OptionSelected != null && newSelectedOption != null && OptionSelected(newSelectedOption))
+                {
+                    _currentSelectedOption = newSelectedOption;
+                }
                 else
                 {
                     // If the selected option is not in the list of items, reset the selected option

--- a/src/Core/Components/List/FluentCombobox.razor.cs
+++ b/src/Core/Components/List/FluentCombobox.razor.cs
@@ -105,6 +105,7 @@ public partial class FluentCombobox<TOption> : ListComponentBase<TOption> where 
                 }
                 else if (OptionSelected != null && newSelectedOption != null && OptionSelected(newSelectedOption))
                 {
+                    // The selected option might not be part of the Items list. But we can use OptionSelected to compare the current option.
                     _currentSelectedOption = newSelectedOption;
                 }
                 else


### PR DESCRIPTION
# Pull Request

## 📖 Description

Checks the object by using the `OptionSelected` parameter when this parameter is set.

### 🎫 Issues
Fixes:  #2101 

