### PR TITLE
[DatePicker] Added OnDoubleClick event and DoubleClickToDate parameter

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -2698,9 +2698,9 @@
             Command executed when the user double-clicks on the date picker.
             </summary>
         </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDatePicker.DoubleClickToToday">
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDatePicker.DoubleClickToDate">
             <summary>
-            Gets or sets a value indicating whether today's date is set when double-clicking on the text field of date picker.
+            Gets or sets a value which will be set when double-clicking on the text field of date picker.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentTimePicker.StyleValue">

--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -2693,6 +2693,16 @@
             Fired when the display month changes.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDatePicker.OnDoubleClick">
+            <summary>
+            Command executed when the user double-clicks on the date picker.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDatePicker.DoubleClickToToday">
+            <summary>
+            Gets or sets a value indicating whether today's date is set when double-clicking on the text field of date picker.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentTimePicker.StyleValue">
             <summary />
         </member>

--- a/examples/Demo/Shared/Pages/DateTimes/Examples/DatePickerDefault.razor
+++ b/examples/Demo/Shared/Pages/DateTimes/Examples/DatePickerDefault.razor
@@ -1,19 +1,26 @@
-﻿<div style="display: flex; flex-direction:row;  ">
-    <div style="margin-right: 10px;">
+﻿<p>
+    <FluentCheckbox Label="Double-click the text field to set Today's date" @bind-value="@DoubleClickToToday" />
+</p>
+<div style="display: flex; flex-direction:row; gap:10px; ">
+    <div>
         <FluentDatePicker Label="Meeting date" @bind-Value="@SelectedValue" ReadOnly />
     </div>
-    <div style="margin-right: 10px;">
-        <FluentDatePicker Label="Days view" AriaLabel="To" @bind-Value="@SelectedValue" />
-    </div>
-    <div style="margin-right: 10px;">
-        <FluentDatePicker Label="Months view" AriaLabel="To" @bind-Value="@SelectedValue" View="CalendarViews.Months" />
+    <div>
+        <FluentDatePicker Label="Days view" AriaLabel="To" @bind-Value="@SelectedValue" DoubleClickToToday="@DoubleClickToToday" />
     </div>
     <div>
-        <FluentDatePicker Label="Years view" AriaLabel="To" @bind-Value="@SelectedValue" View="CalendarViews.Years" />
+        <FluentDatePicker Label="Months view" AriaLabel="To" @bind-Value="@SelectedValue" View="CalendarViews.Months" DoubleClickToToday="@DoubleClickToToday" />
+    </div>
+    <div>
+        <FluentDatePicker Label="Years view" AriaLabel="To" @bind-Value="@SelectedValue" View="CalendarViews.Years" DoubleClickToToday="@DoubleClickToToday" />
     </div>
 </div>
-<p>Selected Date: @(SelectedValue?.ToString("yyyy-MM-dd"))</p>
+<p>
+    Selected Date: @(SelectedValue?.ToString("yyyy-MM-dd"))
+</p>
+
 @code
 {
     private DateTime? SelectedValue = DateTime.Today.AddDays(-2);
+    private bool DoubleClickToToday;
 }

--- a/examples/Demo/Shared/Pages/DateTimes/Examples/DatePickerDefault.razor
+++ b/examples/Demo/Shared/Pages/DateTimes/Examples/DatePickerDefault.razor
@@ -6,13 +6,13 @@
         <FluentDatePicker Label="Meeting date" @bind-Value="@SelectedValue" ReadOnly />
     </div>
     <div>
-        <FluentDatePicker Label="Days view" AriaLabel="To" @bind-Value="@SelectedValue" DoubleClickToToday="@DoubleClickToToday" />
+        <FluentDatePicker Label="Days view" AriaLabel="To" @bind-Value="@SelectedValue" DoubleClickToDate="@DoubleClickToDate" />
     </div>
     <div>
-        <FluentDatePicker Label="Months view" AriaLabel="To" @bind-Value="@SelectedValue" View="CalendarViews.Months" DoubleClickToToday="@DoubleClickToToday" />
+        <FluentDatePicker Label="Months view" AriaLabel="To" @bind-Value="@SelectedValue" View="CalendarViews.Months" DoubleClickToDate="@DoubleClickToDate" />
     </div>
     <div>
