### PR TITLE
[TreeView] Fix the first item never selected

### DIFF
--- a/src/Core/Components/TreeView/FluentTreeItem.razor.cs
+++ b/src/Core/Components/TreeView/FluentTreeItem.razor.cs
@@ -207,7 +207,7 @@ public partial class FluentTreeItem : FluentComponentBase, IDisposable
         {
             int i = 0;
             builder.OpenComponent<FluentTreeItem>(i++);
-            builder.AddAttribute(i++, "Id", item.Id);
+            builder.AddAttribute(i++, "Id", item.Id);            
             builder.AddAttribute(i++, "Items", item.Items);
             builder.AddAttribute(i++, "Text", item.Text);
             builder.AddAttribute(i++, "Selected", owner.SelectedItem == item);
@@ -215,6 +215,7 @@ public partial class FluentTreeItem : FluentComponentBase, IDisposable
             builder.AddAttribute(i++, "Disabled", item.Disabled);
             builder.AddAttribute(i++, "IconCollapsed", item.IconCollapsed);
             builder.AddAttribute(i++, "IconExpanded", item.IconExpanded);
+            builder.SetKey(item.Id);
 
             if (owner.ItemTemplate != null)
             {

--- a/src/Core/Components/TreeView/FluentTreeItem.razor.cs
+++ b/src/Core/Components/TreeView/FluentTreeItem.razor.cs
@@ -207,7 +207,7 @@ public partial class FluentTreeItem : FluentComponentBase, IDisposable
         {
             int i = 0;
             builder.OpenComponent<FluentTreeItem>(i++);
-            builder.AddAttribute(i++, "Id", item.Id);            
+            builder.AddAttribute(i++, "Id", item.Id);
             builder.AddAttribute(i++, "Items", item.Items);
             builder.AddAttribute(i++, "Text", item.Text);
             builder.AddAttribute(i++, "Selected", owner.SelectedItem == item);


### PR DESCRIPTION
# [TreeView] Fix the first item never selected.

In the "unlimited items" example, the first sub-item of an item is never selected.
All other items will update `SelectedItem`, but never the first.

## before
![peek_2](https://github.com/user-attachments/assets/c8e30011-1948-4dd6-a6c8-471ef3838e6b)

## After
![peek_1](https://github.com/user-attachments/assets/e6ab63dd-dba2-44fa-9045-11723c77842a)

## Unit Tests

No change