### PR TITLE
[FluentAutocomplete] Add SelectValueOnTab attribute

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -4845,6 +4845,7 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.SelectValueOnTab">
             <summary>
             Gets or sets whether the currently selected item from the drop-down (if it is open) is selected.
+            Default is false.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.ListStyleValue">

--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -4842,6 +4842,11 @@
             Gets or sets the delay, in milliseconds, before to raise the <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.OnOptionsSearch"/> event.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.SelectValueOnTab">
+            <summary>
+            Gets or sets whether the currently selected item from the drop-down (if it is open) is selected.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.ListStyleValue">
             <summary />
         </member>

--- a/examples/Demo/Shared/Pages/List/Autocomplete/Examples/AutocompleteDefault.razor
+++ b/examples/Demo/Shared/Pages/List/Autocomplete/Examples/AutocompleteDefault.razor
@@ -5,7 +5,6 @@
                     Autofocus="true"
                     Label="Select a country"
                     Width="250px"
-                    SelectValueOnTab="true"
                     MaxAutoHeight="@(AutoHeight ? "200px" : null)"
                     Placeholder="Select countries"
                     OnOptionsSearch="@OnSearchAsync"

--- a/examples/Demo/Shared/Pages/List/Autocomplete/Examples/AutocompleteDefault.razor
+++ b/examples/Demo/Shared/Pages/List/Autocomplete/Examples/AutocompleteDefault.razor
@@ -5,6 +5,7 @@
                     Autofocus="true"
                     Label="Select a country"
                     Width="250px"
+                    SelectValueOnTab="true"
                     MaxAutoHeight="@(AutoHeight ? "200px" : null)"
                     Placeholder="Select countries"
                     OnOptionsSearch="@OnSearchAsync"

--- a/src/Core/Components/List/FluentAutocomplete.razor
+++ b/src/Core/Components/List/FluentAutocomplete.razor
@@ -23,7 +23,7 @@
                          Required="@Required"
                          @onclick="@OnDropDownExpandedAsync"
                          @oninput="@InputHandlerAsync"
-                         @onfocusout="@(e => { IsReachedMaxItems = false; })"
+                         @onfocusout="@(e => { IsReachedMaxItems = false; IsMultiSelectOpened = false; })"
                          autofocus="@Autofocus"
                          Style="@ComponentWidth">
             @* Selected Items *@

--- a/src/Core/Components/List/FluentAutocomplete.razor
+++ b/src/Core/Components/List/FluentAutocomplete.razor
@@ -25,8 +25,7 @@
                          @oninput="@InputHandlerAsync"
                          @onfocusout="@(e => { IsReachedMaxItems = false; })"
                          autofocus="@Autofocus"
