### PR TITLE
[DesignToken] Add WithDefault overload

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -9277,7 +9277,7 @@
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.DesignTokens.DesignToken`1.Name">
             <summary>
-            Gets the name of this design token 
+            Gets the name of this design token
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.DesignTokens.DesignToken`1.Value">
@@ -9303,9 +9303,16 @@
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.DesignTokens.DesignToken`1.OnAfterRenderAsync(System.Boolean)">
             <inheritdoc/>
         </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.DesignTokens.DesignToken`1.WithDefault(System.String)">
+            <summary>
+            Sets the default value of this token
+            Value is a string
+            </summary>
+        </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.DesignTokens.DesignToken`1.WithDefault(`0)">
             <summary>
             Sets the default value of this token
+            Value is a type T
             </summary>
         </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.DesignTokens.DesignToken`1.Create(System.String)">

--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -6312,7 +6312,7 @@
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentNavGroup.Gap">
             <summary>
-            Defines the vertical spacing between the NavGroup and adjecent items.
+            Defines the vertical spacing between the NavGroup and adjacent items.
             Needs to be a valid CSS value.
             </summary>
         </member>
@@ -6324,7 +6324,7 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentNavGroup.TitleTemplate">
             <summary>
             Allows for specific markup and styling to be applied for the group title
-            When using this, the containded <see cref="T:Microsoft.FluentUI.AspNetCore.Components.FluentNavLink"/>s and <see cref="T:Microsoft.FluentUI.AspNetCore.Components.FluentNavGroup"/>s need to be placed in a ChildContent tag.
+            When using this, the contained <see cref="T:Microsoft.FluentUI.AspNetCore.Components.FluentNavLink"/>s and <see cref="T:Microsoft.FluentUI.AspNetCore.Components.FluentNavGroup"/>s need to be placed in a ChildContent tag.
             When specifying both Title and TitleTemplate, both will be rendered.
             </summary>
         </member>

--- a/src/Core/Components/Base/FluentInputBase.cs
+++ b/src/Core/Components/Base/FluentInputBase.cs
@@ -162,7 +162,7 @@ public abstract partial class FluentInputBase<TValue> : FluentComponentBase, IDi
         Value = value;
         if (ValueChanged.HasDelegate)
         {
-            // Thread Safety: Force `ValueChanged` to be re-associated with the Dispatcher, prior to invokation.
+            // Thread Safety: Force `ValueChanged` to be re-associated with the Dispatcher, prior to invocation.
             await InvokeAsync(async () => await ValueChanged.InvokeAsync(value));
         }
         if (FieldBound)

--- a/src/Core/DesignTokens/DesignToken.razor.cs
+++ b/src/Core/DesignTokens/DesignToken.razor.cs
@@ -16,7 +16,7 @@ public partial class DesignToken<T> : ComponentBase, IDesignToken<T>, IAsyncDisp
     //private T? _defaultValue;
 
     /// <summary>
-    /// Gets the name of this design token 
+    /// Gets the name of this design token
     /// </summary>
     public string? Name { get; init; }
 
@@ -70,8 +70,21 @@ public partial class DesignToken<T> : ComponentBase, IDesignToken<T>, IAsyncDisp
         _jsModule ??= await JSRuntime.InvokeAsync<IJSObjectReference>("import", "./_content/Microsoft.FluentUI.AspNetCore.Components/Microsoft.FluentUI.AspNetCore.Components.lib.module.js");
     }
 
+#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods
     /// <summary>
     /// Sets the default value of this token
+    /// Value is a string
+    /// </summary>
+    public async ValueTask<DesignToken<T>> WithDefault(string value)
+    {
+        await InitJSReferenceAsync();
+        await _jsModule.InvokeVoidAsync(Name + ".withDefault", value);
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the default value of this token
+    /// Value is a type T
     /// </summary>
     public async ValueTask<DesignToken<T>> WithDefault(T value)
     {
@@ -134,6 +147,7 @@ public partial class DesignToken<T> : ComponentBase, IDesignToken<T>, IAsyncDisp
         await InitJSReferenceAsync();
         return await _jsModule.InvokeAsync<object>("parseColorHexRGB", color);
     }
+#pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
 
     public async ValueTask DisposeAsync()
     {


### PR DESCRIPTION
When working with colors, the Design Token methods work with the `.ToSwatch()` extension to convert a string to a swatch. This does not work in the case of the `.WithDefault` method. To solve this, a string based `.WithDefault` overload has been added.

Fix #2158. Code from that issue has been used to verify the change.