-        <FluentDatePicker Label="Years view" AriaLabel="To" @bind-Value="@SelectedValue" View="CalendarViews.Years" DoubleClickToToday="@DoubleClickToToday" />
+        <FluentDatePicker Label="Years view" AriaLabel="To" @bind-Value="@SelectedValue" View="CalendarViews.Years" DoubleClickToDate="@DoubleClickToDate" />
     </div>
 </div>
 <p>
@@ -22,5 +22,11 @@
 @code
 {
     private DateTime? SelectedValue = DateTime.Today.AddDays(-2);
-    private bool DoubleClickToToday;
+    private DateTime? DoubleClickToDate = null;
+
+    private bool DoubleClickToToday
+    {
+        get => DoubleClickToDate.HasValue;
+        set => DoubleClickToDate = value ? DateTime.Today : null;
+    }
 }

--- a/src/Core/Components/DateTime/FluentDatePicker.razor
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor
@@ -11,6 +11,7 @@
                  Appearance="@Appearance"
                  @bind-Value="@CurrentValueAsString"
                  @onclick="@OnCalendarOpenHandlerAsync"
+                 @ondblclick="@OnDoubleClickHandlerAsync"
                  ReadOnly="@ReadOnly"
                  Disabled="@Disabled"
                  Required="@Required"

--- a/src/Core/Components/DateTime/FluentDatePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor.cs
@@ -50,6 +50,18 @@ public partial class FluentDatePicker : FluentCalendarBase
     [Parameter]
     public virtual EventCallback<DateTime> PickerMonthChanged { get; set; }
 
+    /// <summary>
+    /// Command executed when the user double-clicks on the date picker.
+    /// </summary>
+    [Parameter]
+    public EventCallback<MouseEventArgs> OnDoubleClick { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether today's date is set when double-clicking on the text field of date picker.
+    /// </summary>
+    [Parameter]
+    public bool DoubleClickToToday { get; set; }
+
     public bool Opened { get; set; } = false;
 
     protected override string? FormatValueAsString(DateTime? value)
@@ -89,6 +101,22 @@ public partial class FluentDatePicker : FluentCalendarBase
         }
         Opened = false;
         await OnSelectedDateHandlerAsync(updatedValue);
+    }
+
+    protected async Task OnDoubleClickHandlerAsync(MouseEventArgs e)
+    {
+        if (!ReadOnly)
+        {
+            if (DoubleClickToToday)
+            {
+                await OnSelectedDateAsync(DateTime.Today);
+            }
+
+            if (OnDoubleClick.HasDelegate)
+            {
+                await OnDoubleClick.InvokeAsync(e);
+            }
+        }
     }
 
     protected override bool TryParseValueFromString(string? value, out DateTime? result, [NotNullWhen(false)] out string? validationErrorMessage)