-                         Style="@ComponentWidth"
-                         >
+                         Style="@ComponentWidth">
             @* Selected Items *@
             @if (this.SelectedOptions?.Any() == true)
             {
@@ -102,6 +101,14 @@
         @* List of available items *@
         @if (IsMultiSelectOpened && (ShowOverlayOnEmptyResults || Items?.Any() == true))
         {
+            @if (SelectValueOnTab)
+            {
+                <FluentKeyCode Anchor="@Id"
+                               OnKeyDown="@KeyDownHandlerAsync"
+                               Only="@SelectValueOnTabOnly"
+                               PreventDefaultOnly="@SelectValueOnTabOnly" />
+            }
+
             <FluentOverlay OnClose="@(e => IsMultiSelectOpened = false)" Visible="true" Transparent="true" FullScreen="true" />
             <FluentAnchoredRegion Anchor="@Id"
                                   HorizontalDefaultPosition="HorizontalPosition.Right"

--- a/src/Core/Components/List/FluentAutocomplete.razor.cs
+++ b/src/Core/Components/List/FluentAutocomplete.razor.cs
@@ -214,6 +214,12 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
     [Parameter]
     public int ImmediateDelay { get; set; } = 0;
 
+    /// <summary>
+    /// Gets or sets whether the currently selected item from the drop-down (if it is open) is selected.
+    /// </summary>
+    [Parameter]
+    public bool SelectValueOnTab { get; set; } = false;
+
     /// <summary />
     private string? ListStyleValue => new StyleBuilder()
         .AddStyle("width", Width, when: !string.IsNullOrEmpty(Width))
@@ -281,7 +287,7 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
 
         if (ImmediateDelay > 0)
         {
-           await _debouncer.DebounceAsync(ImmediateDelay, () => InvokeAsync(() => OnOptionsSearch.InvokeAsync(args)));
+            await _debouncer.DebounceAsync(ImmediateDelay, () => InvokeAsync(() => OnOptionsSearch.InvokeAsync(args)));
         }
         else
         {
@@ -318,6 +324,7 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
 
     private static readonly KeyCode[] CatchOnly = new[] { KeyCode.Escape, KeyCode.Enter, KeyCode.Backspace, KeyCode.Down, KeyCode.Up };
     private static readonly KeyCode[] PreventOnly = CatchOnly.Except(new[] { KeyCode.Backspace }).ToArray();
+    private static readonly KeyCode[] SelectValueOnTabOnly = new[] { KeyCode.Tab };
 
     /// <summary />
     protected async Task KeyDownHandlerAsync(FluentKeyCodeEventArgs e)
@@ -329,6 +336,7 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
                 break;
 
             case KeyCode.Enter:
+            case KeyCode.Tab:
                 if (IsMultiSelectOpened)
                 {
                     var optionDisabled = SelectableItem != null && OptionDisabled != null

--- a/src/Core/Components/List/FluentAutocomplete.razor.cs
+++ b/src/Core/Components/List/FluentAutocomplete.razor.cs
@@ -216,6 +216,7 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
 
     /// <summary>
     /// Gets or sets whether the currently selected item from the drop-down (if it is open) is selected.
+    /// Default is false.
     /// </summary>
     [Parameter]
     public bool SelectValueOnTab { get; set; } = false;

--- a/tests/Core/List/FluentAutocompleteTests.razor
+++ b/tests/Core/List/FluentAutocompleteTests.razor
@@ -19,8 +19,8 @@
         // Arrange
         var cut = RenderComponent<FluentAutocomplete<Customer>>(parameters =>
         {
-            parameters.Add(p => p.Id, "myComponent");
-            parameters.Add(p => p.Items, GetCustomers());
+    parameters.Add(p => p.Id, "myComponent");
+    parameters.Add(p => p.Items, GetCustomers());
         });
 
         // Assert
@@ -33,9 +33,9 @@
         // Arrange
         var cut = RenderComponent<FluentAutocomplete<Customer>>(parameters =>
         {
-            parameters.Add(p => p.Id, "myComponent");
-            parameters.Add(p => p.Items, GetCustomers());
-            parameters.Add(p => p.Width, string.Empty);
+    parameters.Add(p => p.Id, "myComponent");
+    parameters.Add(p => p.Items, GetCustomers());
+    parameters.Add(p => p.Width, string.Empty);
         });
 
         // Assert
@@ -49,8 +49,8 @@
         // Arrange
         var cut = RenderComponent<FluentAutocomplete<Customer>>(parameters =>
         {
-            parameters.Add(p => p.Id, "myComponent");
-            parameters.Add(p => p.Items, GetCustomers());
+    parameters.Add(p => p.Id, "myComponent");
+    parameters.Add(p => p.Items, GetCustomers());
         });
 
         // Act
@@ -79,9 +79,9 @@
         // Arrange
         var cut = RenderComponent<FluentAutocomplete<Customer>>(parameters =>
         {
-            parameters.Add(p => p.Id, "myComponent");
-            parameters.Add(p => p.Items, GetCustomers());
-            parameters.Add(p => p.SelectedOptions, GetCustomers().Take(2));
+    parameters.Add(p => p.Id, "myComponent");
+    parameters.Add(p => p.Items, GetCustomers());
+    parameters.Add(p => p.SelectedOptions, GetCustomers().Take(2));
         });
 
         // Act
@@ -91,6 +91,40 @@
 
         // Assert
         cut.Verify(suffix: keyCode);
+    }
+
+    [Fact]
+    public async Task FluentAutocomplete_SelectValueOnTab()
+    {
+        IEnumerable<Customer> SelectedItems = Array.Empty<Customer>();
+
+        // Arrange
+        var cut = Render<FluentAutocomplete<Customer>>(
+            @<FluentAutocomplete TOption="Customer"
+                    SelectValueOnTab="true"
+                    @bind-SelectedOptions="@SelectedItems"
+                    OnOptionsSearch="@OnSearchAsync" />
+    );
+
+        Task OnSearchAsync(OptionsSearchEventArgs<Customer> e)
+        {
+            e.Items = GetCustomers().Where(i => i.Name.StartsWith(e.Text, StringComparison.OrdinalIgnoreCase))
+                                    .OrderBy(i => i.Name);
+            return Task.CompletedTask;
+        }
+
+        // Act: click to open -> Tab to select
+        var input = cut.Find("fluent-text-field");
+        input.Click();
+
+        // Tab to select
+        await cut.InvokeAsync(async () => await cut.FindComponents<FluentKeyCode>()
+                                                   .ElementAt(1)
+                                                   .Instance
+                                                   .OnKeyDownRaisedAsync((int)KeyCode.Tab, "", false, false, false, false, 0, string.Empty));
+
+        // Assert (One item selected)
+        Assert.Single(SelectedItems);
     }
 
     [Fact]
@@ -326,7 +360,7 @@
         // Act
         cut.Find("fluent-text-field").Click();
 
-        // Assert        
+        // Assert
         Assert.Equal("auto-height", cut.Find("div[slot='start']").ClassName);
         Assert.Equal("max-height: 200px;", cut.Find("div[slot='start']").Attributes["style"]?.Value);
         Assert.True(cut.Find(".fluent-autocomplete-multiselect").HasAttribute("auto-height"));


### PR DESCRIPTION
# [FluentAutocomplete] Add SelectValueOnTab attribute

By activating the `SelectValueOnTab` option, the user can select an item from the list using the `Enter` key (as usual), but also the `Tab` key. If the component is "closed", the `Tab` key come back to its usual function of navigating to the next HTML element.

See the request #1435

##  SelectValueOnTab = False
![Before](https://github.com/microsoft/fluentui-blazor/assets/8350694/726ee2c5-73b1-4df8-b0b3-68e57e5c5183)

##  SelectValueOnTab = True
![After](https://github.com/microsoft/fluentui-blazor/assets/8350694/dfeeda30-53b4-4116-9c0f-1423d0b16fa8)

## Unit Tests
Unit test added.
