### PR TITLE
[DataGrid] Allow programmatic sorting of columns by name or index

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -1718,14 +1718,14 @@
             <param name="direction">The direction of sorting. If the value is <see cref="F:Microsoft.FluentUI.AspNetCore.Components.SortDirection.Auto"/>, then it will toggle the direction on each call.</param>
             <returns>A <see cref="T:System.Threading.Tasks.Task"/> representing the completion of the operation.</returns>
         </member>
-        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.SortByColumnTitleAsync(System.String,Microsoft.FluentUI.AspNetCore.Components.SortDirection)">
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.SortByColumnAsync(System.String,Microsoft.FluentUI.AspNetCore.Components.SortDirection)">
             <summary>
             Sorts the grid by the specified column <paramref name="title"/> found first. If the title is not found, nothing happens.
             </summary>
             <param name="title">The title of the column to sort by.</param>
             <param name="direction">The direction of sorting. The default is <see cref="F:Microsoft.FluentUI.AspNetCore.Components.SortDirection.Auto"/>. If the value is <see cref="F:Microsoft.FluentUI.AspNetCore.Components.SortDirection.Auto"/>, then it will toggle the direction on each call.</param>
         </member>
-        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.SortByColumnIndexAsync(System.Int32,Microsoft.FluentUI.AspNetCore.Components.SortDirection)">
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.SortByColumnAsync(System.Int32,Microsoft.FluentUI.AspNetCore.Components.SortDirection)">
             <summary>
             Sorts the grid by the specified column <paramref name="index"/>. If the index is out of range, nothing happens.
             </summary>

--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -1718,6 +1718,20 @@
             <param name="direction">The direction of sorting. If the value is <see cref="F:Microsoft.FluentUI.AspNetCore.Components.SortDirection.Auto"/>, then it will toggle the direction on each call.</param>
             <returns>A <see cref="T:System.Threading.Tasks.Task"/> representing the completion of the operation.</returns>
         </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.SortByColumnTitleAsync(System.String,Microsoft.FluentUI.AspNetCore.Components.SortDirection)">
