### PR TITLE
[Autocomplete] Fix ReadOnly and Disable properties

### DIFF
--- a/src/Core/Components/List/FluentAutocomplete.razor
+++ b/src/Core/Components/List/FluentAutocomplete.razor
@@ -26,7 +26,7 @@
                          aria-label="@GetAutocompleteAriaLabel()"
                          Value="@ValueText"
                          @onclick="@OnDropDownExpandedAsync"
-                         @oninput="@InputHandlerAsync"                         
+                         @oninput="@InputHandlerAsync"
                          autofocus="@Autofocus"
                          Style="@ComponentWidth">
             @* Selected Items *@
@@ -68,7 +68,7 @@
                 }
 
             }
-            @if (!Disabled)
+            @if (!Disabled && !ReadOnly)
             {
                 if (this.SelectedOptions?.Any() == true || !string.IsNullOrEmpty(ValueText))
                 {
@@ -205,12 +205,22 @@
                 {
                     var text = @GetOptionText(item);
 
-                    <FluentBadge Appearance="@AspNetCore.Components.Appearance.Neutral"
-                                 OnDismissClick="@(e => RemoveSelectedItemAsync(item))"
-                                 DismissTitle="@(string.Format(AccessibilityRemoveItem, text))"
-                                 aria-label="@GetOptionText(item)">
-                        @text
-                    </FluentBadge>
+                    if (ReadOnly || Disabled)
+                    {
+                        <FluentBadge Appearance="@AspNetCore.Components.Appearance.Neutral"
+                                     aria-label="@GetOptionText(item)">
+                            @text
+                        </FluentBadge>
+                    }
+                    else
+                    {
+                        <FluentBadge Appearance="@AspNetCore.Components.Appearance.Neutral"
+                                     OnDismissClick="@(e => RemoveSelectedItemAsync(item))"
+                                     DismissTitle="@(string.Format(AccessibilityRemoveItem, text))"
+                                     aria-label="@GetOptionText(item)">
+                            @text
+                        </FluentBadge>
+                    }
                 }
                 else
                 {

--- a/src/Core/Components/List/FluentAutocomplete.razor.cs
+++ b/src/Core/Components/List/FluentAutocomplete.razor.cs
@@ -265,6 +265,11 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
     /// <summary />
     protected override async Task InputHandlerAsync(ChangeEventArgs e)
     {
+        if (ReadOnly || Disabled)
+        {
+            return;
+        }
+
         ValueText = e.Value?.ToString() ?? string.Empty;
         await RaiseValueTextChangedAsync(ValueText);
 


### PR DESCRIPTION
# [FluentAutocomplete] Fix ReadOnly and Disable properties

The properties `Disabled` and `ReadOnly` was not correctly verified.

## Before (ReadOnly)
![ReadOnly-Before](https://github.com/microsoft/fluentui-blazor/assets/8350694/5ef87aa6-9639-4b5d-a16a-2d2414ef7d43)

## After (ReadOnly)
![ReadOnly-After](https://github.com/microsoft/fluentui-blazor/assets/8350694/6c010a4a-fb88-4fb5-8adb-eb368b912160)

## Unit Tests

No change - Validated