### PR TITLE
[Wizard] Add GoToStepAsync method

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -9469,6 +9469,7 @@
             This configuration overrides the whole rendering of the bottom-right section of the Wizard,
             including the built-in buttons and thus provides a full control over it.
             Custom Wizard buttons do not trigger the component OnChange and OnFinish events.
+            The OnChange event can be triggered using the <see cref="M:Microsoft.FluentUI.AspNetCore.Components.FluentWizard.GoToStepAsync(System.Int32,System.Boolean)"/> method from your code.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentWizard.Steps">
@@ -9502,6 +9503,14 @@
         </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentWizard.OnFinishHandlerAsync(Microsoft.AspNetCore.Components.Web.MouseEventArgs)">
             <summary />
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentWizard.GoToStepAsync(System.Int32,System.Boolean)">
+            <summary>
+            Navigate to the specified step, with or without validate the current EditContexts.
+            </summary>
+            <param name="step">Index number of the step to display</param>
+            <param name="validateEditContexts">Validate the EditContext. Default is false.</param>
+            <returns></returns>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentWizardStep.ClassValue">
             <summary />

--- a/examples/Demo/Shared/Pages/Wizard/Examples/WizardCustomized.razor
+++ b/examples/Demo/Shared/Pages/Wizard/Examples/WizardCustomized.razor
@@ -11,12 +11,13 @@
     }
 </style>
 
-<FluentWizard Id="customized-wizard"
+<FluentWizard @ref="@MyWizard"
+              Id="customized-wizard"
               @bind-Value="@Value"
               StepTitleHiddenWhen="@GridItemHidden.XsAndDown"
               Height="300px">
     <Steps>
-        <FluentWizardStep>
+        <FluentWizardStep OnChange="@OnStepChange">
             <StepTemplate>
                 <div active="@context.Active">
                     Intro
@@ -29,7 +30,7 @@
                 ut blandit dui ullamcorper faucibus. Interdum et malesuada fames ac ante ipsum.
             </ChildContent>
         </FluentWizardStep>
-        <FluentWizardStep>
+        <FluentWizardStep OnChange="@OnStepChange">
             <StepTemplate>
                 <div active="@context.Active">
                     Get Started
@@ -40,7 +41,7 @@
                 Fusce vel porta ex, imperdiet molestie nisl. Vestibulum eu ultricies mauris, eget aliquam quam.
             </ChildContent>
         </FluentWizardStep>
-        <FluentWizardStep>
+        <FluentWizardStep OnChange="@OnStepChange">
             <StepTemplate>
                 <div active="@context.Active">
                     Set budget
@@ -52,7 +53,7 @@
                 turpis, eget molestie ipsum.
             </ChildContent>
         </FluentWizardStep>
-        <FluentWizardStep>
+        <FluentWizardStep OnChange="@OnStepChange">
             <StepTemplate>
                 <div active="@context.Active">
                     Summary
@@ -74,16 +75,16 @@
             <div>
                 @if (index > 0)
                 {
-                    <FluentButton OnClick="@(() => Value = 0)">Go to first page</FluentButton>
-                    <FluentButton OnClick="@(() => Value -= 1)">Previous</FluentButton>
+                    <FluentButton OnClick="@(() => MyWizard.GoToStepAsync(0))">Go to first page</FluentButton>
+                    <FluentButton OnClick="@(() => MyWizard.GoToStepAsync(Value - 1))">Previous</FluentButton>
                 }
             </div>
             <FluentSpacer />
             <div>
                 @if (index != lastStepIndex)
                 {
-                    <FluentButton OnClick="@(() => Value += 1)" Appearance="Appearance.Accent">Next</FluentButton>
-                    <FluentButton OnClick="@(() => Value = lastStepIndex)" Appearance="Appearance.Accent">Go to last page</FluentButton>
+                    <FluentButton OnClick="@(() => MyWizard.GoToStepAsync(Value + 1))" Appearance="Appearance.Accent">Next</FluentButton>
+                    <FluentButton OnClick="@(() => MyWizard.GoToStepAsync(lastStepIndex))" Appearance="Appearance.Accent">Go to last page</FluentButton>
                 }
             </div>
         }
