### PR TITLE
[DataGrid] Fix column options popup being blank

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -8233,7 +8233,7 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentSlider`1.JSRuntime">
             <summary />
         </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentSlider`1._jsModule">
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentSlider`1.Module">
             <summary />
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentSlider`1.Min">

--- a/src/Core/Components/DataGrid/Columns/ColumnBase.razor
+++ b/src/Core/Components/DataGrid/Columns/ColumnBase.razor
@@ -68,7 +68,7 @@
             {
                 @if (Grid.ResizeType is not null)
                 {
-                    <FluentButton Appearance="Appearance.Stealth" class="col-options-button" @onclick="@(() => Grid.ShowColumnOptionsAsync(this))" aria-label="Filter this column">
+                    <FluentButton Appearance="Appearance.Stealth" class="col-options-button" @onclick="@(() => Grid.ShowColumnOptionsAsync(this))" aria-label="Resize/filter this column">
                         <FluentIcon Value="@(new CoreIcons.Regular.Size24.ChevronDown())" Color="Color.Neutral" Width="20px" Style="opacity: 0.5;" />
                     </FluentButton>
                 }

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor
@@ -148,22 +148,47 @@
                                 scope="col"
                                 TGridItem="TGridItem">
                 @col.HeaderContent
-                @if (col == _displayOptionsForColumn)
+
+                @if (HeaderCellAsButtonWithMenu)
                 {
-                    <div class="col-options">
+                    @if (col == _displayOptionsForColumn)
+                    {
+                        <div class="col-options">
                             @col.ColumnOptions
-                    </div>
+                        </div>
+                    }
+                    @if (ResizableColumns && col == _displayResizeForColumn)
+                    {
+                        <div class="col-resize">
+
+                            @if (ResizeType is not null)
+                            {
+                                <ColumnResizeOptions Column="@oneBasedIndex" ResizeType=@ResizeType TGridItem="TGridItem" />
+                            }
+
+                        </div>
+                    }
                 }
-                @if (ResizableColumns && col == _displayResizeForColumn)
+                else
                 {
-                    <div class="col-resize">
+                    @if (col == _displayOptionsForColumn)
+                    {
+                        <div class="col-options">
+                            <FluentStack Orientation="Orientation.Vertical">
+                                @col.ColumnOptions
+                                @if (ResizeType is not null)
+                                {
+                                    @if (@col.ColumnOptions is not null)
+                                    {
+                                        <FluentDivider Role="DividerRole.Separator" Style="width: 100%;" />
+                                    }
 
-                        @if (ResizeType is not null)
-                        {
-                            <ColumnResizeOptions Column="@oneBasedIndex" ResizeType=@ResizeType TGridItem="TGridItem" />
-                        }
+                                    <ColumnResizeOptions Column="@oneBasedIndex" ResizeType=@ResizeType TGridItem="TGridItem" />
+                                }
 
-                    </div>
+                            </FluentStack>
+                        </div>
+                    }
                 }
 
                 @if (ResizableColumns)

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -765,7 +765,7 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
         //return Task.CompletedTask;
     }
 
-    internal async Task SetColumnWidthDiscreteAsync(int? columnIndex, float widthChange)
+    public async Task SetColumnWidthDiscreteAsync(int? columnIndex, float widthChange)
     {
         if (_gridReference is not null && Module is not null)
         {
@@ -773,7 +773,7 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
         }
     }
 
-    internal async Task SetColumnWidthExactAsync(int columnIndex, int width)
+    public async Task SetColumnWidthExactAsync(int columnIndex, int width)
     {
         if (_gridReference is not null && Module is not null)
         {
@@ -781,7 +781,7 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
         }
     }
 
-    internal async Task ResetColumnWidthsAsync()
+    public async Task ResetColumnWidthsAsync()
     {
         if (_gridReference is not null && Module is not null)
         {

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -765,6 +765,12 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
         //return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Resizes the column width by a discrete amount.
+    /// </summary>
+    /// <param name="columnIndex">The column to be resized</param>
+    /// <param name="widthChange">The amount of pixels to change width with</param>
+    /// <returns></returns>
     public async Task SetColumnWidthDiscreteAsync(int? columnIndex, float widthChange)
     {
         if (_gridReference is not null && Module is not null)
@@ -773,6 +779,12 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
         }
     }
 
+    /// <summary>
+    /// Resizes the column width to the exact width specified (in pixels).
+    /// </summary>
+    /// <param name="columnIndex">The column to be resized</param>
+    /// <param name="width">The new width in pixels</param>
+    /// <returns></returns>
     public async Task SetColumnWidthExactAsync(int columnIndex, int width)
     {
         if (_gridReference is not null && Module is not null)
@@ -781,6 +793,11 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
         }
     }
 
+    /// <summary>
+    /// Resets the column widths to their initial values as specified with the <see cref="GridTemplateColumns"/> parameter.
+    /// If no value is specified, the default value is "1fr" for each column.
+    /// </summary>
+    /// <returns></returns>
     public async Task ResetColumnWidthsAsync()
     {
         if (_gridReference is not null && Module is not null)
@@ -788,5 +805,4 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
             await Module.InvokeVoidAsync("resetColumnWidths", _gridReference);
         }
     }
-
 }


### PR DESCRIPTION
- Fix #2669 
- Make Reset and set width methods public

With implementing the `HeaderCellAsButtonWithMenu` a couple of things got mixed up and that is why issue #2669 happened. This PR fixes that.

We added the option to do resize within the same popup as the filter earlier. When using the new `HeaderCellAsButtonWithMenu` parameter set to `true`, the different column action will be shown with a menu. If `false`, the resize action (either discrete or exact and the filter action will show in the same popup:
![image](https://github.com/user-attachments/assets/6065ff6d-bd66-4bbc-9331-828860e16ca2)


