### PR TITLE
[DataGrid] Refactoring ColumnBase events

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -1245,6 +1245,36 @@
             Gets a reference to the enclosing <see cref="T:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1" />.
             </summary>
         </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.ColumnBase`1.OnRowClickAsync(Microsoft.FluentUI.AspNetCore.Components.FluentDataGridRow{`0})">
+            <summary>
+            Event callback for when the row is clicked.
+            </summary>
+            <param name="row"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.ColumnBase`1.OnRowKeyDownAsync(Microsoft.FluentUI.AspNetCore.Components.FluentDataGridRow{`0},Microsoft.AspNetCore.Components.Web.KeyboardEventArgs)">
+            <summary>
+            Event callback for when the key is pressed on a row.
+            </summary>
+            <param name="row"></param>
+            <param name="args"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.ColumnBase`1.OnCellClickAsync(Microsoft.FluentUI.AspNetCore.Components.FluentDataGridCell{`0})">
+            <summary>
+            Event callback for when the cell is clicked.
+            </summary>
+            <param name="cell"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.ColumnBase`1.OnCellKeyDownAsync(Microsoft.FluentUI.AspNetCore.Components.FluentDataGridCell{`0},Microsoft.AspNetCore.Components.Web.KeyboardEventArgs)">
+            <summary>
+            Event callback for when the key is pressed on a cell.
+            </summary>
+            <param name="cell"></param>
+            <param name="args"></param>
+            <returns></returns>
+        </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.ColumnBase`1.CellContent(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder,`0)">
             <summary>
             Overridden by derived components to provide rendering logic for the column's cells.
@@ -1558,6 +1588,36 @@
             Allows to clear the selection.
             </summary>
         </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.SelectColumn`1.OnRowClickAsync(Microsoft.FluentUI.AspNetCore.Components.FluentDataGridRow{`0})">
+            <summary>
+            Select on Unselect an item when the row is clicked.
+            </summary>
+            <param name="row"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.SelectColumn`1.OnRowKeyDownAsync(Microsoft.FluentUI.AspNetCore.Components.FluentDataGridRow{`0},Microsoft.AspNetCore.Components.Web.KeyboardEventArgs)">
+            <summary>
+            Select on Unselect an item when the navigation keys are pressed.
+            </summary>
+            <param name="row"></param>
+            <param name="args"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.SelectColumn`1.OnCellClickAsync(Microsoft.FluentUI.AspNetCore.Components.FluentDataGridCell{`0})">
+            <summary>
+            Select on Unselect an item when the cell is clicked.
+            </summary>
+            <param name="cell"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.SelectColumn`1.OnCellKeyDownAsync(Microsoft.FluentUI.AspNetCore.Components.FluentDataGridCell{`0},Microsoft.AspNetCore.Components.Web.KeyboardEventArgs)">
+            <summary>
+            Select on Unselect an item when the navigation keys are pressed.
+            </summary>
+            <param name="cell"></param>
+            <param name="args"></param>
+            <returns></returns>
+        </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.SelectColumn`1.AddOrRemoveSelectedItemAsync(`0)">
             <summary />
         </member>
@@ -1583,6 +1643,9 @@
             <inheritdoc />
         </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.SelectColumn`1.OnClickAllAsync(Microsoft.AspNetCore.Components.Web.MouseEventArgs)">
+            <summary />
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.SelectColumn`1.OnKeyAllAsync(Microsoft.AspNetCore.Components.Web.KeyboardEventArgs)">
             <summary />
         </member>
         <member name="T:Microsoft.FluentUI.AspNetCore.Components.SortedProperty">
@@ -1771,11 +1834,6 @@
             <summary>
             Gets or sets the content to render when <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.Loading"/> is true.
             A default fragment is used if loading content is not specified.
-            </summary>
-        </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.SelectColumns">
-            <summary>
-            Gets the first (optional) SelectColumn
             </summary>
         </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.#ctor">
