### PR TITLE
[Templates] Fix Template.Client services injection

### DIFF
--- a/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp.Client/Program.cs
+++ b/src/Templates/content/BlazorWeb-CSharp/BlazorWeb-CSharp.Client/Program.cs
@@ -3,8 +3,10 @@ using BlazorWeb_CSharp.Client;
 using Microsoft.AspNetCore.Components.Authorization;
 #endif
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using Microsoft.FluentUI.AspNetCore.Components;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
+builder.Services.AddFluentUIComponents();
 
 #if (IndividualLocalAuth)
 builder.Services.AddAuthorizationCore();


### PR DESCRIPTION
# [Templates] Fix Template.Client services injection

To avoid an error like `Cannot provide a value for property 'LibraryConfiguration'` the services must be included in the Client project.

