### PR TITLE
[DialogService] Fix UpdateDialogAsync to refresh parameters and content

### DIFF
--- a/src/Core/Components/Dialog/FluentDialogProvider.razor
+++ b/src/Core/Components/Dialog/FluentDialogProvider.razor
@@ -14,7 +14,7 @@
     {
         @foreach (DialogReference dialog in _internalDialogContext.References)
         {
-            <FluentDialog @key="@dialog" Id="@dialog.Id" Instance="@dialog.Instance" Data="@dialog.Instance.Content" @ondialogdismiss=OnDismissAsync />
+            <FluentDialog @key="@dialog.GetKey()" Id="@dialog.Id" Instance="@dialog.Instance" Data="@dialog.Instance.Content" @ondialogdismiss=OnDismissAsync />
         }
     }
 }

--- a/src/Core/Components/Dialog/FluentDialogProvider.razor.cs
+++ b/src/Core/Components/Dialog/FluentDialogProvider.razor.cs
@@ -83,10 +83,37 @@ public partial class FluentDialogProvider : IDisposable
             {
                 dialogInstance.Parameters = parameters;
 
+                if (TryGetContent(parameters, out var content) && content != null)
+                {
+                    dialogInstance.Content = content;
+                }
+
                 InvokeAsync(StateHasChanged);
             }
             return reference;
         });
+    }
+
+    // Check if the content object is a IDialogParameters<TContent> and get the Content property.
+    private bool TryGetContent(object obj, out object? content)
+    {
+        content = null;
+
+        // Check if the interface is a generic type and inherits from IDialogParameters<TContent>
+        foreach (var i in obj.GetType().GetInterfaces())
+        {
+            if (i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDialogParameters<>))
+            {
+                var contentProperty = i.GetProperty("Content");
+                if (contentProperty != null)
+                {
+                    content = contentProperty.GetValue(obj);
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     internal void DismissInstance(string id, DialogResult result)

--- a/src/Core/Components/Dialog/Services/DialogInstance.cs
+++ b/src/Core/Components/Dialog/Services/DialogInstance.cs
@@ -14,7 +14,7 @@ public sealed class DialogInstance
 
     public Type? ContentType { get; }
 
-    public object Content { get; } = default!;
+    public object Content { get; internal set; } = default!;
 
     public DialogParameters Parameters { get; internal set; }
 

--- a/src/Core/Components/Dialog/Services/DialogReference.cs
+++ b/src/Core/Components/Dialog/Services/DialogReference.cs
@@ -14,7 +14,7 @@ public class DialogReference : IDialogReference
 
     public DialogInstance Instance { get; set; } = default!;
 
-    internal string GetKey() => $"{Instance.Parameters.GetHashCode()}_{Instance.Content.GetHashCode()}";
+    internal string GetKey() => $"{Instance.Parameters?.GetHashCode() ?? 0}_{Instance.Content?.GetHashCode() ?? 0}";
 
     public string Id { get; }
 

--- a/src/Core/Components/Dialog/Services/DialogReference.cs
+++ b/src/Core/Components/Dialog/Services/DialogReference.cs
@@ -14,6 +14,8 @@ public class DialogReference : IDialogReference
 
     public DialogInstance Instance { get; set; } = default!;
 
+    internal string GetKey() => $"{Instance.Parameters.GetHashCode()}_{Instance.Content.GetHashCode()}";
+
     public string Id { get; }
 
     public Task<DialogResult> Result => _resultCompletion.Task;

--- a/tests/Core/Dialog/FluentDialogServiceTests.razor
+++ b/tests/Core/Dialog/FluentDialogServiceTests.razor
@@ -64,9 +64,9 @@
 
         // Act
         var dialog = await dialogService.ShowDialogAsync(@<div>
-This is from a render fragment
-            </div>,
-            new DialogParameters()
+        This is from a render fragment
+    </div>,
+        new DialogParameters()
             {
                 Title = "Render Fragment Example",
                 PreventDismissOnOverlayClick = true,
@@ -75,5 +75,49 @@ This is from a render fragment
 
         // Assert
         cut.Verify();
+    }
+
+    [Fact]
+    public async Task FluentDialogService_UpdateDialogAsync()
+    {
+        Services.AddFluentUIComponents();
+
+        // Arrange
+        var cut = Render(@<FluentDialogProvider />);
+        var dialogService = Services.GetRequiredService<IDialogService>();
+
+        var myUser = new UpdateDialogUser()
+            {
+                Id = 1,
+                Name = "Denis",
+            };
+
+        var parameters = new DialogParameters<UpdateDialogUser>()
+            {
+                Height = "200px",
+                Title = "My title",
+                PrimaryAction = "Yes",
+                PrimaryActionEnabled = false,
+                SecondaryAction = "No",
+            };
+
+        // Act
+        var dialog = await dialogService.ShowDialogAsync<TestDialogHeaderFooter>(myUser, parameters);
+
+        parameters.Title = "My new title";
+        parameters.PrimaryAction = "Oh yes";
+        parameters.Content = new() { Id = 2, Name = "Vincent" };
+
+        await dialogService.UpdateDialogAsync(dialog.Id, parameters);
+
+        // Assert
+        Assert.Equal("My new title", cut.Find("h4").InnerHtml);
+        Assert.Equal("Oh yes", cut.Find("fluent-button[appearance='accent']").InnerHtml);
+    }
+
+    private class UpdateDialogUser
+    {
+        public int Id { get; set; } = 0;
+        public string Name { get; set; } = string.Empty;
     }
 }


### PR DESCRIPTION
# [DialogService] Fix UpdateDialogAsync to refresh parameters and content

Update the `UpdateDialogAsync` to refresh all data: parameters (title, buttons, ...) and the content.

See #2040 for an example.

```csharp
var dialog = await dialogService.ShowDialogAsync<TestDialogHeaderFooter>(myUser, parameters);

parameters.Title = "My new title";
parameters.PrimaryAction = "Oh yes";
parameters.Content = new() { Id = 2, Name = "Vincent" };

await dialogService.UpdateDialogAsync(dialog.Id, parameters);
```

![peek_1](https://github.com/microsoft/fluentui-blazor/assets/8350694/35d6e2f8-facc-4443-ba8b-35b4eeaf7044)


# Unit Tests

One unit test added to verify this case.