### PR TITLE
[DatePicker] Fix unable to set when value is null

### DIFF
--- a/src/Core/Components/DateTime/FluentDatePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor.cs
@@ -64,8 +64,6 @@ public partial class FluentDatePicker : FluentCalendarBase
 
     protected async Task OnSelectedDateAsync(DateTime? value)
     {
-        Opened = false;
-
         DateTime? updatedValue = value;
 
         if (Value is not null && value is not null)
@@ -74,7 +72,7 @@ public partial class FluentDatePicker : FluentCalendarBase
             ? value?.Date + Value?.TimeOfDay
             : value;
         }
-        
+        Opened = false;
         await OnSelectedDateHandlerAsync(updatedValue);
     }
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request
Proposed Fix 2237
## 📖 Description
Issue when trying to select a date using FluentDatePicker when the Value is null, the selected date does not update the Value. Probable due to the fact that the FluentCalendar is being closed prematurely.

### 🎫 Issues

https://github.com/microsoft/fluentui-blazor/issues/2237

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan
Tested while debugging.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new compontent
- [x] I have modified an existing component
- [ ] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component 

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
