### PR TITLE
[Progress] Fix height in Indeterminate mode by using InvariantCulture

### DIFF
--- a/src/Core/Components/Progress/FluentProgress.razor.cs
+++ b/src/Core/Components/Progress/FluentProgress.razor.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components.Utilities;
+using System.Globalization;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
@@ -90,7 +91,7 @@ public partial class FluentProgress : FluentComponentBase
     private string StyleProgressIndicator => $"height: calc((var(--stroke-width) * {StrokeDetails.BarHeight}) * 1px); " +
                                              $"background-color: {(string.IsNullOrEmpty(Color) ? "var(--accent-fill-rest)" : Color)};";
 
-    private string StyleIndeterminate => $"--stroke-width: {((double)StrokeDetails.BarHeight / 3d).ToString("0.00")}; " +
+    private string StyleIndeterminate => $"--stroke-width: {((double)StrokeDetails.BarHeight / 3d).ToString("0.00", CultureInfo.InvariantCulture)}; " +
                                          $"height: calc((1 * {StrokeDetails.BackgroundHeight}) * 1px); " +
                                          $"background-color: {(string.IsNullOrEmpty(BackgroundColor) ? $"var({StrokeDetails.DefaultBackgroundColor})" : BackgroundColor)};";
 


### PR DESCRIPTION
# Pull Request
Add CultureInfo.InvariantCulture to ToString("0.00") in FluentProgress component
## 📖 Description

As described in #2107 this PR fixes the call to ToString("0.00") adding CultureInfo.InvariantCulture:
https://github.com/microsoft/fluentui-blazor/blob/758dce12b21e91021d67d05d7ddc0268f4266191/src/Core/Components/Progress/FluentProgress.razor.cs#L93

Without this fix --stroke-width couldn't be set correctly for cultures other than the US.

### 🎫 Issues

#2107 

## 👩‍💻 Reviewer Notes

## 📑 Test Plan

## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