+            <summary>
+            Sorts the grid by the specified column <paramref name="title"/> found first. If the title is not found, nothing happens.
+            </summary>
+            <param name="title">The title of the column to sort by.</param>
+            <param name="direction">The direction of sorting. The default is <see cref="F:Microsoft.FluentUI.AspNetCore.Components.SortDirection.Auto"/>. If the value is <see cref="F:Microsoft.FluentUI.AspNetCore.Components.SortDirection.Auto"/>, then it will toggle the direction on each call.</param>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.SortByColumnIndexAsync(System.Int32,Microsoft.FluentUI.AspNetCore.Components.SortDirection)">
+            <summary>
+            Sorts the grid by the specified column <paramref name="index"/>. If the index is out of range, nothing happens.
+            </summary>
+            <param name="index">The index of the column to sort by.</param>
+            <param name="direction">The direction of sorting. The default is <see cref="F:Microsoft.FluentUI.AspNetCore.Components.SortDirection.Auto"/>. If the value is <see cref="F:Microsoft.FluentUI.AspNetCore.Components.SortDirection.Auto"/>, then it will toggle the direction on each call.</param>
+        </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.RemoveSortByColumnAsync(Microsoft.FluentUI.AspNetCore.Components.ColumnBase{`0})">
             <summary>
             Removes the grid's sort on double click if this is specified <paramref name="column"/> currently sorted on.
@@ -6312,7 +6326,7 @@
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentNavGroup.Gap">
             <summary>
-            Defines the vertical spacing between the NavGroup and adjecent items.
+            Defines the vertical spacing between the NavGroup and adjacent items.
             Needs to be a valid CSS value.
             </summary>
         </member>
@@ -6324,7 +6338,7 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentNavGroup.TitleTemplate">
             <summary>
             Allows for specific markup and styling to be applied for the group title
-            When using this, the containded <see cref="T:Microsoft.FluentUI.AspNetCore.Components.FluentNavLink"/>s and <see cref="T:Microsoft.FluentUI.AspNetCore.Components.FluentNavGroup"/>s need to be placed in a ChildContent tag.
+            When using this, the contained <see cref="T:Microsoft.FluentUI.AspNetCore.Components.FluentNavLink"/>s and <see cref="T:Microsoft.FluentUI.AspNetCore.Components.FluentNavGroup"/>s need to be placed in a ChildContent tag.
             When specifying both Title and TitleTemplate, both will be rendered.
             </summary>
         </member>

--- a/examples/Demo/Shared/Pages/DataGrid/DataGridPage.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/DataGridPage.razor
@@ -100,13 +100,15 @@ fluent-data-grid-row:has([row-selected]) {
     <br /><br />
 
     Example:
-<CodeSnippet Language="razor">&lt;SelectAllTemplate>
-    @@(context.AllSelected == true ? "✅" : context.AllSelected == null ? "➖" : "⬜")
-&lt;/SelectAllTemplate>
-&lt;ChildContent>
-    @@(SelectedItems.Contains(context) ? "✅" : " ") @@* Using SelectedItems         *@@
-    @@(context.Selected ? "✅" : " ")                @@* Using Property and OnSelect *@@
-&lt;/ChildContent></CodeSnippet>
+    <CodeSnippet Language="razor">
+        &lt;SelectAllTemplate>
+        @@(context.AllSelected == true ? "✅" : context.AllSelected == null ? "➖" : "⬜")
+        &lt;/SelectAllTemplate>
+        &lt;ChildContent>
+        @@(SelectedItems.Contains(context) ? "✅" : " ") @@* Using SelectedItems         *@@
+        @@(context.Selected ? "✅" : " ")                @@* Using Property and OnSelect *@@
+        &lt;/ChildContent>
+    </CodeSnippet>
 </p>
 
 <DemoSection Title="Typical usage" Component="@typeof(DataGridTypical)" CollocatedFiles="@(new[] {"css"})">
@@ -158,7 +160,7 @@ fluent-data-grid-row:has([row-selected]) {
         </p>
         <p>
             This grid is using a 'sticky' header (i.e. the header is always visible when scrolling). The buttons in the last column disappear under the header when scrolling.
-            In this example they don't relly do anything more than writting a message in the console log'
+            In this example they don't really do anything more than writing a message in the console log'
         </p>
         <p>
             The second column has a custom <code>Style</code> parameter set and applied to it. The 4th column has its <code>Tooltip</code>
@@ -185,7 +187,7 @@ fluent-data-grid-row:has([row-selected]) {
         <p>
             Enabling virtualization is just a matter of passing <code>Virtualize="true"</code>. For it to work
             properly and reliably, every row rendered must have the same known height. <strong>
-                This is handeled by the
+                This is handled by the
                 <code>FluentDataGrid</code> code
             </strong>.
         </p>
@@ -195,7 +197,7 @@ fluent-data-grid-row:has([row-selected]) {
 <DemoSection Title="Intermittent loading" Component="@typeof(DataGridNotVirtualizedLoadingAndEmpty)">
     <Description>
         <p>
-            Use the options below the grid to togle the content of this non virtualized gri on and off and to simulate a loading state
+            Use the options below the grid to toggle the content of this non virtualized grid on and off and to simulate a loading state
         </p>
     </Description>
 </DemoSection>
@@ -215,7 +217,7 @@ fluent-data-grid-row:has([row-selected]) {
             You can make columns appear conditionally using normal Razor logic such as <code>@@if</code>. Example:
         </p>
         <p>
-            Also, in this example the columns's Width parameter is being set instead of specifying all widths for all
+            Also, in this example the column's Width parameter is being set instead of specifying all widths for all
             columns in the <code>GridTemplateColumn</code> parameter.
         </p>
     </Description>
@@ -227,7 +229,7 @@ fluent-data-grid-row:has([row-selected]) {
             Here a custom comparer is being used to sort counties by the length of their name. The code has examples for both
             <code>PropertyColumn</code> and <code>TemplateColumn</code> implementations (see the Razor tab).<br />
             For this example the code for the comparer is placed in the <code>DataGridCustomComparer.razor.cs</code> file but it
-            could of couse be placed in its own file.
+            could of course be placed in its own file.
         </p>
         <p>
             For the paginator, this example also shows how to use the <code>SummaryTemplate</code> and <code>PaginationTextTemplate</code> parameters.
@@ -295,7 +297,7 @@ fluent-data-grid-row:has([row-selected]) {
 
 <div class="demopanel">
     <p>
-        <strong>The <code>FluentDataGridRow</code> and <code>FluentDataGridCell</code> API's are usually not used directely </strong>
+        <strong>The <code>FluentDataGridRow</code> and <code>FluentDataGridCell</code> API's are usually not used directly </strong>
     </p>
 </div>
 

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -374,7 +374,7 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     /// </summary>
     /// <param name="title">The title of the column to sort by.</param>
     /// <param name="direction">The direction of sorting. The default is <see cref="SortDirection.Auto"/>. If the value is <see cref="SortDirection.Auto"/>, then it will toggle the direction on each call.</param>
-    public Task SortByColumnTitleAsync(string title, SortDirection direction = SortDirection.Auto)
+    public Task SortByColumnAsync(string title, SortDirection direction = SortDirection.Auto)
     {
         var column = _columns.FirstOrDefault(c => c.Title?.Equals(title, StringComparison.InvariantCultureIgnoreCase) ?? false);
 
@@ -391,7 +391,7 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     /// </summary>
     /// <param name="index">The index of the column to sort by.</param>
     /// <param name="direction">The direction of sorting. The default is <see cref="SortDirection.Auto"/>. If the value is <see cref="SortDirection.Auto"/>, then it will toggle the direction on each call.</param>
-    public Task SortByColumnIndexAsync(int index, SortDirection direction = SortDirection.Auto)
+    public Task SortByColumnAsync(int index, SortDirection direction = SortDirection.Auto)
     {
         if (index >= 0 && index < _columns.Count)
         {

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -370,6 +370,38 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     }
 
     /// <summary>
+    /// Sorts the grid by the specified column <paramref name="title"/> found first. If the title is not found, nothing happens.
+    /// </summary>
+    /// <param name="title">The title of the column to sort by.</param>
+    /// <param name="direction">The direction of sorting. The default is <see cref="SortDirection.Auto"/>. If the value is <see cref="SortDirection.Auto"/>, then it will toggle the direction on each call.</param>
+    public Task SortByColumnTitleAsync(string title, SortDirection direction = SortDirection.Auto)
+    {
+        var column = _columns.FirstOrDefault(c => c.Title?.Equals(title, StringComparison.InvariantCultureIgnoreCase) ?? false);
+
+        if (column is not null)
+        {
+            return SortByColumnAsync(column, direction);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Sorts the grid by the specified column <paramref name="index"/>. If the index is out of range, nothing happens.
+    /// </summary>
+    /// <param name="index">The index of the column to sort by.</param>
+    /// <param name="direction">The direction of sorting. The default is <see cref="SortDirection.Auto"/>. If the value is <see cref="SortDirection.Auto"/>, then it will toggle the direction on each call.</param>
+    public Task SortByColumnIndexAsync(int index, SortDirection direction = SortDirection.Auto)
+    {
+        if (index >= 0 && index < _columns.Count)
+        {
+            return SortByColumnAsync(_columns[index], direction);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
     /// Removes the grid's sort on double click if this is specified <paramref name="column"/> currently sorted on.
     /// </summary>
     /// <param name="column">The column to check against the current sorted on column.</param>

--- a/tests/Core/DataGrid/DataGridSortByTests.DataGridSortByTests_SortByColumnIndex_Ascending.verified.razor.html
+++ b/tests/Core/DataGrid/DataGridSortByTests.DataGridSortByTests_SortByColumnIndex_Ascending.verified.razor.html
@@ -1,0 +1,31 @@
+
+<fluent-data-grid generate-header="none" aria-rowcount="5" blazor:onrowfocus="1" blazor:onclosecolumnoptions="2" b-ppmhrkw1mj="" blazor:elementreference="">
+  <fluent-data-grid-row row-id="r1" row-index="0" row-type="header" blazor:onkeydown="3" blazor:onclick="4" blazor:ondblclick="5" blazor:oncellfocus="6" b-upi3f9mbnn="">
+    <fluent-data-grid-cell cell-id="c1" cell-type="columnheader" grid-column="1" class="column-header col-justify-start  col-sort-asc" aria-sort="ascending" scope="col" b-w6qdxfylwy="">
+      <div class="col-title" b-pxhtqoo8qd="">
+        <div class="col-title-text" b-pxhtqoo8qd="">Item1</div>
+      </div>
+    </fluent-data-grid-cell>
+    <fluent-data-grid-cell cell-id="c2" cell-type="columnheader" grid-column="2" class="column-header col-justify-start " aria-sort="none" scope="col" b-w6qdxfylwy="">
+      <div class="col-title" b-pxhtqoo8qd="">
+        <div class="col-title-text" b-pxhtqoo8qd="">Item2</div>
+      </div>
+    </fluent-data-grid-cell>
+  </fluent-data-grid-row>
+  <fluent-data-grid-row row-id="r3" row-index="2" row-type="default" blazor:onkeydown="11" blazor:onclick="12" blazor:ondblclick="13" aria-rowindex="2" blazor:oncellfocus="14" b-upi3f9mbnn="">
+    <fluent-data-grid-cell cell-id="c5" cell-type="default" grid-column="1" class="col-justify-start " b-w6qdxfylwy="">A</fluent-data-grid-cell>
+    <fluent-data-grid-cell cell-id="c6" cell-type="default" grid-column="2" class="col-justify-start " b-w6qdxfylwy="">D</fluent-data-grid-cell>
+  </fluent-data-grid-row>
+  <fluent-data-grid-row row-id="r2" row-index="1" row-type="default" blazor:onkeydown="7" blazor:onclick="8" blazor:ondblclick="9" aria-rowindex="3" blazor:oncellfocus="10" b-upi3f9mbnn="">
+    <fluent-data-grid-cell cell-id="c3" cell-type="default" grid-column="1" class="col-justify-start " b-w6qdxfylwy="">B</fluent-data-grid-cell>
+    <fluent-data-grid-cell cell-id="c4" cell-type="default" grid-column="2" class="col-justify-start " b-w6qdxfylwy="">C</fluent-data-grid-cell>
+  </fluent-data-grid-row>
+  <fluent-data-grid-row row-id="r5" row-index="4" row-type="default" blazor:onkeydown="19" blazor:onclick="20" blazor:ondblclick="21" aria-rowindex="4" blazor:oncellfocus="22" b-upi3f9mbnn="">
+    <fluent-data-grid-cell cell-id="c9" cell-type="default" grid-column="1" class="col-justify-start " b-w6qdxfylwy="">C</fluent-data-grid-cell>
+    <fluent-data-grid-cell cell-id="c10" cell-type="default" grid-column="2" class="col-justify-start " b-w6qdxfylwy="">B</fluent-data-grid-cell>
+  </fluent-data-grid-row>
+  <fluent-data-grid-row row-id="r4" row-index="3" row-type="default" blazor:onkeydown="15" blazor:onclick="16" blazor:ondblclick="17" aria-rowindex="5" blazor:oncellfocus="18" b-upi3f9mbnn="">
+    <fluent-data-grid-cell cell-id="c7" cell-type="default" grid-column="1" class="col-justify-start " b-w6qdxfylwy="">D</fluent-data-grid-cell>
+    <fluent-data-grid-cell cell-id="c8" cell-type="default" grid-column="2" class="col-justify-start " b-w6qdxfylwy="">A</fluent-data-grid-cell>
+  </fluent-data-grid-row>
+</fluent-data-grid>

--- a/tests/Core/DataGrid/DataGridSortByTests.DataGridSortByTests_SortByColumnIndex_Descending.verified.razor.html
+++ b/tests/Core/DataGrid/DataGridSortByTests.DataGridSortByTests_SortByColumnIndex_Descending.verified.razor.html
@@ -1,0 +1,31 @@
+
+<fluent-data-grid generate-header="none" aria-rowcount="5" blazor:onrowfocus="1" blazor:onclosecolumnoptions="2" b-ppmhrkw1mj="" blazor:elementreference="">
+  <fluent-data-grid-row row-id="r1" row-index="0" row-type="header" blazor:onkeydown="3" blazor:onclick="4" blazor:ondblclick="5" blazor:oncellfocus="6" b-upi3f9mbnn="">
+    <fluent-data-grid-cell cell-id="c1" cell-type="columnheader" grid-column="1" class="column-header col-justify-start  col-sort-desc" aria-sort="descending" scope="col" b-w6qdxfylwy="">
+      <div class="col-title" b-pxhtqoo8qd="">
+        <div class="col-title-text" b-pxhtqoo8qd="">Item1</div>
+      </div>
+    </fluent-data-grid-cell>
+    <fluent-data-grid-cell cell-id="c2" cell-type="columnheader" grid-column="2" class="column-header col-justify-start " aria-sort="none" scope="col" b-w6qdxfylwy="">
+      <div class="col-title" b-pxhtqoo8qd="">
+        <div class="col-title-text" b-pxhtqoo8qd="">Item2</div>
+      </div>
+    </fluent-data-grid-cell>
+  </fluent-data-grid-row>
+  <fluent-data-grid-row row-id="r4" row-index="3" row-type="default" blazor:onkeydown="15" blazor:onclick="16" blazor:ondblclick="17" aria-rowindex="2" blazor:oncellfocus="18" b-upi3f9mbnn="">
+    <fluent-data-grid-cell cell-id="c7" cell-type="default" grid-column="1" class="col-justify-start " b-w6qdxfylwy="">D</fluent-data-grid-cell>
+    <fluent-data-grid-cell cell-id="c8" cell-type="default" grid-column="2" class="col-justify-start " b-w6qdxfylwy="">A</fluent-data-grid-cell>
+  </fluent-data-grid-row>
+  <fluent-data-grid-row row-id="r5" row-index="4" row-type="default" blazor:onkeydown="19" blazor:onclick="20" blazor:ondblclick="21" aria-rowindex="3" blazor:oncellfocus="22" b-upi3f9mbnn="">
+    <fluent-data-grid-cell cell-id="c9" cell-type="default" grid-column="1" class="col-justify-start " b-w6qdxfylwy="">C</fluent-data-grid-cell>
+    <fluent-data-grid-cell cell-id="c10" cell-type="default" grid-column="2" class="col-justify-start " b-w6qdxfylwy="">B</fluent-data-grid-cell>
+  </fluent-data-grid-row>
+  <fluent-data-grid-row row-id="r2" row-index="1" row-type="default" blazor:onkeydown="7" blazor:onclick="8" blazor:ondblclick="9" aria-rowindex="4" blazor:oncellfocus="10" b-upi3f9mbnn="">
+    <fluent-data-grid-cell cell-id="c3" cell-type="default" grid-column="1" class="col-justify-start " b-w6qdxfylwy="">B</fluent-data-grid-cell>
+    <fluent-data-grid-cell cell-id="c4" cell-type="default" grid-column="2" class="col-justify-start " b-w6qdxfylwy="">C</fluent-data-grid-cell>
+  </fluent-data-grid-row>
+  <fluent-data-grid-row row-id="r3" row-index="2" row-type="default" blazor:onkeydown="11" blazor:onclick="12" blazor:ondblclick="13" aria-rowindex="5" blazor:oncellfocus="14" b-upi3f9mbnn="">
+    <fluent-data-grid-cell cell-id="c5" cell-type="default" grid-column="1" class="col-justify-start " b-w6qdxfylwy="">A</fluent-data-grid-cell>
+    <fluent-data-grid-cell cell-id="c6" cell-type="default" grid-column="2" class="col-justify-start " b-w6qdxfylwy="">D</fluent-data-grid-cell>
+  </fluent-data-grid-row>
+</fluent-data-grid>

--- a/tests/Core/DataGrid/DataGridSortByTests.DataGridSortByTests_SortByColumnTitle_Ascending.verified.razor.html
+++ b/tests/Core/DataGrid/DataGridSortByTests.DataGridSortByTests_SortByColumnTitle_Ascending.verified.razor.html
@@ -1,0 +1,31 @@
+
+<fluent-data-grid generate-header="none" aria-rowcount="5" blazor:onrowfocus="1" blazor:onclosecolumnoptions="2" b-ppmhrkw1mj="" blazor:elementreference="">
+    <fluent-data-grid-row row-id="r1" row-index="0" row-type="header" blazor:onkeydown="3" blazor:onclick="4" blazor:ondblclick="5" blazor:oncellfocus="6" b-upi3f9mbnn="">
+        <fluent-data-grid-cell cell-id="c1" cell-type="columnheader" grid-column="1" class="column-header col-justify-start  col-sort-asc" aria-sort="ascending" scope="col" b-w6qdxfylwy="">
+            <div class="col-title" b-pxhtqoo8qd="">
+                <div class="col-title-text" b-pxhtqoo8qd="">Item1</div>
+            </div>
+        </fluent-data-grid-cell>
+        <fluent-data-grid-cell cell-id="c2" cell-type="columnheader" grid-column="2" class="column-header col-justify-start " aria-sort="none" scope="col" b-w6qdxfylwy="">
+            <div class="col-title" b-pxhtqoo8qd="">
+                <div class="col-title-text" b-pxhtqoo8qd="">Item2</div>
+            </div>
+        </fluent-data-grid-cell>
+    </fluent-data-grid-row>
+    <fluent-data-grid-row row-id="r3" row-index="2" row-type="default" blazor:onkeydown="11" blazor:onclick="12" blazor:ondblclick="13" aria-rowindex="2" blazor:oncellfocus="14" b-upi3f9mbnn="">
+        <fluent-data-grid-cell cell-id="c5" cell-type="default" grid-column="1" class="col-justify-start " b-w6qdxfylwy="">A</fluent-data-grid-cell>
+        <fluent-data-grid-cell cell-id="c6" cell-type="default" grid-column="2" class="col-justify-start " b-w6qdxfylwy="">D</fluent-data-grid-cell>
+    </fluent-data-grid-row>
+    <fluent-data-grid-row row-id="r2" row-index="1" row-type="default" blazor:onkeydown="7" blazor:onclick="8" blazor:ondblclick="9" aria-rowindex="3" blazor:oncellfocus="10" b-upi3f9mbnn="">
+        <fluent-data-grid-cell cell-id="c3" cell-type="default" grid-column="1" class="col-justify-start " b-w6qdxfylwy="">B</fluent-data-grid-cell>
+        <fluent-data-grid-cell cell-id="c4" cell-type="default" grid-column="2" class="col-justify-start " b-w6qdxfylwy="">C</fluent-data-grid-cell>
+    </fluent-data-grid-row>
+    <fluent-data-grid-row row-id="r5" row-index="4" row-type="default" blazor:onkeydown="19" blazor:onclick="20" blazor:ondblclick="21" aria-rowindex="4" blazor:oncellfocus="22" b-upi3f9mbnn="">
+        <fluent-data-grid-cell cell-id="c9" cell-type="default" grid-column="1" class="col-justify-start " b-w6qdxfylwy="">C</fluent-data-grid-cell>
+        <fluent-data-grid-cell cell-id="c10" cell-type="default" grid-column="2" class="col-justify-start " b-w6qdxfylwy="">B</fluent-data-grid-cell>
+    </fluent-data-grid-row>
+    <fluent-data-grid-row row-id="r4" row-index="3" row-type="default" blazor:onkeydown="15" blazor:onclick="16" blazor:ondblclick="17" aria-rowindex="5" blazor:oncellfocus="18" b-upi3f9mbnn="">
+        <fluent-data-grid-cell cell-id="c7" cell-type="default" grid-column="1" class="col-justify-start " b-w6qdxfylwy="">D</fluent-data-grid-cell>
+        <fluent-data-grid-cell cell-id="c8" cell-type="default" grid-column="2" class="col-justify-start " b-w6qdxfylwy="">A</fluent-data-grid-cell>
+    </fluent-data-grid-row>
+</fluent-data-grid>

--- a/tests/Core/DataGrid/DataGridSortByTests.DataGridSortByTests_SortByColumnTitle_Descending.verified.razor.html
+++ b/tests/Core/DataGrid/DataGridSortByTests.DataGridSortByTests_SortByColumnTitle_Descending.verified.razor.html
@@ -1,0 +1,31 @@
+
+<fluent-data-grid generate-header="none" aria-rowcount="5" blazor:onrowfocus="1" blazor:onclosecolumnoptions="2" b-ppmhrkw1mj="" blazor:elementreference="">
+  <fluent-data-grid-row row-id="r1" row-index="0" row-type="header" blazor:onkeydown="3" blazor:onclick="4" blazor:ondblclick="5" blazor:oncellfocus="6" b-upi3f9mbnn="">
+    <fluent-data-grid-cell cell-id="c1" cell-type="columnheader" grid-column="1" class="column-header col-justify-start  col-sort-desc" aria-sort="descending" scope="col" b-w6qdxfylwy="">
+      <div class="col-title" b-pxhtqoo8qd="">
+        <div class="col-title-text" b-pxhtqoo8qd="">Item1</div>
+      </div>
+    </fluent-data-grid-cell>
+    <fluent-data-grid-cell cell-id="c2" cell-type="columnheader" grid-column="2" class="column-header col-justify-start " aria-sort="none" scope="col" b-w6qdxfylwy="">
+      <div class="col-title" b-pxhtqoo8qd="">
+        <div class="col-title-text" b-pxhtqoo8qd="">Item2</div>
+      </div>
+    </fluent-data-grid-cell>
+  </fluent-data-grid-row>
+  <fluent-data-grid-row row-id="r4" row-index="3" row-type="default" blazor:onkeydown="15" blazor:onclick="16" blazor:ondblclick="17" aria-rowindex="2" blazor:oncellfocus="18" b-upi3f9mbnn="">
+    <fluent-data-grid-cell cell-id="c7" cell-type="default" grid-column="1" class="col-justify-start " b-w6qdxfylwy="">D</fluent-data-grid-cell>
+    <fluent-data-grid-cell cell-id="c8" cell-type="default" grid-column="2" class="col-justify-start " b-w6qdxfylwy="">A</fluent-data-grid-cell>
+  </fluent-data-grid-row>
+  <fluent-data-grid-row row-id="r5" row-index="4" row-type="default" blazor:onkeydown="19" blazor:onclick="20" blazor:ondblclick="21" aria-rowindex="3" blazor:oncellfocus="22" b-upi3f9mbnn="">
+    <fluent-data-grid-cell cell-id="c9" cell-type="default" grid-column="1" class="col-justify-start " b-w6qdxfylwy="">C</fluent-data-grid-cell>
+    <fluent-data-grid-cell cell-id="c10" cell-type="default" grid-column="2" class="col-justify-start " b-w6qdxfylwy="">B</fluent-data-grid-cell>
+  </fluent-data-grid-row>
+  <fluent-data-grid-row row-id="r2" row-index="1" row-type="default" blazor:onkeydown="7" blazor:onclick="8" blazor:ondblclick="9" aria-rowindex="4" blazor:oncellfocus="10" b-upi3f9mbnn="">
+    <fluent-data-grid-cell cell-id="c3" cell-type="default" grid-column="1" class="col-justify-start " b-w6qdxfylwy="">B</fluent-data-grid-cell>
+    <fluent-data-grid-cell cell-id="c4" cell-type="default" grid-column="2" class="col-justify-start " b-w6qdxfylwy="">C</fluent-data-grid-cell>
+  </fluent-data-grid-row>
+  <fluent-data-grid-row row-id="r3" row-index="2" row-type="default" blazor:onkeydown="11" blazor:onclick="12" blazor:ondblclick="13" aria-rowindex="5" blazor:oncellfocus="14" b-upi3f9mbnn="">
+    <fluent-data-grid-cell cell-id="c5" cell-type="default" grid-column="1" class="col-justify-start " b-w6qdxfylwy="">A</fluent-data-grid-cell>
+    <fluent-data-grid-cell cell-id="c6" cell-type="default" grid-column="2" class="col-justify-start " b-w6qdxfylwy="">D</fluent-data-grid-cell>
+  </fluent-data-grid-row>
+</fluent-data-grid>

--- a/tests/Core/DataGrid/DataGridSortByTests.razor
+++ b/tests/Core/DataGrid/DataGridSortByTests.razor
@@ -1,0 +1,87 @@
+﻿@using Bunit
+@using FluentAssertions
+@using Xunit
+
+@inherits TestContext
+
+@code {
+
+    public DataGridSortByTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        // Register Service
+        var keycodeService = new KeyCodeService();
+        Services.AddScoped<IKeyCodeService>(factory => keycodeService);
+    }
+
+    private readonly IQueryable<(string, string)> _items = new List<(string, string)> { ("B", "C"), ("A", "D"), ("D", "A"), ("C", "B") }.AsQueryable();
+
+    [Fact]
+    public async void DataGridSortByTests_SortByColumnTitle_Ascending()
+    {
+        string[] expected = ["A", "B", "C", "D"];
+        FluentDataGrid<(string, string)> _dataGrid = null!;
+
+        var cut = Render(
+    @<FluentDataGrid TGridItem="(string, string)" Items="@_items" @ref="_dataGrid">
+        <PropertyColumn Title="Item1" Property="@(x => x.Item1)" />
+        <PropertyColumn Title="Item2" Property="@(x => x.Item2)" />
+    </FluentDataGrid>);
+
+        await cut.InvokeAsync(() => _dataGrid.SortByColumnTitleAsync("Item1", SortDirection.Ascending));
+
+        cut.Verify();
+    }
+
+    [Fact]
+    public async void DataGridSortByTests_SortByColumnTitle_Descending()
+    {
+        string[] expected = ["D", "C", "B", "A"];
+        FluentDataGrid<(string, string)> _dataGrid = null!;
+
+        var cut = Render(
+    @<FluentDataGrid TGridItem="(string, string)" Items="@_items" @ref="_dataGrid">
+        <PropertyColumn Title="Item1" Property="@(x => x.Item1)" />
+        <PropertyColumn Title="Item2" Property="@(x => x.Item2)" />
+    </FluentDataGrid>);
+
+        await cut.InvokeAsync(() => _dataGrid.SortByColumnTitleAsync("Item1", SortDirection.Descending));
+
+        cut.Verify();
+    }
+
+    [Fact]
+    public async void DataGridSortByTests_SortByColumnIndex_Ascending()
+    {
+        string[] expected = ["A", "B", "C", "D"];
+        FluentDataGrid<(string, string)> _dataGrid = null!;
+
+        var cut = Render(
+    @<FluentDataGrid TGridItem="(string, string)" Items="@_items" @ref="_dataGrid">
+        <PropertyColumn Title="Item1" Property="@(x => x.Item1)" />
+        <PropertyColumn Title="Item2" Property="@(x => x.Item2)" />
+    </FluentDataGrid>);
+
+        await cut.InvokeAsync(() => _dataGrid.SortByColumnIndexAsync(0, SortDirection.Ascending));
+
+        cut.Verify();
+    }
+
+    [Fact]
+    public async void DataGridSortByTests_SortByColumnIndex_Descending()
+    {
+        string[] expected = ["D", "C", "B", "A"];
+        FluentDataGrid<(string, string)> _dataGrid = null!;
+
+        var cut = Render(
+    @<FluentDataGrid TGridItem="(string, string)" Items="@_items" @ref="_dataGrid">
+        <PropertyColumn Title="Item1" Property="@(x => x.Item1)" />
+        <PropertyColumn Title="Item2" Property="@(x => x.Item2)" />
+    </FluentDataGrid>);
+
+        await cut.InvokeAsync(() => _dataGrid.SortByColumnIndexAsync(0, SortDirection.Descending));
+
+        cut.Verify();
+    }
+}

--- a/tests/Core/DataGrid/DataGridSortByTests.razor
+++ b/tests/Core/DataGrid/DataGridSortByTests.razor
@@ -18,7 +18,7 @@
     private readonly IQueryable<(string, string)> _items = new List<(string, string)> { ("B", "C"), ("A", "D"), ("D", "A"), ("C", "B") }.AsQueryable();
 
     [Fact]
-    public async void DataGridSortByTests_SortByColumnTitle_Ascending()
+    public async Task DataGridSortByTests_SortByColumnTitle_Ascending()
     {
         string[] expected = ["A", "B", "C", "D"];
         FluentDataGrid<(string, string)> _dataGrid = null!;
@@ -29,13 +29,13 @@
         <PropertyColumn Title="Item2" Property="@(x => x.Item2)" />
     </FluentDataGrid>);
 
-        await cut.InvokeAsync(() => _dataGrid.SortByColumnTitleAsync("Item1", SortDirection.Ascending));
+        await cut.InvokeAsync(() => _dataGrid.SortByColumnAsync("Item1", SortDirection.Ascending));
 
         cut.Verify();
     }
 
     [Fact]
-    public async void DataGridSortByTests_SortByColumnTitle_Descending()
+    public async Task DataGridSortByTests_SortByColumnTitle_Descending()
     {
         string[] expected = ["D", "C", "B", "A"];
         FluentDataGrid<(string, string)> _dataGrid = null!;
@@ -46,7 +46,7 @@
         <PropertyColumn Title="Item2" Property="@(x => x.Item2)" />
     </FluentDataGrid>);
 
-        await cut.InvokeAsync(() => _dataGrid.SortByColumnTitleAsync("Item1", SortDirection.Descending));
+        await cut.InvokeAsync(() => _dataGrid.SortByColumnAsync("Item1", SortDirection.Descending));
 
         cut.Verify();
     }
@@ -63,7 +63,7 @@
         <PropertyColumn Title="Item2" Property="@(x => x.Item2)" />
     </FluentDataGrid>);
 
-        await cut.InvokeAsync(() => _dataGrid.SortByColumnIndexAsync(0, SortDirection.Ascending));
+        await cut.InvokeAsync(() => _dataGrid.SortByColumnAsync(0, SortDirection.Ascending));
 
         cut.Verify();
     }
@@ -80,7 +80,7 @@
         <PropertyColumn Title="Item2" Property="@(x => x.Item2)" />
     </FluentDataGrid>);
 
-        await cut.InvokeAsync(() => _dataGrid.SortByColumnIndexAsync(0, SortDirection.Descending));
+        await cut.InvokeAsync(() => _dataGrid.SortByColumnAsync(0, SortDirection.Descending));
 
         cut.Verify();
     }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
The publicly exposed method of programmatically setting a DataGrid's sort order requires the user to have a reference to the `ColumnBase<TGridItem>` which the API does not expose. In order to restore the state of a DataGrid, the sort order needs to be settable.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->
[#2148](https://github.com/microsoft/fluentui-blazor/issues/2148) - DataGrid: add access to columns


## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->
I added 2 logical methods that one would sort by. I did find another `internal` method that could have been used but decided to just add these. I think it would be OK to mark `SortByColumnAsync`, 'RemoveSortByColumnAsync', and `ShowColumnOptionsAsync` as `internal` as it is necessary to have a `ColumnBase<TGridItem>` reference in order to execute those methods, which is something that's not exposed outside of the library.

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->
I added new tests for this function based on other existing tests. I used methodology from other tests. I did have to use the `cut.InvokeAsync` method as there is a `StateHasChanged()` call within the component.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [X] I have added tests for my changes.
- [X] I have tested my changes.
- [X] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

I did some spellchecking on the DataGrid page.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [X] I have modified an existing component
- [X] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component 

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->