@@ -92,5 +93,11 @@
 
 @code
 {
+    FluentWizard MyWizard = default!;
     int Value = 0;
+
+    void OnStepChange(FluentWizardStepChangeEventArgs e)
+    {
+        DemoLogger.WriteLine($"Go to step {e.TargetLabel} (#{e.TargetIndex})");
+    }
 }

--- a/src/Core/Components/Wizard/FluentWizard.razor.cs
+++ b/src/Core/Components/Wizard/FluentWizard.razor.cs
@@ -118,6 +118,7 @@ public partial class FluentWizard : FluentComponentBase
     /// This configuration overrides the whole rendering of the bottom-right section of the Wizard,
     /// including the built-in buttons and thus provides a full control over it.
     /// Custom Wizard buttons do not trigger the component OnChange and OnFinish events.
+    /// The OnChange event can be triggered using the <see cref="GoToStepAsync(int, bool)"/> method from your code.
     /// </summary>
     [Parameter]
     public RenderFragment<int>? ButtonTemplate { get; set; }
@@ -248,7 +249,19 @@ public partial class FluentWizard : FluentComponentBase
         }
     }
 
-    internal async Task GoToStepAsync(int targetIndex, bool validateEditContexts)
+    /// <summary>
+    /// Navigate to the specified step, with or without validate the current EditContexts.
+    /// </summary>
+    /// <param name="step">Index number of the step to display</param>
+    /// <param name="validateEditContexts">Validate the EditContext. Default is false.</param>
+    /// <returns></returns>
+    public Task GoToStepAsync(int step, bool validateEditContexts = false)
+    {
+        Value = step;
+        return ValidateAndGoToStepAsync(step, validateEditContexts);
+    }
+
+    internal async Task ValidateAndGoToStepAsync(int targetIndex, bool validateEditContexts)
     {
         var stepChangeArgs = await OnStepChangeHandlerAsync(targetIndex, validateEditContexts);
         var isCanceled = stepChangeArgs?.IsCancelled ?? false;

--- a/src/Core/Components/Wizard/FluentWizardStep.razor.cs
+++ b/src/Core/Components/Wizard/FluentWizardStep.razor.cs
@@ -192,7 +192,7 @@ public partial class FluentWizardStep : FluentComponentBase
             return;
         }
 
-        await FluentWizard.GoToStepAsync(Index, validateEditContexts: Index > FluentWizard.Value);
+        await FluentWizard.ValidateAndGoToStepAsync(Index, validateEditContexts: Index > FluentWizard.Value);
     }
 
     private bool IsStepClickable


### PR DESCRIPTION
# [Wizard] Add GoToStepAsync method

When the `ButtonTemplate` property is set, as the documentation states, "Custom Wizard buttons do not trigger the component OnChange and OnFinish events.

In some development projects, it may be simpler to use `WizardStep.OnChange` events. This makes it easier to organize the code.

To trigger this `OnChange` event, we've added a `GoToStepAsync` method that positions the user on the specified step and triggers this event.

### GoToStepAsync(int step, bool validateEditContexts = false)
Navigate to the specified step, with or without validate the current EditContexts.
- `step` Index number of the step to display
- `validateEditContexts` Validate the EditContext. Default is false.

### Example
```razor
<ButtonTemplate>
    @{
        var index = context;
        var lastStepIndex = 3;

        <div>
            @if (index > 0)
            {
                <FluentButton OnClick="@(() => MyWizard.GoToStepAsync(0))">Go to first page</FluentButton>
                <FluentButton OnClick="@(() => MyWizard.GoToStepAsync(Value - 1))">Previous</FluentButton>
            }
        </div>
        <FluentSpacer />
        <div>
            @if (index != lastStepIndex)
            {
                <FluentButton OnClick="@(() => MyWizard.GoToStepAsync(Value + 1))" Appearance="Appearance.Accent">Next</FluentButton>
                <FluentButton OnClick="@(() => MyWizard.GoToStepAsync(lastStepIndex))" Appearance="Appearance.Accent">Go to last page</FluentButton>
            }
        </div>
    }
</ButtonTemplate>
```