### PR TITLE
[NavMenu] Fix double click needed for expanding/collapsing child elements when prerendering is turned off

### DIFF
--- a/src/Core/Components/NavMenu/FluentNavGroup.razor.cs
+++ b/src/Core/Components/NavMenu/FluentNavGroup.razor.cs
@@ -13,6 +13,9 @@ public partial class FluentNavGroup : FluentNavBase
     private readonly RenderFragment _renderButton;
     private bool _open;
 
+    private static int _renderCount = 0;
+    private bool _negate = false;
+
     protected string? ClassValue =>
         new CssBuilder("fluent-nav-group")
             .AddClass("fluent-nav-item")
@@ -102,8 +105,22 @@ public partial class FluentNavGroup : FluentNavBase
         _renderButton = RenderButton;
     }
 
+    protected override void OnInitialized()
+    {
+        _renderCount ++;
+        if (_renderCount > 1)
+        {
+            _negate = true;
+        }
+    }
+
     private async Task ToggleExpandedAsync()
     {
+
+        if (_negate)
+        {
+            Expanded = !Expanded;
+        }
 
         if (!Owner.Expanded && Owner.CollapsedChildNavigation)
         {

--- a/src/Core/Components/NavMenu/FluentNavGroup.razor.cs
+++ b/src/Core/Components/NavMenu/FluentNavGroup.razor.cs
@@ -50,7 +50,7 @@ public partial class FluentNavGroup : FluentNavBase
     public string? Title { get; set; }
 
     /// <summary>
-    /// If true, expands the nav group, otherwise collapse it. 
+    /// If true, expands the nav group, otherwise collapse it.
     /// Two-way bindable
     /// </summary>
     [Parameter]
@@ -69,7 +69,7 @@ public partial class FluentNavGroup : FluentNavBase
     public string? MaxHeight { get; set; }
 
     /// <summary>
-    /// Defines the vertical spacing between the NavGroup and adjecent items. 
+    /// Defines the vertical spacing between the NavGroup and adjecent items.
     /// Needs to be a valid CSS value.
     /// </summary>
     [Parameter]
@@ -82,7 +82,7 @@ public partial class FluentNavGroup : FluentNavBase
     public Icon ExpandIcon { get; set; } = new CoreIcons.Regular.Size12.ChevronRight();
 
     /// <summary>
-    /// Allows for specific markup and styling to be applied for the group title 
+    /// Allows for specific markup and styling to be applied for the group title
     /// When using this, the containded <see cref="FluentNavLink"/>s and <see cref="FluentNavGroup"/>s need to be placed in a ChildContent tag.
     /// When specifying both Title and TitleTemplate, both will be rendered.
     /// </summary>
@@ -102,15 +102,16 @@ public partial class FluentNavGroup : FluentNavBase
         _renderButton = RenderButton;
     }
 
-    private Task ToggleExpandedAsync()
+    private async Task ToggleExpandedAsync()
     {
+
         if (!Owner.Expanded && Owner.CollapsedChildNavigation)
         {
-            return SetExpandedAsync(!_open);
+            await SetExpandedAsync(!_open);
         }
         else
         {
-            return SetExpandedAsync(!Expanded);
+            await SetExpandedAsync(Expanded);
         }
     }
 


### PR DESCRIPTION
Fix error behavior by changing the toggle logic based on prerendering being true/false