### PR TITLE
[DataGrid] Fix LoadingContent height when Virtualize is true

### DIFF
--- a/src/Core/Components/DataGrid/FluentDataGridCell.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGridCell.razor.cs
@@ -50,8 +50,8 @@ public partial class FluentDataGridCell<TGridItem> : FluentComponentBase
     private InternalGridContext<TGridItem> GridContext { get; set; } = default!;
 
     protected string? StyleValue => new StyleBuilder(Style)
-       .AddStyle("height", $"{GridContext.Grid.ItemSize:0}px", () => GridContext.Grid.Virtualize && Owner.RowType == DataGridRowType.Default)
-       .AddStyle("align-content", "center", () => GridContext.Grid.Virtualize && Owner.RowType == DataGridRowType.Default && string.IsNullOrEmpty(Style))
+       .AddStyle("height", $"{GridContext.Grid.ItemSize:0}px", () => !GridContext.Grid.Loading && GridContext.Grid.Virtualize && Owner.RowType == DataGridRowType.Default)
+       .AddStyle("align-content", "center", () => !GridContext.Grid.Loading && GridContext.Grid.Virtualize && Owner.RowType == DataGridRowType.Default && string.IsNullOrEmpty(Style))
        .Build();
 
     protected override void OnInitialized()


### PR DESCRIPTION
Fix #2187 (regression) cell height style should not be applied if loading=true