### PR TITLE
Fix validation when @bind-Value is set for FluentWizard component

### DIFF
--- a/src/Core/Components/Wizard/FluentWizard.razor.cs
+++ b/src/Core/Components/Wizard/FluentWizard.razor.cs
@@ -191,12 +191,11 @@ public partial class FluentWizard : FluentComponentBase
     /// <summary />
     protected virtual async Task<FluentWizardStepChangeEventArgs> OnStepChangeHandlerAsync(int targetIndex, bool validateEditContexts)
     {
-        var stepChangeArgs = new FluentWizardStepChangeEventArgs(targetIndex, _steps[targetIndex].Label);
-        var allEditContextsAreValid = false;        
+        var stepChangeArgs = new FluentWizardStepChangeEventArgs(targetIndex, _steps[targetIndex].Label);               
 
         if (validateEditContexts)
         {
-            allEditContextsAreValid = _steps[Value].ValidateEditContexts();
+            var allEditContextsAreValid = _steps[Value].ValidateEditContexts();
             stepChangeArgs.IsCancelled = !allEditContextsAreValid;
 
             if (!allEditContextsAreValid)

--- a/src/Core/Components/Wizard/FluentWizard.razor.cs
+++ b/src/Core/Components/Wizard/FluentWizard.razor.cs
@@ -160,6 +160,7 @@ public partial class FluentWizard : FluentComponentBase
         if (!isCanceled)
         {
             Value = targetIndex;
+            await ValueChanged.InvokeAsync(targetIndex);
             StateHasChanged();
         }
     }
@@ -182,6 +183,7 @@ public partial class FluentWizard : FluentComponentBase
         if (!isCanceled)
         {
             Value = targetIndex;
+            await ValueChanged.InvokeAsync(targetIndex);
             StateHasChanged();
         }
     }
@@ -190,9 +192,11 @@ public partial class FluentWizard : FluentComponentBase
     protected virtual async Task<FluentWizardStepChangeEventArgs> OnStepChangeHandlerAsync(int targetIndex, bool validateEditContexts)
     {
         var stepChangeArgs = new FluentWizardStepChangeEventArgs(targetIndex, _steps[targetIndex].Label);
+        var allEditContextsAreValid = false;        
+
         if (validateEditContexts)
         {
-            var allEditContextsAreValid = _steps[Value].ValidateEditContexts();
+            allEditContextsAreValid = _steps[Value].ValidateEditContexts();
             stepChangeArgs.IsCancelled = !allEditContextsAreValid;
 
             if (!allEditContextsAreValid)
@@ -207,8 +211,6 @@ public partial class FluentWizard : FluentComponentBase
 
             await _steps[Value].InvokeOnSubmitForEditFormsAsync();
         }
-
-        await ValueChanged.InvokeAsync(targetIndex);
 
         return await OnStepChangeHandlerAsync(stepChangeArgs);
     }
@@ -256,6 +258,7 @@ public partial class FluentWizard : FluentComponentBase
         if (!isCanceled)
         {
             Value = targetIndex;
+            await ValueChanged.InvokeAsync(targetIndex);
             StateHasChanged();
         }
     }

--- a/tests/Core/Wizard/FluentWizardTests.razor
+++ b/tests/Core/Wizard/FluentWizardTests.razor
@@ -323,6 +323,8 @@
     [Fact]
     public void FluentWizard_EditForm_EditContextIsInValid_OnNext()
     {
+        int stepIndex = 0;
+
         var testRecord1 = new TestRecord
             {
                 NumberBetween1and10 = 15,
@@ -331,9 +333,9 @@
         var testRecord2 = new TestRecord
             {
                 NumberBetween1and10 = 15,
-            };
+            };        
 
-        var cut = Render(@<FluentWizard OnFinish="OnFinishHandler">
+        var cut = Render(@<FluentWizard OnFinish="OnFinishHandler" @bind-Value="@stepIndex">
         <Steps>
             <FluentWizardStep>
                 <FluentEditForm Model="testRecord1">
@@ -367,9 +369,11 @@
         void OnFinishHandler()
         {
             finishHandled = true;
+
         }
 
         Assert.False(finishHandled);
+        Assert.Equal(0, stepIndex);
     }
 
     [Fact]

--- a/tests/Core/Wizard/FluentWizardTests.razor
+++ b/tests/Core/Wizard/FluentWizardTests.razor
@@ -333,7 +333,7 @@
         var testRecord2 = new TestRecord
             {
                 NumberBetween1and10 = 15,
-            };        
+            };
 
         var cut = Render(@<FluentWizard OnFinish="OnFinishHandler" @bind-Value="@stepIndex">
         <Steps>
@@ -369,7 +369,6 @@
         void OnFinishHandler()
         {
             finishHandled = true;
-
         }
 
         Assert.False(finishHandled);


### PR DESCRIPTION
# Pull Request

## 📖 Description

Update the Wizard component to honor the FluentFormEdit validation components when @bind-Value is set.

### 🎫 Issues

When @bind-Value is set on the Wizard Component the next button will work even if there is a FluentFormEdit component within the FluentWizardStep component and the model is invalid for that WizardStep component.

## 👩‍💻 Reviewer Notes

## 📑 Test Plan

1. Update a test for FluentWizard_EditForm_EditContextIsInValid_OnNext a @bind-Value to an integer, assert this value will not change to a new value once the next button is clicked.
2. Run the test; expect failure.
3. Update the component to only run the ValueChanged event for Value when it is valid and not cancelled.
4. Run the text; expect success.

## ✅ Checklist

### General

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new compontent
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component 
