### PR TITLE
[DatePicker] Added OnDoubleClick event and DoubleClickToToday parameter.

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -2667,6 +2667,12 @@
             Gets the identifier of the year in the format yyyy.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDatePicker.LibraryConfiguration">
+            <summary />
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDatePicker.JSRuntime">
+            <summary />
+        </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDatePicker.#ctor">
             <summary />
         </member>
@@ -2691,6 +2697,16 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDatePicker.PickerMonthChanged">
             <summary>
             Fired when the display month changes.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDatePicker.OnDoubleClick">
+            <summary>
+            Command executed when the user double-clicks on the date picker.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDatePicker.DoubleClickToToday">
+            <summary>
+            Gets or sets a value indicating whether today's date is set when double-clicking on the text field of date picker.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentTimePicker.StyleValue">

--- a/src/Core/Components/DateTime/FluentDatePicker.razor
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor
@@ -11,6 +11,7 @@
                  Appearance="@Appearance"
                  @bind-Value="@CurrentValueAsString"
                  @onclick="@OnCalendarOpenHandlerAsync"
+                 @ondblclick="@OnDoubleClickHandlerAsync"
                  ReadOnly="@ReadOnly"
                  Disabled="@Disabled"
                  Required="@Required"
@@ -22,8 +23,8 @@
 
 @if (Opened)
 {
-    <FluentOverlay @bind-Visible="@Opened" Dismissable="true" FullScreen="true" />
     <FluentAnchoredRegion Anchor="@Id"
+                          Id="@CalendarId"
                           HorizontalDefaultPosition="@(System.Globalization.CultureInfo.CurrentUICulture.TextInfo.IsRightToLeft ? HorizontalPosition.Left : HorizontalPosition.Right)"
                           HorizontalInset="true"
                           VerticalDefaultPosition="@VerticalPosition.Unset"

--- a/src/Core/Components/DateTime/FluentDatePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor.cs
@@ -1,12 +1,27 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.FluentUI.AspNetCore.Components.Extensions;
 using Microsoft.FluentUI.AspNetCore.Components.Utilities;
+using Microsoft.JSInterop;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
-public partial class FluentDatePicker : FluentCalendarBase
+public partial class FluentDatePicker : FluentCalendarBase, IAsyncDisposable
 {
+    private const string JAVASCRIPT_FILE = "./_content/Microsoft.FluentUI.AspNetCore.Components/Components/DateTime/FluentDatePicker.razor.js";
+    private string CalendarId => $"{Id}_Calendar";
+    private IJSObjectReference _jsModule = default!;
+    private DotNetObjectReference<FluentDatePicker>? _dotNetHelper = null;
+
+    /// <summary />
+    [Inject]
+    private LibraryConfiguration LibraryConfiguration { get; set; } = default!;
+
+    /// <summary />
+    [Inject]
+    private IJSRuntime JSRuntime { get; set; } = default!;
+
     public static string CalendarIcon = "<svg slot=\"end\" width=\"20\" height=\"20\" viewBox=\"0 0 24 24\" fill=\"var(--neutral-fill-strong-focus)\" xmlns=\"http://www.w3.org/2000/svg\"><path d=\"M17.75 3C19.55 3 21 4.46 21 6.25v11.5c0 1.8-1.46 3.25-3.25 3.25H6.25A3.25 3.25 0 013 17.75V6.25C3 4.45 4.46 3 6.25 3h11.5zm1.75 5.5h-15v9.25c0 .97.78 1.75 1.75 1.75h11.5c.97 0 1.75-.78 1.75-1.75V8.5zm-11.75 6a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zm4.25 0a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zm-4.25-4a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zm4.25 0a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zm4.25 0a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zm1.5-6H6.25c-.97 0-1.75.78-1.75 1.75V7h15v-.75c0-.97-.78-1.75-1.75-1.75z\"/>";
 
     /// <summary />
@@ -50,7 +65,28 @@ public partial class FluentDatePicker : FluentCalendarBase
     [Parameter]
     public virtual EventCallback<DateTime> PickerMonthChanged { get; set; }
 
+    /// <summary>
+    /// Command executed when the user double-clicks on the date picker.
+    /// </summary>
+    [Parameter]
+    public EventCallback<MouseEventArgs> OnDoubleClick { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether today's date is set when double-clicking on the text field of date picker.
+    /// </summary>
+    [Parameter]
+    public bool DoubleClickToToday { get; set; }
+
     public bool Opened { get; set; } = false;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _jsModule = await JSRuntime.InvokeAsync<IJSObjectReference>("import", JAVASCRIPT_FILE.FormatCollocatedUrl(LibraryConfiguration));
+            _dotNetHelper = DotNetObjectReference.Create(this);
+        }
+    }
 
     protected override string? FormatValueAsString(DateTime? value)
     {
@@ -62,19 +98,26 @@ public partial class FluentDatePicker : FluentCalendarBase
         }, Culture);
     }
 
