### PR TITLE
[NavMenu] Enhance working in mobile view

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -6248,11 +6248,6 @@
             For  <see cref="T:Microsoft.FluentUI.AspNetCore.Components.FluentNavGroup" /> the <c>Title</c> is used as fallback.
             </summary>
         </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentNavBase.HasIcon">
-            <summary>
-            Returns <see langword="true"/> if the item has an <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentNavBase.Icon"/> set.
-            </summary>
-        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentNavBase.OnClick">
             <summary>
             The callback to invoke when the item is clicked.
@@ -6261,6 +6256,11 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentNavBase.ForceLoad">
             <summary>
             If true, force browser to redirect outside component router-space.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentNavBase.HasIcon">
+            <summary>
+            Returns <see langword="true"/> if the item has an <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentNavBase.Icon"/> set.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentNavGroup.Title">

--- a/examples/Demo/Shared/Shared/DemoNavMenu.razor
+++ b/examples/Demo/Shared/Shared/DemoNavMenu.razor
@@ -3,8 +3,8 @@
 <div class="navmenu">
     <input type="checkbox" title="Menu expand/collapse toggle" id="navmenu-toggle" class="navmenu-icon" />
     <label for="navmenu-toggle" class="navmenu-icon"><FluentIcon Value="@(new Icons.Regular.Size20.Navigation())" Color="Color.Neutral" /></label>
