### PR TITLE
[Demo] Removes FluentPersona DemoSection from AutoComplete page

### DIFF
--- a/examples/Demo/Shared/Pages/List/Autocomplete/AutocompletePage.razor
+++ b/examples/Demo/Shared/Pages/List/Autocomplete/AutocompletePage.razor
@@ -20,9 +20,6 @@
     </Description>
 </DemoSection>
 
-
-<DemoSection Title="FluentPersona" Component="@typeof(AutocompletePersona)" />
-
 <h2 id="documentation">Documentation</h2>
 
 <ApiDocumentation Component="typeof(FluentAutocomplete<>)" GenericLabel="TOption" />


### PR DESCRIPTION
# Pull Request

## 📖 Description

Removes FluentPersona DemoSection from AutoComplete page

### 🎫 Issues

- Misplaced.

## 👩‍💻 Reviewer Notes

This appears to be a simple mistake.

## 📑 Test Plan

## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [X] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps
