### PR TITLE
[dev-v5] Add Debounce.RunAsync method

### DIFF
--- a/src/Core/Utilities/InternalDebounce/DebounceAction.cs
+++ b/src/Core/Utilities/InternalDebounce/DebounceAction.cs
@@ -49,6 +49,20 @@ internal class DebounceAction : IDisposable
     }
 
     /// <summary>
+    /// Delays the invocation of an action until a predetermined interval has elapsed since the last call.
+    /// </summary>
+    /// <param name="milliseconds"></param>
+    /// <param name="action"></param>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD003:Avoid awaiting foreign Tasks", Justification = "Required to return the current Task.")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "MA0042:Do not use blocking calls in an async method", Justification = "Special case using CurrentTask")]
+    public Task RunAsync(int milliseconds, Func<Task> action)
+    {
+        Run(milliseconds, action);
+        return CurrentTask;
+    }
+
+    /// <summary>
     /// Releases all resources used by the DebounceTask dispatcher.
     /// </summary>
     public void Dispose()

--- a/src/Core/Utilities/InternalDebounce/DebounceTask.cs
+++ b/src/Core/Utilities/InternalDebounce/DebounceTask.cs
@@ -74,11 +74,26 @@ public class DebounceTask : IDisposable
     }
 
     /// <summary>
+    /// Delays the invocation of an action until a predetermined interval has elapsed since the last call.
+    /// </summary>
+    /// <param name="milliseconds"></param>
+    /// <param name="action"></param>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD003:Avoid awaiting foreign Tasks", Justification = "Required to return the current Task.")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "MA0042:Do not use blocking calls in an async method", Justification = "Special case using CurrentTask")]
+    public Task RunAsync(int milliseconds, Func<Task> action)
+    {
+        Run(milliseconds, action);
+        return CurrentTask;
+    }
+
+    /// <summary>
     /// Releases all resources used by the DebounceTask dispatcher.
     /// </summary>
     public void Dispose()
     {
         _disposed = true;
         _cts?.Cancel();
+        GC.SuppressFinalize(this);
     }
 }

--- a/src/Core/Utilities/InternalDebounce/DispatcherTimerExtensions.cs
+++ b/src/Core/Utilities/InternalDebounce/DispatcherTimerExtensions.cs
@@ -36,7 +36,13 @@ internal static class DispatcherTimerExtensions
         timer.Elapsed += Timer_Elapsed;
 
         // Store/Update function
-        TimerDebounceItem updateValueFactory(System.Timers.Timer k, TimerDebounceItem v) => v.UpdateAction(action);
+        TimerDebounceItem updateValueFactory(System.Timers.Timer k, TimerDebounceItem v)
+        {
+            v.Status.SetCanceled();
+            v.Status = new TaskCompletionSource();
+            return v.UpdateAction(action);
+        }
+
         var item = _debounceInstances.AddOrUpdate(
                         key: timer,
                         addValue: new TimerDebounceItem()
@@ -81,7 +87,7 @@ internal static class DispatcherTimerExtensions
         /// <summary>
         /// Gets the task completion source.
         /// </summary>
-        public required TaskCompletionSource Status { get; init; }
+        public required TaskCompletionSource Status { get; set; }
 
         /// <summary>
         /// Gets or sets the action to execute.

--- a/tests/Core/Utilities/DebounceTaskTests.cs
+++ b/tests/Core/Utilities/DebounceTaskTests.cs
@@ -2,20 +2,14 @@
 // MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
 // ------------------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Text;
-using System.Threading.Tasks;
-using Bunit;
-using Microsoft.FluentUI.AspNetCore.Components.Utilities;
 using Microsoft.FluentUI.AspNetCore.Components.Utilities.InternalDebounce;
-using Microsoft.VisualStudio.TestPlatform.Utilities;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.FluentUI.AspNetCore.Components.Tests.Utilities;
 
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Tests purpose")]
 public class DebounceTaskTests
 {
     private readonly ITestOutputHelper Output;
@@ -86,28 +80,36 @@ public class DebounceTaskTests
         var debounce = new DebounceTask();
         var actionCalledCount = 0;
         var actionCalled = string.Empty;
+        var actionNextCount = 0;
+        var actionNextCalled = string.Empty;
 
         // Act: simulate two async calls
-        _ = Task.Run(() =>
+        _ = Task.Run(async () =>
         {
-            debounce.Run(50, async () =>
+            await debounce.RunAsync(50, async () =>
             {
                 actionCalled = "Step1";
                 actionCalledCount++;
                 await Task.CompletedTask;
             });
+
+            actionNextCalled = "Next1";
+            actionNextCount++;
         });
 
         await Task.Delay(5);     // To ensure the second call is made after the first one
 
-        _ = Task.Run(() =>
+        _ = Task.Run(async () =>
         {
-            debounce.Run(40, async () =>
+            await debounce.RunAsync(40, async () =>
             {
                 actionCalled = "Step2";
                 actionCalledCount++;
                 await Task.CompletedTask;
             });
+
+            actionNextCalled = "Next2";
+            actionNextCount++;
         });
 
         await Task.Delay(100);   // Wait for the debounce to complete
@@ -115,6 +117,9 @@ public class DebounceTaskTests
         // Assert
         Assert.Equal("Step2", actionCalled);
         Assert.Equal(1, actionCalledCount);
+
+        Assert.Equal("Next2", actionNextCalled);
+        Assert.Equal(1, actionNextCount);
     }
 
     [Fact]


### PR DESCRIPTION
# [dev-v5] Add `Debounce.RunAsync` method

Add an async method to simplify the asynchronous calls 

```csharp
await debounce.RunAsync(50, async () => ...);
```

Update TimerDispatcher to cancel the previous call when a new call is initiated.

## Unit Tests

Updated