-    <nav class="sitenav" aria-labelledby="main-menu">
-        <FluentNavMenu Id="main-menu" Title="Main menu">
+    <nav class="sitenav" aria-labelledby="main-menu" >
+        <FluentNavMenu Id="main-menu" Title="Main menu" CustomToggle="true" >
             @foreach(var item in NavProvider.NavMenuItems)
             {
                 <DemoNavMenuItem Value="item"/>

--- a/src/Core.Assets/Microsoft.FluentUI.AspNetCore.Components.Assets.esproj
+++ b/src/Core.Assets/Microsoft.FluentUI.AspNetCore.Components.Assets.esproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.VisualStudio.JavaScript.Sdk/1.0.1088444">
+﻿<Project Sdk="Microsoft.VisualStudio.JavaScript.Sdk/1.0.1147595">
 	<PropertyGroup>
 		<DebugAssetsDirectory>dist\</DebugAssetsDirectory>
 		<StaticWebAssetSourceId>Microsoft.FluentUI.AspNetCore.Components</StaticWebAssetSourceId>

--- a/src/Core/Components/NavMenu/FluentNavBase.cs
+++ b/src/Core/Components/NavMenu/FluentNavBase.cs
@@ -75,17 +75,6 @@ public abstract class FluentNavBase : FluentComponentBase
     [Parameter]
     public string? Tooltip { get; set; }
 
-    [CascadingParameter]
-    public FluentNavMenu Owner { get; set; } = default!;
-
-    [CascadingParameter]
-    public FluentMenu? SubMenu { get; set; }
-
-    /// <summary>
-    /// Returns <see langword="true"/> if the item has an <see cref="Icon"/> set.
-    /// </summary>
-    internal bool HasIcon => Icon is not null;
-
     /// <summary>
     /// The callback to invoke when the item is clicked.
     /// </summary>
@@ -98,8 +87,32 @@ public abstract class FluentNavBase : FluentComponentBase
     [Parameter]
     public bool ForceLoad { get; set; }
 
+    /// <summary>
+    /// Gets or sets the id of the custom toggle element
+    /// Defaults to navmenu-toggle
+    /// </summary>
+    [Parameter]
+    public string CustomToggleId { get; set; } = "navmenu-toggle";
+
+    [CascadingParameter]
+    public FluentNavMenu Owner { get; set; } = default!;
+
+    [CascadingParameter]
+    public FluentMenu? SubMenu { get; set; }
+
     [Inject]
     private NavigationManager NavigationManager { get; set; } = default!;
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the item has an <see cref="Icon"/> set.
+    /// </summary>
+    internal bool HasIcon => Icon is not null;
+
+    /// <summary>
+    /// If a custom toggle is being used to hide/show the menu, this defines the 'onclick' code
+    /// Uses the <see cref="CustomToggleId"/> as the id of the elemet that will be clicked
+    /// </summary>
+    internal string? CustomToggleCode => Owner.CustomToggle ? $"document.getElementById('{CustomToggleId}').click();" : null;
 
     protected async Task OnClickHandlerAsync(MouseEventArgs ev)
     {

--- a/src/Core/Components/NavMenu/FluentNavGroup.razor
+++ b/src/Core/Components/NavMenu/FluentNavGroup.razor
@@ -14,7 +14,8 @@
                      @attributes="@Attributes"
                      Match="@Match"
                      ActiveClass="@ActiveClass"
-                     title="@(Tooltip ?? Title)">
+                     title="@(Tooltip ?? Title)"
+                     onclick="@CustomToggleCode">
                 <div class="positioning-region">
                     <div class="content-region">
                         @_renderContent
@@ -26,7 +27,7 @@
         else
         {
             <div class="fluent-nav-link notactive" tabindex="@(Disabled ? "-1" : "0")">
-                <div class="positioning-region" @onclick="ToggleExpandedAsync" title="@(Tooltip ?? Title)">
+                <div class="positioning-region" @onclick="ToggleExpandedAsync" @onclick:stopPropagation="true" title="@(Tooltip ?? Title)">
                     <div class="content-region">
                         @_renderContent
                         @_renderButton
@@ -36,7 +37,7 @@
         }
 
         <FluentCollapsibleRegion @bind-Expanded="@Expanded" MaxHeight="@MaxHeight" Class="items" role="group">
-            <FluentNavMenu Data="_data">
+            <FluentNavMenu Data="_data" CustomToggle="Owner.CustomToggle">
                 @ChildContent
             </FluentNavMenu>
         </FluentCollapsibleRegion>

--- a/src/Core/Components/NavMenu/FluentNavLink.razor
+++ b/src/Core/Components/NavMenu/FluentNavLink.razor
@@ -13,7 +13,8 @@
                      @attributes="@Attributes"
                      Match="@Match"
                      ActiveClass="@ActiveClass"
-                     title="@Tooltip">
+                     title="@Tooltip"
+                     onclick="@CustomToggleCode">
                 <div class="positioning-region">
                     <div class="content-region">
                         @_renderContent

--- a/src/Core/Components/NavMenu/FluentNavMenu.razor.cs
+++ b/src/Core/Components/NavMenu/FluentNavMenu.razor.cs
@@ -69,6 +69,9 @@ public partial class FluentNavMenu : FluentComponentBase
     public string? Margin { get; set; }
 
     [Parameter]
+    public bool CustomToggle { get; set; } = false;
+
+    [Parameter]
     public RenderFragment? ChildContent { get; set; }
 
     /// <summary>


### PR DESCRIPTION
> When using a `FluentNavGroup` and tap on it in mobile view it closes the opened navigation. When you use the dropdown buttons instead the navigation will open just like expected without closing the mobile menu.

The demo site was already configured for this but it would not work that way in a site created with the template.  With these changes clicking on either the button or the group will just expand/collapse that group (when no href set on the group) for template created sites. 

The template created sites had an (JS) `onclick` event on the `nav` element so that the menu would be closed after navigating to an item. This PR moves that logic to the `FluentNavGroup`/`FluentNavLink` (when an href is set)

With these change we get consistent behavior in both demo and template sites whare a menu group can be expanded/collapsed by clicking it and clicking an item navigates to that item and closes the menu:

### Before:
![better-menu-before](https://github.com/microsoft/fluentui-blazor/assets/1761079/d83bc9b6-7e30-4a9d-977b-8abf68ae6fdd)


### After:
![better-menu](https://github.com/microsoft/fluentui-blazor/assets/1761079/8085f153-67d2-4f94-aeb9-dbf98f8ea3d0)

Changes:
- Add CustomToggle parameter to FluentNavMenu
- Add CustomToggleId to FluentNavBase
- Add onclick to FluentNavGroup/FluentNavLink

