### PR TITLE
[DragContainer] Add an event "onDragEnd"

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -3902,6 +3902,11 @@
             This event is fired when the user starts dragging an element.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDragContainer`1.OnDragEnd">
+            <summary>
+            This event is fired when the drag operation ends (such as releasing a mouse button or hitting the Esc key).
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDragContainer`1.OnDragEnter">
             <summary>
             This event is fired when a dragged element enters a valid drop target.
@@ -3986,6 +3991,11 @@
             This event is fired when the user starts dragging an element.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDropZone`1.OnDragEnd">
+            <summary>
+            This event is fired when the drag operation ends (such as releasing a mouse button or hitting the Esc key).
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDropZone`1.OnDragEnter">
             <summary>
             This event is fired when a dragged element enters a valid drop target.
@@ -4010,6 +4020,9 @@
             <summary />
         </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDropZone`1.OnDragStartHandler(Microsoft.AspNetCore.Components.Web.DragEventArgs)">
+            <summary />
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDropZone`1.OnDragEndHandler(Microsoft.AspNetCore.Components.Web.DragEventArgs)">
             <summary />
         </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDropZone`1.OnDragEnterHandler(Microsoft.AspNetCore.Components.Web.DragEventArgs)">

--- a/examples/Demo/Shared/Pages/Drag/Examples/DragDropBasic.razor
+++ b/examples/Demo/Shared/Pages/Drag/Examples/DragDropBasic.razor
@@ -1,4 +1,5 @@
-<FluentDragContainer TItem="string"
+﻿<FluentDragContainer TItem="string"
+                     OnDragEnd="@(e => DemoLogger.WriteLine($"{e.Source.Id} drag ended"))"
                      OnDragEnter="@(e => DemoLogger.WriteLine($"{e.Source.Id} is entered in  {e.Target.Id}"))"
                      OnDragLeave="@(e => DemoLogger.WriteLine($"{e.Source.Id} has left {e.Target.Id}"))"
                      OnDropEnd="@(e => DemoLogger.WriteLine($"{e.Source.Id} dropped in {e.Target.Id}"))">

--- a/src/Core/Components/Drag/FluentDragContainer.razor.cs
+++ b/src/Core/Components/Drag/FluentDragContainer.razor.cs
@@ -29,6 +29,12 @@ public partial class FluentDragContainer<TItem> : FluentComponentBase
     public Action<FluentDragEventArgs<TItem>>? OnDragStart { get; set; }
 
     /// <summary>
+    /// This event is fired when the drag operation ends (such as releasing a mouse button or hitting the Esc key).
+    /// </summary>
+    [Parameter]
+    public Action<FluentDragEventArgs<TItem>>? OnDragEnd { get; set; }
+
+    /// <summary>
     /// This event is fired when a dragged element enters a valid drop target.
     /// </summary>
     [Parameter]

--- a/src/Core/Components/Drag/FluentDropZone.razor
+++ b/src/Core/Components/Drag/FluentDropZone.razor
@@ -1,4 +1,4 @@
-@namespace Microsoft.FluentUI.AspNetCore.Components
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 @inherits FluentComponentBase
 
 @typeparam TItem
@@ -14,6 +14,7 @@
      @ondragenter:preventDefault="@Droppable"
      @ondragleave=@OnDragLeaveHandler
      @ondragleave:preventDefault="@Droppable"
+     @ondragend=@OnDragEndHandler
      @ondrop=@OnDropHandler @ondrop:preventDefault>
     @ChildContent
 </div>

--- a/src/Core/Components/Drag/FluentDropZone.razor.cs
+++ b/src/Core/Components/Drag/FluentDropZone.razor.cs
@@ -53,6 +53,12 @@ public partial class FluentDropZone<TItem> : FluentComponentBase
     public Action<FluentDragEventArgs<TItem>>? OnDragStart { get; set; }
 
     /// <summary>
+    /// This event is fired when the drag operation ends (such as releasing a mouse button or hitting the Esc key).
+    /// </summary>
+    [Parameter]
+    public Action<FluentDragEventArgs<TItem>>? OnDragEnd { get; set; }
+
+    /// <summary>
     /// This event is fired when a dragged element enters a valid drop target.
     /// </summary>
     [Parameter]
@@ -97,6 +103,25 @@ public partial class FluentDropZone<TItem> : FluentComponentBase
         if (Container.OnDragStart != null)
         {
             Container.OnDragStart(new FluentDragEventArgs<TItem>(this, this));
+        }
+    }
+
+    /// <summary />
+    private void OnDragEndHandler(DragEventArgs e)
+    {
+        if (!Draggable)
+        {
+            return;
+        }
+
+        if (OnDragEnd != null)
+        {
+            OnDragEnd(new FluentDragEventArgs<TItem>(this, this));
+        }
+
+        if (Container.OnDragEnd != null)
+        {
+            Container.OnDragEnd(new FluentDragEventArgs<TItem>(this, this));
         }
     }
 

--- a/tests/Core/Drag/FluentDragTests.cs
+++ b/tests/Core/Drag/FluentDragTests.cs
@@ -15,6 +15,7 @@ public class FluentDragTests : TestBase
         var cut = ctx.RenderComponent<FluentDragContainer<int>>(parameters =>
         {
             parameters.Add(p => p.OnDragStart, (e) => { });
+            parameters.Add(p => p.OnDragEnd, (e) => { });
             parameters.Add(p => p.OnDragEnter, (e) => { });
             parameters.Add(p => p.OnDragOver, (e) => { });
             parameters.Add(p => p.OnDragLeave, (e) => { });
@@ -27,6 +28,7 @@ public class FluentDragTests : TestBase
                 zone.AddChildContent("Item 1");
 
                 zone.Add(p => p.OnDragStart, (e) => { });
+                zone.Add(p => p.OnDragEnd, (e) => { });
                 zone.Add(p => p.OnDragEnter, (e) => { });
                 zone.Add(p => p.OnDragOver, (e) => { });
                 zone.Add(p => p.OnDragLeave, (e) => { });
@@ -40,6 +42,7 @@ public class FluentDragTests : TestBase
                 zone.AddChildContent("Item 2");
 
                 zone.Add(p => p.OnDragStart, (e) => { });
+                zone.Add(p => p.OnDragEnd, (e) => { });
                 zone.Add(p => p.OnDragEnter, (e) => { });
                 zone.Add(p => p.OnDragOver, (e) => { });
                 zone.Add(p => p.OnDragLeave, (e) => { });


### PR DESCRIPTION
# [DragContainer] Add an event "onDragEnd"

In order to respond to certain situations, such as the possibility of detecting that the user has dropped an item outside the processing zone, we have added the `OnDragEnd` event. This event matches the [dragend event ](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/dragend_event) of the HTML Drag and Drop API

![peek_2](https://github.com/user-attachments/assets/b3c3cb62-39f8-4878-a5b4-a0ad2b76ab72)

See #2494