### PR TITLE
[NavMenu] Revert fix for when prerender set to false

### DIFF
--- a/examples/Demo/Shared/Shared/DemoNavMenuItem.razor
+++ b/examples/Demo/Shared/Shared/DemoNavMenuItem.razor
@@ -1,9 +1,9 @@
 ﻿@using NavLink = FluentUI.Demo.Shared.NavLink
 
-@switch(Value)
+@switch (Value)
 {
     case NavGroup group:
-        <FluentNavGroup Expanded="@group.Expanded" Gap="@group.Gap" Icon="@group.Icon">
+        <FluentNavGroup @bind-Expanded="@group.Expanded" Gap="@group.Gap" Icon="@group.Icon" >
             <TitleTemplate>
                 <h3>@group.Title</h3></TitleTemplate>
             <ChildContent>

--- a/examples/Demo/Shared/Shared/NavItem.cs
+++ b/examples/Demo/Shared/Shared/NavItem.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------
+// ------------------------------------------------------------------------
 // MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
 // ------------------------------------------------------------------------
 
@@ -28,7 +28,7 @@ public record NavLink : NavItem
 
 public record NavGroup : NavItem
 {
-    public bool Expanded { get; init; }
+    public bool Expanded { get; set; }
     public string Gap { get; init; }
     public IReadOnlyList<NavItem> Children { get; }
 

--- a/src/Core/Components/NavMenu/FluentNavGroup.razor.cs
+++ b/src/Core/Components/NavMenu/FluentNavGroup.razor.cs
@@ -13,9 +13,6 @@ public partial class FluentNavGroup : FluentNavBase
     private readonly RenderFragment _renderButton;
     private bool _open;
 
-    private static int _renderCount = 0;
-    private static bool _negate = false;
-
     protected string? ClassValue =>
         new CssBuilder("fluent-nav-group")
             .AddClass("fluent-nav-item")
@@ -105,22 +102,8 @@ public partial class FluentNavGroup : FluentNavBase
         _renderButton = RenderButton;
     }
 
-    protected override void OnInitialized()
-    {
-        _renderCount ++;
-        if (_renderCount > 1)
-        {
-            _negate = true;
-        }
-    }
-
     private async Task ToggleExpandedAsync()
     {
-
-        if (_negate)
-        {
-            Expanded = !Expanded;
-        }
 
         if (!Owner.Expanded && Owner.CollapsedChildNavigation)
         {
@@ -128,7 +111,7 @@ public partial class FluentNavGroup : FluentNavBase
         }
         else
         {
-            await SetExpandedAsync(Expanded);
+            await SetExpandedAsync(!Expanded);
         }
     }
 

--- a/src/Core/Components/NavMenu/FluentNavMenu.razor
+++ b/src/Core/Components/NavMenu/FluentNavMenu.razor
@@ -1,9 +1,5 @@
 ﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 @inherits FluentComponentBase
-@if (Data is null)
-{
-    <FluentPageScript Src="./_content/Microsoft.FluentUI.AspNetCore.Components/Components/NavMenu/FluentNavMenu.razor.js"></FluentPageScript>
-}
 <div id="@Id" @ref="@Element" @attributes="AdditionalAttributes" class="@ClassValue" style="@StyleValue" aria-label="@(Collapsible ? null : @Title)" role="menu" aria-expanded="@Expanded">
     <CascadingValue Value="this" IsFixed="true">
         @if (Collapsible)

--- a/src/Core/Components/NavMenu/FluentNavMenu.razor
+++ b/src/Core/Components/NavMenu/FluentNavMenu.razor
@@ -1,5 +1,9 @@
 ﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 @inherits FluentComponentBase
+@if (Data is null)
+{
+    <FluentPageScript Src="./_content/Microsoft.FluentUI.AspNetCore.Components/Components/NavMenu/FluentNavMenu.razor.js"></FluentPageScript>
+}
 <div id="@Id" @ref="@Element" @attributes="AdditionalAttributes" class="@ClassValue" style="@StyleValue" aria-label="@(Collapsible ? null : @Title)" role="menu" aria-expanded="@Expanded">
     <CascadingValue Value="this" IsFixed="true">
         @if (Collapsible)


### PR DESCRIPTION
We made a change to the NavMenu to accommodate working with prerendering set to false. See #2097 and PR #2133. With this PR we are reverting that change. It lead to a couple of other unwanted (side) effects.

What happens when prerendering is false is that the page script component gets triggered and expanding/collapsing is actually being done by the script instead of by the interactive code. This is not desired so we need to tell the menu to **not** use the page script when in interactive server rendermode. Fortunately this can easily be done by setting the `Data` parameter of the `FluentNavMenu` to a not null value, so something like:

```
 Data="@("no-pagescript")
```

Data is of type `object` so you cannot set a string value to it directly.