### PR TITLE
[General] Inject LibraryConfiguring into DesignToken

### DIFF
--- a/src/Core/DesignTokens/DesignToken.razor.cs
+++ b/src/Core/DesignTokens/DesignToken.razor.cs
@@ -51,9 +51,10 @@ public partial class DesignToken<T> : ComponentBase, IDesignToken<T>, IAsyncDisp
     /// <summary>
     /// Constructs an instance of a DesignToken.
     /// </summary>
-    public DesignToken(IJSRuntime jsRuntime)
+    public DesignToken(IJSRuntime jsRuntime, LibraryConfiguration libraryConfiguration)
     {
         JSRuntime = jsRuntime;
+        LibraryConfiguration = libraryConfiguration;
     }
 
     /// <inheritdoc/>

--- a/src/Extensions/DesignToken.Generator/DesignTokenGenerator.cs
+++ b/src/Extensions/DesignToken.Generator/DesignTokenGenerator.cs
@@ -66,7 +66,8 @@ public class DesignTokenGenerator : IIncrementalGenerator
             sb.AppendLine($"\t/// Constructs an instance of the {name} design token");
             sb.AppendLine("\t/// </summary>");
             sb.AppendLine("\t/// <param name=\"jsRuntime\">IJSRuntime reference</param>");
-            sb.AppendLine($"\tpublic {name}(IJSRuntime jsRuntime) : base(jsRuntime)");
+            sb.AppendLine("\t/// <param name=\"libraryConfiguration\">LibraryConfiguration reference</param>");
+            sb.AppendLine($"\tpublic {name}(IJSRuntime jsRuntime, LibraryConfiguration libraryConfiguration) : base(jsRuntime, libraryConfiguration)");
             sb.AppendLine("\t{");
             sb.AppendLine($"\t\tName = Constants.{name};");
             sb.AppendLine("\t}");


### PR DESCRIPTION
# Pull Request

## 📖 Description

This issue occurs exclusively in version 4.9.2, downgrading to 4.9.1 resolves the issue.

When injecting any design token and calling `.SetValue()` with any element reference, the `DesignToken` class fails to inject the registered `LibraryConfiguration` causing an `Object reference not set to an instance of an object`  exception to be thrown inside `UrlFormatterExtensions.cs`.

### 🎫 Issues

Fix for #2425

## 👩‍💻 Reviewer Notes

### Component:

```csharp
@using Microsoft.FluentUI.AspNetCore.Components.DesignTokens

<div class="container">
	<FluentTextField @ref="Test" @bind-Value=Title></FluentTextField>
</div>

@code {
	[Parameter, EditorRequired]
	public string Title { get; set; } = null!;

	FluentTextField Test;

	[Inject]
	private Density _density { get; set; } = default!;

	protected override async Task OnAfterRenderAsync(bool firstRender)
	{
		if (firstRender)
		{
			await _density.SetValueFor(Test.Element, 10);

			StateHasChanged();
		}
	}
}
```

### Startup:

```csharp
    public static class MauiProgram
    {
        public static MauiApp CreateMauiApp()
        {
            var builder = MauiApp.CreateBuilder();
            builder
                .UseMauiApp<App>()
                .ConfigureFonts(fonts =>
                {
                    fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
                });

            builder.Services.AddMauiBlazorWebView();
	    builder.Services.AddHttpClient();
            builder.Services.AddFluentUIComponents();

#if DEBUG
            builder.Services.AddBlazorWebViewDeveloperTools();
            builder.Logging.AddDebug();
#endif

            return builder.Build();
        }
    }
```

## 📑 Test Plan

Utilize the above code to reproduce this issue on version 4.9.2.

Rendering the Component code I outlined above, you should receive an exception on the following line without my change:

`await _density.SetValueFor(Test.Element, 10);`

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [X] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [X] I have modified an existing component
- [ ] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps
