### PR TITLE
[Github]Update the actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build-core-lib.yml
+++ b/.github/workflows/build-core-lib.yml
@@ -133,7 +133,7 @@ jobs:
          reporttypes: 'HtmlInline;MarkdownSummaryGithub'
 
      - name: Upload coverage report
-       uses: actions/upload-artifact@v2
+       uses: actions/upload-artifact@v4
        with:
          name: CoverageReports
          path: CoverageReports


### PR DESCRIPTION
# [Github]Update the actions/upload-artifact to v4

`actions/upload-artifact` v1, v2 and v3 are deprectated.