### PR TITLE
[SplashScreen] Pass parameters.Modal to `ShowSplashScreen...` methods

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -7020,15 +7020,15 @@
             Gets or sets the content to display. All first HTML elements are included in the items flow.
             </summary>
         </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentOverflowItem.Overflow">
-            <summary>
-            Gets True if this component is out of panel.
-            </summary>
-        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentOverflowItem.Fixed">
             <summary>
             Gets or sets if this item dos not participates in overflow logic.
             Defaults to false
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentOverflowItem.Overflow">
+            <summary>
+            Gets True if this component is out of panel.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentOverflowItem.Text">

--- a/examples/Demo/Shared/Pages/SplashScreen/Examples/CustomSplashScreen.razor
+++ b/examples/Demo/Shared/Pages/SplashScreen/Examples/CustomSplashScreen.razor
@@ -36,8 +36,9 @@
     {
         if (firstRender)
         {
+
             // Simulation of loading process
-            await Task.Delay(7000);
+            await Task.Delay(Content.DisplayTime);
 
             // Close the dialog
             await Dialog.CloseAsync();

--- a/examples/Demo/Shared/Pages/SplashScreen/Examples/DialogSplashScreenCustom.razor.cs
+++ b/examples/Demo/Shared/Pages/SplashScreen/Examples/DialogSplashScreenCustom.razor.cs
@@ -17,6 +17,7 @@ public partial class DialogSplashScreenCustom
                 LoadingText = "Filling the re-useable bottles...",
                 Message = (MarkupString)"Don't drink <strong>too</strong> much water!",
                 Logo = "_content/FluentUI.Demo.Shared/images/Splash_Corporation_logo.png",
+                DisplayTime = 7000
             },
             Width = "500px",
             Height = "300px",
@@ -35,7 +36,7 @@ public partial class DialogSplashScreenCustom
     }
     private void OpenSplashCustom()
     {
-        DemoLogger.WriteLine($"Open custom splashscreen for 7 seconds");
+        DemoLogger.WriteLine($"Open custom splashscreen for 4 seconds");
         DialogParameters<SplashScreenContent> parameters = new()
         {
             Content = new()

--- a/examples/Demo/Shared/Pages/SplashScreen/Examples/DialogSplashScreenDefault.razor.cs
+++ b/examples/Demo/Shared/Pages/SplashScreen/Examples/DialogSplashScreenDefault.razor.cs
@@ -22,6 +22,7 @@ public partial class DialogSplashScreenDefault
                 Logo = FluentSplashScreen.LOGO,
             },
             PreventDismissOnOverlayClick = true,
+            Modal = false,
             Width = "640px",
             Height = "480px",
         };
@@ -57,6 +58,7 @@ public partial class DialogSplashScreenDefault
             },
             Width = "640px",
             Height = "480px",
+            Modal = true,
         };
         DialogService.ShowSplashScreen(this, HandleDefaultSplashAsync, parameters);
     }

--- a/src/Core/Components/Dialog/Services/DialogService-SplashScreen.cs
+++ b/src/Core/Components/Dialog/Services/DialogService-SplashScreen.cs
@@ -36,7 +36,7 @@ public partial class DialogService
         {
             DialogType = DialogType.SplashScreen,
             Alignment = HorizontalAlignment.Center,
-            Modal = true,
+            Modal = parameters.Modal,
             PreventDismissOnOverlayClick = parameters.PreventDismissOnOverlayClick,
             ShowDismiss = false,
             ShowTitle = false,
@@ -101,7 +101,7 @@ public partial class DialogService
         {
             DialogType = DialogType.SplashScreen,
             Alignment = HorizontalAlignment.Center,
-            Modal = false,
+            Modal = parameters.Modal,
             PreventDismissOnOverlayClick = parameters.PreventDismissOnOverlayClick,
             ShowDismiss = false,
             ShowTitle = false,


### PR DESCRIPTION
Fix #2367 by passing through `parameters.Modal`

Also adjust the samples to show these behaviors

