### PR TITLE
[DataGrid] Make `PropertyColumn` use `DisplayAttribute` value for enum

### DIFF
--- a/examples/Demo/Shared/Pages/Lab/IssueTester.razor
+++ b/examples/Demo/Shared/Pages/Lab/IssueTester.razor
@@ -12,8 +12,7 @@
 
     public enum Positions
     {
-        [Display(Name = "Employee (DA)")]
-        Employee,
+        employee,
         [Display(Name = "HR Manager (DA)")]
         HrManager,
         [Display(Name = "Project Manager (DA)")]
@@ -37,7 +36,7 @@
 
     private List<Employee> employees = new List<Employee>
     {
-        new Employee { Id = 1, FullName = "John Doe", Subdivision = "IT", Position = Positions.Employee },
+        new Employee { Id = 1, FullName = "John Doe", Subdivision = "IT", Position = Positions.employee },
         new Employee { Id = 2, FullName = "Jane Doe", Subdivision = "HR", Position = Positions.HrManager },
         new Employee { Id = 3, FullName = "John Smith", Subdivision = "IT", Position = Positions.ProjectManager },
         new Employee { Id = 4, FullName = "Jane Smith", Subdivision = "HR", Position = Positions.Administrator }

--- a/examples/Demo/Shared/Pages/Lab/IssueTester.razor
+++ b/examples/Demo/Shared/Pages/Lab/IssueTester.razor
@@ -1,3 +1,47 @@
 ﻿@page "/issue-tester"
+@using System.ComponentModel.DataAnnotations
 
-<FluentUI.Demo.Shared.Pages.DataGrid.Examples.DataGridTypical />
+<FluentDataGrid Items="@employees.AsQueryable()" >
+    <PropertyColumn Property="@(e => e.Id)" />
+    <PropertyColumn Property="@(e => e.FullName)" />
+    <PropertyColumn Property="@(e => e.Subdivision)" />
+    <PropertyColumn Property="@(e => e.Position)" />
+</FluentDataGrid>
+
+@code {
+
+    public enum Positions
+    {
+        [Display(Name = "Employee (DA)")]
+        Employee,
+        [Display(Name = "HR Manager (DA)")]
+        HrManager,
+        [Display(Name = "Project Manager (DA)")]
+        ProjectManager,
+        [Display(Name = "Administrator (DA)")]
+        Administrator
+    }
+
+    public class Employee
+    {
+        [Display(Name = "Id")]
+        public int Id { get; set; }
+        [Required, Display(Name = "Full Name")]
+        public string FullName { get; set; }
+        [Required, Display(Name = "Subdivision")]
+        public string Subdivision { get; set; }
+        [Required, Display(Name = "Position")]
+        public Positions Position { get; set; }
+
+    }
+
+    private List<Employee> employees = new List<Employee>
+    {
+        new Employee { Id = 1, FullName = "John Doe", Subdivision = "IT", Position = Positions.Employee },
+        new Employee { Id = 2, FullName = "Jane Doe", Subdivision = "HR", Position = Positions.HrManager },
+        new Employee { Id = 3, FullName = "John Smith", Subdivision = "IT", Position = Positions.ProjectManager },
+        new Employee { Id = 4, FullName = "Jane Smith", Subdivision = "HR", Position = Positions.Administrator }
+    };
+
+
+}

--- a/src/Core/Components/DataGrid/Columns/PropertyColumn.cs
+++ b/src/Core/Components/DataGrid/Columns/PropertyColumn.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.FluentUI.AspNetCore.Components.DataGrid.Infrastructure;
+using Microsoft.FluentUI.AspNetCore.Components.Extensions;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
@@ -73,7 +74,20 @@ public class PropertyColumn<TGridItem, TProp> : ColumnBase<TGridItem>, IBindable
             }
             else
             {
-                _cellTextFunc = item => compiledPropertyExpression!(item)?.ToString();
+                _cellTextFunc = item =>
+                {
+                    var value = compiledPropertyExpression!(item);
+
+                    if (typeof(TProp).IsEnum)
+                    {
+                        var displayValue = (value as Enum)?.GetDisplayName();
+                        return displayValue;
+                    }
+                    else
+                    {
+                        return value?.ToString();
+                    }
+                };
             }
 
             _sortBuilder = Comparer is not null ? GridSort<TGridItem>.ByAscending(Property, Comparer) : GridSort<TGridItem>.ByAscending(Property);

--- a/src/Core/Components/DataGrid/Columns/PropertyColumn.cs
+++ b/src/Core/Components/DataGrid/Columns/PropertyColumn.cs
@@ -80,8 +80,7 @@ public class PropertyColumn<TGridItem, TProp> : ColumnBase<TGridItem>, IBindable
 
                     if (typeof(TProp).IsEnum)
                     {
-                        var displayValue = (value as Enum)?.GetDisplayName();
-                        return displayValue;
+                        return (value as Enum)?.GetDisplayName();
                     }
                     else
                     {

--- a/src/Core/Extensions/EnumExtensions.cs
+++ b/src/Core/Extensions/EnumExtensions.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 
 namespace Microsoft.FluentUI.AspNetCore.Components.Extensions;
@@ -37,5 +38,12 @@ public static class EnumExtensions
         }
 
         return description;
+    }
+
+    public static string GetDisplayName(this Enum enumValue)
+    {
+        var memberInfo = enumValue.GetType().GetMember(enumValue.ToString());
+        var displayAttribute = memberInfo[0].GetCustomAttribute<DisplayAttribute>();
+        return displayAttribute?.Name ?? enumValue.ToString();
     }
 }


### PR DESCRIPTION
When a `PropertyColumn` in a data grid defines an expression, it always returns a string value. In case on an enum it just returns the string representation of that value. By using `DisplayAttribute` it is possible to define a display friendly name for that value. With this PR that defined value will be used, if specified.

So using the following example code:
```
 @using System.ComponentModel.DataAnnotations

<FluentDataGrid Items="@employees.AsQueryable()" >
    <PropertyColumn Property="@(e => e.Id)" />
    <PropertyColumn Property="@(e => e.FullName)" />
    <PropertyColumn Property="@(e => e.Subdivision)" />
    <PropertyColumn Property="@(e => e.Position)" />
</FluentDataGrid>

@code {

    public enum Positions
    {
        employee,
        [Display(Name = "HR Manager (DA)")]
        HrManager,
        [Display(Name = "Project Manager (DA)")]
        ProjectManager,
        [Display(Name = "Administrator (DA)")]
        Administrator
    }

    public class Employee
    {
        [Display(Name = "Id")]
        public int Id { get; set; }
        [Required, Display(Name = "Full Name")]
        public string FullName { get; set; }
        [Required, Display(Name = "Subdivision")]
        public string Subdivision { get; set; }
        [Required, Display(Name = "Position")]
        public Positions Position { get; set; }

    }

    private List<Employee> employees = new List<Employee>
    {
        new Employee { Id = 1, FullName = "John Doe", Subdivision = "IT", Position = Positions.employee },
        new Employee { Id = 2, FullName = "Jane Doe", Subdivision = "HR", Position = Positions.HrManager },
        new Employee { Id = 3, FullName = "John Smith", Subdivision = "IT", Position = Positions.ProjectManager },
        new Employee { Id = 4, FullName = "Jane Smith", Subdivision = "HR", Position = Positions.Administrator }
    };
}
```

Notice that **no** DisplayAttribute is defined for employee enum **value**, so the actual value is displayed.

Will render as:
![image](https://github.com/microsoft/fluentui-blazor/assets/1761079/e785e883-a400-4c2a-8c50-89dfffe419b9)
