### PR TITLE
[Docs] Add MarkupString to DemoSearch

### DIFF
--- a/examples/Demo/Shared/Shared/DemoSearch.razor
+++ b/examples/Demo/Shared/Shared/DemoSearch.razor
@@ -14,6 +14,6 @@
         <span slot="start">
             <FluentIcon Value="@(context.Icon)" Class="search-result-icon" Color="Color.Neutral" Slot="start"/>
         </span>
-        @context.Title
+        @((MarkupString)@context.Title)
     </OptionTemplate>
 </FluentAutocomplete>


### PR DESCRIPTION
# Pull Request

## 📖 Description

Fixes displaying of HTML as title in the DemoSearch component within the docs.

Before:
![grafik](https://github.com/user-attachments/assets/93769bf4-76a2-4e7e-b4d6-54e12dbf2e7d)

After:
![grafik](https://github.com/user-attachments/assets/bc691cbf-3f3c-4776-8be1-73df9ee4d8d0)



## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.


