### PR TITLE
[dev-v5] Update Unit Tests Framework

### DIFF
--- a/.github/workflows/build-core-lib.yml
+++ b/.github/workflows/build-core-lib.yml
@@ -128,7 +128,7 @@ jobs:
      - name: Report Generator
        uses: danielpalme/ReportGenerator-GitHub-Action@5.2.4
        with:
-         reports: '**/coverage.net8.0.cobertura.xml;**/coverage.net9.0.cobertura.xml'
+         reports: '**/coverage.cobertura.xml;**/coverage.net8.0.cobertura.xml;**/coverage.net9.0.cobertura.xml'
          targetdir: 'CoverageReports'
          title: 'Unit Tests Code Coverage'
          classfilters: '-Microsoft.FluentUI.AspNetCore.Components.DesignTokens.*'

--- a/examples/Tools/FluentUI.Demo.DocViewer.Tests/FluentUI.Demo.DocViewer.Tests.csproj
+++ b/examples/Tools/FluentUI.Demo.DocViewer.Tests/FluentUI.Demo.DocViewer.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/examples/Tools/FluentUI.Demo.DocViewer.Tests/_StartCodeCoverage.cmd
+++ b/examples/Tools/FluentUI.Demo.DocViewer.Tests/_StartCodeCoverage.cmd
@@ -1,0 +1,23 @@
+echo off
+
+REM 0. Include the NuGet Package "coverlet.msbuild" in the UnitTests project.
+REM 1. Install tools:
+REM     $:\> dotnet tool install --global coverlet.console --version 3.2.0
+REM     $:\> dotnet tool install --global dotnet-reportgenerator-globaltool --version 5.3.7
+REM    
+REM     Use this command to list existing installed tools:
+REM     $:\> dotnet tool list --global
+REM
+REM 2. Start a code coverage in the UnitTests project:
+REM     $:\> dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura
+REM 
+REM 3. Display the Coverage Report:
+REM     $:\> reportgenerator "-reports:coverage.cobertura.xml" "-targetdir:C:\Temp\FluentUI\Coverage" -reporttypes:HtmlInline_AzurePipelines
+REM     $:\> explorer C:\Temp\Coverage\index.html
+
+echo on
+cls
+
+dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura
+reportgenerator "-reports:coverage.cobertura.xml" "-targetdir:C:\Temp\FluentUI\Coverage-DocViewer" -reporttypes:HtmlInline_AzurePipelines riskHotspotsAnalysisThresholds:metricThresholdForCrapScore=30 riskHotspotsAnalysisThresholds:metricThresholdForCyclomaticComplexity=30
+start "" "C:\Temp\FluentUI\Coverage-DocViewer\index.htm"

--- a/tests/Core/Microsoft.FluentUI.AspNetCore.Components.Tests.csproj
+++ b/tests/Core/Microsoft.FluentUI.AspNetCore.Components.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
# [dev-v5] Update Unit Tests Framework

Use only `net9` for Unit Tests to avoid multiplication of "same" tests.

![image](https://github.com/user-attachments/assets/394e13ed-28d2-4a33-8110-0f623cdc56f5)
