### PR TITLE
Adds FieldIdentifier parameter to FluentInputBase

### DIFF
--- a/src/Core/Components/Base/FluentInputBase.cs
+++ b/src/Core/Components/Base/FluentInputBase.cs
@@ -96,6 +96,13 @@ public abstract partial class FluentInputBase<TValue> : FluentComponentBase, IDi
     public Expression<Func<TValue>>? ValueExpression { get; set; }
 
     /// <summary>
+    /// Gets or sets the <see cref="FieldIdentifier"/> that identifies the bound value.
+    /// If set, this parameter takes precedence over <see cref="ValueExpression"/>.
+    /// </summary>
+    [Parameter]
+    public FieldIdentifier? Field { get; set; }
+
+    /// <summary>
     /// Gets or sets the display name for this field.
     /// <para>This value is used when generating error messages when the input value fails to parse correctly.</para>
     /// </summary>
@@ -115,7 +122,7 @@ public abstract partial class FluentInputBase<TValue> : FluentComponentBase, IDi
     public virtual string? Placeholder { get; set; }
 
     /// <summary>
-    /// Gets or sets if the derived component is embedded in another component. 
+    /// Gets or sets if the derived component is embedded in another component.
     /// If true, the ClassValue property will not include the EditContext's FieldCssClass.
     /// </summary>
     [Parameter]
@@ -132,7 +139,7 @@ public abstract partial class FluentInputBase<TValue> : FluentComponentBase, IDi
     /// </summary>
     protected internal FieldIdentifier FieldIdentifier { get; set; }
 
-    internal bool FieldBound => ValueExpression != null || ValueChanged.HasDelegate;
+    internal bool FieldBound => Field is not null || ValueExpression != null || ValueChanged.HasDelegate;
 
     protected async Task SetCurrentValueAsync(TValue? value)
     {
@@ -296,7 +303,11 @@ public abstract partial class FluentInputBase<TValue> : FluentComponentBase, IDi
             // This is the first run
             // Could put this logic in OnInit, but its nice to avoid forcing people who override OnInit to call base.OnInit()
 
-            if (ValueExpression is not null)
+            if(Field is not null)
+            {
+                FieldIdentifier = (FieldIdentifier)Field;
+            }
+            else if (ValueExpression is not null)
             {
                 FieldIdentifier = FieldIdentifier.Create(ValueExpression);
             }
@@ -345,9 +356,9 @@ public abstract partial class FluentInputBase<TValue> : FluentComponentBase, IDi
     /// <summary>
     /// Exposes the elements FocusAsync(bool preventScroll) method.
     /// </summary>
-    /// <param name="preventScroll">A Boolean value indicating whether or not the browser should scroll 
-    /// the document to bring the newly-focused element into view. A value of false for preventScroll (the default) 
-    /// means that the browser will scroll the element into view after focusing it. 
+    /// <param name="preventScroll">A Boolean value indicating whether or not the browser should scroll
+    /// the document to bring the newly-focused element into view. A value of false for preventScroll (the default)
+    /// means that the browser will scroll the element into view after focusing it.
     /// If preventScroll is set to true, no scrolling will occur.</param>
     [SuppressMessage("Style", "VSTHRD200:Use `Async` suffix for async methods", Justification = "#vNext: To update in the next version")]
     public async void FocusAsync(bool preventScroll)


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

This PR adds a new parameter ```Field``` (of type ```FieldIdentifier```) to ```FluentInputBase```. I'm working on a system that allows users to create their own dynamic forms, this means my model contains a list of fields and each of those has a base class where the value is stored as an ```object?``` and inheriting classes override this with a specific type. When passing to input components the ```Value``` parameter gets cast to the correct type, but the ```FluentValidationMessage``` component can only be passed the ```object?``` version due to ```FieldIdentifiers``` not supporting the ```UnaryExpression``` that is created by casting. This means that the ```FluentInputBase``` has a different internal ```FieldIdentifier``` due to the unboxing, and means the validation message shows correctly when the value is invalid but the field stays showing as valid. By allowing the ```FieldIdentifier``` to be manually set this limitation can be overcome.

In normal statically typed models this additional parameter is not needed as everything will already work. However for dynamic use cases like mine, where design-time accessors are not possible, a ```FieldIdentifier``` works best. ```ValueExpression``` will also not work in this case as it also requires statically typed accessors. 

#1489 added a similar feature for ```FluentValidationMessage``` so I largely used the same code.

### Example

This is a basic example of how this works, it uses the FluentValidation library to simplify validating the dynamic model. This example is simpler than my use case but demonstrates the same issue:

```razor
<EditForm Model="FormState">
    <FluentValidationValidator />
    @foreach(var field in FormState.Fields)
    {
        @if(field.FieldType == "int")
        {
            <FluentNumberField Id="@field.FieldName"
                TValue="int?"
                Label="@field.FieldName" 
                Required="true"
                Placeholder="Enter a number"
                Value="(int?)field.Value"
                Field="@(FieldIdentifier.Create(() => field.Value))"
                ValueChanged="@(value => OnValueChanged(field, value))" />
        } else if (field.FieldType == "string")
        {
            <FluentTextField Id="@field.FieldName"
                Label="@field.FieldName"
                Required="true"
                Placeholder="Enter a string"
                Value="@((string?)field.Value)"
                Field="@(FieldIdentifier.Create(() => field.Value))"
                ValueChanged="@(value => OnValueChanged(field, value))" />
        }
        <FluentValidationMessage For="@(() => field.Value)" />
    }
</EditForm>

@code {
    private MyFormState FormState = new()
    {
        Fields = new()
        {
            new() {FieldType = "string", FieldName = "StringField", Value = ""},
            new() {FieldType = "int", FieldName = "IntField", Value = 1}
        }
    };

    private void OnValueChanged(MyFormField field, object? value)
    {
        field.Value = value;
    }

    public class MyFormState
    {
        public List<MyFormField> Fields { get; set; } = [];
    }

    public class MyFormField
    {
        public string FieldType { get; set; } = "string";
        public required string FieldName { get; set; }
        public object? Value { get; set; }
    }

    public class MyFormStateValidator : AbstractValidator<MyFormState>
    {
        public MyFormStateValidator()
        {
            RuleForEach(x => x.Fields).SetValidator(new MyFormFieldValidator());
        }
    }

    public class MyFormFieldValidator : AbstractValidator<MyFormField>
    {
        public MyFormFieldValidator()
        {
            RuleFor(x => (int?)x.Value).GreaterThan(2).WithName(x => x.FieldName).When(x => x.FieldType == "int");
            RuleFor(x => (string?)x.Value).NotEmpty().WithName(x => x.FieldName).When(x => x.FieldType == "string");
        }
    }
}
```

Without using ```Field``` and invalid the fields are still marked as valid
![image](https://github.com/microsoft/fluentui-blazor/assets/4594567/ab0b8560-e321-42b6-89e3-e816a57537b0)

When using ```Field``` and invalid the fields are now correctly marked as invalid
![image](https://github.com/microsoft/fluentui-blazor/assets/4594567/43e18768-0012-4c6f-bdb7-0deeebdef000)


### 🎫 Issues

<!---
* List and link relevant issues here.
-->

No issues currently reported, but for this niche use case it is required

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

No tests affected by this extra parameter, but all existing tests for ```FluentInputBase``` components pass. I have tested this code by creating custom versions of the number and text inputs in my project and verifying it works in both the above example and a more complex scenario, as well as making sure existing forms that don't use this new parameter still work.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new compontent
- [x] I have modified an existing component
- [ ] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component 

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
