### PR TITLE
[Dialog] Fix regression, see #2542 for details

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -3333,6 +3333,11 @@
             outside the dialog. Defaults to false.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.DialogParameters.Visible">
+            <summary>
+            Gets or sets if a dialog is visible or nt (Hidden)
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.DialogParameters.PreventScroll">
             <summary>
             Prevents scrolling outside of the dialog while it is shown.

--- a/src/Core/Components/Dialog/FluentDialog.razor.cs
+++ b/src/Core/Components/Dialog/FluentDialog.razor.cs
@@ -165,6 +165,7 @@ public partial class FluentDialog : FluentComponentBase
     public void Show()
     {
         Hidden = false;
+        Instance.Parameters.Visible = true;
         RefreshHeaderFooter();
     }
 
@@ -174,7 +175,8 @@ public partial class FluentDialog : FluentComponentBase
     public void Hide()
     {
         Hidden = true;
-        RefreshHeaderFooter();
+        Instance.Parameters.Visible = false;
+        //RefreshHeaderFooter();
     }
 
     /// <summary>

--- a/src/Core/Components/Dialog/FluentDialogProvider.razor
+++ b/src/Core/Components/Dialog/FluentDialogProvider.razor
@@ -14,7 +14,10 @@
     {
         @foreach (DialogReference dialog in _internalDialogContext.References)
         {
-            <FluentDialog @key="@dialog.GetKey()" Id="@dialog.Id" Instance="@dialog.Instance" Data="@dialog.Instance.Content" @ondialogdismiss=OnDismissAsync />
+            if (dialog.Instance.Parameters.Visible)
+            {
+                <FluentDialog @key="@dialog.GetKey()" Id="@dialog.Id" Instance="@dialog.Instance" Data="@dialog.Instance.Content" @ondialogdismiss=OnDismissAsync />
+            }
         }
     }
 }

--- a/src/Core/Components/Dialog/Parameters/DialogParameters.cs
+++ b/src/Core/Components/Dialog/Parameters/DialogParameters.cs
@@ -31,6 +31,11 @@ public class DialogParameters : ComponentParameters, IDialogParameters
     public bool PreventDismissOnOverlayClick { get; set; } = false;
 
     /// <summary>
+    /// Gets or sets if a dialog is visible or not (Hidden)
+    /// </summary>
+    public bool Visible { get; set; } = true;
+
+    /// <summary>
     /// Prevents scrolling outside of the dialog while it is shown.
     /// </summary>to use
     public bool PreventScroll { get; set; } = true;
@@ -87,7 +92,7 @@ public class DialogParameters : ComponentParameters, IDialogParameters
     /// <summary>
     /// Gets or sets the height of the dialog. Must be a valid CSS height value like "600px" or "3em"
     /// Only used if Alignment is set to "HorizontalAlignment.Center"
-    /// </summary>  
+    /// </summary>
     public string? Height { get; set; }
 
     /// <summary>
@@ -121,7 +126,7 @@ public class DialogParameters : ComponentParameters, IDialogParameters
     internal bool ShowPrimaryAction => !string.IsNullOrEmpty(PrimaryAction);
 
     /// <summary>
-    /// Gets whether the secondary button is displayed or not. Depends on SecondaryAction having a value. 
+    /// Gets whether the secondary button is displayed or not. Depends on SecondaryAction having a value.
     /// </summary>
     internal bool ShowSecondaryAction => !string.IsNullOrEmpty(SecondaryAction);
 

--- a/src/Core/Components/Dialog/Parameters/IDialogParameters.cs
+++ b/src/Core/Components/Dialog/Parameters/IDialogParameters.cs
@@ -25,6 +25,7 @@ public interface IDialogParameters
     DialogType DialogType { get; set; }
     bool PreventScroll { get; set; }
     bool PreventDismissOnOverlayClick { get; set; }
+    bool Visible { get; set; }
     EventCallback<DialogResult> OnDialogResult { get; set; }
     EventCallback<DialogInstance> OnDialogClosing { get; set; }
     EventCallback<DialogInstance> OnDialogOpened { get; set; }

--- a/src/Core/Components/Dialog/Services/DialogReference.cs
+++ b/src/Core/Components/Dialog/Services/DialogReference.cs
@@ -14,7 +14,7 @@ public class DialogReference : IDialogReference
 
     public DialogInstance Instance { get; set; } = default!;
 
-    internal string GetKey() => $"{Instance.Parameters?.GetHashCode() ?? 0}_{Instance.Content?.GetHashCode() ?? 0}";
+    internal string GetKey() => $"{Instance.Parameters?.GetHashCode() ?? 0}";
 
     public string Id { get; }
 

--- a/src/Core/Components/Dialog/Services/DialogReference.cs
+++ b/src/Core/Components/Dialog/Services/DialogReference.cs
@@ -14,7 +14,7 @@ public class DialogReference : IDialogReference
 
     public DialogInstance Instance { get; set; } = default!;
 
-    internal string GetKey() => $"{Instance.Parameters?.GetHashCode() ?? 0}";
+    internal string GetKey() => $"{Instance.Parameters?.GetHashCode() ?? 0}_{Instance.Content?.GetHashCode() ?? 0}";
 
     public string Id { get; }
 


### PR DESCRIPTION
Fix #2542 by

- Adding `Visible` (bool, default = true) to IDialogParameters and DialogParameters
- Set its value in `FluentDialog` Show()/Hide() methods
- In provider, only process dialogreferences where Instance.Parameters.Visible is true

I verified with the following code the the original solution provided with #2310 still works (and tests still pass):

```
@page "/issue-tester"
@using FluentUI.Demo.Shared.Pages.Dialog.Examples
@inject IDialogService DialogService

<FluentButton Appearance="Appearance.Accent" @onclick="OpenDialogAsync">Open Dialog</FluentButton>

@code {
   

    public SimplePerson simplePerson = new() { Firstname = "Jane", Lastname = "Doe", Age = 30 };

    private async Task OpenDialogAsync()
    {
        DialogParameters<SimplePerson> parameters = new()
            {
                Title = $"Hello {simplePerson.Firstname}",
                PrimaryAction = "Yes",
                PrimaryActionEnabled = false,
                SecondaryAction = "No",
                Width = "500px",
                TrapFocus = true,
                Modal = true,
                PreventScroll = true
            };

        IDialogReference dialog = await DialogService.ShowDialogAsync<SimpleDialog>(simplePerson, parameters);

        await Task.Delay(1000);

        // Let's change some params and data in the dialog
        parameters.Title = "Changed title";
        parameters.PrimaryAction = "Oh yes";
        parameters.Content = new() { Firstname = "John", Lastname = "Brown", Age = 50 };

        await DialogService.UpdateDialogAsync<SimplePerson>(dialog.Id, parameters); // nothing changes in the dialog
    }
}

```

![fix-issue-#2542](https://github.com/user-attachments/assets/e2a454ab-b7d5-43c9-8bcb-65f3f1e55dc2)

