### PR TITLE
[DataGrid SelectColum] Allow customization of SelectAll header

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -1380,6 +1380,16 @@
             Gets or sets the content to be rendered for each row in the table.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.SelectColumn`1.SelectAllDisabled">
+            <summary>
+            Gets or sets whether the [All] checkbox is disabled (not clickable).
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.SelectColumn`1.SelectAllTemplate">
+            <summary>
+            Gets or sets the template for the [All] checkbox column template.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.SelectColumn`1.SelectedItems">
             <summary>
             Gets or sets the list of selected items.

--- a/examples/Demo/Shared/Pages/DataGrid/DataGridPage.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/DataGridPage.razor
@@ -93,6 +93,22 @@ fluent-data-grid-row:has([row-selected]) {
     </Description>
 </DemoSection>
 
+<p>
+    Using this <code>SelectColumn</code>, you can customize the checkboxes by using <code>ChildContent</code> to define the contents of the selection for each row of the grid;
+    or <code>SelectAllTemplate</code> to customize the header of this column.
+    If you don't want the user to be able to interact (click and change) on the SelectAll header, you can set the <code>SelectAllDisabled="true"</code> attribute.
+    <br /><br />
+
+    Example:
+<CodeSnippet Language="razor">&lt;SelectAllTemplate>
+    @@(context.AllSelected == true ? "✅" : context.AllSelected == null ? "➖" : "⬜")
+&lt;/SelectAllTemplate>
+&lt;ChildContent>
+    @@(SelectedItems.Contains(context) ? "✅" : " ") @@* Using SelectedItems         *@@
+    @@(context.Selected ? "✅" : " ")                @@* Using Property and OnSelect *@@
+&lt;/ChildContent></CodeSnippet>
+</p>
+
 <DemoSection Title="Typical usage" Component="@typeof(DataGridTypical)" CollocatedFiles="@(new[] {"css"})">
     <Description>
         <p>

--- a/tests/Core/DataGrid/FluentDataGridColumSelectTests.FluentDataGrid_ColumSelect_MultiSelect_Customized_Rendering.verified.razor.html
+++ b/tests/Core/DataGrid/FluentDataGridColumSelectTests.FluentDataGrid_ColumSelect_MultiSelect_Customized_Rendering.verified.razor.html
@@ -1,0 +1,26 @@
+
+<fluent-data-grid generate-header="none" grid-template-columns="50px 1fr" aria-rowcount="4" blazor:onrowfocus="1" blazor:onclosecolumnoptions="2" b-ppmhrkw1mj="" blazor:elementreference="">
+  <fluent-data-grid-row row-id="r1" row-index="0" row-type="header" blazor:onkeydown="3" blazor:onclick="4" blazor:ondblclick="5" blazor:oncellfocus="6" b-upi3f9mbnn="">
+    <fluent-data-grid-cell cell-id="c1" cell-type="columnheader" grid-column="1" class="column-header col-justify-start " aria-sort="none" scope="col" b-w6qdxfylwy="">
+      <div style="cursor: pointer; margin-left: 12px;" blazor:onclick="19">➖</div>
+    </fluent-data-grid-cell>
+    <fluent-data-grid-cell cell-id="c2" cell-type="columnheader" grid-column="2" class="column-header col-justify-start " aria-sort="none" scope="col" b-w6qdxfylwy="">
+      <div class="col-title" b-pxhtqoo8qd="">
+        <div class="col-title-text" b-pxhtqoo8qd="">Name</div>
+      </div>
+    </fluent-data-grid-cell>
+  </fluent-data-grid-row>
+  <fluent-data-grid-row row-id="r2" row-index="1" grid-template-columns="50px 1fr" row-type="default" blazor:onkeydown="7" blazor:onclick="8" blazor:ondblclick="9" aria-rowindex="2" blazor:oncellfocus="10" b-upi3f9mbnn="">
+    <fluent-data-grid-cell cell-id="c3" cell-type="default" grid-column="1" class="col-justify-start " b-w6qdxfylwy="">
+    </fluent-data-grid-cell>
+    <fluent-data-grid-cell cell-id="c4" cell-type="default" grid-column="2" class="col-justify-start " b-w6qdxfylwy="">Jean Martin</fluent-data-grid-cell>
+  </fluent-data-grid-row>
+  <fluent-data-grid-row row-id="r3" row-index="2" grid-template-columns="50px 1fr" row-type="default" blazor:onkeydown="11" blazor:onclick="12" blazor:ondblclick="13" aria-rowindex="3" blazor:oncellfocus="14" b-upi3f9mbnn="">
+    <fluent-data-grid-cell cell-id="c5" cell-type="default" grid-column="1" class="col-justify-start " b-w6qdxfylwy="">✅</fluent-data-grid-cell>
+    <fluent-data-grid-cell cell-id="c6" cell-type="default" grid-column="2" class="col-justify-start " b-w6qdxfylwy="">Kenji Sato</fluent-data-grid-cell>
+  </fluent-data-grid-row>
+  <fluent-data-grid-row row-id="r4" row-index="3" grid-template-columns="50px 1fr" row-type="default" blazor:onkeydown="15" blazor:onclick="16" blazor:ondblclick="17" aria-rowindex="4" blazor:oncellfocus="18" b-upi3f9mbnn="">
+    <fluent-data-grid-cell cell-id="c7" cell-type="default" grid-column="1" class="col-justify-start " b-w6qdxfylwy="">✅</fluent-data-grid-cell>
+    <fluent-data-grid-cell cell-id="c8" cell-type="default" grid-column="2" class="col-justify-start " b-w6qdxfylwy="">Julie Smith</fluent-data-grid-cell>
+  </fluent-data-grid-row>
+</fluent-data-grid>

--- a/tests/Core/DataGrid/FluentDataGridColumSelectTests.razor
+++ b/tests/Core/DataGrid/FluentDataGridColumSelectTests.razor
@@ -15,7 +15,7 @@
                       @bind-SelectedItems="@SelectedItems" />
         <PropertyColumn Property="@(p => p.Name)" />
     </FluentDataGrid>
-    );
+        );
 
         cut.Verify();
     }
@@ -33,7 +33,7 @@
                       @bind-SelectedItems="@SelectedItems" />
         <PropertyColumn Property="@(p => p.Name)" />
     </FluentDataGrid>
-        );
+    );
 
         // Pre-Assert
         Assert.Empty(cut.FindAll("svg[row-selected]"));
@@ -64,7 +64,7 @@
                       OnSelect="@(e => e.Item.Selected = e.Selected)" />
         <PropertyColumn Property="@(p => p.Name)" />
     </FluentDataGrid>
-    );
+        );
 
         // Pre-Assert
         Assert.Empty(cut.FindAll("svg[row-selected]"));
@@ -94,7 +94,7 @@
                       @bind-SelectedItems="@SelectedItems" />
         <PropertyColumn Property="@(p => p.Name)" />
     </FluentDataGrid>
-    );
+        );
 
         cut.Verify();
     }
@@ -112,7 +112,7 @@
                       @bind-SelectedItems="@SelectedItems" />
         <PropertyColumn Property="@(p => p.Name)" />
     </FluentDataGrid>
-        );
+    );
 
         // Pre-Assert
         Assert.Empty(cut.FindAll("svg[row-selected]"));
@@ -149,7 +149,7 @@
                       OnSelect="@(e => e.Item.Selected = e.Selected)" />
         <PropertyColumn Property="@(p => p.Name)" />
     </FluentDataGrid>
-    );
+        );
 
         // Pre-Assert
         Assert.Empty(cut.FindAll("svg[row-selected]"));
@@ -185,7 +185,7 @@
                       @bind-SelectedItems="@SelectedItems" />
         <PropertyColumn Property="@(p => p.Name)" />
     </FluentDataGrid>
-        );
+    );
 
         // Pre-Assert
         Assert.Empty(cut.FindAll("svg[row-selected]"));
@@ -219,7 +219,7 @@
                       SelectAllChanged="@(all => items.ToList().ForEach(p => p.Selected = (all == true)))" />
         <PropertyColumn Property="@(p => p.Name)" />
     </FluentDataGrid>
-        );
+    );
 
         // Pre-Assert
         Assert.Empty(cut.FindAll("svg[row-selected]"));
@@ -250,7 +250,7 @@
                       @bind-SelectedItems="@selectedItems" />
         <PropertyColumn Property="@(p => p.Name)" />
     </FluentDataGrid>
-    );
+        );
 
         // Before the switch
         Assert.Equal(2, cut.FindAll("svg[row-selected]").Count);
@@ -265,6 +265,57 @@
         // After the switch
         Assert.Single(cut.FindAll("svg[row-selected]"));
         Assert.Single(selectedItems);
+    }
+
+    [Fact]
+    public async Task FluentDataGrid_ColumSelect_SelectAll_Disabled()
+    {
+        IEnumerable<Person> SelectedItems = Array.Empty<Person>();
+
+        // Arrange
+        var cut = Render(
+    @<FluentDataGrid Items="@People" TGridItem="Person">
+        <SelectColumn TGridItem="Person"
+                      SelectMode="@DataGridSelectMode.Multiple"
+                      SelectAllDisabled="true"
+                      @bind-SelectedItems="@SelectedItems" />
+        <PropertyColumn Property="@(p => p.Name)" />
+    </FluentDataGrid>
+        );
+
+        // Pre-Assert
+        Assert.Empty(cut.FindAll("svg[row-selected]"));
+        Assert.Empty(SelectedItems);
+
+        // Act - Click on All checkbox to select all => should not work
+        await ClickOnAllAsync(cut);
+        Assert.Empty(cut.FindAll("svg[row-selected]"));
+        Assert.Empty(SelectedItems);
+    }
+
+    [Fact]
+    public void FluentDataGrid_ColumSelect_MultiSelect_Customized_Rendering()
+    {
+        IEnumerable<Person> SelectedItems = new[] { People.ElementAt(1), People.ElementAt(2) };
+
+        // Arrange
+        var cut = Render(
+    @<FluentDataGrid Items="@People" TGridItem="Person">
+        <SelectColumn TGridItem="Person"
+                      SelectMode="@DataGridSelectMode.Multiple"
+                      @bind-SelectedItems="@SelectedItems">
+            <SelectAllTemplate>
+                @(context.AllSelected == true ? "✅" : context.AllSelected == null ? "➖" : "⬜")
+            </SelectAllTemplate>
+            <ChildContent>
+                @(SelectedItems.Contains(context) ? "✅" : " ")
+            </ChildContent>
+        </SelectColumn>
+        <PropertyColumn Property="@(p => p.Name)" />
+    </FluentDataGrid>
+        );
+
+        cut.Verify();
     }
 
     /// <summary>


### PR DESCRIPTION
# [DataGrid SelectColum] Allow customization of SelectAll header

Using this **SelectColumn**, you can customize the checkboxes by using `ChildContent` to define the contents of the selection for each row of the grid; or `SelectAllTemplate `to customize the header of this column.

If you don't want the user to be able to interact (click and change) on the **SelectAll** header, you can set the `SelectAllDisabled="true"` attribute.

Fix #2090

## Example

```razor
<SelectAllTemplate>
    @(context.AllSelected == true ? "✅" : context.AllSelected == null ? "➖" : "⬜")
</SelectAllTemplate>
<ChildContent>
    @(SelectedItems.Contains(context) ? "✅" : " ") @* Using SelectedItems         *@
    @(context.Selected ? "✅" : " ")                @* Using Property and OnSelect *@
</ChildContent>
```

![CustomizeSelectAll](https://github.com/microsoft/fluentui-blazor/assets/8350694/c544cba9-e056-4bf7-9938-918e6013656d)


## Unit Tests

Updated and verified (no breaking change).