### PR TITLE
[ProfileMenu] Fix the initials inner the popup panel

### DIFF
--- a/src/Core/Components/List/FluentPersona.razor.cs
+++ b/src/Core/Components/List/FluentPersona.razor.cs
@@ -94,14 +94,17 @@ public partial class FluentPersona : FluentComponentBase
     public string? DismissTitle { get; set; }
 
     /// <summary />
-    private string GetDefaultInitials()
+    private string GetDefaultInitials() => GetDefaultInitials(Name);
+    
+    /// <summary />
+    internal static string GetDefaultInitials(string? name)
     {
-        if (string.IsNullOrEmpty(Name))
+        if (string.IsNullOrEmpty(name))
         {
             return string.Empty;
         }
 
-        var parts = Name.ToUpper().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var parts = name.ToUpper().Split(' ', StringSplitOptions.RemoveEmptyEntries);
         return parts == null
                 || parts.Length == 0
                 || (parts.Length == 1 && parts[0] == string.Empty)

--- a/src/Core/Components/ProfileMenu/FluentProfileMenu.razor
+++ b/src/Core/Components/ProfileMenu/FluentProfileMenu.razor
@@ -48,8 +48,8 @@
             <FluentStack Style="height: 100%;">
                 <FluentPersona Image="@Image"
                                ImageSize="@ImageSize"
-                               Initials="@Initials"
-                               Style="align-items: normal;">
+                               Initials="@(Initials ?? FluentPersona.GetDefaultInitials(FullName))"
+                               Style="align-items: normal; font-size: x-large;">
                     <FluentLabel part="fullname" Typo="@Typography.Header" Style="font-weight: bold;">@FullName</FluentLabel>
                     <FluentLabel part="email">@EMail</FluentLabel>
                 </FluentPersona>

--- a/tests/Core/ProfileMenu/FluentProfileMenuTests.FluentProfileMenu_Default.verified.razor.html
+++ b/tests/Core/ProfileMenu/FluentProfileMenuTests.FluentProfileMenu_Default.verified.razor.html
@@ -31,7 +31,7 @@
         </div>
         <div part="body" b-qp3z8ghd2d="">
           <div class="stack-horizontal" style="justify-content: start; align-items: start; column-gap: 10px; row-gap: 10px; width: 100%; height: 100%;" b-0nr62qx0mz="">
-            <div class="fluent-persona" style="align-items: normal;" position="end" b-n7zog0zvqi="">
+            <div class="fluent-persona" style="align-items: normal; font-size: x-large;" position="end" b-n7zog0zvqi="">
               <div class="initials" b-n7zog0zvqi="">
                 <div class="fluent-presence-badge" title="" b-1o8tp31nhy="">
                   <div style="display: table-cell; vertical-align: middle; width: 48px; min-width: 48px; height: 48px; min-height: 48px;" b-n7zog0zvqi="">


### PR DESCRIPTION
# [ProfileMenu] Fix the initials inner the popup panel

This PR adds the initials to the **FluentPersona** used in the popup panel, based on the `FullName` property.
See #2286

```xml
<FluentProfileMenu FullName="First Last" />
```

![image](https://github.com/microsoft/fluentui-blazor/assets/8350694/f5a676d0-40f5-4eae-98c8-3692501f62eb)

## Unit Tests

Updated