### PR TITLE
[TimePicker] Fix TimePicker Null value

### DIFF
--- a/src/Core/Components/DateTime/FluentTimePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentTimePicker.razor.cs
@@ -20,7 +20,11 @@ public partial class FluentTimePicker : FluentInputBase<DateTime?>
     {
         DateTime currentValue = Value ?? DateTime.MinValue;
 
-        if (value != null && DateTime.TryParse(value, out var valueConverted))
+        if (string.IsNullOrEmpty(value))
+        {
+            result = null;
+        }
+        else if (value != null && DateTime.TryParse(value, out var valueConverted))
         {
             result = currentValue.Date + valueConverted.TimeOfDay;
         }

--- a/tests/Core/DateTime/FluentTimePickerTests.cs
+++ b/tests/Core/DateTime/FluentTimePickerTests.cs
@@ -55,6 +55,24 @@ public class FluentTimePickerTests : TestBase
         }
     }
 
+    [Fact]
+    public void FluentTimePicker_ResetValue()
+    {
+        // Arrange
+        var picker = new TestTimePicker()
+        {
+            Value = System.DateTime.Today,   // Default date 
+        };
+
+        // Set a value
+        picker.CallTryParseValueFromString("01:23", out var initialDate, out var _);
+        Assert.Equal("01:23:00", initialDate?.ToString("HH:mm:ss"));
+
+        // Reset
+        picker.CallTryParseValueFromString(string.Empty, out var resultDate, out var _);
+        Assert.Null(resultDate?.ToString("HH:mm:ss"));
+    }
+
     // Temporary class to expose protected method
     private class TestTimePicker : FluentTimePicker
     {


### PR DESCRIPTION
# [TimePicker] Fix TimePicker Null value

**FluentTimePicker** supports nullable values but when inserting and removing a value, the value stays at the last value (which is 00:00 because backspace sets it first back to `00:00` and then to `--:--`).
See #2230

## Before
![Before](https://github.com/microsoft/fluentui-blazor/assets/8350694/e38e0f3d-6430-448e-94b8-a7df2359a241)

## After
![After](https://github.com/microsoft/fluentui-blazor/assets/8350694/a77ced93-3c80-4aa2-9e8c-d18becf75f0c)