@@ -5448,6 +5506,9 @@
             </summary>
         </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentPersona.GetDefaultInitials">
+            <summary />
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentPersona.GetDefaultInitials(System.String)">
             <summary />
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentSelect`1.InlineStyleValue">

--- a/src/Core/Components/DataGrid/Columns/ColumnBase.razor.cs
+++ b/src/Core/Components/DataGrid/Columns/ColumnBase.razor.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.Web.Virtualization;
 using Microsoft.FluentUI.AspNetCore.Components.DataGrid.Infrastructure;
 
@@ -11,48 +12,56 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// <typeparam name="TGridItem">The type of data represented by each row in the grid.</typeparam>
 public abstract partial class ColumnBase<TGridItem>
 {
-    [CascadingParameter] internal InternalGridContext<TGridItem> InternalGridContext { get; set; } = default!;
+    [CascadingParameter]
+    internal InternalGridContext<TGridItem> InternalGridContext { get; set; } = default!;
 
     /// <summary>
     /// Gets or sets the title text for the column.
     /// This is rendered automatically if <see cref="HeaderCellItemTemplate" /> is not used.
     /// </summary>
-    [Parameter] public string? Title { get; set; }
+    [Parameter]
+    public string? Title { get; set; }
 
     /// <summary>
     /// Gets or sets the an optional CSS class name.
     /// If specified, this is included in the class attribute of header and grid cells
     /// for this column.
     /// </summary>
-    [Parameter] public string? Class { get; set; }
+    [Parameter]
+    public string? Class { get; set; }
 
     /// <summary>
     /// Gets or sets an optional CSS style specification.
     /// If specified, this is included in the style attribute of header and grid cells
     /// for this column.
     /// </summary>
-    [Parameter] public string? Style { get; set; }
+    [Parameter]
+    public string? Style { get; set; }
 
     /// <summary>
     /// If specified, controls the justification of header and grid cells for this column.
     /// </summary>
-    [Parameter] public Align Align { get; set; }
+    [Parameter]
+    public Align Align { get; set; }
 
     /// <summary>
     /// If true, generates a title and aria-label attribute for the cell contents
     /// </summary>
-    [Parameter] public bool Tooltip { get; set; } = false;
+    [Parameter]
+    public bool Tooltip { get; set; } = false;
 
     /// <summary>
     /// Gets or sets the value to be used as the tooltip and aria-label in this column's cells
     /// </summary>
-    [Parameter] public Func<TGridItem, string?>? TooltipText { get; set; }
+    [Parameter]
+    public Func<TGridItem, string?>? TooltipText { get; set; }
 
     /// <summary>
     /// Gets or sets an optional template for this column's header cell.
     /// If not specified, the default header template includes the <see cref="Title" /> along with any applicable sort indicators and options buttons.
     /// </summary>
-    [Parameter] public RenderFragment<ColumnBase<TGridItem>>? HeaderCellItemTemplate { get; set; }
+    [Parameter]
+    public RenderFragment<ColumnBase<TGridItem>>? HeaderCellItemTemplate { get; set; }
 
     /// <summary>
     /// If specified, indicates that this column has this associated options UI. A button to display this
@@ -61,7 +70,8 @@ public abstract partial class ColumnBase<TGridItem>
     /// If <see cref="HeaderCellItemTemplate" /> is used, it is left up to that template to render any relevant
     /// "show options" UI and invoke the grid's <see cref="FluentDataGrid{TGridItem}.ShowColumnOptionsAsync(ColumnBase{TGridItem})" />).
     /// </summary>
-    [Parameter] public RenderFragment? ColumnOptions { get; set; }
+    [Parameter]
+    public RenderFragment? ColumnOptions { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the data should be sortable by this column.
@@ -70,14 +80,16 @@ public abstract partial class ColumnBase<TGridItem>
     /// or <see cref="PropertyColumn{TGridItem, TProp}" /> is sortable by default if any<see cref="TemplateColumn{TGridItem}.SortBy" />
     /// or <see cref="PropertyColumn{TGridItem, TProp}.SortBy" /> parameter is specified).
     /// </summary>
-    [Parameter] public bool? Sortable { get; set; }
+    [Parameter]
+    public bool? Sortable { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the data is currently filtered by this column.
     ///
     /// The default value is false.
     /// </summary>
-    [Parameter] public bool? Filtered { get; set; }
+    [Parameter]
+    public bool? Filtered { get; set; }
 
     /// <summary>
     /// Gets or sets the sorting rules for a column.
@@ -88,29 +100,75 @@ public abstract partial class ColumnBase<TGridItem>
     /// Gets or sets the initial sort direction.
     /// if <see cref="IsDefaultSortColumn"/> is true.
     /// </summary>
-    [Parameter] public SortDirection InitialSortDirection { get; set; } = default;
+    [Parameter]
+    public SortDirection InitialSortDirection { get; set; } = default;
 
     /// <summary>
     /// Gets or sets a value indicating whether this column should be sorted by default.
     /// </summary>
-    [Parameter] public bool IsDefaultSortColumn { get; set; } = false;
+    [Parameter]
+    public bool IsDefaultSortColumn { get; set; } = false;
 
     /// <summary>
     /// If specified, virtualized grids will use this template to render cells whose data has not yet been loaded.
     /// </summary>
-    [Parameter] public RenderFragment<PlaceholderContext>? PlaceholderTemplate { get; set; }
+    [Parameter]
+    public RenderFragment<PlaceholderContext>? PlaceholderTemplate { get; set; }
 
     /// <summary>
     /// Gets or sets the width of the column.
     /// Use either this or the <see cref="FluentDataGrid{TGridItem}"/> GridTemplateColumns parameter but not both.
     /// Needs to be a valid CSS width value like '100px', '10%' or '0.5fr'.
     /// </summary>
-    [Parameter] public string? Width { get; set; }
+    [Parameter]
+    public string? Width { get; set; }
 
     /// <summary>
     /// Gets a reference to the enclosing <see cref="FluentDataGrid{TGridItem}" />.
     /// </summary>
-    public FluentDataGrid<TGridItem> Grid => InternalGridContext.Grid;
+    internal FluentDataGrid<TGridItem> Grid => InternalGridContext.Grid;
+
+    /// <summary>
+    /// Event callback for when the row is clicked.
+    /// </summary>
+    /// <param name="row"></param>
+    /// <returns></returns>
+    protected internal virtual Task OnRowClickAsync(FluentDataGridRow<TGridItem> row)
+    {
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Event callback for when the key is pressed on a row.
+    /// </summary>
+    /// <param name="row"></param>
+    /// <param name="args"></param>
+    /// <returns></returns>
+    protected internal virtual Task OnRowKeyDownAsync(FluentDataGridRow<TGridItem> row, KeyboardEventArgs args)
+    {
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Event callback for when the cell is clicked.
+    /// </summary>
+    /// <param name="cell"></param>
+    /// <returns></returns>
+    protected internal virtual Task OnCellClickAsync(FluentDataGridCell<TGridItem> cell)
+    {
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Event callback for when the key is pressed on a cell.
+    /// </summary>
+    /// <param name="cell"></param>
+    /// <param name="args"></param>
+    /// <returns></returns>
+    protected internal virtual Task OnCellKeyDownAsync(FluentDataGridCell<TGridItem> cell, KeyboardEventArgs args)
+    {
+        return Task.CompletedTask;
+    }
 
     /// <summary>
     /// Overridden by derived components to provide rendering logic for the column's cells.

--- a/src/Core/Components/DataGrid/Columns/SelectColumn.cs
+++ b/src/Core/Components/DataGrid/Columns/SelectColumn.cs
@@ -200,13 +200,76 @@ public class SelectColumn<TGridItem> : ColumnBase<TGridItem>
     /// </summary>
     public async Task ClearSelectionAsync()
     {
-        _selectedItems.Clear();
-        RefreshHeaderContent();
+        ClearSelection();
         await Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Select on Unselect an item when the row is clicked.
+    /// </summary>
+    /// <param name="row"></param>
+    /// <returns></returns>
+    protected internal override Task OnRowClickAsync(FluentDataGridRow<TGridItem> row)
+    {
+        if (SelectFromEntireRow == true && row.RowType == DataGridRowType.Default)
+        {
+            return AddOrRemoveSelectedItemAsync(row.Item);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Select on Unselect an item when the navigation keys are pressed.
+    /// </summary>
+    /// <param name="row"></param>
+    /// <param name="args"></param>
+    /// <returns></returns>
+    protected internal override Task OnRowKeyDownAsync(FluentDataGridRow<TGridItem> row, KeyboardEventArgs args)
+    {
+        if (SelectFromEntireRow == true && row.RowType == DataGridRowType.Default)
+        {
+            return AddOrRemoveSelectedItemAsync(row.Item);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Select on Unselect an item when the cell is clicked.
+    /// </summary>
+    /// <param name="cell"></param>
+    /// <returns></returns>
+    protected internal override Task OnCellClickAsync(FluentDataGridCell<TGridItem> cell)
+    {
+        // If the cell is a checkbox cell, add or remove the item from the selected items list.
+        if (SelectFromEntireRow == false && cell.CellType == DataGridCellType.Default)
+        {
+            return AddOrRemoveSelectedItemAsync(cell.Item);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Select on Unselect an item when the navigation keys are pressed.
+    /// </summary>
+    /// <param name="cell"></param>
+    /// <param name="args"></param>
+    /// <returns></returns>
+    protected internal override Task OnCellKeyDownAsync(FluentDataGridCell<TGridItem> cell, KeyboardEventArgs args)
+    {
+        // If the cell is a checkbox cell, add or remove the item from the selected items list.
+        if (SelectFromEntireRow == false && cell.CellType == DataGridCellType.Default)
+        {
+            return AddOrRemoveSelectedItemAsync(cell.Item);
+        }
+
+        return Task.CompletedTask;
+    }
+
     /// <summary />
-    internal async Task AddOrRemoveSelectedItemAsync(TGridItem? item)
+    private async Task AddOrRemoveSelectedItemAsync(TGridItem? item)
     {
         if (item != null)
         {
@@ -348,9 +411,10 @@ public class SelectColumn<TGridItem> : ColumnBase<TGridItem>
                     if (!SelectAllDisabled)
                     {
                         builder.AddAttribute(3, "OnClick", EventCallback.Factory.Create<MouseEventArgs>(this, OnClickAllAsync));
+                        builder.AddAttribute(4, "onkeydown", EventCallback.Factory.Create<KeyboardEventArgs>(this, OnKeyAllAsync));
                     }
-                    builder.AddAttribute(4, "Style", "margin-left: 12px;");
-                    builder.AddAttribute(5, "Title", iconAllChecked == IconIndeterminate
+                    builder.AddAttribute(5, "Style", "margin-left: 12px;");
+                    builder.AddAttribute(6, "Title", iconAllChecked == IconIndeterminate
                                                         ? TitleAllIndeterminate
                                                         : (iconAllChecked == GetIcon(true) ? TitleAllChecked : TitleAllUnchecked));
                     builder.CloseComponent();
@@ -377,8 +441,9 @@ public class SelectColumn<TGridItem> : ColumnBase<TGridItem>
                 {
                     builder.AddAttribute(1, "style", "cursor: pointer; margin-left: 12px;");
                     builder.AddAttribute(2, "onclick", EventCallback.Factory.Create<MouseEventArgs>(this, OnClickAllAsync));
+                    builder.AddAttribute(3, "onkeydown", EventCallback.Factory.Create<KeyboardEventArgs>(this, OnKeyAllAsync));
                 }
-                builder.AddContent(3, SelectAllTemplate.Invoke(new SelectAllTemplateArgs(GetSelectAll())));
+                builder.AddContent(4, SelectAllTemplate.Invoke(new SelectAllTemplateArgs(GetSelectAll())));
                 builder.CloseElement();
             });
         }
@@ -450,6 +515,15 @@ public class SelectColumn<TGridItem> : ColumnBase<TGridItem>
         }
 
         RefreshHeaderContent();
+    }
+
+    /// <summary />
+    internal async Task OnKeyAllAsync(KeyboardEventArgs e)
+    {
+        if (KEYBOARD_SELECT_KEYS.Contains(e.Code))
+        {
+            await OnClickAllAsync(new MouseEventArgs());
+        }
     }
 }
 

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -178,11 +178,6 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     [Inject] private IJSRuntime JSRuntime { get; set; } = default!;
     [Inject] private IKeyCodeService KeyCodeService { get; set; } = default!;
 
-    /// <summary>
-    /// Gets the first (optional) SelectColumn
-    /// </summary>
-    internal IEnumerable<SelectColumn<TGridItem>> SelectColumns => _columns.Where(col => col is SelectColumn<TGridItem>).Cast< SelectColumn<TGridItem>>();
-
     private ElementReference? _gridReference;
     private Virtualize<(int, TGridItem)>? _virtualizeComponent;
 

--- a/src/Core/Components/DataGrid/FluentDataGridCell.razor
+++ b/src/Core/Components/DataGrid/FluentDataGridCell.razor
@@ -6,6 +6,7 @@
                        grid-column=@GridColumn
                        class="@Class"
                        style="@StyleValue"
+                       @onkeydown="@HandleOnCellKeyDownAsync"
                        @onclick="@HandleOnCellClickAsync"
                        @attributes="AdditionalAttributes">
     @ChildContent

--- a/src/Core/Components/DataGrid/FluentDataGridCell.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGridCell.razor.cs
@@ -3,6 +3,7 @@
 // ------------------------------------------------------------------------
 
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.FluentUI.AspNetCore.Components.DataGrid.Infrastructure;
 using Microsoft.FluentUI.AspNetCore.Components.Utilities;
 
@@ -72,11 +73,22 @@ public partial class FluentDataGridCell<TGridItem> : FluentComponentBase
             await GridContext.Grid.OnCellClick.InvokeAsync(this);
         }
 
-        // If the cell is a checkbox cell, add or remove the item from the selected items list.
-        var selectColumn = Column as SelectColumn<TGridItem>;
-        if (CellType == DataGridCellType.Default && selectColumn != null && selectColumn.SelectFromEntireRow == false)
+        if (Column != null)
         {
-            await selectColumn.AddOrRemoveSelectedItemAsync(Item);
+            await Column.OnCellClickAsync(this);
+        }
+    }
+
+    internal async Task HandleOnCellKeyDownAsync(KeyboardEventArgs e)
+    {
+        if (!SelectColumn<TGridItem>.KEYBOARD_SELECT_KEYS.Contains(e.Code))
+        {
+            return;
+        }
+
+        if (Column != null)
+        {
+            await Column.OnCellKeyDownAsync(this, e);
         }
     }
 

--- a/src/Core/Components/DataGrid/FluentDataGridRow.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGridRow.razor.cs
@@ -103,19 +103,18 @@ public partial class FluentDataGridRow<TGridItem> : FluentComponentBase, IHandle
     /// <summary />
     internal async Task HandleOnRowClickAsync(string rowId)
     {
-        if (Owner.Rows.TryGetValue(rowId, out var row))
-        {
-            if (Owner.Grid.OnRowClick.HasDelegate)
-            {
-                await Owner.Grid.OnRowClick.InvokeAsync(row);
-            }
+        var row = GetRow(rowId);
 
-            if (row != null && row.RowType == DataGridRowType.Default)
+        if (row != null && Owner.Grid.OnRowClick.HasDelegate)
+        {
+            await Owner.Grid.OnRowClick.InvokeAsync(row);
+        }
+
+        if (row != null && row.RowType == DataGridRowType.Default)
+        {
+            foreach (var column in Owner.Grid._columns)
             {
-                foreach (var selColumn in Owner.Grid.SelectColumns.Where(i => i.SelectFromEntireRow))
-                {
-                    await selColumn.AddOrRemoveSelectedItemAsync(Item);
-                }
+                await column.OnRowClickAsync(row);
             }
         }
     }
@@ -123,32 +122,41 @@ public partial class FluentDataGridRow<TGridItem> : FluentComponentBase, IHandle
     /// <summary />
     internal async Task HandleOnRowDoubleClickAsync(string rowId)
     {
-        if (Owner.Rows.TryGetValue(rowId, out var row))
+        var row = GetRow(rowId);
+        if (row != null && Owner.Grid.OnRowDoubleClick.HasDelegate)
         {
-            if (Owner.Grid.OnRowDoubleClick.HasDelegate)
-            {
-                await Owner.Grid.OnRowDoubleClick.InvokeAsync(row);
-            }
+            await Owner.Grid.OnRowDoubleClick.InvokeAsync(row);
         }
     }
 
     /// <summary />
     internal async Task HandleOnRowKeyDownAsync(string rowId, KeyboardEventArgs e)
     {
-        // Enter when a SelectColumn is defined.
-        if (SelectColumn<TGridItem>.KEYBOARD_SELECT_KEYS.Contains(e.Code))
+        if (!SelectColumn<TGridItem>.KEYBOARD_SELECT_KEYS.Contains(e.Code))
         {
-            if (Owner.Rows.TryGetValue(rowId, out var row))
+            return;
+        }
+
+        var row = GetRow(rowId, r => r.RowType == DataGridRowType.Default);
+        if (row != null)
+        {
+            foreach (var column in Owner.Grid._columns)
             {
-                if (row != null && row.RowType == DataGridRowType.Default)
-                {
-                    foreach (var selColumn in Owner.Grid.SelectColumns)
-                    {
-                        await selColumn.AddOrRemoveSelectedItemAsync(Item);
-                    }
-                }
+                await column.OnRowKeyDownAsync(row, e);
             }
         }
+    }
+
+    private FluentDataGridRow<TGridItem>? GetRow(string rowId, Func<FluentDataGridRow<TGridItem>, bool>? where = null)
+    {
+        if (!string.IsNullOrEmpty(rowId) && Owner.Rows.TryGetValue(rowId, out var row))
+        {
+            return where == null
+                 ? row
+                 : row is not null && where(row) ? row : null;
+        }
+
+        return null;
     }
 
     /// <summary />


### PR DESCRIPTION
# [DataGrid] Refactoring ColumnBase events, using method inheritance and overloading.

Add these overloadable methods to the `ColumnBase` class.
- `OnRowClickAsync` is triggered when the user clicks on a row.
- `OnRowKeyDownAsync` is triggered when the user presses a key on a row.
- `OnCellClickAsync` is triggered when the user clicks on a cell of this column.
- `OnCellKeyDownAsync` is triggered when the user presses a key on a cell of this column.

This code was moved to the `SelectColumn` class.

```csharp
protected internal override Task OnRowClickAsync(FluentDataGridRow<TGridItem> row)
{
    if (SelectFromEntireRow == true && row.RowType == DataGridRowType.Default)
    {
        return AddOrRemoveSelectedItemAsync(row.Item);
    }
    return Task.CompletedTask;
}

protected internal override Task OnRowKeyDownAsync(FluentDataGridRow<TGridItem> row, KeyboardEventArgs args)
{
    if (SelectFromEntireRow == true && row.RowType == DataGridRowType.Default)
    {
        return AddOrRemoveSelectedItemAsync(row.Item);
    }
    return Task.CompletedTask;
}

...
```

## Unit Tests

Validated (unchanged)