### PR TITLE
[Anchor] Fix hypertext appearance with icon in start/end slot

### DIFF
--- a/examples/Demo/Shared/Pages/Anchor/Examples/AnchorIcons.razor
+++ b/examples/Demo/Shared/Pages/Anchor/Examples/AnchorIcons.razor
@@ -1,4 +1,5 @@
-﻿<div style="display: flex; align-items: center; gap: 10px; margin-bottom: 1em;">
+﻿<h4>Neutral appearane</h4>
+<div style="display: flex; align-items: center; gap: 10px; margin-bottom: 1em;">
     <FluentAnchor Href="#" IconStart="@(new Icons.Regular.Size16.Globe())">
         With icon at start
     </FluentAnchor>
@@ -7,14 +8,27 @@
         With icon at end
     </FluentAnchor>
 </div>
+<h4>Hypertext appearane</h4>
+<div style="display: flex; align-items: center; gap: 10px; margin-bottom: 1em;">
+    <FluentAnchor Appearance="@Appearance.Hypertext" Href="#" IconStart="@(new Icons.Regular.Size16.Globe())">
+        With icon at start
+    </FluentAnchor>
+
+    <FluentAnchor Appearance="@Appearance.Hypertext" Href="#" IconEnd="@(new Icons.Regular.Size16.Globe())">
+        With icon at end
+    </FluentAnchor>
+</div>
 
 <p>With icon in the content. By doing it this way, it is possible to specify <code>Color</code> for the icon.</p>
 <FluentAnchor Href="#">
-        With icon in content
-    <FluentIcon Value="@(new Icons.Regular.Size32.Globe())" Color="@Color.Accent" Slot="end" />
-    </FluentAnchor>
+    With icon in content
+    <FluentIcon Value="@(new Icons.Regular.Size32.Globe())" Color="@Color.Success" Slot="end" />
+</FluentAnchor>
 
-
+<FluentAnchor Appearance="@Appearance.Hypertext"  Href="#">
+    With icon in content
+    <FluentIcon Value="@(new Icons.Regular.Size32.Globe())" Color="@Color.Success" Slot="end" />
+</FluentAnchor>
 
 <div style="display: flex; align-items: center; gap: 10px; margin-top: 1em;">
     With icon in default slot:

--- a/src/Core/Components/Anchor/FluentAnchor.razor.css
+++ b/src/Core/Components/Anchor/FluentAnchor.razor.css
@@ -1,0 +1,11 @@
+fluent-anchor[appearance="hypertext"]::part(control) {
+    display: inline-flex !important;
+}
+
+fluent-anchor[appearance="hypertext"]::part(start) {
+    margin-inline-end: calc(var(--design-unit) * 1px);
+}
+
+fluent-anchor[appearance="hypertext"]::part(end) {
+    margin-inline-start: calc(var(--design-unit) * 1px);
+}


### PR DESCRIPTION
When using the `Appearance=Appearance.Hypertext` style, an icon in end or start slot would get displayed incorrectly:

![image](https://github.com/user-attachments/assets/7b1f22b6-1fbd-49b9-824a-4ec15f520868)

Adding some CSS to fix that for this specific case and make it look better. We are not changing anything on the current design for any of the other appearances

```
fluent-anchor[appearance="hypertext"]::part(control) {
    display: inline-flex !important;
}

fluent-anchor[appearance="hypertext"]::part(start) {
    margin-inline-end: calc(var(--design-unit) * 1px);
}

fluent-anchor[appearance="hypertext"]::part(end) {
    margin-inline-start: calc(var(--design-unit) * 1px);
}

```
and you'll get this:

![image](https://github.com/user-attachments/assets/24963604-e117-4e00-9aa2-733678e6e70c)


Fixes #2611 
