### PR TITLE
[Search] Add AutoComplete parameter

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -7020,15 +7020,15 @@
             Gets or sets the content to display. All first HTML elements are included in the items flow.
             </summary>
         </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentOverflowItem.Overflow">
-            <summary>
-            Gets True if this component is out of panel.
-            </summary>
-        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentOverflowItem.Fixed">
             <summary>
             Gets or sets if this item dos not participates in overflow logic.
             Defaults to false
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentOverflowItem.Overflow">
+            <summary>
+            Gets True if this component is out of panel.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentOverflowItem.Text">
@@ -7856,6 +7856,12 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentSearch.Appearance">
             <summary>
             Gets or sets the visual appearance. See <see cref="T:Microsoft.FluentUI.AspNetCore.Components.Appearance"/>
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentSearch.AutoComplete">
+            <summary>
+            Specifies whether a form or an input field should have autocomplete "on" or "off" or another value.
+            An Id value must be set to use this property.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentSearch.ChildContent">

--- a/examples/Demo/Shared/Pages/Search/Examples/SearchDefault.razor
+++ b/examples/Demo/Shared/Pages/Search/Examples/SearchDefault.razor
@@ -2,7 +2,7 @@
     Without a label: <FluentSearch @bind-Value=value AriaLabel="Search"/>
 </div>
 <div>
-    <FluentSearch @bind-Value=value Label="With a label" />
+    <FluentSearch @bind-Value=value Label="With a label" AutoComplete="off" />
 </div>
 @code {
     string? value;

--- a/examples/Demo/Shared/Pages/Search/SearchPage.razor
+++ b/examples/Demo/Shared/Pages/Search/SearchPage.razor
@@ -7,7 +7,7 @@
 <h1>Search</h1>
 
 <p>
-    An implementation of a <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input/search" rel="nofollow">search</a> component. 
+    An implementation of a <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input/search" rel="nofollow">search</a> component.
     The <code>&lt;FluentSearch&gt;</code> supports two visual appearances, outline and filled, with the control defaulting to the outline appearance.
 </p>
 <p>
@@ -17,7 +17,11 @@
 
 <h2 id="example">Examples</h2>
 
-<DemoSection Title="Default" Component="@typeof(SearchDefault)"></DemoSection>
+<DemoSection Title="Default" Component="@typeof(SearchDefault)">
+    <Description>
+        <p>The search box with a label has autocomplete turned off explicitly by using the <code>AutoComplete</code> parameter</p>
+    </Description>
+</DemoSection>
 
 <DemoSection Title="Interactive" Component="@typeof(SearchInteractive)"></DemoSection>
 

--- a/src/Core/Components/Search/FluentSearch.razor.cs
+++ b/src/Core/Components/Search/FluentSearch.razor.cs
@@ -63,6 +63,13 @@ public partial class FluentSearch : FluentInputBase<string?>
     public FluentInputAppearance Appearance { get; set; } = FluentInputAppearance.Outline;
 
     /// <summary>
+    /// Specifies whether a form or an input field should have autocomplete "on" or "off" or another value.
+    /// An Id value must be set to use this property.
+    /// </summary>
+    [Parameter]
+    public string? AutoComplete { get; set; }
+
+    /// <summary>
     /// Gets or sets the content to be rendered inside the component.
     /// </summary>
     [Parameter]
@@ -79,11 +86,14 @@ public partial class FluentSearch : FluentInputBase<string?>
 
         if (firstRender)
         {
-            //if (!string.IsNullOrEmpty(Id))
-            //{
             Module ??= await JSRuntime.InvokeAsync<IJSObjectReference>("import", JAVASCRIPT_FILE.FormatCollocatedUrl(LibraryConfiguration));
             await Module.InvokeVoidAsync("addAriaHidden", Id);
-            //}
+
+            if (AutoComplete != null)
+            {
+                Module ??= await JSRuntime.InvokeAsync<IJSObjectReference>("import", JAVASCRIPT_FILE.FormatCollocatedUrl(LibraryConfiguration));
+                await Module.InvokeVoidAsync("setControlAttribute", Id, "autocomplete", AutoComplete);
+            }
         }
     }
 

--- a/src/Core/Components/Search/FluentSearch.razor.cs
+++ b/src/Core/Components/Search/FluentSearch.razor.cs
@@ -63,8 +63,7 @@ public partial class FluentSearch : FluentInputBase<string?>
     public FluentInputAppearance Appearance { get; set; } = FluentInputAppearance.Outline;
 
     /// <summary>
-    /// Specifies whether a form or an input field should have autocomplete "on" or "off" or another value.
-    /// An Id value must be set to use this property.
+    /// Gets or sets whether a form or an input field should have autocomplete "on" or "off" or another value.
     /// </summary>
     [Parameter]
     public string? AutoComplete { get; set; }
@@ -91,7 +90,6 @@ public partial class FluentSearch : FluentInputBase<string?>
 
             if (AutoComplete != null)
             {
-                Module ??= await JSRuntime.InvokeAsync<IJSObjectReference>("import", JAVASCRIPT_FILE.FormatCollocatedUrl(LibraryConfiguration));
                 await Module.InvokeVoidAsync("setControlAttribute", Id, "autocomplete", AutoComplete);
             }
         }

--- a/src/Core/Components/Search/FluentSearch.razor.js
+++ b/src/Core/Components/Search/FluentSearch.razor.js
@@ -5,3 +5,11 @@ export function addAriaHidden(id) {
         fieldElement?.setAttribute("aria-hidden", "true");
     }
 }
+
+export function setControlAttribute(id, attrName, value) {
+    const fieldElement = document.querySelector("#" + id)?.shadowRoot?.querySelector("#control");
+
+    if (!!fieldElement) {
+        fieldElement?.setAttribute(attrName, value);
+    }
+}


### PR DESCRIPTION
Follows the same method as used in TextField. Result:

![search-autocomplete](https://github.com/user-attachments/assets/e7980cea-ad03-43bd-9ffb-0e37acbfde95)

Fix #2394 