### PR TITLE
[dev-v5] Add Extra Files to the Source Code component

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Counter/CounterPage.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Counter/CounterPage.md
@@ -28,6 +28,8 @@ Value: @Value
 
 {{ MyCounter SourceCode=false }}
 
+{{ MyCounter Files=Razor:MyCounter.razor;Source:MyCounter.razor.js;CSS:MyCounter.razor.css;404:MyCounter.not.found }}
+
 This code is a live demo of a Counter
 
 |Example|Table|

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Counter/Samples/MyCounter.razor.css
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Counter/Samples/MyCounter.razor.css
@@ -1,0 +1,10 @@
+/* Ensure all the flags are the same size, and centered */
+.flag {
+  height: 1rem;
+  margin: auto;
+  border: 1px solid var(--neutral-layer-3);
+}
+
+.my-counter {
+    /* Test */
+}

--- a/examples/Demo/FluentUI.Demo.Client/FluentUI.Demo.Client.csproj
+++ b/examples/Demo/FluentUI.Demo.Client/FluentUI.Demo.Client.csproj
@@ -43,28 +43,13 @@
   <!-- Copy all .razor files to .txt files in wwwroot\sources -->
   <Target Name="CopySources" BeforeTargets="BeforeBuild" Condition="'$(TargetFramework)'=='net8.0'">
     <ItemGroup>
-      <Sources Include="$(ProjectDir)\Documentation\**\*.razor" />
+      <Sources Include="$(ProjectDir)\Documentation\**\*.razor*" />
     </ItemGroup>
     <Copy SourceFiles="@(Sources)" DestinationFiles="@(Sources->'$(ProjectDir)wwwroot\sources\%(Filename)%(Extension).txt')" SkipUnchangedFiles="true" />
 
     <!-- Add a task to generate files.txt with all filenames -->
     <WriteLinesToFile File="$(ProjectDir)wwwroot\sources\files.txt" Lines="@(Sources->'%(Filename)%(Extension).txt')" Overwrite="true" />
   </Target>
-
-  <!-- TODO
-  <Target Name="CopyMarkdown" BeforeTargets="BeforeBuild">
-    <ItemGroup>
-      <Sources Include="$(ProjectDir)\Documentation\**\*.md" />
-    </ItemGroup>
-    <Copy SourceFiles="@(Sources)" DestinationFiles="@(Sources->'$(ProjectDir)wwwroot\documentation\%(Filename)%(Extension).txt')" SkipUnchangedFiles="true" />
-
-    Add a task to generate files.txt with all filenames
-    <WriteLinesToFile
-      File="$(ProjectDir)wwwroot\documentation\files.txt"
-      Lines="@(Sources->'%(Filename)%(Extension).txt')"
-      Overwrite="true" />
-  </Target>
-  -->
 
   <!-- Embedd other languages under root resx file -->
   <ItemGroup>

--- a/examples/Demo/FluentUI.Demo.Client/Infrastructure/ServiceCollectionExtensions.cs
+++ b/examples/Demo/FluentUI.Demo.Client/Infrastructure/ServiceCollectionExtensions.cs
@@ -65,7 +65,7 @@ public static class ServiceCollectionExtensions
             options.ResourcesAssembly = typeof(Client._Imports).Assembly;
             options.ApiAssembly = typeof(Microsoft.FluentUI.AspNetCore.Components._Imports).Assembly;
             options.ApiCommentSummary = (component, member) => member is null ? CodeComments.GetSummary(component.Name) : CodeComments.GetSummary(member);
-            options.SourceCodeUrl = "/sources/{0}.razor.txt";
+            options.SourceCodeUrl = "/sources/{0}.txt";
         });
 
         return new DemoServices(services);

--- a/examples/Tools/FluentUI.Demo.DocViewer/Components/MarkdownViewer.razor
+++ b/examples/Tools/FluentUI.Demo.DocViewer/Components/MarkdownViewer.razor
@@ -39,6 +39,28 @@
                     {
                         <DynamicComponent Type="@component" />
                     }
