### PR TITLE
[ComponentBase] Add unit tests to validate use of all default attributes (Id, Class, Style, AdditionalAttributes)

### DIFF
--- a/src/Core/Components/Base/FluentComponentBase.cs
+++ b/src/Core/Components/Base/FluentComponentBase.cs
@@ -41,7 +41,7 @@ public abstract class FluentComponentBase : ComponentBase
     {
         if (_jsModule is null)
         {
-            _jsModule = await JSRuntime.InvokeAsync<IJSObjectReference>("import", file);  // .FormatCollocatedUrl(LibraryConfiguration)
+            _jsModule = await JSRuntime.InvokeAsync<IJSObjectReference>("import", file);  // TO ADD: .FormatCollocatedUrl(LibraryConfiguration)
         }
 
         return _jsModule;

--- a/src/Core/Components/Layout/FluentLayout.razor
+++ b/src/Core/Components/Layout/FluentLayout.razor
@@ -2,7 +2,7 @@
 @inherits FluentComponentBase
 
 <CascadingValue Value="this" IsFixed="true">
-    <div id="@Id" class="@ClassValue" style="@Style" global-scrollbar="@GlobalScrollbar">
+    <div id="@Id" class="@ClassValue" style="@Style" @attributes="AdditionalAttributes" global-scrollbar="@GlobalScrollbar">
         @ChildContent
     </div>
 </CascadingValue>

--- a/tests/Core/Components/Base/ComponentBaseTests.cs
+++ b/tests/Core/Components/Base/ComponentBaseTests.cs
@@ -3,6 +3,8 @@
 // ------------------------------------------------------------------------
 
 using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
@@ -28,11 +30,24 @@ public class ComponentBaseTests : TestContext
         { typeof(FluentIcon<>), type => type.MakeGenericType(typeof(Samples.Icons.Samples.Info)) }
     };
 
-    [Fact]
-    public void ComponentBase_Id()
+    /// <summary>
+    /// Test to verify that all FluentUI components implement the default properties (Id, Class, Style)
+    /// from <see cref="FluentComponentBase"/>.
+    ///
+    /// ⚠️ DO NOT CHANGE THE FOLLOWING TEST.
+    /// </summary>
+    /// <param name="propName">Blazor Component property name</param>
+    /// <param name="htmlName">HTML attribute name</param>
+    /// <param name="value">Value</param>
+    [Theory]
+    [InlineData("Id", "id", "My-Specific-ID")]
+    [InlineData("Class", "class", "My-Specific-Class")]
+    [InlineData("Style", "style", "My-Specific-Style")]
+    [InlineData("extra-attribute", "extra-attribute", "My-Specific-Attribute")]  // AdditionalAttributes
+    public void ComponentBase_DefaultProperties(string propName, string? htmlName, string value)
     {
-        using var ctx = new TestContext();
-        
+        var errors = new StringBuilder();
+
         foreach (var componentType in GetFluentComponents())
         {
             // Convert to generic type if needed
@@ -43,20 +58,33 @@ public class ComponentBaseTests : TestContext
             }
 
             // Arrange and Act
-            var renderedComponent = ctx.RenderComponent<DynamicComponent>(parameters =>
+            var renderedComponent = RenderComponent<DynamicComponent>(parameters =>
             {
                 parameters.Add(p => p.Type, type);
                 parameters.Add(p => p.Parameters, new Dictionary<string, object>
                 {
-                    { "Id", "My-Specific-ID" }
+                    { propName, value }
                 });
             });
 
             // Assert
-            Assert.True(renderedComponent.Markup.Contains("My-Specific-ID", StringComparison.Ordinal), $"{componentType.Name} does not implement the 'Id' property.");
+            var pattern = @$"\b{htmlName}\s*=\s*[""'][^""']*\b{value}\b[^""']*[""']";
+            var isMatch = Regex.IsMatch(renderedComponent.Markup, pattern);
+
+            if (!isMatch)
+            {
+                var error = $"\"{componentType.Name}\" does not use the \"{propName}\" property/attribute (missing HTML attribute {htmlName}=\"{value}\").";
+                errors.AppendLine(error);
+            }
         }
+
+        Assert.True(errors.Length == 0, errors.ToString());
     }
 
