### PR TITLE
[Button] Remove style override when in loading state

### DIFF
--- a/src/Core/Components/Button/FluentButton.razor
+++ b/src/Core/Components/Button/FluentButton.razor
@@ -21,7 +21,7 @@ else
     {
         <fluent-button @ref=Element
                class="@(LoadingOverlay ? string.Empty : Class)"
-               style="@(LoadingOverlay ? "width: 100%;" : Style)"
+               style="@Style"
                autofocus=@Autofocus
                form=@FormId
                formaction=@Action

--- a/src/Core/Components/Button/FluentButton.razor.css
+++ b/src/Core/Components/Button/FluentButton.razor.css
@@ -1,5 +1,7 @@
 .loading-button {
     position: relative;
+    height: calc((var(--base-height-multiplier) + var(--density))* var(--design-unit)* 1px);
+    display: inline-block;
 }
 
     .loading-button ::deep fluent-progress-ring {


### PR DESCRIPTION
Fixes #2684 

A button was hard-coded to use full width for the underlying web component: 
```
<fluent-button @ref=Element
       class="@(LoadingOverlay ? string.Empty : Class)"
       style="@(LoadingOverlay ? "width: 100%;" : Style)"
```
This was causing issues as described in #2684. This PR fixes that by:
- Using the same style for both button as the 'overlay' (span)
- Making sure the overlay has the correct initial height and display styles

Overriding the button height by applying the `Style` parameter still works. The overlay will use that same style (which overrules the initial height set by the class). See the left button in the image below. The right button does not have any specific styling applied.

![image](https://github.com/user-attachments/assets/ad482c2d-53a8-4384-b842-badc10b3f947)

