### PR TITLE
[Autocomplete] Accessibility: Scrolling not working with keyboard

### DIFF
--- a/examples/Demo/Shared/Pages/List/Autocomplete/Examples/AutocompleteCustomized.razor
+++ b/examples/Demo/Shared/Pages/List/Autocomplete/Examples/AutocompleteCustomized.razor
@@ -1,4 +1,4 @@
-@inject DataSource Data
+﻿@inject DataSource Data
 
 <FluentAutocomplete Id="my-customized"
                     @ref="ContactList"
@@ -7,7 +7,7 @@
                     Placeholder="search"
                     OnOptionsSearch="@OnSearch"
                     MaximumSelectedOptions="3"
-                    OptionText="@(item => item.LastName)"
+                    OptionText="@(item => item.FirstName)"
                     OptionStyle="min-height: 40px;"
                     @bind-SelectedOptions="@SelectedItems">
 

--- a/src/Core/Components/List/FluentAutocomplete.razor.cs
+++ b/src/Core/Components/List/FluentAutocomplete.razor.cs
@@ -405,7 +405,7 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
         }
 
         // ArrowUp
-        Task KeyDown_ArrowUpAsync()
+        async Task KeyDown_ArrowUpAsync()
         {
             if (Items != null && Items.Any())
             {
@@ -423,13 +423,16 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
                         break;
                     }
                 }
-            }
 
-            return Task.CompletedTask;
+                if (Module != null)
+                {
+                    await Module.InvokeVoidAsync("scrollToFirstSelectable", IdPopup, false);
+                }
+            }
         }
 
         // ArrowDown
-        Task KeyDown_ArrowDownAsync()
+        async Task KeyDown_ArrowDownAsync()
         {
             if (Items != null && Items.Any())
             {
@@ -447,9 +450,12 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
                         break;
                     }
                 }
-            }
 
-            return Task.CompletedTask;
+                if (Module != null)
+                {
+                    await Module.InvokeVoidAsync("scrollToFirstSelectable", IdPopup, true);
+                }
+            }
         }
 
         // Enter

--- a/src/Core/Components/List/FluentAutocomplete.razor.js
+++ b/src/Core/Components/List/FluentAutocomplete.razor.js
@@ -17,6 +17,18 @@ export function displayLastSelectedItem(id) {
     }
 }
 
+export function scrollToFirstSelectable(idPopup, goDown) {
+
+    const popup = document.getElementById(idPopup);
+    const item = popup?.querySelector("fluent-option[selectable]")
+    const next = goDown ? item?.nextElementSibling : item?.previousElementSibling;
+
+    if (!!next) {
+        next.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'start' });
+    }
+
+}
+
 export function focusOn(id) {
     var item = document.getElementById(id);
     if (!!item) {


### PR DESCRIPTION
# [FluentAutocomplete] Accessibility: Scrolling not working with keyboard

Fix the issue #2220, adding a script to display the "selectable" item.

Script added:
```javascript
export function scrollToFirstSelectable(idPopup, goDown) {

    const popup = document.getElementById(idPopup);
    const item = popup?.querySelector("fluent-option[selectable]")
    const next = goDown ? item?.nextElementSibling : item?.previousElementSibling;

    if (!!next) {
        next.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'start' });
    }

}
```

![peek_2](https://github.com/microsoft/fluentui-blazor/assets/8350694/6e141d99-de31-4fdd-842d-1e5bd1aedc70)