+    /// <summary>
+    /// Returns all FluentUI components, which inherit from <see cref="FluentComponentBase"/>.
+    /// </summary>
+    /// <returns></returns>
     private IEnumerable<Type> GetFluentComponents()
     {
         var componentBaseType = typeof(FluentComponentBase);

--- a/tests/Core/Components/Base/ComponentBaseTests.cs
+++ b/tests/Core/Components/Base/ComponentBaseTests.cs
@@ -1,0 +1,68 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using System.Reflection;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.FluentUI.AspNetCore.Components;
+using Xunit;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Tests.Components.Base;
+
+public class ComponentBaseTests : TestContext
+{
+    /// <summary>
+    /// List of components to exclude from the test.
+    /// </summary>
+    private static readonly Type[] Excluded = new[]
+    {
+        typeof(AspNetCore.Components._Imports)
+    };
+
+    /// <summary>
+    /// List of customized actions to initialize the component with a specific type.
+    /// </summary>
+    private static readonly Dictionary<Type, Func<Type, Type>> ComponentInitializer = new()
+    {
+        { typeof(FluentIcon<>), type => type.MakeGenericType(typeof(Samples.Icons.Samples.Info)) }
+    };
+
+    [Fact]
+    public void ComponentBase_Id()
+    {
+        using var ctx = new TestContext();
+        
+        foreach (var componentType in GetFluentComponents())
+        {
+            // Convert to generic type if needed
+            var type = componentType;
+            if (ComponentInitializer.ContainsKey(componentType))
+            {
+                type = ComponentInitializer[componentType](componentType);
+            }
+
+            // Arrange and Act
+            var renderedComponent = ctx.RenderComponent<DynamicComponent>(parameters =>
+            {
+                parameters.Add(p => p.Type, type);
+                parameters.Add(p => p.Parameters, new Dictionary<string, object>
+                {
+                    { "Id", "My-Specific-ID" }
+                });
+            });
+
+            // Assert
+            Assert.True(renderedComponent.Markup.Contains("My-Specific-ID", StringComparison.Ordinal), $"{componentType.Name} does not implement the 'Id' property.");
+        }
+    }
+
+    private IEnumerable<Type> GetFluentComponents()
+    {
+        var componentBaseType = typeof(FluentComponentBase);
+        var assembly = typeof(AspNetCore.Components._Imports).Assembly;
+
+        return assembly.GetTypes()
+                       .Where(t => componentBaseType.IsAssignableFrom(t) && !t.IsAbstract && !Excluded.Contains(t));
+    }
+}

--- a/tests/Core/Components/Button/FluentButtonTests.razor
+++ b/tests/Core/Components/Button/FluentButtonTests.razor
@@ -1,6 +1,6 @@
-﻿@using Microsoft.FluentUI.AspNetCore.Components.Tests.Extensions
-@using Microsoft.FluentUI.AspNetCore.Components.Utilities
+﻿@using Microsoft.FluentUI.AspNetCore.Components.Utilities
 @using Xunit;
+@using Microsoft.FluentUI.AspNetCore.Components.Tests.Samples;
 @inherits TestContext
 @code
 {
@@ -256,7 +256,7 @@
     public void FluentButton_IconStart()
     {
         // Arrange && Act
-        var cut = Render(@<FluentButton IconStart="@SampleIcons.Info">My button</FluentButton>);
+        var cut = Render(@<FluentButton IconStart="@Samples.Icons.Info">My button</FluentButton>);
 
         // Assert
         cut.Verify();
@@ -266,7 +266,7 @@
     public void FluentButton_IconEnd()
     {
         // Arrange && Act
-        var cut = Render(@<FluentButton IconEnd="@SampleIcons.Info">My button</FluentButton>);
+        var cut = Render(@<FluentButton IconEnd="@Samples.Icons.Info">My button</FluentButton>);
 
         // Assert
         cut.Verify();
@@ -276,7 +276,7 @@
     public void FluentButton_IconStartNoContent()
     {
         // Arrange && Act
-        var cut = Render(@<FluentButton IconStart="@SampleIcons.Info" />);
+        var cut = Render(@<FluentButton IconStart="@Samples.Icons.Info" />);
 
         // Assert
         cut.Verify();
@@ -286,7 +286,7 @@
     public void FluentButton_IconEndNoContent()
     {
         // Arrange && Act
-        var cut = Render(@<FluentButton IconEnd="@SampleIcons.Info" />);
+        var cut = Render(@<FluentButton IconEnd="@Samples.Icons.Info" />);
 
         // Assert
         cut.Verify();
@@ -377,7 +377,7 @@
     public void FluentButton_Loading_IconStart()
     {
         // Arrange && Act
-        var cut = Render(@<FluentButton Loading="true" IconStart="@SampleIcons.Info">My button</FluentButton>);
+        var cut = Render(@<FluentButton Loading="true" IconStart="@Samples.Icons.Info">My button</FluentButton>);
 
         // Assert
         cut.Verify();
@@ -387,7 +387,7 @@
     public void FluentButton_Loading_IconEnd()
     {
         // Arrange && Act
-        var cut = Render(@<FluentButton Loading="true" IconEnd="@SampleIcons.Info">My button</FluentButton>);
+        var cut = Render(@<FluentButton Loading="true" IconEnd="@Samples.Icons.Info">My button</FluentButton>);
 
         // Assert
         cut.Verify();

--- a/tests/Core/Components/Icons/FluentIconTests.razor
+++ b/tests/Core/Components/Icons/FluentIconTests.razor
@@ -1,5 +1,5 @@
-﻿@using Microsoft.FluentUI.AspNetCore.Components.Tests.Extensions
-@using Xunit;
+﻿@using Xunit;
+@using Microsoft.FluentUI.AspNetCore.Components.Tests.Samples;
 @inherits TestContext
 
 @code
@@ -13,7 +13,7 @@
     public void FluentIcon_Default()
     {
         // Arrange & Act
-        var icon = new SampleIcons.Samples.Info();
+        var icon = new Icons.Samples.Info();
         var cut = Render(@<FluentIcon Value="@icon" />);
 
         // Assert
@@ -24,7 +24,7 @@
     public void FluentIcon_Type()
     {
         // Arrange & Act
-        var cut = Render(@<FluentIcon Icon="SampleIcons.Samples.Info" />);
+        var cut = Render(@<FluentIcon Icon="Icons.Samples.Info" />);
 
         // Assert
         cut.Verify();
@@ -34,8 +34,8 @@
     public void FluentIcon_Icon()
     {
         // Arrange & Act
-        var cut = Render(@<FluentIcon Icon="SampleIcons.Samples.Info" />);
-        var icon = cut.FindComponent<FluentIcon<SampleIcons.Samples.Info>>();
+        var cut = Render(@<FluentIcon Icon="Icons.Samples.Info" />);
+        var icon = cut.FindComponent<FluentIcon<Icons.Samples.Info>>();
 
         // Assert
         Assert.Contains("data:image/svg+xml;base64,PHN2ZyB4bWxucz0", icon.Instance.Value.ToDataUri());
@@ -45,7 +45,7 @@
     public void FluentIcon_SlotTitle()
     {
         // Arrange & Act
-        var icon = new SampleIcons.Samples.Info();
+        var icon = new Icons.Samples.Info();
         var cut = Render(@<FluentIcon Value="@icon" Slot="start" Title="My title" />);
 
         // Assert
@@ -56,7 +56,7 @@
     public void FluentIcon_Color()
     {
         // Arrange & Act
-        var icon = new SampleIcons.Samples.Info();
+        var icon = new Icons.Samples.Info();
         var cut = Render(@<FluentIcon Value="@icon" Color="Color.Info" />);
 
         // Assert
@@ -67,7 +67,7 @@
     public void FluentIcon_Type_Color()
     {
         // Arrange & Act
-        var cut = Render(@<FluentIcon Icon="SampleIcons.Samples.Info" Color="Color.Info" />);
+        var cut = Render(@<FluentIcon Icon="Icons.Samples.Info" Color="Color.Info" />);
 
         // Assert
         cut.Verify();
@@ -77,7 +77,7 @@
     public void FluentIcon_CustomColor()
     {
         // Arrange & Act
-        var icon = new SampleIcons.Samples.Info();
+        var icon = new Icons.Samples.Info();
         var cut = Render(@<FluentIcon Value="@icon" Color="Color.Custom" CustomColor="#ff0000" />);
 
         // Assert
@@ -90,7 +90,7 @@
         Assert.Throws<ArgumentException>(() =>
         {
             // Arrange & Act
-            var icon = new SampleIcons.Samples.Info();
+            var icon = new Icons.Samples.Info();
             var cut = Render(@<FluentIcon Value="@icon" CustomColor="#ff0000" />);
 
             // Assert an exception because Color=Color.Custom is required
@@ -101,7 +101,7 @@
     public void FluentIcon_Width()
     {
         // Arrange & Act
-        var icon = new SampleIcons.Samples.Info();
+        var icon = new Icons.Samples.Info();
         var cut = Render(@<FluentIcon Value="@icon" Width="100px" />);
 
         // Assert
@@ -112,7 +112,7 @@
     public void FluentIcon_Width_EmptyString()
     {
         // Arrange & Act
-        var icon = new SampleIcons.Samples.Info();
+        var icon = new Icons.Samples.Info();
         var cut = Render(@<FluentIcon Value="@icon" Width="" />);
 
         // Assert
@@ -125,7 +125,7 @@
         var isClicked = false;
 
         // Arrange
-        var icon = new SampleIcons.Samples.Info();
+        var icon = new Icons.Samples.Info();
         var cut = Render(@<FluentIcon Value="@icon" OnClick="@(e => isClicked = true)" />);
 
         // Act
@@ -141,7 +141,7 @@
         var isClicked = false;
 
         // Arrange
-        var icon = new SampleIcons.Samples.Info();
+        var icon = new Icons.Samples.Info();
         var cut = Render(@<FluentIcon Value="@icon" />);
 
         // Act
@@ -161,7 +161,7 @@
         var isClicked = false;
 
         // Arrange
-        var icon = new SampleIcons.Samples.Info();
+        var icon = new Icons.Samples.Info();
         var cut = Render(@<FluentIcon Value="@icon" OnClick="@(e => isClicked = true)" />);
 
         // Act
@@ -206,7 +206,7 @@
     public void FluentIcon_Icon_WithColorRed()
     {
         // Arrange & Act
-        var icon = new SampleIcons.Samples.Info();
+        var icon = new Icons.Samples.Info();
         var cut = Render(@<FluentIcon Value="@(icon.WithColor("red"))" />);
 
         // Assert
@@ -217,7 +217,7 @@
     public void FluentIcon_Icon_WithCustomColorRed()
     {
         // Arrange & Act
-        var icon = new SampleIcons.Samples.Info();
+        var icon = new Icons.Samples.Info();
         var cut = Render(@<FluentIcon Value="@(icon.WithColor("red"))" Color="Color.Custom" />);
 
         // Assert
@@ -230,7 +230,7 @@
     public void FluentIcon_Icon_WithColorRed_OverriddenByColor()
     {
         // Arrange & Act
-        var icon = new SampleIcons.Samples.Info();
+        var icon = new Icons.Samples.Info();
         var cut = Render(@<FluentIcon Value="@(icon.WithColor("red"))" Color="Color.Info" />);
 
         // Assert
@@ -241,7 +241,7 @@
     public void FluentIcon_Icon_WithColorSuccess()
     {
         // Arrange & Act
-        var icon = new SampleIcons.Samples.Info();
+        var icon = new Icons.Samples.Info();
         var cut = Render(@<FluentIcon Value="@(icon.WithColor(Color.Success))" />);
 
         // Assert
@@ -252,7 +252,7 @@
     public void FluentIcon_Icon_ToMarkup()
     {
         // Arrange & Act
-        var icon = new SampleIcons.Samples.Info();
+        var icon = new Icons.Samples.Info();
         var cut = Render(@<div>@icon.ToMarkup()</div>);
 
         // Assert
@@ -263,7 +263,7 @@
     public void FluentIcon_Icon_ToMarkupSize()
     {
         // Arrange & Act
-        var icon = new SampleIcons.Samples.Info();
+        var icon = new Icons.Samples.Info();
         var cut = Render(@<div>@icon.ToMarkup(size: "100px")</div>);
 
         // Assert
@@ -274,7 +274,7 @@
     public void FluentIcon_Icon_ToMarkupColor()
     {
         // Arrange & Act
-        var icon = new SampleIcons.Samples.Info();
+        var icon = new Icons.Samples.Info();
         var cut = Render(@<div>@icon.ToMarkup(color: "blue")</div>);
 
         // Assert
@@ -285,7 +285,7 @@
     public void FluentIcon_Icon_ToMarkupCustomIcon()
     {
         // Arrange & Act
-        var icon = new SampleIcons.Samples.MyCircle();
+        var icon = new Icons.Samples.MyCircle();
         var cut = Render(@<div>@icon.ToMarkup()</div>);
 
         // Assert
@@ -296,7 +296,7 @@
     public void FluentIcon_Icon_ToMarkupCustomIcon_SizeColor()
     {
         // Arrange & Act
-        var icon = new SampleIcons.Samples.MyCircle();
+        var icon = new Icons.Samples.MyCircle();
         var cut = Render(@<div>@icon.ToMarkup(size: "20px", color: "blue")</div>);
 
         // Assert
@@ -309,7 +309,7 @@
     public void FluentIcon_InverseColor(bool accentContainer, string? expectedResult)
     {
         // Arrange
-        var icon = new SampleIcons.Samples.Info();
+        var icon = new Icons.Samples.Info();
 
         // Act
         icon.InverseColor(accentContainer);
@@ -322,7 +322,7 @@
     public void FluentIcon_Icon_ToDataUri()
     {
         // Arrange & Act
-        var icon = new SampleIcons.Samples.Info();
+        var icon = new Icons.Samples.Info();
 
         // Assert
         Assert.StartsWith("data:image/svg+xml;base64,PHN2ZyB4bWxucz0", icon.ToDataUri());
@@ -332,7 +332,7 @@
     public void FluentIcon_Icon_FromType()
     {
         // Arrange & Act
-        var icon = Icon.FromType<SampleIcons.Samples.Info>();
+        var icon = Icon.FromType<Icons.Samples.Info>();
 
         // Assert
         Assert.StartsWith("data:image/svg+xml;base64,PHN2ZyB4bWxucz0", icon.ToDataUri());
@@ -352,7 +352,7 @@
     public void FluentIcon_AdditionalAttributes()
     {
         // Arrange & Act
-        var icon = new SampleIcons.Samples.Info();
+        var icon = new Icons.Samples.Info();
         var cut = Render(@<FluentIcon Value="@icon" extra="My-Extra-Attribute" />);
 
         // Assert
@@ -363,12 +363,12 @@
     public void FluentIcon_Data()
     {
         // Arrange
-        var icon = new SampleIcons.Samples.Info();
+        var icon = new Icons.Samples.Info();
         var myData = "MyData";
         var cut = Render(@<FluentIcon Value="@icon" Data="@myData" />);
 
         // Assert
-        var component = cut.FindComponent<FluentIcon<SampleIcons.Samples.Info>>();
+        var component = cut.FindComponent<FluentIcon<Icons.Samples.Info>>();
         Assert.Equal("MyData", component.Instance.Data);
     }
 }

--- a/tests/Core/Samples/Icons.cs
+++ b/tests/Core/Samples/Icons.cs
@@ -2,9 +2,9 @@
 // MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
 // ------------------------------------------------------------------------
 
-namespace Microsoft.FluentUI.AspNetCore.Components.Tests.Extensions;
+namespace Microsoft.FluentUI.AspNetCore.Components.Tests.Samples;
 
-public static class SampleIcons
+public static class Icons
 {
     public static readonly Icon Info = new Samples.Info();
 


### PR DESCRIPTION
# [ComponentBase] Add unit tests to validate use of all default attributes (Id, Class, Style, AdditionalAttributes)

A global test will verify that all components that inherits from `FluentComponentBase` correctly implement the `Id`, `Class`, `Style` and `AdditionalAttributes` properties.

If not, the following message will be raised.

```
"FluentButton" does not use the "Id" property/attribute (missing HTML attribute id="My-Specific-ID").
```