-    protected Task OnCalendarOpenHandlerAsync(MouseEventArgs e)
+    protected async Task OnCalendarOpenHandlerAsync(MouseEventArgs e)
     {
         if (!ReadOnly)
         {
             Opened = !Opened;
 
+            if (Opened)
+            {
+                await _jsModule.InvokeVoidAsync("addEventListenerToCheckExternalClick", _dotNetHelper, Id, CalendarId);
+            }
+            else
+            {
+                await _jsModule.InvokeVoidAsync("removeEventListenerToCheckExternalClick");
+            }
+
             if (OnCalendarOpen.HasDelegate)
             {
-                return OnCalendarOpen.InvokeAsync(Opened);
+                await  OnCalendarOpen.InvokeAsync(Opened);
             }
         }
-
-        return Task.CompletedTask;
     }
 
     protected async Task OnSelectedDateAsync(DateTime? value)
@@ -88,7 +131,24 @@ public partial class FluentDatePicker : FluentCalendarBase
             : value;
         }
         Opened = false;
+        await _jsModule.InvokeVoidAsync("removeEventListenerToCheckExternalClick");
         await OnSelectedDateHandlerAsync(updatedValue);
+    }
+
+    protected async Task OnDoubleClickHandlerAsync(MouseEventArgs e)
+    {
+        if (!ReadOnly)
+        {
+            if (DoubleClickToToday)
+            {
+                await OnSelectedDateAsync(DateTime.Today);
+            }
+
+            if (OnDoubleClick.HasDelegate)
+            {
+                await OnDoubleClick.InvokeAsync(e);
+            }
+        }
     }
 
     protected override bool TryParseValueFromString(string? value, out DateTime? result, [NotNullWhen(false)] out string? validationErrorMessage)
@@ -111,4 +171,30 @@ public partial class FluentDatePicker : FluentCalendarBase
             CalendarViews.Months => Culture.DateTimeFormat.YearMonthPattern,
             _ => Culture.DateTimeFormat.ShortDatePattern
         };
+
+    [JSInvokable]
+    public async Task CloseCalendarFromExternalClickAsync()
+    {
+        await OnCalendarOpenHandlerAsync(new MouseEventArgs());
+        StateHasChanged();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            if (_jsModule is not null)
+            {
+                await _jsModule.DisposeAsync();
+            }
+
+            _dotNetHelper?.Dispose();
+        }
+        catch (Exception ex) when (ex is JSDisconnectedException ||
+                                   ex is OperationCanceledException)
+        {
+            // The JSRuntime side may routinely be gone already if the reason we're disposing is that
+            // the client disconnected. This is not an error.
+        }
+    }
 }

