### PR TITLE
[Templates] Replace faulty `Appearance.Filled` with `Appearance.Accent` for buttons

### DIFF
--- a/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/GenerateRecoveryCodes.razor
+++ b/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/GenerateRecoveryCodes.razor
@@ -33,7 +33,7 @@ else
     <div>
         <form @formname="generate-recovery-codes" @onsubmit="OnSubmitAsync" method="post">
             <AntiforgeryToken />
-            <FluentButton Type="ButtonType.Submit" Appearance="Appearance.Filled">Generate Recovery Codes</FluentButton>
+            <FluentButton Type="ButtonType.Submit" Appearance="Appearance.Accent">Generate Recovery Codes</FluentButton>
         </form>
     </div>
 }

--- a/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/ResetAuthenticator.razor
+++ b/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/ResetAuthenticator.razor
@@ -26,7 +26,7 @@
 <div>
     <form @formname="reset-authenticator" @onsubmit="OnSubmitAsync" method="post">
         <AntiforgeryToken />
-        <FluentButton Type="ButtonType.Submit" Appearance="Appearance.Filled">Reset authenticator key</FluentButton>
+        <FluentButton Type="ButtonType.Submit" Appearance="Appearance.Accent">Reset authenticator key</FluentButton>
     </form>
 </div>
 


### PR DESCRIPTION
There were a couple of `FluentButton` occurrences that used a wrong value for Appearance. This PR corrects that