--- a/src/Core/Components/DateTime/FluentDatePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor.cs
@@ -57,10 +57,10 @@ public partial class FluentDatePicker : FluentCalendarBase
     public EventCallback<MouseEventArgs> OnDoubleClick { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether today's date is set when double-clicking on the text field of date picker.
+    /// Gets or sets a value which will be set when double-clicking on the text field of date picker.
     /// </summary>
     [Parameter]
-    public bool DoubleClickToToday { get; set; }
+    public DateTime? DoubleClickToDate { get; set; }
 
     public bool Opened { get; set; } = false;
 
@@ -107,9 +107,9 @@ public partial class FluentDatePicker : FluentCalendarBase
     {
         if (!ReadOnly)
         {
-            if (DoubleClickToToday)
+            if (DoubleClickToDate.HasValue)
             {
-                await OnSelectedDateAsync(DateTime.Today);
+                await OnSelectedDateAsync(DoubleClickToDate.Value);
             }
 
             if (OnDoubleClick.HasDelegate)

--- a/tests/Core/DateTime/FluentDatePickerTests.cs
+++ b/tests/Core/DateTime/FluentDatePickerTests.cs
@@ -225,4 +225,38 @@ public class FluentDatePickerTests : TestBase
         // Assert
         Assert.Equal(System.DateTime.Parse("2022-03-12"), picker.Instance.Value);
     }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void FluentDatePicker_DoubleClickToSetTodayInTextField(bool doubleClickToToday)
+    {
+        // Arrange
+        using var ctx = new TestContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+        ctx.Services.AddSingleton(LibraryConfiguration);
+
+        // Act
+        var picker = ctx.RenderComponent<FluentDatePicker>(parameters =>
+        {
+            parameters.Add(p => p.DoubleClickToToday, doubleClickToToday);
+        });
+
+        var textField = picker.Find("fluent-text-field");
+
+        // Double-Click
+        textField.DoubleClick();
+
+        // Assert
+        Assert.False(picker.Instance.Opened);
+
+        if (doubleClickToToday)
+        {
+            Assert.Equal(System.DateTime.Today, picker.Instance.Value);
+        }
+        else
+        {
+            Assert.Null(picker.Instance.Value);
+        }
+    }
 }

--- a/tests/Core/DateTime/FluentDatePickerTests.cs
+++ b/tests/Core/DateTime/FluentDatePickerTests.cs
@@ -227,19 +227,20 @@ public class FluentDatePickerTests : TestBase
     }
 
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void FluentDatePicker_DoubleClickToSetTodayInTextField(bool doubleClickToToday)
+    [InlineData(null)]
+    [InlineData("2024-06-05")]
+    public void FluentDatePicker_DoubleClickToSetDateInTextField(string plainDateTime)
     {
         // Arrange
         using var ctx = new TestContext();
         ctx.JSInterop.Mode = JSRuntimeMode.Loose;
         ctx.Services.AddSingleton(LibraryConfiguration);
+        System.DateTime? dt = string.IsNullOrEmpty(plainDateTime) ? null : System.DateTime.Parse(plainDateTime);
 
         // Act
         var picker = ctx.RenderComponent<FluentDatePicker>(parameters =>
         {
-            parameters.Add(p => p.DoubleClickToToday, doubleClickToToday);
+            parameters.Add(p => p.DoubleClickToDate, dt);
         });
 
         var textField = picker.Find("fluent-text-field");
@@ -250,13 +251,39 @@ public class FluentDatePickerTests : TestBase
         // Assert
         Assert.False(picker.Instance.Opened);
 
-        if (doubleClickToToday)
+        if (dt.HasValue)
         {
-            Assert.Equal(System.DateTime.Today, picker.Instance.Value);
+            Assert.Equal(dt.Value, picker.Instance.Value);
         }
         else
         {
             Assert.Null(picker.Instance.Value);
         }
+    }
+
+    [Fact]
+    public void FluentDatePicker_OnDoubleClickEventTriggers()
+    {
+        // Arrange
+        using var ctx = new TestContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+        ctx.Services.AddSingleton(LibraryConfiguration);
+        var expected = "EventWorks";
+
+        // Act
+        var actual = string.Empty;
+
+        var picker = ctx.RenderComponent<FluentDatePicker>(parameters =>
+        {
+            parameters.Add(p => p.OnDoubleClick, e => actual = expected);
+        });
+
+        var textField = picker.Find("fluent-text-field");
+
+        // Double-Click
+        textField.DoubleClick();
+
+        // Assert
+        Assert.Equal(expected, actual);
     }
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

1. Added `OnDoubleClick` event to DatePicker component.
2. Added `DoubleClickToDate` parameter to DatePicker component.
3. Updated DatePickerDefault page in demo site to add `DoubleClickToDate` option

### 🎫 Issues

The PR was related to
1. The discussion #2524 How can I extend FluentDatePicker to support double-click event on its text field?
2. The PR #2563 [DatePicker] Added OnDoubleClick event and DoubleClickToToday parameter.

## 👩‍💻 Reviewer Notes

This is the first PR of the 2 separated PRs asked by @dvoituron which implemented the `DoubleClickToDate` feature only.

## 📑 Test Plan

This PR kept the `FluentOverlay` as-is, so it's very difficult to trigger the double-click event on the text field of the date picker, thus difficult to see this feature works. Commenting out the `FluentOverlay` temporarily could help a lot during the manual tests.

However, the `FluentOverlay` has no side-effect when running the test method `FluentDatePicker_DoubleClickToSetTodayInTextField`, so it runs successfully. I think that's a sample of the cases that automatic tests are not exactly the same as manual tests.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

I'll move the rest "`FluentOverlay` replacement" part of the original PR #2563 to a new PR.

