### PR TITLE
[DataGrid] Fix resizing to initial column widths issue

### DIFF
--- a/src/Core/Components/DataGrid/FluentDataGrid.razor
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor
@@ -18,6 +18,7 @@
         <ColumnsCollectedNotifier TGridItem="TGridItem" />
 
         <fluent-data-grid @ref=_gridReference
+                          id="@Id"
                           no-tabbing=@NoTabbing
                           generate-header="none"
                           grid-template-columns=@_internalGridTemplateColumns

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -280,6 +280,7 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(DataGridRowFocusEventArgs))]
     public FluentDataGrid()
     {
+        Id = Identifier.NewId();
         _columns = [];
         _internalGridContext = new(this);
         _currentPageItemsChanged = new(EventCallback.Factory.Create<PaginationState>(this, RefreshDataCoreAsync));

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.js
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.js
@@ -1,4 +1,4 @@
-var initialColumnsWidths = '';
+let initialColumnsWidths = {};
 var latestGridElement = null;
 
 export function init(gridElement) {
@@ -7,7 +7,7 @@ export function init(gridElement) {
     };
 
     if (gridElement.querySelectorAll('.column-header.resizable').length > 0) {
-        initialColumnsWidths = gridElement.gridTemplateColumns;
+        initialColumnsWidths[gridElement.id] = gridElement.gridTemplateColumns ;
         enableColumnResizing(gridElement);
     }
 
@@ -158,8 +158,8 @@ export function enableColumnResizing(gridElement) {
 }
 
 export function resetColumnWidths(gridElement) {
-    
-    gridElement.gridTemplateColumns = initialColumnsWidths;
+
+    gridElement.gridTemplateColumns = initialColumnsWidths[gridElement.id];
 }
 
 export function resizeColumnDiscrete(gridElement, column, change) {
@@ -231,7 +231,7 @@ export function autoFitGridColumns(gridElement, columnCount) {
     gridElement.setAttribute("grid-template-columns", gridTemplateColumns);
     gridElement.classList.remove("auto-fit");
 
-    initialColumnsWidths = gridTemplateColumns;
+    initialColumnsWidths[gridElement.id] = gridTemplateColumns;
 }
 
 export function resizeColumnExact(gridElement, column, width) {

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.js
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.js
@@ -63,6 +63,7 @@ export function init(gridElement) {
             document.body.removeEventListener('click', bodyClickHandler);
             document.body.removeEventListener('mousedown', bodyClickHandler);
             document.body.removeEventListener('keydown', keyDownHandler);
+            delete initialColumnsWidths[gridElement.id];
         }
     };
 }


### PR DESCRIPTION
Fix #2517 

Previously, we were not storing the initialColumnsWidth value for each DataGrid. With this PR that is changed.

As we only pass a simple `ElementReference` from C# to JS, we don't have any object uniquely identifying each grid. This is solved by setting the `Id` parameter in the `FluentDataGrid` constructor (and rendering it in the `fluent-data-grid` tag which was _not_ being done yet!). The `Id` is then used as the key for the 'dictionary' on the JS side.
