### PR TITLE
[Icon Explorer] Update the Variant selector

### DIFF
--- a/examples/Demo/AssetExplorer/Components/Pages/IconExplorer.razor
+++ b/examples/Demo/AssetExplorer/Components/Pages/IconExplorer.razor
@@ -14,13 +14,13 @@
     <FluentGrid Style="width: 100%;" Spacing="1">
         <FluentGridItem Style="min-width: 200px;">
             <FluentSearch @bind-Value="@Criteria.SearchTerm"
-                          @bind-Value:after="@StartNewSearchAsync"
+                          @bind-Value:after="@(() => StartNewSearchAsync(nameof(Criteria.SearchTerm)))"
                           Placeholder="Part of icon name..." />
         </FluentGridItem>
         <FluentGridItem Gap="0">
             <FluentSelect TOption="int"
                           @bind-SelectedOption="@Criteria.Size"
-                          @bind-SelectedOption:after="@StartNewSearchAsync"
+                          @bind-SelectedOption:after="@(() => StartNewSearchAsync(nameof(Criteria.Size)))"
                           Style="min-width: 100px;"
                           Items="@AllAvailableSizes"
                           OptionText="@(i => i > 0 ? $"Size{i}" : "[All]")" />
@@ -28,21 +28,21 @@
         <FluentGridItem>
             <FluentSelect TOption="IconVariant"
                           @bind-SelectedOption="@Criteria.Variant"
-                          @bind-SelectedOption:after="@StartNewSearchAsync"
+                          @bind-SelectedOption:after="@(() => StartNewSearchAsync(nameof(Criteria.Variant)))"
                           Style="min-width: 100px;"
                           Items="@(Enum.GetValues<IconVariant>())" />
         </FluentGridItem>
         <FluentGridItem>
             <FluentSelect TOption="Color"
                           @bind-SelectedOption="@Criteria.Color"
-                          @bind-SelectedOption:after="@StartNewSearchAsync"
+                          @bind-SelectedOption:after="@(() => StartNewSearchAsync(nameof(Criteria.Color)))"
                           Style="min-width: 100px;"
                           Items="@(Enum.GetValues<Color>().Where(i => i != Color.Custom))"
                           OptionValue="@(i => i.ToAttributeValue())" />
         </FluentGridItem>
         <FluentGridItem>
             <FluentButton IconStart="@(new Icons.Regular.Size24.ArrowCircleRight())"
-                          OnClick="@StartNewSearchAsync" />
+                          OnClick="@(() => StartNewSearchAsync(string.Empty))" />
         </FluentGridItem>
     </FluentGrid>
 

--- a/examples/Demo/AssetExplorer/Components/Pages/IconExplorer.razor.cs
+++ b/examples/Demo/AssetExplorer/Components/Pages/IconExplorer.razor.cs
@@ -42,8 +42,13 @@ public partial class IconExplorer
         }
     }
 
-    private async Task StartNewSearchAsync()
+    private async Task StartNewSearchAsync(string property)
     {
+        if (property == nameof(Criteria.Variant) && Criteria.Variant == IconVariant.Light && Criteria.Size != 32)
+        {
+            Criteria.Size = 32;
+        }
+
         SearchInProgress = true;
         await Task.Delay(1); // Display spinner
 
@@ -71,7 +76,7 @@ public partial class IconExplorer
     {
         get
         {
-            var sizes = Enum.GetValues<IconSize>().Select(i => (int)i).ToList();
+            var sizes = Enum.GetValues<IconSize>().Where(i => i > 0).Select(i => (int)i).ToList();
             var empty = new int[] { 0 };
             return empty.Concat(sizes);
         }


### PR DESCRIPTION
# [Icon Explorer] Update the Variant selector

Update the Variant selector to accept **Light** icons (now, only for 32 pixels)

Site already published.

![image](https://github.com/microsoft/fluentui-blazor/assets/8350694/379b5359-4e30-4530-b6fa-4152eee2f671)
