### PR TITLE
[Multisplitter] Fix width panels

### DIFF
--- a/src/Core/Components/Splitter/FluentMultiSplitter.razor.css
+++ b/src/Core/Components/Splitter/FluentMultiSplitter.razor.css
@@ -1,4 +1,4 @@
-﻿.fluent-multi-splitter {
+.fluent-multi-splitter {
     /* Resize Icon colors */
     --fluent-multi-splitter-color: var(--neutral-stroke-strong-rest);
     --fluent-multi-splitter-color-active: var(--neutral-stroke-strong-hover);
@@ -151,6 +151,8 @@
     overflow: hidden;
     position: relative;
     flex: 0 1 auto;
+    flex-grow: 0;
+    flex-shrink: 0;
 }
 
     .fluent-multi-splitter ::deep > .fluent-multi-splitter-pane[status="collapsed"] {

--- a/src/Core/Components/Splitter/FluentMultiSplitter.razor.js
+++ b/src/Core/Components/Splitter/FluentMultiSplitter.razor.js
@@ -73,7 +73,10 @@ export function startSplitterResize(
         paneLength: paneLength,
         paneNextLength: isFinite(paneNextLength) ? paneNextLength : 0,
         mouseUpHandler: function (e) {
-            if (document.splitterData[el]) {
+            if (document.splitterData[el] &&
+                pane.style.flexBasis.includes('%') &&
+                paneNext.style.flexBasis.includes('%')) {
+
                 splitter.invokeMethodAsync(
                     'FluentMultiSplitter.OnPaneResizedAsync',
                     parseInt(pane.getAttribute('data-index')),

--- a/src/Core/Components/Splitter/FluentMultiSplitterPane.razor.cs
+++ b/src/Core/Components/Splitter/FluentMultiSplitterPane.razor.cs
@@ -183,7 +183,6 @@ public partial class FluentMultiSplitterPane : FluentComponentBase, IDisposable
     /// <summary />
     protected string? StyleValue => new StyleBuilder(Style)
         .AddStyle("flex-basis", Size)
-        .AddStyle("min-width", Size, when: !Resizable && !string.IsNullOrEmpty(Size))
         .Build();
 
     /// <summary />

--- a/tests/Core/Splitter/FluentMultiSplitterTests.FluentMultiSplitter_Size_Fixed.verified.razor.html
+++ b/tests/Core/Splitter/FluentMultiSplitterTests.FluentMultiSplitter_Size_Fixed.verified.razor.html
@@ -2,5 +2,5 @@
 <div class="fluent-multi-splitter" orientation="horizontal" b-ug2ltnxcve="" blazor:elementreference="xxx">
   <div id="xxx" status="lastresizable" class="fluent-multi-splitter-pane" style="flex-basis: 100%;" data-index="0">Pane A</div>
   <div class="fluent-multi-splitter-bar" status="lastresizable" blazor:onmousedown="1" blazor:onclick:preventdefault="" blazor:onclick:stoppropagation=""></div>
-  <div id="xxx" status="locked" class="fluent-multi-splitter-pane" style="flex-basis: 300px; min-width: 300px;" data-index="1">Pane B</div>
+  <div id="xxx" status="locked" class="fluent-multi-splitter-pane" style="flex-basis: 300px;" data-index="1">Pane B</div>
 </div>


### PR DESCRIPTION
# [FluentMultisplitter] Fix width panels

By specifying a fixed Panel size and a variable size, the fixed-size panel has the wrong width.

Examples from #2204

![peek_1](https://github.com/microsoft/fluentui-blazor/assets/8350694/26e078d2-d0cd-4c3a-9c2e-a36879667680)
