### PR TITLE
[DataGrid] Several issues addressed

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -8482,12 +8482,6 @@
             Gets or sets a value indicating whether the active indicator is displayed.
             </summary>
         </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentTabs.ShowOverflow">
-            <summary>
-            Gets or sets whether tabs can overflow
-            Default is set to true to maintain original behavior.
-            </summary>
-        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentTabs.ChildContent">
             <summary>
             Gets or sets the content to be rendered inside the component.

--- a/src/Core/Components/DataGrid/Columns/ColumnBase.razor.cs
+++ b/src/Core/Components/DataGrid/Columns/ColumnBase.razor.cs
@@ -126,7 +126,7 @@ public abstract partial class ColumnBase<TGridItem>
     /// <summary>
     /// Gets a reference to the enclosing <see cref="FluentDataGrid{TGridItem}" />.
     /// </summary>
-    public FluentDataGrid<TGridItem> Grid => InternalGridContext.Grid;
+    protected FluentDataGrid<TGridItem> Grid => InternalGridContext.Grid;
 
     /// <summary>
     /// Event callback for when the row is clicked.

--- a/src/Core/Components/DataGrid/Columns/PropertyColumn.cs
+++ b/src/Core/Components/DataGrid/Columns/PropertyColumn.cs
@@ -78,7 +78,7 @@ public class PropertyColumn<TGridItem, TProp> : ColumnBase<TGridItem>, IBindable
                 {
                     var value = compiledPropertyExpression!(item);
 
-                    if (typeof(TProp).IsEnum)
+                    if (typeof(TProp).IsEnum || typeof(TProp).IsNullableEnum())
                     {
                         return (value as Enum)?.GetDisplayName();
                     }

--- a/src/Core/Extensions/EnumExtensions.cs
+++ b/src/Core/Extensions/EnumExtensions.cs
@@ -46,4 +46,9 @@ public static class EnumExtensions
         var displayAttribute = memberInfo[0].GetCustomAttribute<DisplayAttribute>();
         return displayAttribute?.GetName() ?? enumValue.ToString();
     }
+
+    public static bool IsNullableEnum(this Type t)
+    {
+        return Nullable.GetUnderlyingType(t)?.IsEnum == true;
+    }
 }

--- a/src/Core/Extensions/EnumExtensions.cs
+++ b/src/Core/Extensions/EnumExtensions.cs
@@ -44,6 +44,6 @@ public static class EnumExtensions
     {
         var memberInfo = enumValue.GetType().GetMember(enumValue.ToString());
         var displayAttribute = memberInfo[0].GetCustomAttribute<DisplayAttribute>();
-        return displayAttribute?.Name ?? enumValue.ToString();
+        return displayAttribute?.GetName() ?? enumValue.ToString();
     }
 }


### PR DESCRIPTION
- The Grid property of the `ColumnBase` should not be `public` but `protected`
- The enum extension for getting the display attribute should use the `GetName()` method instead of using `Name` (following C# guidelines)
- When using the new display attribute to use an enum for property value in a column, this should also work for nullable enums. Added a check for that