### PR TITLE
[Demo] Fixes link for Time picker in demo projects

### DIFF
--- a/examples/Demo/Shared/Shared/DemoNavProvider.cs
+++ b/examples/Demo/Shared/Shared/DemoNavProvider.cs
@@ -257,7 +257,7 @@ public class DemoNavProvider
                         title: "Text Field"
                     ),
                     new NavLink(
-                        href: "/DateTime#fluenttimepicker-class",
+                        href: "/DateTime",
                         icon: new Icons.Regular.Size20.Clock(),
                         title: "Time picker"
                     )

--- a/examples/Demo/Shared/Shared/DemoNavProvider.cs
+++ b/examples/Demo/Shared/Shared/DemoNavProvider.cs
@@ -257,7 +257,7 @@ public class DemoNavProvider
                         title: "Text Field"
                     ),
                     new NavLink(
-                        href: "/DateTime",
+                        href: "/DateTime#defaulttimepicker",
                         icon: new Icons.Regular.Size20.Clock(),
                         title: "Time picker"
                     )


### PR DESCRIPTION
# Pull Request

## 📖 Description

this PR removes the fragment from the demo navigation for the `/DateTime` link. 


### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

