### PR TITLE
[FluenWizard] Fix Done button when last step is disabled

### DIFF
--- a/src/Core/Components/Wizard/FluentWizard.razor
+++ b/src/Core/Components/Wizard/FluentWizard.razor
@@ -32,7 +32,7 @@
             {
                 string buttonWidth = "80px;";
 
-                @if (Value > 0)
+                @if (DisplayPreviousButton)
                 {
                     <FluentButton Appearance="Appearance.Neutral"
                                   Style="@($"width: {buttonWidth};")"
@@ -43,7 +43,7 @@
 
                 <span style="margin-right: 10px" />
 
-                @if (Value < _steps.Count - 1)
+                @if (DisplayNextButton)
                 {
                     <FluentButton Appearance="Appearance.Accent"
                                   Style="@($"width: {buttonWidth};")"

--- a/src/Core/Components/Wizard/FluentWizard.razor.cs
+++ b/src/Core/Components/Wizard/FluentWizard.razor.cs
@@ -192,7 +192,7 @@ public partial class FluentWizard : FluentComponentBase
     /// <summary />
     protected virtual async Task<FluentWizardStepChangeEventArgs> OnStepChangeHandlerAsync(int targetIndex, bool validateEditContexts)
     {
-        var stepChangeArgs = new FluentWizardStepChangeEventArgs(targetIndex, _steps[targetIndex].Label);               
+        var stepChangeArgs = new FluentWizardStepChangeEventArgs(targetIndex, _steps[targetIndex].Label);
 
         if (validateEditContexts)
         {
@@ -341,4 +341,8 @@ public partial class FluentWizard : FluentComponentBase
 
         return null;
     }
+
+    private bool DisplayPreviousButton => Value > 0 && _steps[..Value].Any(i => !i.Disabled);
+
+    private bool DisplayNextButton => Value < _steps.Count - 1 && _steps[(Value + 1)..].Any(i => !i.Disabled);
 }

--- a/tests/Core/Wizard/FluentWizardTests.razor
+++ b/tests/Core/Wizard/FluentWizardTests.razor
@@ -477,6 +477,34 @@
         Assert.Equal(indexFirstItem, currentIndex);
     }
 
+    [Theory]
+    [InlineData(true, true, true, 2)]
+    [InlineData(true, true, false, 1)]
+    [InlineData(true, false, false, 0)]
+    [InlineData(false, false, false, 0)]
+    public void FluentWizard_LastDisableSteps(bool firstEnabled, bool secondEnabled, bool thirdEnabled, int nbClicks)
+    {
+        // Arrange
+        var cut = Render(@<FluentWizard>
+        <Steps>
+            <FluentWizardStep Disabled="@(!firstEnabled)" />
+            <FluentWizardStep Disabled="@(!secondEnabled)" />
+            <FluentWizardStep Disabled="@(!thirdEnabled)" />
+        </Steps>
+    </FluentWizard>
+    );
+
+        // Act: Click
+        for (int i = 0; i < nbClicks; i++)
+        {
+            var buttonNext = cut.Find("fluent-button[appearance='accent']");
+            buttonNext.Click();
+        }
+
+        // Assert
+        Assert.Contains("Done", cut.Markup);
+    }
+
     private record TestRecord
     {
         [Range(1, 10)]


### PR DESCRIPTION
# [FluenWizard] Fix Done button when last step is disabled

If the last step is disabled, the component could continue to display this step.
The display of the [Done] button has been revised to show only if there is at least one Enabled step afterwards.

Fix #2497

## Unit Tests

Added