### PR TITLE
[Javascript Caching] Do not add version number to lib.module.js file

### DIFF
--- a/src/Core/DesignTokens/DesignToken.razor.cs
+++ b/src/Core/DesignTokens/DesignToken.razor.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
-using Microsoft.FluentUI.AspNetCore.Components.Extensions;
 using Microsoft.JSInterop;
 
 namespace Microsoft.FluentUI.AspNetCore.Components.DesignTokens;
@@ -74,7 +73,7 @@ public partial class DesignToken<T> : ComponentBase, IDesignToken<T>, IAsyncDisp
 
     private async Task InitJSReferenceAsync()
     {
-        _jsModule ??= await JSRuntime.InvokeAsync<IJSObjectReference>("import", JAVASCRIPT_FILE.FormatCollocatedUrl(LibraryConfiguration));
+        _jsModule ??= await JSRuntime.InvokeAsync<IJSObjectReference>("import", JAVASCRIPT_FILE);
     }
 
 #pragma warning disable VSTHRD200 // Use "Async" suffix for async methods


### PR DESCRIPTION
Because then it will be included twice and that does funky stuff. Like causing issue #2546

Fix #2546 