### PR TITLE
[Multi Splitter] Fix the Splitter OnMouseMove

### DIFF
--- a/examples/Demo/Shared/Pages/Splitter/Examples/MultiSplitterDefault.razor
+++ b/examples/Demo/Shared/Pages/Splitter/Examples/MultiSplitterDefault.razor
@@ -3,7 +3,7 @@
         Left Menu
     </FluentMultiSplitterPane>
     <FluentMultiSplitterPane Size="50%">
-        <FluentMultiSplitter OnResize="@OnResizeHandler" Orientation="Orientation.Vertical">
+        <FluentMultiSplitter OnResize="@OnResizeHandler" OnExpand="@OnCollapseExpand" OnCollapse="@OnCollapseExpand" Orientation="Orientation.Vertical">
             <FluentMultiSplitterPane Collapsible="true">
                 Main Content
             </FluentMultiSplitterPane>
@@ -22,5 +22,11 @@
     void OnResizeHandler(FluentMultiSplitterResizeEventArgs e)
     {
         DemoLogger.WriteLine($"Pane {e.PaneIndex} Resize (New size {e.NewSize})");
+    }
+
+    void OnCollapseExpand(FluentMultiSplitterEventArgs e)
+    {
+        bool willCollapse = !e.Pane.Collapsed;
+        DemoLogger.WriteLine($"Pane {e.PaneIndex} {(willCollapse ? "collapsed" : "expanded")}");
     }
 }

--- a/src/Core/Components/Splitter/FluentMultiSplitter.razor.js
+++ b/src/Core/Components/Splitter/FluentMultiSplitter.razor.js
@@ -73,7 +73,6 @@ export function startSplitterResize(
         paneLength: paneLength,
         paneNextLength: isFinite(paneNextLength) ? paneNextLength : 0,
         mouseUpHandler: function (e) {
-            console.log("Up", e);
             if (document.splitterData[el] &&
                 pane.style.flexBasis.includes('%') &&
                 paneNext.style.flexBasis.includes('%')) {
@@ -100,7 +99,6 @@ export function startSplitterResize(
             }
         },
         mouseMoveHandler: function (e) {
-            console.log("moved", e);
             if (document.splitterData[el]) {
 
                 document.splitterData[el].moved = true;

--- a/src/Core/Components/Splitter/FluentMultiSplitter.razor.js
+++ b/src/Core/Components/Splitter/FluentMultiSplitter.razor.js
@@ -73,26 +73,37 @@ export function startSplitterResize(
         paneLength: paneLength,
         paneNextLength: isFinite(paneNextLength) ? paneNextLength : 0,
         mouseUpHandler: function (e) {
+            console.log("Up", e);
             if (document.splitterData[el] &&
                 pane.style.flexBasis.includes('%') &&
                 paneNext.style.flexBasis.includes('%')) {
 
-                splitter.invokeMethodAsync(
-                    'FluentMultiSplitter.OnPaneResizedAsync',
-                    parseInt(pane.getAttribute('data-index')),
-                    parseFloat(pane.style.flexBasis),
-                    paneNext ? parseInt(paneNext.getAttribute('data-index')) : null,
-                    paneNext ? parseFloat(paneNext.style.flexBasis) : null
-                );
+                if (document.splitterData[el].moved === true) {
+                    splitter.invokeMethodAsync(
+                        'FluentMultiSplitter.OnPaneResizedAsync',
+                        parseInt(pane.getAttribute('data-index')),
+                        parseFloat(pane.style.flexBasis),
+                        paneNext ? parseInt(paneNext.getAttribute('data-index')) : null,
+                        paneNext ? parseFloat(paneNext.style.flexBasis) : null
+                    );
+                }
+
                 document.removeEventListener('mousemove', document.splitterData[el].mouseMoveHandler);
                 document.removeEventListener('mouseup', document.splitterData[el].mouseUpHandler);
                 document.removeEventListener('touchmove', document.splitterData[el].touchMoveHandler);
                 document.removeEventListener('touchend', document.splitterData[el].mouseUpHandler);
                 document.splitterData[el] = null;
             }
+
+            if (document.splitterData[el]) {
+                document.splitterData[el].moved = false;
+            }
         },
         mouseMoveHandler: function (e) {
+            console.log("moved", e);
             if (document.splitterData[el]) {
+
+                document.splitterData[el].moved = true;
 
                 var spacePerc = document.splitterData[el].panePerc + document.splitterData[el].paneNextPerc;
                 var spaceLength = document.splitterData[el].paneLength + document.splitterData[el].paneNextLength;


### PR DESCRIPTION
# [Multi Splitter] Fix the Splitter OnMouseMove

## Issue

See #2321
It seems the `OnResize` event callback of `MultiSplitter` is called each time a mouse click on the "resize bar" is performed - even if the panes / "resize bar" is not moved / resized at all.

## Fix

Detection of the `mousemove` when the `mouseup` is raised.

![MultiSplitter](https://github.com/microsoft/fluentui-blazor/assets/8350694/919583ef-1513-428a-a813-6ec82be14335)
