### PR TITLE
[TimePicker] Add null check for empty string

### DIFF
--- a/src/Core/Components/DateTime/FluentTimePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentTimePicker.razor.cs
@@ -26,7 +26,7 @@ public partial class FluentTimePicker : FluentInputBase<DateTime?>
         }
         else
         {
-            result = Value?.Date;
+            result = string.IsNullOrWhiteSpace(value) ? null : Value?.Date;
         }
 
         validationErrorMessage = null;

--- a/src/Core/Components/DateTime/FluentTimePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentTimePicker.razor.cs
@@ -20,13 +20,17 @@ public partial class FluentTimePicker : FluentInputBase<DateTime?>
     {
         DateTime currentValue = Value ?? DateTime.MinValue;
 
-        if (value != null && DateTime.TryParse(value, out var valueConverted))
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            result = null;
+        }
+        else if (value != null && DateTime.TryParse(value, out var valueConverted))
         {
             result = currentValue.Date + valueConverted.TimeOfDay;
         }
         else
         {
-            result = string.IsNullOrWhiteSpace(value) ? null : Value?.Date;
+            result = Value?.Date;
         }
 
         validationErrorMessage = null;

--- a/tests/Core/DateTime/FluentTimePickerTests.cs
+++ b/tests/Core/DateTime/FluentTimePickerTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.FluentUI.AspNetCore.Components.Tests.DateTime;
@@ -53,6 +54,19 @@ public class FluentTimePickerTests : TestBase
         {
             Assert.Null(resultDate);
         }
+    }
+
+    [Fact]
+    public void FluentTimePicker_EmptyStringToNull()
+    {
+        // Arrange
+        var picker = new TestTimePicker();
+
+        // Act
+        var _ = picker.CallTryParseValueFromString(string.Empty, out var resultDate, out var _);
+
+        // Assert
+        Assert.Null(resultDate);
     }
 
     // Temporary class to expose protected method

--- a/tests/Core/DateTime/FluentTimePickerTests.cs
+++ b/tests/Core/DateTime/FluentTimePickerTests.cs
@@ -59,13 +59,18 @@ public class FluentTimePickerTests : TestBase
     public void FluentTimePicker_EmptyStringToNull()
     {
         // Arrange
-        var picker = new TestTimePicker();
+        var picker = new TestTimePicker()
+        {
+            Value = System.DateTime.Today,   // Default date 
+        };
 
-        // Act
-        var _ = picker.CallTryParseValueFromString(string.Empty, out var resultDate, out var _);
+        // Set a value
+        picker.CallTryParseValueFromString("01:23", out var initialDate, out var _);
+        Assert.Equal("01:23:00", initialDate?.ToString("HH:mm:ss"));
 
-        // Assert
-        Assert.Null(resultDate);
+        // Reset
+        picker.CallTryParseValueFromString(string.Empty, out var resultDate, out var _);
+        Assert.Null(resultDate?.ToString("HH:mm:ss"));
     }
 
     // Temporary class to expose protected method

--- a/tests/Core/DateTime/FluentTimePickerTests.cs
+++ b/tests/Core/DateTime/FluentTimePickerTests.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
-using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.FluentUI.AspNetCore.Components.Tests.DateTime;


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR adds a null check for the `FluentTimePicker` which converts empty strings to `DateTime?`.

### 🎫 Issues

* #2230


## 👩‍💻 Reviewer Notes


## 📑 Test Plan

I've added a new UNIT Test `FluentTimePicker_EmptyStringToNull` to verfiy the results.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.


