### PR TITLE
[RadioGroup] Fix keyboard selection

### DIFF
--- a/src/Core.Assets/src/index.ts
+++ b/src/Core.Assets/src/index.ts
@@ -109,18 +109,6 @@ export function afterServerStarted(blazor: any) {
 
 export function afterStarted(blazor: Blazor, mode: string) {
 
-  blazor.registerCustomEventType('radiogroupclick', {
-    browserEventName: 'click',
-    createEventArgs: event => {
-      if (event.target!._readOnly || event.target!._disabled) {
-        return null;
-      }
-      return {
-        value: event.target!.value
-      };
-    }
-  });
-
   blazor.registerCustomEventType('checkedchange', {
     browserEventName: 'change',
     createEventArgs: event => {
@@ -182,6 +170,19 @@ export function afterStarted(blazor: Blazor, mode: string) {
       return null;
     }
   });
+
+  blazor.registerCustomEventType('radiogroupchange', {
+    browserEventName: 'change',
+    createEventArgs: event => {
+      if (event.target!.localName == 'fluent-radio-group') {
+        return {
+          value: event.target.value,
+        }
+      };
+      return null;
+    }
+  });
+
   blazor.registerCustomEventType('selectedchange', {
     browserEventName: 'selected-change',
     createEventArgs: event => {

--- a/src/Core/Components/Radio/FluentRadioGroup.razor
+++ b/src/Core/Components/Radio/FluentRadioGroup.razor
@@ -1,4 +1,4 @@
-@namespace Microsoft.FluentUI.AspNetCore.Components
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 @inherits FluentInputBase<TValue>
 @typeparam TValue
 <CascadingValue TValue="FluentRadioContext" Value="_context">
@@ -10,10 +10,9 @@
                         readonly=@ReadOnly
                         disabled=@Disabled
                         name="@_context!.GroupName"
-                        value="@BindConverter.FormatValue(Value?.ToString())"
                         orientation="@Orientation.ToAttributeValue()"
                         required="@Required"
-                        @onradiogroupclick="@((e) => CurrentValueAsString = e?.Value?.ToString())"
+                        @onradiogroupchange="HandleChange"
                         @attributes="AdditionalAttributes">
         @ChildContent
     </fluent-radio-group>

--- a/src/Core/Components/Radio/FluentRadioGroup.razor.cs
+++ b/src/Core/Components/Radio/FluentRadioGroup.razor.cs
@@ -7,7 +7,7 @@ using Microsoft.FluentUI.AspNetCore.Components.Extensions;
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 /// <summary>
-/// Groups child <see cref="FluentRadio{TValue}"/> components. 
+/// Groups child <see cref="FluentRadio{TValue}"/> components.
 /// </summary>
 
 [CascadingTypeParameter(nameof(TValue))]
@@ -28,7 +28,7 @@ public partial class FluentRadioGroup<[DynamicallyAccessedMembers(DynamicallyAcc
     public Orientation? Orientation { get; set; }
 
     /// <summary>
-    /// Gets or sets the child content to be rendering inside the <see cref="FluentRadioGroup{TValue}"/>. 
+    /// Gets or sets the child content to be rendering inside the <see cref="FluentRadioGroup{TValue}"/>.
     /// </summary>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
@@ -62,4 +62,12 @@ public partial class FluentRadioGroup<[DynamicallyAccessedMembers(DynamicallyAcc
     /// <inheritdoc />
     protected override bool TryParseValueFromString(string? value, [MaybeNullWhen(false)] out TValue result, [NotNullWhen(false)] out string? validationErrorMessage)
     => this.TryParseSelectableValueFromString(value, out result, out validationErrorMessage);
+
+    private void HandleChange(ChangeEventArgs e)
+    {
+        if (CurrentValueAsString != e?.Value?.ToString())
+        {
+            CurrentValueAsString = e?.Value?.ToString();
+        }
+    }
 }

--- a/src/Core/Events/EventHandlers.cs
+++ b/src/Core/Events/EventHandlers.cs
@@ -4,7 +4,7 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 
 [EventHandler("oncheckedchange", typeof(CheckboxChangeEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
 [EventHandler("onswitchcheckedchange", typeof(CheckboxChangeEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
-[EventHandler("onradiogroupclick", typeof(ChangeEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
+[EventHandler("onradiogroupchange", typeof(ChangeEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
 [EventHandler("onsliderchange", typeof(ChangeEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
 [EventHandler("ontabchange", typeof(TabChangeEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
 [EventHandler("onselectedchange", typeof(TreeChangeEventArgs), enableStopPropagation: true, enablePreventDefault: true)]


### PR DESCRIPTION
Fix #2652

It turned out the custom event handler for `radiogroupclick` was never being called. 

To use the web components change logic, a new custom event handler (`radiogroupchange`) has been added. The `FluentRadioGroup` component uses this handler now. To prevent the controls in a group from 'looping', the code that sets the value from the C# side has been removed. It uses the web components for this. By making these changes we get keyboard handling 'for free' (ie through the web components)