--- a/src/Core/Components/DateTime/FluentDatePicker.razor.js
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor.js
@@ -1,0 +1,45 @@
+let eventName = 'mousedown';
+let closeCalendarFromExternalClickFunctionName = 'CloseCalendarFromExternalClickAsync';
+let mouseDownEventHandler = null;
+
+export function addEventListenerToCheckExternalClick(dotNetHelper, datePickerTextFieldId, calenderId) {
+    if (mouseDownEventHandler) {
+        return;
+    }
+
+    let isOnCalendar = function (element, id) {
+        while (element) {
+            if (element.id === id) {
+                return true;
+            }
+
+            element = element.parentElement;
+        }
+
+        return false;
+    }
+
+    mouseDownEventHandler = function (event) {
+        if (event.target.id === datePickerTextFieldId || isOnCalendar(event.target, calenderId)) {
+            return;
+        };
+
+        try {
+            // setTimeout: https://github.com/dotnet/aspnetcore/issues/26809
+            setTimeout(() => {
+                dotNetHelper.invokeMethodAsync(closeCalendarFromExternalClickFunctionName);
+            }, 0);
+        } catch (error) {
+            console.error(`FluentDatePicker: failing to call ${closeCalendarFromExternalClickFunctionName}.`, error);
+        }
+    }
+
+    document.addEventListener(eventName, mouseDownEventHandler);
+ }
+
+export function removeEventListenerToCheckExternalClick() {
+    if (mouseDownEventHandler) {
+        document.removeEventListener(eventName, mouseDownEventHandler);
+        mouseDownEventHandler = null;
+    }
+}

--- a/tests/Core/DateTime/FluentDatePickerTests.cs
+++ b/tests/Core/DateTime/FluentDatePickerTests.cs
@@ -225,4 +225,38 @@ public class FluentDatePickerTests : TestBase
         // Assert
         Assert.Equal(System.DateTime.Parse("2022-03-12"), picker.Instance.Value);
     }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void FluentDatePicker_DoubleClickToSetTodayInTextField(bool doubleClickToToday)
+    {
+        // Arrange
+        using var ctx = new TestContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+        ctx.Services.AddSingleton(LibraryConfiguration);
+
+        // Act
+        var picker = ctx.RenderComponent<FluentDatePicker>(parameters =>
+        {
+            parameters.Add(p => p.DoubleClickToToday, doubleClickToToday);
+        });
+
+        var textField = picker.Find("fluent-text-field");
+
+        // Double-Click
+        textField.DoubleClick();
+
+        // Assert
+        Assert.False(picker.Instance.Opened);
+
+        if (doubleClickToToday)
+        {
+            Assert.Equal(System.DateTime.Today, picker.Instance.Value);
+        }
+        else
+        {
+            Assert.Null(picker.Instance.Value);
+        }
+    }
 }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

1. Added `OnDoubleClick` event to DatePicker component.
2. Added `DoubleClickToToday` parameter to DatePicker component.
2.1 When `DoubleClickToToday` is `true`,  today's date is set to the date picker after a user double-clicks on the text field of the date picker.
3. Refactored the way how calendar is closed when clicking on the outside of the date picker.
    1. Currently there's an overlay over the text field which is used to close the calendar when a user clicks outside of the date picker. This leads to two issues:
        1. It's difficult to trigger double-click event on the text field because one click is taken by the overlay?
        2. It makes switching to other components by mouse click not smoothly. I click on date picker and calendar shows, then I click another component but the focus doesn't switch to that component because the click is taken by the overlay to close the calendar.
    2. I tried solving this issue by removing the overlay and leveraging the JavaScript mousedown event on document element to close calendar when clicking on outside of the date picker.

### 🎫 Issues

The PR was related to the discussion #2524 How can I extend FluentDatePicker to support double-click event on its text field?

## 👩‍💻 Reviewer Notes
3 functionalities to test:
1. The `OnDoubleClick` event should work.
2. The `DoubleClickToToday` parameter should work.
3. When the calendar of date picker is open, click elsewhere of the date picker should close the calendar, meanwhile the element on which the mouse clicks should get focus.

## 📑 Test Plan

Only DatePicker needs to be tested, it should not affect other components.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

No follow-up work to this PR.