### PR TITLE
[DataGrid] Add OnCellClick event and SelectColumn.SelectFromEntireRow property

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -1449,6 +1449,11 @@
             Gets or sets whether the [All] checkbox is disabled (not clickable).
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.SelectColumn`1.SelectFromEntireRow">
+            <summary>
+            Gets or sets whether the selection of rows is restricted to the SelectColumn (false) or if the whole row can be clicked to toggled the selection (true).
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.SelectColumn`1.SelectAllTemplate">
             <summary>
             Gets or sets the template for the [All] checkbox column template.
@@ -1720,6 +1725,11 @@
             Gets or sets a callback when a row is focused.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.OnCellClick">
+            <summary>
+            Gets or sets a callback when a cell is clicked.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.OnRowClick">
             <summary>
             Gets or sets a callback when a row is clicked.
@@ -1854,6 +1864,9 @@
             <summary>
             Gets or sets the owning <see cref="T:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1"/> component
             </summary>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDataGridCell`1.HandleOnCellClickAsync">
+            <summary />
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDataGridRow`1.Item">
             <summary>

--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -1452,6 +1452,7 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.SelectColumn`1.SelectFromEntireRow">
             <summary>
             Gets or sets whether the selection of rows is restricted to the SelectColumn (false) or if the whole row can be clicked to toggled the selection (true).
+            Default is True.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.SelectColumn`1.SelectAllTemplate">
@@ -1863,6 +1864,11 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDataGridCell`1.GridContext">
             <summary>
             Gets or sets the owning <see cref="T:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1"/> component
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDataGridCell`1.Column">
+            <summary>
+            Gets a reference to the column that this cell belongs to.
             </summary>
         </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDataGridCell`1.HandleOnCellClickAsync">

--- a/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridMultiSelect.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridMultiSelect.razor
@@ -11,7 +11,7 @@
     @* Sample using SelectedItems  *@
     <div>Using SelectedItems</div>
 
-    <FluentDataGrid Items="@People" ShowHover="true" TGridItem="Person">
+    <FluentDataGrid Items="@People" ShowHover="true" TGridItem="Person" OnRowClick="@(e => Console.WriteLine(e.RowIndex))" OnCellClick="@(e => Console.WriteLine(e.GridColumn))">
         <SelectColumn TGridItem="Person"
                       SelectMode="@Mode"
                       @bind-SelectedItems="@SelectedItems" />

--- a/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridMultiSelect.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridMultiSelect.razor
@@ -4,6 +4,9 @@
     <FluentCheckbox @bind-Value="@UseSelectedItems"
                     @bind-Value:after="@(() => ResetSelectItems())"
                     Label="Use `SelectedItems` property" />
+    <FluentCheckbox @bind-Value="@SelectFromEntireRow"
+                    @bind-Value:after="@(() => ResetSelectItems())"
+                    Label="Use `SelectFromEntireRow` property" />
 </FluentStack>
 
 @if (UseSelectedItems)
@@ -11,9 +14,10 @@
     @* Sample using SelectedItems  *@
     <div>Using SelectedItems</div>
 
-    <FluentDataGrid Items="@People" ShowHover="true" TGridItem="Person" OnRowClick="@(e => Console.WriteLine(e.RowIndex))" OnCellClick="@(e => Console.WriteLine(e.GridColumn))">
+    <FluentDataGrid Items="@People" ShowHover="@SelectFromEntireRow" TGridItem="Person">
         <SelectColumn TGridItem="Person"
                       SelectMode="@Mode"
+                      SelectFromEntireRow="@SelectFromEntireRow"
                       @bind-SelectedItems="@SelectedItems" />
         <PropertyColumn Width="100px" Property="@(p => p.PersonId)" Title="ID" />
         <PropertyColumn Width="300px" Property="@(p => p.Name)" />
@@ -30,9 +34,10 @@ else
     @* Sample using Property and OnSelect  *@
     <div>Using Property and OnSelect</div>
 
-    <FluentDataGrid Items="@People" ShowHover="true" TGridItem="Person">
+    <FluentDataGrid Items="@People" ShowHover="@SelectFromEntireRow" TGridItem="Person">
         <SelectColumn TGridItem="Person"
                       SelectMode="@Mode"
+                      SelectFromEntireRow="@SelectFromEntireRow"
                       Property="@(e => e.Selected)"
                       OnSelect="@(e => e.Item.Selected = e.Selected)"
                       SelectAll="@(People.All(p => p.Selected))"
@@ -50,6 +55,7 @@ else
 
 @code {
     bool UseSelectedItems = true;
+    bool SelectFromEntireRow = true;
     DataGridSelectMode Mode = DataGridSelectMode.Single;
 
     IEnumerable<Person> SelectedItems = People.Where(p => p.Selected);

--- a/src/Core/Components/DataGrid/Columns/SelectColumn.cs
+++ b/src/Core/Components/DataGrid/Columns/SelectColumn.cs
@@ -46,6 +46,7 @@ public class SelectColumn<TGridItem> : ColumnBase<TGridItem>
 
     /// <summary>
     /// Gets or sets whether the selection of rows is restricted to the SelectColumn (false) or if the whole row can be clicked to toggled the selection (true).
+    /// Default is True.
     /// </summary>
     [Parameter]
     public bool SelectFromEntireRow { get; set; } = true;

--- a/src/Core/Components/DataGrid/Columns/SelectColumn.cs
+++ b/src/Core/Components/DataGrid/Columns/SelectColumn.cs
@@ -316,8 +316,12 @@ public class SelectColumn<TGridItem> : ColumnBase<TGridItem>
 
             builder.OpenComponent<FluentIcon<Icon>>(0);
             builder.AddAttribute(1, "Value", GetIcon(selected));
-            builder.AddAttribute(1, "Title", selected ? TitleChecked : TitleUnchecked);
-            builder.AddAttribute(2, "row-selected", selected);
+            builder.AddAttribute(2, "Title", selected ? TitleChecked : TitleUnchecked);
+            builder.AddAttribute(3, "row-selected", selected);
+            if (!SelectFromEntireRow)
+            {
+                builder.AddAttribute(4, "style", "cursor: pointer;");
+            }
             builder.CloseComponent();
         });
     }

--- a/src/Core/Components/DataGrid/Columns/SelectColumn.cs
+++ b/src/Core/Components/DataGrid/Columns/SelectColumn.cs
@@ -45,6 +45,12 @@ public class SelectColumn<TGridItem> : ColumnBase<TGridItem>
     public bool SelectAllDisabled { get; set; } = false;
 
     /// <summary>
+    /// Gets or sets whether the selection of rows is restricted to the SelectColumn (false) or if the whole row can be clicked to toggled the selection (true).
+    /// </summary>
+    [Parameter]
+    public bool SelectFromEntireRow { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets the template for the [All] checkbox column template.
     /// </summary>
     [Parameter]

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -125,6 +125,12 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     public EventCallback<FluentDataGridCell<TGridItem>> OnCellFocus { get; set; }
 
     /// <summary>
+    /// Gets or sets a callback when a cell is clicked.
+    /// </summary>
+    [Parameter]
+    public EventCallback<FluentDataGridCell<TGridItem>> OnCellClick { get; set; }
+
+    /// <summary>
     /// Gets or sets a callback when a row is clicked.
     /// </summary>
     [Parameter]

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -193,7 +193,7 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     // We cascade the InternalGridContext to descendants, which in turn call it to add themselves to _columns
     // This happens on every render so that the column list can be updated dynamically
     private readonly InternalGridContext<TGridItem> _internalGridContext;
-    private readonly List<ColumnBase<TGridItem>> _columns;
+    internal readonly List<ColumnBase<TGridItem>> _columns;
     private bool _collectingColumns; // Columns might re-render themselves arbitrarily. We only want to capture them at a defined time.
 
     // Tracking state for options and sorting

--- a/src/Core/Components/DataGrid/FluentDataGridCell.razor
+++ b/src/Core/Components/DataGrid/FluentDataGridCell.razor
@@ -6,6 +6,7 @@
                        grid-column=@GridColumn
                        class="@Class"
                        style="@StyleValue"
+                       @onclick="@HandleOnCellClickAsync"
                        @attributes="AdditionalAttributes">
     @ChildContent
 </fluent-data-grid-cell>

--- a/src/Core/Components/DataGrid/FluentDataGridCell.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGridCell.razor.cs
@@ -41,7 +41,7 @@ public partial class FluentDataGridCell<TGridItem> : FluentComponentBase
     /// Gets or sets the owning <see cref="FluentDataGridRow{TItem}"/> component.
     /// </summary>
     [CascadingParameter(Name = "OwningRow")]
-    public FluentDataGridRow<TGridItem> Owner { get; set; } = default!;
+    internal FluentDataGridRow<TGridItem> Owner { get; set; } = default!;
 
     /// <summary>
     /// Gets or sets the owning <see cref="FluentDataGrid{TItem}"/> component
@@ -57,6 +57,26 @@ public partial class FluentDataGridCell<TGridItem> : FluentComponentBase
     protected override void OnInitialized()
     {
         Owner.Register(this);
+    }
+
+    /// <summary />
+    private async Task HandleOnCellClickAsync()
+    {
+        if (GridContext.Grid.OnCellClick.HasDelegate)
+        {
+            await GridContext.Grid.OnCellClick.InvokeAsync(this);
+        }
+
+        //if (CellType == DataGridCellType.Default && Owner.Owner.Grid.SelectColumns.Any(selColumn => selColumn.RestrictToCheckbox))
+        //{
+        //    foreach (var selColumn in Owner.Owner.Grid.SelectColumns)
+        //    {
+        //        if (selColumn != null && selColumn.RestrictToCheckbox is true && Owner.Owner.Grid.Columns.IndexOf(selColumn) == GridColumn - 1)
+        //        {
+        //            await selColumn.AddOrRemoveSelectedItemAsync(Item);
+        //        }
+        //    }
+        //}
     }
 
     public void Dispose() => Owner.Unregister(this);

--- a/src/Core/Components/DataGrid/FluentDataGridCell.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGridCell.razor.cs
@@ -65,7 +65,7 @@ public partial class FluentDataGridCell<TGridItem> : FluentComponentBase
     }
 
     /// <summary />
-    private async Task HandleOnCellClickAsync()
+    internal async Task HandleOnCellClickAsync()
     {
         if (GridContext.Grid.OnCellClick.HasDelegate)
         {

--- a/src/Core/Components/DataGrid/FluentDataGridRow.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGridRow.razor.cs
@@ -56,7 +56,7 @@ public partial class FluentDataGridRow<TGridItem> : FluentComponentBase, IHandle
     /// Gets or sets the owning <see cref="FluentDataGrid{TItem}"/> component
     /// </summary>
     [CascadingParameter]
-    private InternalGridContext<TGridItem> Owner { get; set; } = default!;
+    internal InternalGridContext<TGridItem> Owner { get; set; } = default!;
 
     protected string? ClassValue => new CssBuilder(Class)
         .AddClass("hover", when: Owner.Grid.ShowHover)

--- a/src/Core/Components/DataGrid/FluentDataGridRow.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGridRow.razor.cs
@@ -112,7 +112,7 @@ public partial class FluentDataGridRow<TGridItem> : FluentComponentBase, IHandle
 
             if (row != null && row.RowType == DataGridRowType.Default)
             {
-                foreach (var selColumn in Owner.Grid.SelectColumns)
+                foreach (var selColumn in Owner.Grid.SelectColumns.Where(i => i.SelectFromEntireRow))
                 {
                     await selColumn.AddOrRemoveSelectedItemAsync(Item);
                 }

--- a/tests/Core/DataGrid/FluentDataGridColumSelectTests.razor
+++ b/tests/Core/DataGrid/FluentDataGridColumSelectTests.razor
@@ -15,7 +15,7 @@
                       @bind-SelectedItems="@SelectedItems" />
         <PropertyColumn Property="@(p => p.Name)" />
     </FluentDataGrid>
-        );
+    );
 
         cut.Verify();
     }
@@ -33,7 +33,7 @@
                       @bind-SelectedItems="@SelectedItems" />
         <PropertyColumn Property="@(p => p.Name)" />
     </FluentDataGrid>
-    );
+        );
 
         // Pre-Assert
         Assert.Empty(cut.FindAll("svg[row-selected]"));
@@ -64,7 +64,7 @@
                       OnSelect="@(e => e.Item.Selected = e.Selected)" />
         <PropertyColumn Property="@(p => p.Name)" />
     </FluentDataGrid>
-        );
+    );
 
         // Pre-Assert
         Assert.Empty(cut.FindAll("svg[row-selected]"));
@@ -94,7 +94,7 @@
                       @bind-SelectedItems="@SelectedItems" />
         <PropertyColumn Property="@(p => p.Name)" />
     </FluentDataGrid>
-        );
+    );
 
         cut.Verify();
     }
@@ -112,7 +112,7 @@
                       @bind-SelectedItems="@SelectedItems" />
         <PropertyColumn Property="@(p => p.Name)" />
     </FluentDataGrid>
-    );
+        );
 
         // Pre-Assert
         Assert.Empty(cut.FindAll("svg[row-selected]"));
@@ -149,7 +149,7 @@
                       OnSelect="@(e => e.Item.Selected = e.Selected)" />
         <PropertyColumn Property="@(p => p.Name)" />
     </FluentDataGrid>
-        );
+    );
 
         // Pre-Assert
         Assert.Empty(cut.FindAll("svg[row-selected]"));
@@ -185,7 +185,7 @@
                       @bind-SelectedItems="@SelectedItems" />
         <PropertyColumn Property="@(p => p.Name)" />
     </FluentDataGrid>
-    );
+        );
 
         // Pre-Assert
         Assert.Empty(cut.FindAll("svg[row-selected]"));
@@ -219,7 +219,7 @@
                       SelectAllChanged="@(all => items.ToList().ForEach(p => p.Selected = (all == true)))" />
         <PropertyColumn Property="@(p => p.Name)" />
     </FluentDataGrid>
-    );
+        );
 
         // Pre-Assert
         Assert.Empty(cut.FindAll("svg[row-selected]"));
@@ -250,7 +250,7 @@
                       @bind-SelectedItems="@selectedItems" />
         <PropertyColumn Property="@(p => p.Name)" />
     </FluentDataGrid>
-        );
+    );
 
         // Before the switch
         Assert.Equal(2, cut.FindAll("svg[row-selected]").Count);
@@ -281,7 +281,7 @@
                       @bind-SelectedItems="@SelectedItems" />
         <PropertyColumn Property="@(p => p.Name)" />
     </FluentDataGrid>
-        );
+    );
 
         // Pre-Assert
         Assert.Empty(cut.FindAll("svg[row-selected]"));
@@ -313,9 +313,77 @@
         </SelectColumn>
         <PropertyColumn Property="@(p => p.Name)" />
     </FluentDataGrid>
-        );
+    );
 
         cut.Verify();
+    }
+
+    [Fact]
+    public async Task FluentDataGrid_ColumSelect_SingleSelect_NotSelectFromEntireRow()
+    {
+        IEnumerable<Person> SelectedItems = Array.Empty<Person>();
+
+        // Arrange
+        var cut = Render(
+    @<FluentDataGrid Items="@People" TGridItem="Person">
+        <SelectColumn TGridItem="Person"
+                      SelectFromEntireRow="false"
+                      SelectMode="@DataGridSelectMode.Single"
+                      @bind-SelectedItems="@SelectedItems" />
+        <PropertyColumn Property="@(p => p.Name)" />
+    </FluentDataGrid>
+    );
+
+        // Act - Click on the second cell => no selection
+        await ClickOnRowAsync(cut, row: 0, col: 1);
+        Assert.Empty(SelectedItems);
+
+        // Act - Click on the first cell => select the row
+        await ClickOnRowAsync(cut, row: 0, col: 0);
+        Assert.Single(SelectedItems);
+        Assert.Equal(1, SelectedItems.First().PersonId);
+
+        // Act - Click on the second cell => keep the selection
+        await ClickOnRowAsync(cut, row: 1, col: 1);
+        Assert.Single(SelectedItems);
+        Assert.Equal(1, SelectedItems.First().PersonId);
+    }
+
+    [Fact]
+    public async Task FluentDataGrid_ColumSelect_MultiSelect_NotSelectFromEntireRow()
+    {
+        IEnumerable<Person> SelectedItems = Array.Empty<Person>();
+
+        // Arrange
+        var cut = Render(
+    @<FluentDataGrid Items="@People" TGridItem="Person">
+        <SelectColumn TGridItem="Person"
+                      SelectFromEntireRow="false"
+                      SelectMode="@DataGridSelectMode.Multiple"
+                      @bind-SelectedItems="@SelectedItems" />
+        <PropertyColumn Property="@(p => p.Name)" />
+    </FluentDataGrid>
+    );
+
+        // Act - Click on the second cell => no selection
+        await ClickOnRowAsync(cut, row: 0, col: 1);
+        Assert.Empty(SelectedItems);
+
+        // Act - Click on the first cell => select the row
+        await ClickOnRowAsync(cut, row: 0, col: 0);
+        Assert.Single(SelectedItems);
+        Assert.Equal(1, SelectedItems.First().PersonId);
+
+        // Act - Click on the second cell => keep the selection
+        await ClickOnRowAsync(cut, row: 1, col: 1);
+        Assert.Single(SelectedItems);
+        Assert.Equal(1, SelectedItems.First().PersonId);
+
+        // Act - Click on the first cell => select another row
+        await ClickOnRowAsync(cut, row: 1, col: 0);
+        Assert.Equal(2, SelectedItems.Count());
+        Assert.Equal(1, SelectedItems.ElementAt(0).PersonId);
+        Assert.Equal(2, SelectedItems.ElementAt(1).PersonId);
     }
 
     /// <summary>
@@ -323,12 +391,24 @@
     /// </summary>
     /// <param name="cut"></param>
     /// <param name="row"></param>
+    /// <param name="col"></param>
     /// <returns></returns>
-    private async Task ClickOnRowAsync(IRenderedFragment cut, int row)
+    private async Task ClickOnRowAsync(IRenderedFragment cut, int row, int? col = null)
     {
-        var item = cut.FindComponents<FluentDataGridRow<Person>>().ElementAt(row + 1);
-        await item.Instance.HandleOnRowClickAsync(item.Instance.RowId);
-        cut.FindComponent<FluentDataGrid<Person>>().Render();
+        if (col == null)
+        {
+            var item = cut.FindComponents<FluentDataGridRow<Person>>().ElementAt(row + 1);
+            await item.Instance.HandleOnRowClickAsync(item.Instance.RowId);
+            cut.FindComponent<FluentDataGrid<Person>>().Render();
+        }
+        else
+        {
+            var item = cut.FindComponents<FluentDataGridCell<Person>>()
+                          .Where(i => i.Instance.GridColumn == col + 1)
+                          .ElementAt(row + 1);
+            await item.Instance.HandleOnCellClickAsync();
+            cut.FindComponent<FluentDataGrid<Person>>().Render();
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
# [DataGrid] Add OnCellClick event and SelectColumn.SelectFromEntireRow property

Add an `OnCellClick` event and allows restricting the selection of rows to the checkboxes of the select column.

This PR replaces #2160 and fixes #2130 and [#1952 comment](https://github.com/microsoft/fluentui-blazor/pull/1952#issuecomment-2150964551).

# Example (_simplified_)

```xml
<FluentDataGrid Items="@People" TGridItem="Person">
    <SelectColumn TGridItem="Person"
                    SelectMode="..."
                    SelectFromEntireRow="@SelectFromEntireRow"    // 👈 New property
                    @bind-SelectedItems="@SelectedItems" />
    <PropertyColumn Width="100px" Property="@(p => p.PersonId)" />
    <PropertyColumn Width="300px" Property="@(p => p.Name)" />
    <PropertyColumn Width="150px" Property="@(p => p.BirthDate)" />
</FluentDataGrid>
```

![peek_1](https://github.com/microsoft/fluentui-blazor/assets/8350694/cb6eeb00-80f3-4609-83df-d4be97a5edde)


# Unit Tests

Verified and added