+                    else if (section.ExtraFiles.Count > 0)
+                    {
+                        <div class="demo-tabs">
+                            <fluent-tabs>
+                                <fluent-tab>Example</fluent-tab>
+                                @foreach (var tabName in section.ExtraFiles.Keys)
+                                {
+                                    <fluent-tab>@tabName</fluent-tab>
+                                }
+
+                                <fluent-tab-panel class="demo-section-example">
+                                    <DynamicComponent Type="@component" />
+                                </fluent-tab-panel>
+                                @foreach (var item in section.ExtraFiles)
+                                {
+                                    <fluent-tab-panel>
+                                        <pre><code id="@($"{section.Id}-{item.Key}")" class="@GetLanguageClassName(item.Value)" source>Loading...</code></pre>
+                                    </fluent-tab-panel>
+                                }
+                            </fluent-tabs>
+                        </div>
+                    }
                     else
                     {
                         <div class="demo-tabs">
@@ -50,7 +72,7 @@
                                     <DynamicComponent Type="@component" />
                                 </fluent-tab-panel>
                                 <fluent-tab-panel>
-                                    <pre><code id="@(section.Id)" class="language-razor" source>Loading...</code></pre>
+                                    <pre><code id="@(section.Id)" class="@GetLanguageClassName()" source>Loading...</code></pre>
                                 </fluent-tab-panel>
                             </fluent-tabs>
                         </div>

--- a/examples/Tools/FluentUI.Demo.DocViewer/Models/Section.cs
+++ b/examples/Tools/FluentUI.Demo.DocViewer/Models/Section.cs
@@ -29,6 +29,11 @@ public record Section
     public const string ARGUMENT_SOURCECODE = "sourcecode";
 
     /// <summary>
+    /// Key for the extra files displayed in the Component.
+    /// </summary>
+    public const string ARGUMENT_EXTRA_FILES = "files";
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="Section"/> class.
     /// </summary>
     /// <param name="docViewerService"></param>
@@ -51,6 +56,24 @@ public record Section
     /// Gets True if the contains SourceCode="false" in the arguments.
     /// </summary>
     public bool NoCode => Arguments.TryGetValue(ARGUMENT_SOURCECODE, out var sourceCodeValue) && sourceCodeValue.Equals("false", StringComparison.CurrentCultureIgnoreCase);
+
+    /// <summary>
+    /// Gets the files to display in extra tabs in the Component.
+    /// The format is "Tab1=File1;Tab2=File2".
+    /// </summary>
+    public IDictionary<string, string> ExtraFiles
+    {
+        get
+        {
+            if (Arguments.TryGetValue(ARGUMENT_EXTRA_FILES, out var extraFileValue))
+            {
+                var files = extraFileValue.Split(';');
+                return files.Select(f => f.Split(':')).ToDictionary(f => f[0].Trim(), f => f[1].Trim());
+            }
+
+            return new Dictionary<string, string>();
+        }
+    }
 
     /// <summary>
     /// Gets the parameters of the section. All keys are in lowercase.

--- a/examples/Tools/FluentUI.Demo.DocViewer/Services/DocViewerOptions.cs
+++ b/examples/Tools/FluentUI.Demo.DocViewer/Services/DocViewerOptions.cs
@@ -37,9 +37,9 @@ public class DocViewerOptions
     public Func<Type, MemberInfo?, string> ApiCommentSummary { get; set; } = (type, member) => member?.Name ?? type.Name;
 
     /// <summary>
-    /// Path to the external source code files, where {0} will be replaced by the component name.
+    /// Path to the external source code files, where {0} will be replaced by the razor component name 
     /// </summary>
-    public string SourceCodeUrl { get; set; } = "/sources/{0}.razor.txt";
+    public string SourceCodeUrl { get; set; } = "/sources/{0}.txt";
 
     /// <summary>
     /// Gets or sets whether to use the console log provider.


### PR DESCRIPTION
# [dev-v5] Add Extra Files to the Source Code component

With this PR, we can add many additional files to the Source Code component, replacing the default Code tab.

The files attribute is a list of `[TabName]:[FileName]` items.

## Example 
![{8ADBA37A-CAF1-4617-82E3-30FA48749E56}](https://github.com/user-attachments/assets/f9516d61-4811-4f7c-b6a4-ab43eff4e531)

```
{{ MyCounter Files=Razor:MyCounter.razor;Source:MyCounter.razor.js;CSS:MyCounter.razor.css;404:MyCounter.not.found }}
```

![peek_1](https://github.com/user-attachments/assets/b4c23bef-ce8b-4cae-8ed0-c444039e27a5)
