### PR TITLE
[FluentMultiSplitter] Fixed panel size

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -7766,12 +7766,6 @@
             Gets or sets the width of the spacer (in pixels).
             </summary>
         </member>
-        <member name="T:Microsoft.FluentUI.AspNetCore.Components.FluentMultiSplitter">
-            <summary>
-            This component is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-            Add this line to suppress de compilation error: `@{ #pragma warning disable FluentMultiSplitter }`
-            </summary>
-        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentMultiSplitter.ChildContent">
             <summary>
             Gets or sets the child content.

--- a/examples/Demo/Shared/Pages/Splitter/Examples/MultiSplitterDefault.razor
+++ b/examples/Demo/Shared/Pages/Splitter/Examples/MultiSplitterDefault.razor
@@ -1,6 +1,4 @@
-@{ #pragma warning disable FluentMultiSplitter }
-
-<FluentMultiSplitter OnResize="@OnResizeHandler" Height="150px" Style="border: 1px dashed var(--accent-fill-rest);">
+﻿<FluentMultiSplitter OnResize="@OnResizeHandler" Height="150px" Style="border: 1px dashed var(--accent-fill-rest);">
     <FluentMultiSplitterPane Size="20%" Min="50px" Max="70%">
         Left Menu
     </FluentMultiSplitterPane>

--- a/examples/Demo/Shared/Pages/Splitter/MultSplitterPage.razor
+++ b/examples/Demo/Shared/Pages/Splitter/MultSplitterPage.razor
@@ -37,7 +37,6 @@
 <blockquote>
     <p>Why have we created this new component when FluentSplitter already exists?</p>
     <p>We want to generalize this component by making it easier to have several (>2) panels per container. We've also used CSS variables to simplify the customization of colors and sizes.</p>
-    <p>Give us your feedback</p>
 </blockquote>
 
 <h2 id="example">Examples</h2>

--- a/examples/Demo/Shared/Pages/Splitter/MultSplitterPage.razor
+++ b/examples/Demo/Shared/Pages/Splitter/MultSplitterPage.razor
@@ -1,18 +1,9 @@
 ﻿@page "/MultiSplitter"
 @using FluentUI.Demo.Shared.Pages.Splitter.Examples
-@{
-#pragma warning disable FluentMultiSplitter
-}
 
 <PageTitle>@App.PageTitle("MultiSplitter")</PageTitle>
 
-<h1>MultiSplitter (Experimental)</h1>
-
-<blockquote style="font-style: normal;">
-    ⚠️ <b>This component is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.</b>.<br />
-    To use it, you need to add the following line to the top of your razor file <br />
-    <code>@($"@{{ #pragma warning disable FluentMultiSplitter }}")</code>
-</blockquote>
+<h1>MultiSplitter</h1>
 
 <p>The <b>MultiSplitter</b> splits the page into multiple sections and allows the user to control the page layout.</p>
 

--- a/examples/Demo/Shared/Shared/DemoNavProvider.cs
+++ b/examples/Demo/Shared/Shared/DemoNavProvider.cs
@@ -155,6 +155,11 @@ public class DemoNavProvider
                         title: "Splitter"
                     ),
                     new NavLink(
+                        href: "/MultiSplitter",
+                        icon: new Icons.Regular.Size20.SplitHorizontal(),
+                        title: "Splitter Multi"
+                    ),
+                    new NavLink(
                         href: "/Stack",
                         icon: new Icons.Regular.Size20.Stack(),
                         title: "Stack"
@@ -542,11 +547,6 @@ public class DemoNavProvider
                         title: "TableOfContents"
                     ),
 
-                    new NavLink(
-                        href: "/MultiSplitter",
-                        icon: new Icons.Regular.Size20.SplitHorizontal(),
-                        title: "Multi Splitter"
-                    ),
                 ]
             )
         ];

