### PR TITLE
[ProfileMenu] Fix the `TopCorner` style

### DIFF
--- a/examples/Demo/Shared/Pages/ProfileMenu/ProfileMenuPage.razor
+++ b/examples/Demo/Shared/Pages/ProfileMenu/ProfileMenuPage.razor
@@ -6,6 +6,22 @@
 
 <h1>ProfileMenu</h1>
 
+<FluentLayout>
+    <FluentHeader Style="height: 48px; background: var(--neutral-layer-4); color: var(--neutral-foreground-rest);">
+        <FluentSpacer />
+        <FluentProfileMenu Image="@(new Icons.Regular.Size48.Person().ToDataUri())"
+                           TopCorner="true">
+            <HeaderTemplate>
+                    <FluentButton Appearance="@Appearance.Accent">Sign In</FluentButton>
+            </HeaderTemplate>
+            <ChildContent>
+            </ChildContent>
+            <FooterTemplate>
+            </FooterTemplate>
+        </FluentProfileMenu>
+    </FluentHeader>
+</FluentLayout>
+
 <p>
     A "User Profile Menu" is a component commonly found on websites or applications.
     It typically appears in the top-right corner of a web page and provides options related to

--- a/examples/Demo/Shared/Pages/ProfileMenu/ProfileMenuPage.razor
+++ b/examples/Demo/Shared/Pages/ProfileMenu/ProfileMenuPage.razor
@@ -6,22 +6,6 @@
 
 <h1>ProfileMenu</h1>
 
-<FluentLayout>
-    <FluentHeader Style="height: 48px; background: var(--neutral-layer-4); color: var(--neutral-foreground-rest);">
-        <FluentSpacer />
-        <FluentProfileMenu Image="@(new Icons.Regular.Size48.Person().ToDataUri())"
-                           TopCorner="true">
-            <HeaderTemplate>
-                    <FluentButton Appearance="@Appearance.Accent">Sign In</FluentButton>
-            </HeaderTemplate>
-            <ChildContent>
-            </ChildContent>
-            <FooterTemplate>
-            </FooterTemplate>
-        </FluentProfileMenu>
-    </FluentHeader>
-</FluentLayout>
-
 <p>
     A "User Profile Menu" is a component commonly found on websites or applications.
     It typically appears in the top-right corner of a web page and provides options related to

--- a/src/Core/Components/ProfileMenu/FluentProfileMenu.razor.css
+++ b/src/Core/Components/ProfileMenu/FluentProfileMenu.razor.css
@@ -18,10 +18,12 @@
         transform: unset !important;
         left: unset;
         right: -4px;
+        top: 32px;
     }
 
 [dir="rtl"] .fluent-profile-menu[top-corner] ::deep + div + fluent-anchored-region {
     transform: unset !important;
     left: -4px;
     right: unset;
+    top: 32px;
 }

--- a/src/Core/Components/ProfileMenu/FluentProfileMenu.razor.css
+++ b/src/Core/Components/ProfileMenu/FluentProfileMenu.razor.css
@@ -14,13 +14,13 @@
         display: none;
     }
 
-    .fluent-profile-menu[top-corner] ::deep fluent-anchored-region {
+    .fluent-profile-menu[top-corner] ::deep + div + fluent-anchored-region {
         transform: unset !important;
         left: unset;
         right: -4px;
     }
 
-[dir="rtl"] .fluent-profile-menu[top-corner] ::deep fluent-anchored-region {
+[dir="rtl"] .fluent-profile-menu[top-corner] ::deep + div + fluent-anchored-region {
     transform: unset !important;
     left: -4px;
     right: unset;


### PR DESCRIPTION
# [ProfileMenu] Fix the `TopCorner` style

Due to a previous change (#2010), the style defined for `TopCorner=“ true”` was not applied.
This code corrects this problem.

See #2621

![image](https://github.com/user-attachments/assets/22edaff1-52d7-4edc-953a-10d88134b763)
