### PR TITLE
[DataGrid] Add ClearSelection method to SelectColumn

### DIFF
--- a/src/Core/Components/DataGrid/Columns/SelectColumn.cs
+++ b/src/Core/Components/DataGrid/Columns/SelectColumn.cs
@@ -188,6 +188,16 @@ public class SelectColumn<TGridItem> : ColumnBase<TGridItem>
         RefreshHeaderContent();
     }
 
+    /// <summary>
+    /// Allows to clear the selection.
+    /// </summary>
+    public async Task ClearSelectionAsync()
+    {
+        _selectedItems.Clear();
+        RefreshHeaderContent();
+        await Task.CompletedTask;
+    }
+
     /// <summary />
     internal async Task AddOrRemoveSelectedItemAsync(TGridItem? item)
     {

--- a/src/Core/Components/DataGrid/Columns/SelectColumn.cs
+++ b/src/Core/Components/DataGrid/Columns/SelectColumn.cs
@@ -179,6 +179,15 @@ public class SelectColumn<TGridItem> : ColumnBase<TGridItem>
     [Parameter]
     public override GridSort<TGridItem>? SortBy { get; set; }
 
+    /// <summary>
+    /// Allows to clear the selection.
+    /// </summary>
+    public void ClearSelection()
+    {
+        _selectedItems.Clear();
+        RefreshHeaderContent();
+    }
+
     /// <summary />
     internal async Task AddOrRemoveSelectedItemAsync(TGridItem? item)
     {


### PR DESCRIPTION
Fix #2163 by adding a `ClearSelection` method to `SelectColumn`

When defining grid like this:
```
<FluentDataGrid TGridItem="CollectionWrapper" Items="@FilteredItems" Pagination="@pagination">
    <SelectColumn @ref="selectColumn" TGridItem="CollectionWrapper" SelectMode="DataGridSelectMode.Multiple" @bind-SelectedItems="@SelectedItems" />
```

Method can be called like this:
```
        private async Task DeleteCollectionsAsync(MouseEventArgs mouseEventArgs)
        {
            var itemstodelete = this.SelectedItems
                .Select(x => x.designCollectionDTO.DesignCollectionUUID)
                .ToArray();

            await this.CollectionService.RemoveDesignCollectionsAsync(itemstodelete, CancellationToken.None);

       
            this.selectColumn.ClearSelection();
        }
```

Prevents BL0005 warning.