--- a/src/Core/Components/Splitter/FluentMultiSplitter.razor.cs
+++ b/src/Core/Components/Splitter/FluentMultiSplitter.razor.cs
@@ -2,7 +2,6 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // --------------------------------------------------------------
 
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -11,11 +10,6 @@ using Microsoft.JSInterop;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
-/// <summary>
-/// This component is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-/// Add this line to suppress de compilation error: `@{ #pragma warning disable FluentMultiSplitter }`
-/// </summary>
-[Experimental("FluentMultiSplitter", UrlFormat = "https://preview.fluentui-blazor.net/MultiSplitter")]
 public partial class FluentMultiSplitter : FluentComponentBase
 {
     private const string JAVASCRIPT_FILE = "./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Splitter/FluentMultiSplitter.razor.js";

--- a/src/Core/Components/Splitter/FluentMultiSplitterPane.razor.cs
+++ b/src/Core/Components/Splitter/FluentMultiSplitterPane.razor.cs
@@ -7,7 +7,6 @@ using Microsoft.FluentUI.AspNetCore.Components.Utilities;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
-#pragma warning disable FluentMultiSplitter // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 public partial class FluentMultiSplitterPane : FluentComponentBase, IDisposable
 {
     private string _size = string.Empty;
@@ -233,4 +232,3 @@ public partial class FluentMultiSplitterPane : FluentComponentBase, IDisposable
         return "locked";
     }
 }
-#pragma warning restore FluentMultiSplitter // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.

--- a/src/Core/Components/Splitter/FluentMultiSplitterPane.razor.cs
+++ b/src/Core/Components/Splitter/FluentMultiSplitterPane.razor.cs
@@ -183,6 +183,7 @@ public partial class FluentMultiSplitterPane : FluentComponentBase, IDisposable
     /// <summary />
     protected string? StyleValue => new StyleBuilder(Style)
         .AddStyle("flex-basis", Size)
+        .AddStyle("min-width", Size, when: !Resizable && !string.IsNullOrEmpty(Size))
         .Build();
 
     /// <summary />

--- a/tests/Core/Splitter/FluentMultiSplitterTests.FluentMultiSplitter_Size_Fixed.verified.razor.html
+++ b/tests/Core/Splitter/FluentMultiSplitterTests.FluentMultiSplitter_Size_Fixed.verified.razor.html
@@ -1,0 +1,6 @@
+
+<div class="fluent-multi-splitter" orientation="horizontal" b-ug2ltnxcve="" blazor:elementreference="xxx">
+  <div id="xxx" status="lastresizable" class="fluent-multi-splitter-pane" style="flex-basis: 100%;" data-index="0">Pane A</div>
+  <div class="fluent-multi-splitter-bar" status="lastresizable" blazor:onmousedown="1" blazor:onclick:preventdefault="" blazor:onclick:stoppropagation=""></div>
+  <div id="xxx" status="locked" class="fluent-multi-splitter-pane" style="flex-basis: 300px; min-width: 300px;" data-index="1">Pane B</div>
+</div>

--- a/tests/Core/Splitter/FluentMultiSplitterTests.razor
+++ b/tests/Core/Splitter/FluentMultiSplitterTests.razor
@@ -169,6 +169,22 @@
     }
 
     [Fact]
+    public void FluentMultiSplitter_Size_Fixed()
+    {
+        // Arrange
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var cut = Render(
+            @<FluentMultiSplitter>
+                <FluentMultiSplitterPane>Pane A</FluentMultiSplitterPane>
+                <FluentMultiSplitterPane Resizable="false" Size="300px">Pane B</FluentMultiSplitterPane>
+            </FluentMultiSplitter>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
     public void FluentMultiSplitter_Expand()
     {
         FluentMultiSplitter_ExpandCollapse("expand");

--- a/tests/Core/Splitter/FluentMultiSplitterTests.razor
+++ b/tests/Core/Splitter/FluentMultiSplitterTests.razor
@@ -1,8 +1,6 @@
-@using Xunit;
+﻿@using Xunit;
 @inherits TestContext
-@{
-#pragma warning disable FluentMultiSplitter
-}
+
 @code
 {
     [Fact]


### PR DESCRIPTION
[FluentMultiSplitter] Fixed panel size

Fixed this issue.

> With a simple `FluentMultiSplitter` having 2 panes, the left pane with no size specified, the right pane with a fixed size.
> The right pane will not have the correct size. 
> 
> See #2175