### PR TITLE
[DateTime] Accessibility - Add `role`, `tabindex` and catch Enter/Space

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -2833,6 +2833,21 @@
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentTimePicker.TryParseValueFromString(System.String,System.Nullable{System.DateTime}@,System.String@)">
             <summary />
         </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.KeyDown.SimulateClickAsync(Microsoft.AspNetCore.Components.Web.KeyboardEventArgs,System.Func{Microsoft.AspNetCore.Components.Web.MouseEventArgs,System.Threading.Tasks.Task})">
+            <summary />
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.KeyDown.SimulateClickAsync(Microsoft.AspNetCore.Components.Web.KeyboardEventArgs,System.Func{System.DateTime,System.Boolean,System.Threading.Tasks.Task},System.DateTime,System.Boolean)">
+            <summary />
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.KeyDown.SimulateClickAsync(Microsoft.AspNetCore.Components.Web.KeyboardEventArgs,System.Func{Microsoft.FluentUI.AspNetCore.Components.CalendarTitles,System.Threading.Tasks.Task},Microsoft.FluentUI.AspNetCore.Components.CalendarTitles)">
+            <summary />
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.KeyDown.SimulateClickAsync(Microsoft.AspNetCore.Components.Web.KeyboardEventArgs,System.Func{System.Int32,System.Int32,System.Boolean,System.Threading.Tasks.Task},System.Int32,System.Int32,System.Boolean)">
+            <summary />
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.KeyDown.SimulateClickAsync(Microsoft.AspNetCore.Components.Web.KeyboardEventArgs,System.Func{System.Int32,System.Boolean,System.Threading.Tasks.Task},System.Int32,System.Boolean)">
+            <summary />
+        </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.Components.DateTime.RangeOfDates.#ctor">
             <inheritdoc cref="T:Microsoft.FluentUI.AspNetCore.Components.Utilities.RangeOf`1"/>
         </member>

--- a/src/Core/Components/DateTime/FluentCalendar.razor
+++ b/src/Core/Components/DateTime/FluentCalendar.razor
@@ -2,7 +2,6 @@
 @inherits FluentCalendarBase
 
 <div id="@Id" class="@ClassValue" style="@StyleValue" readonly="@(ReadOnly ? true : null)">
-
     @if (_pickerView == CalendarViews.Days)
     {
         <div>
@@ -13,7 +12,9 @@
             @* Title bar (label, previous and next buttons) *@
             <div class="title" part="title" aria-label="@titles.Label">
                 <div part="label" class="@GetAnimationClass("label")" readonly="@ReadOnly"
-                     @onclick="@(e => TitleClickHandlerAsync(titles))">
+                     role="button" tabindex="0"
+                     @onclick="@(e => TitleClickHandlerAsync(titles))"
+                     @onkeydown="(e => KeyDown.SimulateClickAsync(e, TitleClickHandlerAsync, titles))">
                     @titles.Label
                 </div>
                 <div part="move" class="change-period">
@@ -23,7 +24,8 @@
                     }
                     else
                     {
-                        <div class="previous" title="@titles.PreviousTitle" @onclick="@OnPreviousButtonHandlerAsync">
+                        <div class="previous" title="@titles.PreviousTitle" @onclick="@OnPreviousButtonHandlerAsync"
+                             role="button" tabindex="0" @onkeydown="(e => KeyDown.SimulateClickAsync(e, OnPreviousButtonHandlerAsync))">
                             @((MarkupString)ArrowUp)
                         </div>
                     }
@@ -33,7 +35,8 @@
                     }
                     else
                     {
-                        <div class="next" title="@titles.NextTitle" @onclick="@OnNextButtonHandlerAsync">
+                        <div class="next" title="@titles.NextTitle" @onclick="@OnNextButtonHandlerAsync"
+                             role="button" tabindex="0" @onkeydown="(e => KeyDown.SimulateClickAsync(e, OnNextButtonHandlerAsync))">
                             @((MarkupString)ArrowDown)
                         </div>
                     }
@@ -69,6 +72,8 @@
 
                                     <div part="day"
                                          class="@GetAnimationClass("day")"
+                                         role="@(dayProperties.IsDisabled || dayProperties.IsInactive ? null : "button")"
+                                         tabindex="@(dayProperties.IsDisabled || dayProperties.IsInactive ? null : 0)"
                                          disabled="@dayProperties.IsDisabled"
                                          inactive="@dayProperties.IsInactive"
                                          today="@dayProperties.IsToday"
@@ -79,6 +84,7 @@
                                          multi-end="@(multipleSelection.IsMultiple && SelectMode == CalendarSelectMode.Range && multipleSelection.Max == day)"
                                          aria-label="@dayProperties.Title"
                                          value="@dayProperties.DayIdentifier"
+                                         @onkeydown="(e => KeyDown.SimulateClickAsync(e, OnSelectDayHandlerAsync, day, dayProperties.IsDisabled || dayProperties.IsInactive))"
                                          @onclick="@(e => OnSelectDayHandlerAsync(day, dayProperties.IsDisabled || dayProperties.IsInactive))"
                                          @onmouseover="@(e => OnSelectDayMouseOverAsync(day, dayProperties.IsDisabled || dayProperties.IsInactive))">
                                         @if (DaysTemplate == null)
@@ -111,6 +117,9 @@
                                  aria-label="@monthProperties.Title"
                                  title="@monthProperties.Title"
                                  value="@monthProperties.MonthIdentifier"
+                                 role="button"
+                                 tabindex="@(monthProperties.IsDisabled || monthProperties.IsReadOnly ? null : 0)"
+                                 @onkeydown="(e => KeyDown.SimulateClickAsync(e, OnSelectMonthHandlerAsync, year, month.Index, monthProperties.IsReadOnly))"
                                  @onclick="@(e => OnSelectMonthHandlerAsync(year, month.Index, monthProperties.IsReadOnly))">
                                 @month.Abbreviated
                             </div>
@@ -132,6 +141,8 @@
                                  aria-label="@year.Year"
                                  title="@year.Year"
                                  value="@yearProperties.YearIdentifier"
+                                 tabindex="@(yearProperties.IsDisabled || yearProperties.IsReadOnly ? null : 0)"
+                                 @onkeydown="(e => KeyDown.SimulateClickAsync(e, OnSelectYearHandlerAsync, year.Year, yearProperties.IsReadOnly))"
                                  @onclick="@(e => OnSelectYearHandlerAsync(year.Year, yearProperties.IsReadOnly))">
                                 @year.Year
                             </div>

--- a/src/Core/Components/DateTime/FluentDatePicker.razor
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor
@@ -12,6 +12,7 @@
                  @bind-Value="@CurrentValueAsString"
                  @onclick="@OnCalendarOpenHandlerAsync"
                  @ondblclick="@OnDoubleClickHandlerAsync"
+                 @onkeydown="(e => KeyDown.SimulateClickAsync(e, OnCalendarOpenHandlerAsync))"
                  ReadOnly="@ReadOnly"
                  Disabled="@Disabled"
                  Required="@Required"

--- a/src/Core/Components/DateTime/KeyDown.cs
+++ b/src/Core/Components/DateTime/KeyDown.cs
@@ -1,0 +1,61 @@
+using Microsoft.AspNetCore.Components.Web;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+internal static class KeyDown
+{
+    /// <summary />
+    public static Task SimulateClickAsync(KeyboardEventArgs e, Func<MouseEventArgs, Task> onClickAsync)
+    {
+        if (e.Key == "Enter" || e.Key == " ")
+        {
+            return onClickAsync.Invoke(new MouseEventArgs());
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary />
+    public static Task SimulateClickAsync(KeyboardEventArgs e, Func<DateTime, bool, Task> onClickAsync, DateTime value, bool dayDisabled)
+    {
+        if (e.Key == "Enter" || e.Key == " ")
+        {
+            return onClickAsync.Invoke(value, dayDisabled);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary />
+    public static Task SimulateClickAsync(KeyboardEventArgs e, Func<CalendarTitles, Task> onClickAsync, CalendarTitles title)
+    {
+        if (e.Key == "Enter" || e.Key == " ")
+        {
+            return onClickAsync.Invoke(title);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary />
+    public static Task SimulateClickAsync(KeyboardEventArgs e, Func<int, int, bool, Task> onClickAsync, int year, int month, bool isReadOnly)
+    {
+        if (e.Key == "Enter" || e.Key == " ")
+        {
+            return onClickAsync.Invoke(year, month, isReadOnly);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary />
+    public static Task SimulateClickAsync(KeyboardEventArgs e, Func<int, bool, Task> onClickAsync, int year, bool isReadOnly)
+    {
+        if (e.Key == "Enter" || e.Key == " ")
+        {
+            return onClickAsync.Invoke(year, isReadOnly);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Core/DateTime/FluentCalendarTests.FluentCalendar_Default.verified.html
+++ b/tests/Core/DateTime/FluentCalendarTests.FluentCalendar_Default.verified.html
@@ -1,84 +1,84 @@
 
-<div class="fluent-calendar" b-bgn9u4guxz="">
+<div id="xxx" class="fluent-calendar" b-bgn9u4guxz="">
   <div b-bgn9u4guxz="">
     <div class="title" part="title" aria-label="February 2022" b-bgn9u4guxz="">
-      <div part="label" class="label" blazor:onclick="1" b-bgn9u4guxz="">February 2022</div>
+      <div part="label" class="label" role="button" tabindex="0" blazor:onclick="1" blazor:onkeydown="2" b-bgn9u4guxz="">February 2022</div>
       <div part="move" class="change-period" b-bgn9u4guxz="">
-        <div class="previous" title="January" blazor:onclick="2" b-bgn9u4guxz="">
+        <div class="previous" title="January" blazor:onclick="3" role="button" tabindex="0" blazor:onkeydown="4" b-bgn9u4guxz="">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="var(--neutral-fill-strong-focus)" xmlns="http://www.w3.org/2000/svg">
             <path d="M4.2 10.73a.75.75 0 001.1 1.04l5.95-6.25v14.73a.75.75 0 001.5 0V5.52l5.95 6.25a.75.75 0 001.1-1.04l-7.08-7.42a1 1 0 00-1.44 0L4.2 10.73z"></path>
           </svg>
         </div>
-        <div class="next" title="March" blazor:onclick="3" b-bgn9u4guxz="">
+        <div class="next" title="March" blazor:onclick="5" role="button" tabindex="0" blazor:onkeydown="6" b-bgn9u4guxz="">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="var(--neutral-fill-strong-focus)" xmlns="http://www.w3.org/2000/svg">
             <path d="M19.8 13.27a.75.75 0 00-1.1-1.04l-5.95 6.25V3.75a.75.75 0 10-1.5 0v14.73L5.3 12.23a.75.75 0 10-1.1 1.04l7.08 7.42a1 1 0 001.44 0l7.07-7.42z"></path>
           </svg>
         </div>
       </div>
     </div>
-    <div class="days" part="days">
-      <div class="week-days" part="week-days">
-        <div class="week-day" part="week-day" title="Sunday" abbr="Sunday">S</div>
-        <div class="week-day" part="week-day" title="Monday" abbr="Monday">M</div>
-        <div class="week-day" part="week-day" title="Tuesday" abbr="Tuesday">T</div>
-        <div class="week-day" part="week-day" title="Wednesday" abbr="Wednesday">W</div>
-        <div class="week-day" part="week-day" title="Thursday" abbr="Thursday">T</div>
-        <div class="week-day" part="week-day" title="Friday" abbr="Friday">F</div>
-        <div class="week-day" part="week-day" title="Saturday" abbr="Saturday">S</div>
+    <div class="days" part="days" blazor:onmouseleave="7" b-bgn9u4guxz="">
+      <div class="week-days" part="week-days" b-bgn9u4guxz="">
+        <div class="week-day" part="week-day" title="Sunday" abbr="Sunday" b-bgn9u4guxz="">S</div>
+        <div class="week-day" part="week-day" title="Monday" abbr="Monday" b-bgn9u4guxz="">M</div>
+        <div class="week-day" part="week-day" title="Tuesday" abbr="Tuesday" b-bgn9u4guxz="">T</div>
+        <div class="week-day" part="week-day" title="Wednesday" abbr="Wednesday" b-bgn9u4guxz="">W</div>
+        <div class="week-day" part="week-day" title="Thursday" abbr="Thursday" b-bgn9u4guxz="">T</div>
+        <div class="week-day" part="week-day" title="Friday" abbr="Friday" b-bgn9u4guxz="">F</div>
+        <div class="week-day" part="week-day" title="Saturday" abbr="Saturday" b-bgn9u4guxz="">S</div>
       </div>
-      <div class="week">
-        <div part="day" class="day" inactive aria-label="January 30" value="2022-01-30">30</div>
-        <div part="day" class="day" inactive aria-label="January 31" value="2022-01-31">31</div>
-        <div part="day" class="day" aria-label="February 1" value="2022-02-01">1</div>
-        <div part="day" class="day" aria-label="February 2" value="2022-02-02">2</div>
-        <div part="day" class="day" aria-label="February 3" value="2022-02-03">3</div>
-        <div part="day" class="day" aria-label="February 4" value="2022-02-04">4</div>
-        <div part="day" class="day" aria-label="February 5" value="2022-02-05">5</div>
+      <div class="week" b-bgn9u4guxz="">
+        <div part="day" class="day" inactive="" aria-label="January 30" value="2022-01-30" blazor:onkeydown="8" blazor:onclick="9" blazor:onmouseover="10" b-bgn9u4guxz="">30</div>
+        <div part="day" class="day" inactive="" aria-label="January 31" value="2022-01-31" blazor:onkeydown="11" blazor:onclick="12" blazor:onmouseover="13" b-bgn9u4guxz="">31</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 1" value="2022-02-01" blazor:onkeydown="14" blazor:onclick="15" blazor:onmouseover="16" b-bgn9u4guxz="">1</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 2" value="2022-02-02" blazor:onkeydown="17" blazor:onclick="18" blazor:onmouseover="19" b-bgn9u4guxz="">2</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 3" value="2022-02-03" blazor:onkeydown="20" blazor:onclick="21" blazor:onmouseover="22" b-bgn9u4guxz="">3</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 4" value="2022-02-04" blazor:onkeydown="23" blazor:onclick="24" blazor:onmouseover="25" b-bgn9u4guxz="">4</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 5" value="2022-02-05" blazor:onkeydown="26" blazor:onclick="27" blazor:onmouseover="28" b-bgn9u4guxz="">5</div>
       </div>
-      <div class="week">
-        <div part="day" class="day" aria-label="February 6" value="2022-02-06" blazor:onclick="10">6</div>
-        <div part="day" class="day" aria-label="February 7" value="2022-02-07" blazor:onclick="11">7</div>
-        <div part="day" class="day" aria-label="February 8" value="2022-02-08" blazor:onclick="12">8</div>
-        <div part="day" class="day" aria-label="February 9" value="2022-02-09" blazor:onclick="13">9</div>
-        <div part="day" class="day" aria-label="February 10" value="2022-02-10" blazor:onclick="14">10</div>
-        <div part="day" class="day" aria-label="February 11" value="2022-02-11" blazor:onclick="15">11</div>
-        <div part="day" class="day" aria-label="February 12" value="2022-02-12" blazor:onclick="16">12</div>
+      <div class="week" b-bgn9u4guxz="">
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 6" value="2022-02-06" blazor:onkeydown="29" blazor:onclick="30" blazor:onmouseover="31" b-bgn9u4guxz="">6</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 7" value="2022-02-07" blazor:onkeydown="32" blazor:onclick="33" blazor:onmouseover="34" b-bgn9u4guxz="">7</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 8" value="2022-02-08" blazor:onkeydown="35" blazor:onclick="36" blazor:onmouseover="37" b-bgn9u4guxz="">8</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 9" value="2022-02-09" blazor:onkeydown="38" blazor:onclick="39" blazor:onmouseover="40" b-bgn9u4guxz="">9</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 10" value="2022-02-10" blazor:onkeydown="41" blazor:onclick="42" blazor:onmouseover="43" b-bgn9u4guxz="">10</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 11" value="2022-02-11" blazor:onkeydown="44" blazor:onclick="45" blazor:onmouseover="46" b-bgn9u4guxz="">11</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 12" value="2022-02-12" blazor:onkeydown="47" blazor:onclick="48" blazor:onmouseover="49" b-bgn9u4guxz="">12</div>
       </div>
-      <div class="week">
-        <div part="day" class="day" aria-label="February 13" value="2022-02-13" blazor:onclick="17">13</div>
-        <div part="day" class="day" disabled aria-label="February 14" value="2022-02-14" blazor:onclick="18">14</div>
-        <div part="day" class="day" selected aria-label="February 15" value="2022-02-15" blazor:onclick="19">15</div>
-        <div part="day" class="day" aria-label="February 16" value="2022-02-16" blazor:onclick="20">16</div>
-        <div part="day" class="day" aria-label="February 17" value="2022-02-17" blazor:onclick="21">17</div>
-        <div part="day" class="day" aria-label="February 18" value="2022-02-18" blazor:onclick="22">18</div>
-        <div part="day" class="day" aria-label="February 19" value="2022-02-19" blazor:onclick="23">19</div>
+      <div class="week" b-bgn9u4guxz="">
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 13" value="2022-02-13" blazor:onkeydown="50" blazor:onclick="51" blazor:onmouseover="52" b-bgn9u4guxz="">13</div>
+        <div part="day" class="day" disabled="" aria-label="February 14" value="2022-02-14" blazor:onkeydown="53" blazor:onclick="54" blazor:onmouseover="55" b-bgn9u4guxz="">14</div>
+        <div part="day" class="day" role="button" tabindex="0" selected="" aria-label="February 15" value="2022-02-15" blazor:onkeydown="56" blazor:onclick="57" blazor:onmouseover="58" b-bgn9u4guxz="">15</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 16" value="2022-02-16" blazor:onkeydown="59" blazor:onclick="60" blazor:onmouseover="61" b-bgn9u4guxz="">16</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 17" value="2022-02-17" blazor:onkeydown="62" blazor:onclick="63" blazor:onmouseover="64" b-bgn9u4guxz="">17</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 18" value="2022-02-18" blazor:onkeydown="65" blazor:onclick="66" blazor:onmouseover="67" b-bgn9u4guxz="">18</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 19" value="2022-02-19" blazor:onkeydown="68" blazor:onclick="69" blazor:onmouseover="70" b-bgn9u4guxz="">19</div>
       </div>
-      <div class="week">
-        <div part="day" class="day" aria-label="February 20" value="2022-02-20" blazor:onclick="24">20</div>
-        <div part="day" class="day" aria-label="February 21" value="2022-02-21" blazor:onclick="25">21</div>
-        <div part="day" class="day" aria-label="February 22" value="2022-02-22" blazor:onclick="26">22</div>
-        <div part="day" class="day" aria-label="February 23" value="2022-02-23" blazor:onclick="27">23</div>
-        <div part="day" class="day" aria-label="February 24" value="2022-02-24" blazor:onclick="28">24</div>
-        <div part="day" class="day" aria-label="February 25" value="2022-02-25" blazor:onclick="29">25</div>
-        <div part="day" class="day" aria-label="February 26" value="2022-02-26" blazor:onclick="30">26</div>
+      <div class="week" b-bgn9u4guxz="">
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 20" value="2022-02-20" blazor:onkeydown="71" blazor:onclick="72" blazor:onmouseover="73" b-bgn9u4guxz="">20</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 21" value="2022-02-21" blazor:onkeydown="74" blazor:onclick="75" blazor:onmouseover="76" b-bgn9u4guxz="">21</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 22" value="2022-02-22" blazor:onkeydown="77" blazor:onclick="78" blazor:onmouseover="79" b-bgn9u4guxz="">22</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 23" value="2022-02-23" blazor:onkeydown="80" blazor:onclick="81" blazor:onmouseover="82" b-bgn9u4guxz="">23</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 24" value="2022-02-24" blazor:onkeydown="83" blazor:onclick="84" blazor:onmouseover="85" b-bgn9u4guxz="">24</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 25" value="2022-02-25" blazor:onkeydown="86" blazor:onclick="87" blazor:onmouseover="88" b-bgn9u4guxz="">25</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 26" value="2022-02-26" blazor:onkeydown="89" blazor:onclick="90" blazor:onmouseover="91" b-bgn9u4guxz="">26</div>
       </div>
-      <div class="week">
-        <div part="day" class="day" aria-label="February 27" value="2022-02-27" blazor:onclick="31">27</div>
-        <div part="day" class="day" aria-label="February 28" value="2022-02-28" blazor:onclick="32">28</div>
-        <div part="day" class="day" inactive aria-label="March 1" value="2022-03-01" blazor:onclick="33">1</div>
-        <div part="day" class="day" inactive aria-label="March 2" value="2022-03-02" blazor:onclick="34">2</div>
-        <div part="day" class="day" inactive aria-label="March 3" value="2022-03-03" blazor:onclick="35">3</div>
-        <div part="day" class="day" inactive aria-label="March 4" value="2022-03-04" blazor:onclick="36">4</div>
-        <div part="day" class="day" inactive aria-label="March 5" value="2022-03-05" blazor:onclick="37">5</div>
+      <div class="week" b-bgn9u4guxz="">
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 27" value="2022-02-27" blazor:onkeydown="92" blazor:onclick="93" blazor:onmouseover="94" b-bgn9u4guxz="">27</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 28" value="2022-02-28" blazor:onkeydown="95" blazor:onclick="96" blazor:onmouseover="97" b-bgn9u4guxz="">28</div>
+        <div part="day" class="day" inactive="" aria-label="March 1" value="2022-03-01" blazor:onkeydown="98" blazor:onclick="99" blazor:onmouseover="100" b-bgn9u4guxz="">1</div>
+        <div part="day" class="day" inactive="" aria-label="March 2" value="2022-03-02" blazor:onkeydown="101" blazor:onclick="102" blazor:onmouseover="103" b-bgn9u4guxz="">2</div>
+        <div part="day" class="day" inactive="" aria-label="March 3" value="2022-03-03" blazor:onkeydown="104" blazor:onclick="105" blazor:onmouseover="106" b-bgn9u4guxz="">3</div>
+        <div part="day" class="day" inactive="" aria-label="March 4" value="2022-03-04" blazor:onkeydown="107" blazor:onclick="108" blazor:onmouseover="109" b-bgn9u4guxz="">4</div>
+        <div part="day" class="day" inactive="" aria-label="March 5" value="2022-03-05" blazor:onkeydown="110" blazor:onclick="111" blazor:onmouseover="112" b-bgn9u4guxz="">5</div>
       </div>
-      <div class="week">
-        <div part="day" class="day" inactive aria-label="March 6" value="2022-03-06" blazor:onclick="38">6</div>
-        <div part="day" class="day" inactive aria-label="March 7" value="2022-03-07" blazor:onclick="39">7</div>
-        <div part="day" class="day" inactive aria-label="March 8" value="2022-03-08" blazor:onclick="40">8</div>
-        <div part="day" class="day" inactive aria-label="March 9" value="2022-03-09" blazor:onclick="41">9</div>
-        <div part="day" class="day" inactive aria-label="March 10" value="2022-03-10" blazor:onclick="42">10</div>
-        <div part="day" class="day" inactive aria-label="March 11" value="2022-03-11" blazor:onclick="43">11</div>
-        <div part="day" class="day" inactive aria-label="March 12" value="2022-03-12" blazor:onclick="44">12</div>
+      <div class="week" b-bgn9u4guxz="">
+        <div part="day" class="day" inactive="" aria-label="March 6" value="2022-03-06" blazor:onkeydown="113" blazor:onclick="114" blazor:onmouseover="115" b-bgn9u4guxz="">6</div>
+        <div part="day" class="day" inactive="" aria-label="March 7" value="2022-03-07" blazor:onkeydown="116" blazor:onclick="117" blazor:onmouseover="118" b-bgn9u4guxz="">7</div>
+        <div part="day" class="day" inactive="" aria-label="March 8" value="2022-03-08" blazor:onkeydown="119" blazor:onclick="120" blazor:onmouseover="121" b-bgn9u4guxz="">8</div>
+        <div part="day" class="day" inactive="" aria-label="March 9" value="2022-03-09" blazor:onkeydown="122" blazor:onclick="123" blazor:onmouseover="124" b-bgn9u4guxz="">9</div>
+        <div part="day" class="day" inactive="" aria-label="March 10" value="2022-03-10" blazor:onkeydown="125" blazor:onclick="126" blazor:onmouseover="127" b-bgn9u4guxz="">10</div>
+        <div part="day" class="day" inactive="" aria-label="March 11" value="2022-03-11" blazor:onkeydown="128" blazor:onclick="129" blazor:onmouseover="130" b-bgn9u4guxz="">11</div>
+        <div part="day" class="day" inactive="" aria-label="March 12" value="2022-03-12" blazor:onkeydown="131" blazor:onclick="132" blazor:onmouseover="133" b-bgn9u4guxz="">12</div>
       </div>
     </div>
   </div>

--- a/tests/Core/DateTime/FluentCalendarTests.FluentCalendar_Maximum_View-days.verified.razor.html
+++ b/tests/Core/DateTime/FluentCalendarTests.FluentCalendar_Maximum_View-days.verified.razor.html
@@ -1,10 +1,10 @@
 
-<div class="fluent-calendar" b-bgn9u4guxz="">
+<div id="xxx" class="fluent-calendar" b-bgn9u4guxz="">
   <div b-bgn9u4guxz="">
     <div class="title" part="title" aria-label="December 9999" b-bgn9u4guxz="">
-      <div part="label" class="label" blazor:onclick="1" b-bgn9u4guxz="">December 9999</div>
+      <div part="label" class="label" role="button" tabindex="0" blazor:onclick="1" blazor:onkeydown="2" b-bgn9u4guxz="">December 9999</div>
       <div part="move" class="change-period" b-bgn9u4guxz="">
-        <div class="previous" title="November" blazor:onclick="2" b-bgn9u4guxz="">
+        <div class="previous" title="November" blazor:onclick="3" role="button" tabindex="0" blazor:onkeydown="4" b-bgn9u4guxz="">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="var(--neutral-fill-strong-focus)" xmlns="http://www.w3.org/2000/svg">
             <path d="M4.2 10.73a.75.75 0 001.1 1.04l5.95-6.25v14.73a.75.75 0 001.5 0V5.52l5.95 6.25a.75.75 0 001.1-1.04l-7.08-7.42a1 1 0 00-1.44 0L4.2 10.73z"></path>
           </svg>
@@ -12,7 +12,7 @@
         <div class="next" disabled="" b-bgn9u4guxz=""></div>
       </div>
     </div>
-    <div class="days" part="days" b-bgn9u4guxz="">
+    <div class="days" part="days" blazor:onmouseleave="5" b-bgn9u4guxz="">
       <div class="week-days" part="week-days" b-bgn9u4guxz="">
         <div class="week-day" part="week-day" title="Sunday" abbr="Sunday" b-bgn9u4guxz="">S</div>
         <div class="week-day" part="week-day" title="Monday" abbr="Monday" b-bgn9u4guxz="">M</div>
@@ -23,40 +23,40 @@
         <div class="week-day" part="week-day" title="Saturday" abbr="Saturday" b-bgn9u4guxz="">S</div>
       </div>
       <div class="week" b-bgn9u4guxz="">
-        <div part="day" class="day" inactive="" aria-label="November 28" value="9999-11-28" blazor:onclick="3" b-bgn9u4guxz="">28</div>
-        <div part="day" class="day" inactive="" aria-label="November 29" value="9999-11-29" blazor:onclick="4" b-bgn9u4guxz="">29</div>
-        <div part="day" class="day" inactive="" aria-label="November 30" value="9999-11-30" blazor:onclick="5" b-bgn9u4guxz="">30</div>
-        <div part="day" class="day" aria-label="December 1" value="9999-12-01" blazor:onclick="6" b-bgn9u4guxz="">1</div>
-        <div part="day" class="day" aria-label="December 2" value="9999-12-02" blazor:onclick="7" b-bgn9u4guxz="">2</div>
-        <div part="day" class="day" aria-label="December 3" value="9999-12-03" blazor:onclick="8" b-bgn9u4guxz="">3</div>
-        <div part="day" class="day" aria-label="December 4" value="9999-12-04" blazor:onclick="9" b-bgn9u4guxz="">4</div>
+        <div part="day" class="day" inactive="" aria-label="November 28" value="9999-11-28" blazor:onkeydown="6" blazor:onclick="7" blazor:onmouseover="8" b-bgn9u4guxz="">28</div>
+        <div part="day" class="day" inactive="" aria-label="November 29" value="9999-11-29" blazor:onkeydown="9" blazor:onclick="10" blazor:onmouseover="11" b-bgn9u4guxz="">29</div>
+        <div part="day" class="day" inactive="" aria-label="November 30" value="9999-11-30" blazor:onkeydown="12" blazor:onclick="13" blazor:onmouseover="14" b-bgn9u4guxz="">30</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="December 1" value="9999-12-01" blazor:onkeydown="15" blazor:onclick="16" blazor:onmouseover="17" b-bgn9u4guxz="">1</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="December 2" value="9999-12-02" blazor:onkeydown="18" blazor:onclick="19" blazor:onmouseover="20" b-bgn9u4guxz="">2</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="December 3" value="9999-12-03" blazor:onkeydown="21" blazor:onclick="22" blazor:onmouseover="23" b-bgn9u4guxz="">3</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="December 4" value="9999-12-04" blazor:onkeydown="24" blazor:onclick="25" blazor:onmouseover="26" b-bgn9u4guxz="">4</div>
       </div>
       <div class="week" b-bgn9u4guxz="">
-        <div part="day" class="day" aria-label="December 5" value="9999-12-05" blazor:onclick="10" b-bgn9u4guxz="">5</div>
-        <div part="day" class="day" aria-label="December 6" value="9999-12-06" blazor:onclick="11" b-bgn9u4guxz="">6</div>
-        <div part="day" class="day" aria-label="December 7" value="9999-12-07" blazor:onclick="12" b-bgn9u4guxz="">7</div>
-        <div part="day" class="day" aria-label="December 8" value="9999-12-08" blazor:onclick="13" b-bgn9u4guxz="">8</div>
-        <div part="day" class="day" aria-label="December 9" value="9999-12-09" blazor:onclick="14" b-bgn9u4guxz="">9</div>
-        <div part="day" class="day" aria-label="December 10" value="9999-12-10" blazor:onclick="15" b-bgn9u4guxz="">10</div>
-        <div part="day" class="day" aria-label="December 11" value="9999-12-11" blazor:onclick="16" b-bgn9u4guxz="">11</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="December 5" value="9999-12-05" blazor:onkeydown="27" blazor:onclick="28" blazor:onmouseover="29" b-bgn9u4guxz="">5</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="December 6" value="9999-12-06" blazor:onkeydown="30" blazor:onclick="31" blazor:onmouseover="32" b-bgn9u4guxz="">6</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="December 7" value="9999-12-07" blazor:onkeydown="33" blazor:onclick="34" blazor:onmouseover="35" b-bgn9u4guxz="">7</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="December 8" value="9999-12-08" blazor:onkeydown="36" blazor:onclick="37" blazor:onmouseover="38" b-bgn9u4guxz="">8</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="December 9" value="9999-12-09" blazor:onkeydown="39" blazor:onclick="40" blazor:onmouseover="41" b-bgn9u4guxz="">9</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="December 10" value="9999-12-10" blazor:onkeydown="42" blazor:onclick="43" blazor:onmouseover="44" b-bgn9u4guxz="">10</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="December 11" value="9999-12-11" blazor:onkeydown="45" blazor:onclick="46" blazor:onmouseover="47" b-bgn9u4guxz="">11</div>
       </div>
       <div class="week" b-bgn9u4guxz="">
-        <div part="day" class="day" aria-label="December 12" value="9999-12-12" blazor:onclick="17" b-bgn9u4guxz="">12</div>
-        <div part="day" class="day" aria-label="December 13" value="9999-12-13" blazor:onclick="18" b-bgn9u4guxz="">13</div>
-        <div part="day" class="day" aria-label="December 14" value="9999-12-14" blazor:onclick="19" b-bgn9u4guxz="">14</div>
-        <div part="day" class="day" aria-label="December 15" value="9999-12-15" blazor:onclick="20" b-bgn9u4guxz="">15</div>
-        <div part="day" class="day" aria-label="December 16" value="9999-12-16" blazor:onclick="21" b-bgn9u4guxz="">16</div>
-        <div part="day" class="day" aria-label="December 17" value="9999-12-17" blazor:onclick="22" b-bgn9u4guxz="">17</div>
-        <div part="day" class="day" aria-label="December 18" value="9999-12-18" blazor:onclick="23" b-bgn9u4guxz="">18</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="December 12" value="9999-12-12" blazor:onkeydown="48" blazor:onclick="49" blazor:onmouseover="50" b-bgn9u4guxz="">12</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="December 13" value="9999-12-13" blazor:onkeydown="51" blazor:onclick="52" blazor:onmouseover="53" b-bgn9u4guxz="">13</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="December 14" value="9999-12-14" blazor:onkeydown="54" blazor:onclick="55" blazor:onmouseover="56" b-bgn9u4guxz="">14</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="December 15" value="9999-12-15" blazor:onkeydown="57" blazor:onclick="58" blazor:onmouseover="59" b-bgn9u4guxz="">15</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="December 16" value="9999-12-16" blazor:onkeydown="60" blazor:onclick="61" blazor:onmouseover="62" b-bgn9u4guxz="">16</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="December 17" value="9999-12-17" blazor:onkeydown="63" blazor:onclick="64" blazor:onmouseover="65" b-bgn9u4guxz="">17</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="December 18" value="9999-12-18" blazor:onkeydown="66" blazor:onclick="67" blazor:onmouseover="68" b-bgn9u4guxz="">18</div>
       </div>
       <div class="week" b-bgn9u4guxz="">
-        <div part="day" class="day" aria-label="December 19" value="9999-12-19" blazor:onclick="24" b-bgn9u4guxz="">19</div>
-        <div part="day" class="day" aria-label="December 20" value="9999-12-20" blazor:onclick="25" b-bgn9u4guxz="">20</div>
-        <div part="day" class="day" aria-label="December 21" value="9999-12-21" blazor:onclick="26" b-bgn9u4guxz="">21</div>
-        <div part="day" class="day" aria-label="December 22" value="9999-12-22" blazor:onclick="27" b-bgn9u4guxz="">22</div>
-        <div part="day" class="day" aria-label="December 23" value="9999-12-23" blazor:onclick="28" b-bgn9u4guxz="">23</div>
-        <div part="day" class="day" aria-label="December 24" value="9999-12-24" blazor:onclick="29" b-bgn9u4guxz="">24</div>
-        <div part="day" class="day" aria-label="December 25" value="9999-12-25" blazor:onclick="30" b-bgn9u4guxz="">25</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="December 19" value="9999-12-19" blazor:onkeydown="69" blazor:onclick="70" blazor:onmouseover="71" b-bgn9u4guxz="">19</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="December 20" value="9999-12-20" blazor:onkeydown="72" blazor:onclick="73" blazor:onmouseover="74" b-bgn9u4guxz="">20</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="December 21" value="9999-12-21" blazor:onkeydown="75" blazor:onclick="76" blazor:onmouseover="77" b-bgn9u4guxz="">21</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="December 22" value="9999-12-22" blazor:onkeydown="78" blazor:onclick="79" blazor:onmouseover="80" b-bgn9u4guxz="">22</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="December 23" value="9999-12-23" blazor:onkeydown="81" blazor:onclick="82" blazor:onmouseover="83" b-bgn9u4guxz="">23</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="December 24" value="9999-12-24" blazor:onkeydown="84" blazor:onclick="85" blazor:onmouseover="86" b-bgn9u4guxz="">24</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="December 25" value="9999-12-25" blazor:onkeydown="87" blazor:onclick="88" blazor:onmouseover="89" b-bgn9u4guxz="">25</div>
       </div>
       <div class="week" b-bgn9u4guxz=""></div>
       <div class="week" b-bgn9u4guxz=""></div>

--- a/tests/Core/DateTime/FluentCalendarTests.FluentCalendar_Maximum_View-months.verified.razor.html
+++ b/tests/Core/DateTime/FluentCalendarTests.FluentCalendar_Maximum_View-months.verified.razor.html
@@ -1,10 +1,10 @@
 
-<div class="fluent-month" b-bgn9u4guxz="">
+<div id="xxx" class="fluent-month" b-bgn9u4guxz="">
   <div b-bgn9u4guxz="">
     <div class="title" part="title" aria-label="9999" b-bgn9u4guxz="">
-      <div part="label" class="label animation-none" blazor:onclick="1" b-bgn9u4guxz="">9999</div>
+      <div part="label" class="label animation-none" role="button" tabindex="0" blazor:onclick="1" blazor:onkeydown="2" b-bgn9u4guxz="">9999</div>
       <div part="move" class="change-period" b-bgn9u4guxz="">
-        <div class="previous" title="9998" blazor:onclick="2" b-bgn9u4guxz="">
+        <div class="previous" title="9998" blazor:onclick="3" role="button" tabindex="0" blazor:onkeydown="4" b-bgn9u4guxz="">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="var(--neutral-fill-strong-focus)" xmlns="http://www.w3.org/2000/svg">
             <path d="M4.2 10.73a.75.75 0 001.1 1.04l5.95-6.25v14.73a.75.75 0 001.5 0V5.52l5.95 6.25a.75.75 0 001.1-1.04l-7.08-7.42a1 1 0 00-1.44 0L4.2 10.73z"></path>
           </svg>
@@ -13,18 +13,18 @@
       </div>
     </div>
     <div class="months" part="months" b-bgn9u4guxz="">
-      <div class="month animation-none" aria-label="January 9999" title="January 9999" value="9999-01" blazor:onclick="3" b-bgn9u4guxz="">Jan</div>
-      <div class="month animation-none" aria-label="February 9999" title="February 9999" value="9999-02" blazor:onclick="4" b-bgn9u4guxz="">Feb</div>
-      <div class="month animation-none" aria-label="March 9999" title="March 9999" value="9999-03" blazor:onclick="5" b-bgn9u4guxz="">Mar</div>
-      <div class="month animation-none" aria-label="April 9999" title="April 9999" value="9999-04" blazor:onclick="6" b-bgn9u4guxz="">Apr</div>
-      <div class="month animation-none" aria-label="May 9999" title="May 9999" value="9999-05" blazor:onclick="7" b-bgn9u4guxz="">May</div>
-      <div class="month animation-none" aria-label="June 9999" title="June 9999" value="9999-06" blazor:onclick="8" b-bgn9u4guxz="">Jun</div>
-      <div class="month animation-none" aria-label="July 9999" title="July 9999" value="9999-07" blazor:onclick="9" b-bgn9u4guxz="">Jul</div>
-      <div class="month animation-none" aria-label="August 9999" title="August 9999" value="9999-08" blazor:onclick="10" b-bgn9u4guxz="">Aug</div>
-      <div class="month animation-none" aria-label="September 9999" title="September 9999" value="9999-09" blazor:onclick="11" b-bgn9u4guxz="">Sep</div>
-      <div class="month animation-none" aria-label="October 9999" title="October 9999" value="9999-10" blazor:onclick="12" b-bgn9u4guxz="">Oct</div>
-      <div class="month animation-none" aria-label="November 9999" title="November 9999" value="9999-11" blazor:onclick="13" b-bgn9u4guxz="">Nov</div>
-      <div class="month animation-none" selected="" aria-label="December 9999" title="December 9999" value="9999-12" blazor:onclick="14" b-bgn9u4guxz="">Dec</div>
+      <div class="month animation-none" aria-label="January 9999" title="January 9999" value="9999-01" role="button" tabindex="0" blazor:onkeydown="5" blazor:onclick="6" b-bgn9u4guxz="">Jan</div>
+      <div class="month animation-none" aria-label="February 9999" title="February 9999" value="9999-02" role="button" tabindex="0" blazor:onkeydown="7" blazor:onclick="8" b-bgn9u4guxz="">Feb</div>
+      <div class="month animation-none" aria-label="March 9999" title="March 9999" value="9999-03" role="button" tabindex="0" blazor:onkeydown="9" blazor:onclick="10" b-bgn9u4guxz="">Mar</div>
+      <div class="month animation-none" aria-label="April 9999" title="April 9999" value="9999-04" role="button" tabindex="0" blazor:onkeydown="11" blazor:onclick="12" b-bgn9u4guxz="">Apr</div>
+      <div class="month animation-none" aria-label="May 9999" title="May 9999" value="9999-05" role="button" tabindex="0" blazor:onkeydown="13" blazor:onclick="14" b-bgn9u4guxz="">May</div>
+      <div class="month animation-none" aria-label="June 9999" title="June 9999" value="9999-06" role="button" tabindex="0" blazor:onkeydown="15" blazor:onclick="16" b-bgn9u4guxz="">Jun</div>
+      <div class="month animation-none" aria-label="July 9999" title="July 9999" value="9999-07" role="button" tabindex="0" blazor:onkeydown="17" blazor:onclick="18" b-bgn9u4guxz="">Jul</div>
+      <div class="month animation-none" aria-label="August 9999" title="August 9999" value="9999-08" role="button" tabindex="0" blazor:onkeydown="19" blazor:onclick="20" b-bgn9u4guxz="">Aug</div>
+      <div class="month animation-none" aria-label="September 9999" title="September 9999" value="9999-09" role="button" tabindex="0" blazor:onkeydown="21" blazor:onclick="22" b-bgn9u4guxz="">Sep</div>
+      <div class="month animation-none" aria-label="October 9999" title="October 9999" value="9999-10" role="button" tabindex="0" blazor:onkeydown="23" blazor:onclick="24" b-bgn9u4guxz="">Oct</div>
+      <div class="month animation-none" aria-label="November 9999" title="November 9999" value="9999-11" role="button" tabindex="0" blazor:onkeydown="25" blazor:onclick="26" b-bgn9u4guxz="">Nov</div>
+      <div class="month animation-none" selected="" aria-label="December 9999" title="December 9999" value="9999-12" role="button" tabindex="0" blazor:onkeydown="27" blazor:onclick="28" b-bgn9u4guxz="">Dec</div>
     </div>
   </div>
 </div>

--- a/tests/Core/DateTime/FluentCalendarTests.FluentCalendar_Maximum_View-years.verified.razor.html
+++ b/tests/Core/DateTime/FluentCalendarTests.FluentCalendar_Maximum_View-years.verified.razor.html
@@ -1,10 +1,10 @@
 
-<div class="fluent-year" b-bgn9u4guxz="">
+<div id="xxx" class="fluent-year" b-bgn9u4guxz="">
   <div b-bgn9u4guxz="">
     <div class="title" part="title" aria-label="9999" b-bgn9u4guxz="">
-      <div part="label" class="label" blazor:onclick="1" b-bgn9u4guxz="">9999</div>
+      <div part="label" class="label" role="button" tabindex="0" blazor:onclick="1" blazor:onkeydown="2" b-bgn9u4guxz="">9999</div>
       <div part="move" class="change-period" b-bgn9u4guxz="">
-        <div class="previous" title="9987 - 9998" blazor:onclick="2" b-bgn9u4guxz="">
+        <div class="previous" title="9987 - 9998" blazor:onclick="3" role="button" tabindex="0" blazor:onkeydown="4" b-bgn9u4guxz="">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="var(--neutral-fill-strong-focus)" xmlns="http://www.w3.org/2000/svg">
             <path d="M4.2 10.73a.75.75 0 001.1 1.04l5.95-6.25v14.73a.75.75 0 001.5 0V5.52l5.95 6.25a.75.75 0 001.1-1.04l-7.08-7.42a1 1 0 00-1.44 0L4.2 10.73z"></path>
           </svg>
@@ -13,7 +13,7 @@
       </div>
     </div>
     <div class="years" part="years" b-bgn9u4guxz="">
-      <div class="year" selected="" aria-label="9999" title="9999" value="9999" blazor:onclick="3" b-bgn9u4guxz="">9999</div>
+      <div class="year" selected="" aria-label="9999" title="9999" value="9999" tabindex="0" blazor:onkeydown="5" blazor:onclick="6" b-bgn9u4guxz="">9999</div>
     </div>
   </div>
 </div>

--- a/tests/Core/DateTime/FluentCalendarTests.FluentCalendar_Minimum_View-days.verified.razor.html
+++ b/tests/Core/DateTime/FluentCalendarTests.FluentCalendar_Minimum_View-days.verified.razor.html
@@ -1,18 +1,18 @@
 
-<div class="fluent-calendar" b-bgn9u4guxz="">
+<div id="xxx" class="fluent-calendar" b-bgn9u4guxz="">
   <div b-bgn9u4guxz="">
     <div class="title" part="title" aria-label="January 1" b-bgn9u4guxz="">
-      <div part="label" class="label" blazor:onclick="1" b-bgn9u4guxz="">January 1</div>
+      <div part="label" class="label" role="button" tabindex="0" blazor:onclick="1" blazor:onkeydown="2" b-bgn9u4guxz="">January 1</div>
       <div part="move" class="change-period" b-bgn9u4guxz="">
         <div class="previous" disabled="" b-bgn9u4guxz=""></div>
-        <div class="next" title="February" blazor:onclick="2" b-bgn9u4guxz="">
+        <div class="next" title="February" blazor:onclick="3" role="button" tabindex="0" blazor:onkeydown="4" b-bgn9u4guxz="">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="var(--neutral-fill-strong-focus)" xmlns="http://www.w3.org/2000/svg">
             <path d="M19.8 13.27a.75.75 0 00-1.1-1.04l-5.95 6.25V3.75a.75.75 0 10-1.5 0v14.73L5.3 12.23a.75.75 0 10-1.1 1.04l7.08 7.42a1 1 0 001.44 0l7.07-7.42z"></path>
           </svg>
         </div>
       </div>
     </div>
-    <div class="days" part="days" b-bgn9u4guxz="">
+    <div class="days" part="days" blazor:onmouseleave="5" b-bgn9u4guxz="">
       <div class="week-days" part="week-days" b-bgn9u4guxz="">
         <div class="week-day" part="week-day" title="Sunday" abbr="Sunday" b-bgn9u4guxz="">S</div>
         <div class="week-day" part="week-day" title="Monday" abbr="Monday" b-bgn9u4guxz="">M</div>
@@ -23,58 +23,58 @@
         <div class="week-day" part="week-day" title="Saturday" abbr="Saturday" b-bgn9u4guxz="">S</div>
       </div>
       <div class="week" b-bgn9u4guxz="">
-        <div part="day" class="day" selected="" aria-label="January 1" value="0001-01-01" blazor:onclick="3" b-bgn9u4guxz="">1</div>
-        <div part="day" class="day" aria-label="January 2" value="0001-01-02" blazor:onclick="4" b-bgn9u4guxz="">2</div>
-        <div part="day" class="day" aria-label="January 3" value="0001-01-03" blazor:onclick="5" b-bgn9u4guxz="">3</div>
-        <div part="day" class="day" aria-label="January 4" value="0001-01-04" blazor:onclick="6" b-bgn9u4guxz="">4</div>
-        <div part="day" class="day" aria-label="January 5" value="0001-01-05" blazor:onclick="7" b-bgn9u4guxz="">5</div>
-        <div part="day" class="day" aria-label="January 6" value="0001-01-06" blazor:onclick="8" b-bgn9u4guxz="">6</div>
-        <div part="day" class="day" aria-label="January 7" value="0001-01-07" blazor:onclick="9" b-bgn9u4guxz="">7</div>
+        <div part="day" class="day" role="button" tabindex="0" selected="" aria-label="January 1" value="0001-01-01" blazor:onkeydown="6" blazor:onclick="7" blazor:onmouseover="8" b-bgn9u4guxz="">1</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 2" value="0001-01-02" blazor:onkeydown="9" blazor:onclick="10" blazor:onmouseover="11" b-bgn9u4guxz="">2</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 3" value="0001-01-03" blazor:onkeydown="12" blazor:onclick="13" blazor:onmouseover="14" b-bgn9u4guxz="">3</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 4" value="0001-01-04" blazor:onkeydown="15" blazor:onclick="16" blazor:onmouseover="17" b-bgn9u4guxz="">4</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 5" value="0001-01-05" blazor:onkeydown="18" blazor:onclick="19" blazor:onmouseover="20" b-bgn9u4guxz="">5</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 6" value="0001-01-06" blazor:onkeydown="21" blazor:onclick="22" blazor:onmouseover="23" b-bgn9u4guxz="">6</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 7" value="0001-01-07" blazor:onkeydown="24" blazor:onclick="25" blazor:onmouseover="26" b-bgn9u4guxz="">7</div>
       </div>
       <div class="week" b-bgn9u4guxz="">
-        <div part="day" class="day" aria-label="January 7" value="0001-01-07" blazor:onclick="10" b-bgn9u4guxz="">7</div>
-        <div part="day" class="day" aria-label="January 8" value="0001-01-08" blazor:onclick="11" b-bgn9u4guxz="">8</div>
-        <div part="day" class="day" aria-label="January 9" value="0001-01-09" blazor:onclick="12" b-bgn9u4guxz="">9</div>
-        <div part="day" class="day" aria-label="January 10" value="0001-01-10" blazor:onclick="13" b-bgn9u4guxz="">10</div>
-        <div part="day" class="day" aria-label="January 11" value="0001-01-11" blazor:onclick="14" b-bgn9u4guxz="">11</div>
-        <div part="day" class="day" aria-label="January 12" value="0001-01-12" blazor:onclick="15" b-bgn9u4guxz="">12</div>
-        <div part="day" class="day" aria-label="January 13" value="0001-01-13" blazor:onclick="16" b-bgn9u4guxz="">13</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 7" value="0001-01-07" blazor:onkeydown="27" blazor:onclick="28" blazor:onmouseover="29" b-bgn9u4guxz="">7</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 8" value="0001-01-08" blazor:onkeydown="30" blazor:onclick="31" blazor:onmouseover="32" b-bgn9u4guxz="">8</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 9" value="0001-01-09" blazor:onkeydown="33" blazor:onclick="34" blazor:onmouseover="35" b-bgn9u4guxz="">9</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 10" value="0001-01-10" blazor:onkeydown="36" blazor:onclick="37" blazor:onmouseover="38" b-bgn9u4guxz="">10</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 11" value="0001-01-11" blazor:onkeydown="39" blazor:onclick="40" blazor:onmouseover="41" b-bgn9u4guxz="">11</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 12" value="0001-01-12" blazor:onkeydown="42" blazor:onclick="43" blazor:onmouseover="44" b-bgn9u4guxz="">12</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 13" value="0001-01-13" blazor:onkeydown="45" blazor:onclick="46" blazor:onmouseover="47" b-bgn9u4guxz="">13</div>
       </div>
       <div class="week" b-bgn9u4guxz="">
-        <div part="day" class="day" aria-label="January 14" value="0001-01-14" blazor:onclick="17" b-bgn9u4guxz="">14</div>
-        <div part="day" class="day" aria-label="January 15" value="0001-01-15" blazor:onclick="18" b-bgn9u4guxz="">15</div>
-        <div part="day" class="day" aria-label="January 16" value="0001-01-16" blazor:onclick="19" b-bgn9u4guxz="">16</div>
-        <div part="day" class="day" aria-label="January 17" value="0001-01-17" blazor:onclick="20" b-bgn9u4guxz="">17</div>
-        <div part="day" class="day" aria-label="January 18" value="0001-01-18" blazor:onclick="21" b-bgn9u4guxz="">18</div>
-        <div part="day" class="day" aria-label="January 19" value="0001-01-19" blazor:onclick="22" b-bgn9u4guxz="">19</div>
-        <div part="day" class="day" aria-label="January 20" value="0001-01-20" blazor:onclick="23" b-bgn9u4guxz="">20</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 14" value="0001-01-14" blazor:onkeydown="48" blazor:onclick="49" blazor:onmouseover="50" b-bgn9u4guxz="">14</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 15" value="0001-01-15" blazor:onkeydown="51" blazor:onclick="52" blazor:onmouseover="53" b-bgn9u4guxz="">15</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 16" value="0001-01-16" blazor:onkeydown="54" blazor:onclick="55" blazor:onmouseover="56" b-bgn9u4guxz="">16</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 17" value="0001-01-17" blazor:onkeydown="57" blazor:onclick="58" blazor:onmouseover="59" b-bgn9u4guxz="">17</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 18" value="0001-01-18" blazor:onkeydown="60" blazor:onclick="61" blazor:onmouseover="62" b-bgn9u4guxz="">18</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 19" value="0001-01-19" blazor:onkeydown="63" blazor:onclick="64" blazor:onmouseover="65" b-bgn9u4guxz="">19</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 20" value="0001-01-20" blazor:onkeydown="66" blazor:onclick="67" blazor:onmouseover="68" b-bgn9u4guxz="">20</div>
       </div>
       <div class="week" b-bgn9u4guxz="">
-        <div part="day" class="day" aria-label="January 21" value="0001-01-21" blazor:onclick="24" b-bgn9u4guxz="">21</div>
-        <div part="day" class="day" aria-label="January 22" value="0001-01-22" blazor:onclick="25" b-bgn9u4guxz="">22</div>
-        <div part="day" class="day" aria-label="January 23" value="0001-01-23" blazor:onclick="26" b-bgn9u4guxz="">23</div>
-        <div part="day" class="day" aria-label="January 24" value="0001-01-24" blazor:onclick="27" b-bgn9u4guxz="">24</div>
-        <div part="day" class="day" aria-label="January 25" value="0001-01-25" blazor:onclick="28" b-bgn9u4guxz="">25</div>
-        <div part="day" class="day" aria-label="January 26" value="0001-01-26" blazor:onclick="29" b-bgn9u4guxz="">26</div>
-        <div part="day" class="day" aria-label="January 27" value="0001-01-27" blazor:onclick="30" b-bgn9u4guxz="">27</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 21" value="0001-01-21" blazor:onkeydown="69" blazor:onclick="70" blazor:onmouseover="71" b-bgn9u4guxz="">21</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 22" value="0001-01-22" blazor:onkeydown="72" blazor:onclick="73" blazor:onmouseover="74" b-bgn9u4guxz="">22</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 23" value="0001-01-23" blazor:onkeydown="75" blazor:onclick="76" blazor:onmouseover="77" b-bgn9u4guxz="">23</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 24" value="0001-01-24" blazor:onkeydown="78" blazor:onclick="79" blazor:onmouseover="80" b-bgn9u4guxz="">24</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 25" value="0001-01-25" blazor:onkeydown="81" blazor:onclick="82" blazor:onmouseover="83" b-bgn9u4guxz="">25</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 26" value="0001-01-26" blazor:onkeydown="84" blazor:onclick="85" blazor:onmouseover="86" b-bgn9u4guxz="">26</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 27" value="0001-01-27" blazor:onkeydown="87" blazor:onclick="88" blazor:onmouseover="89" b-bgn9u4guxz="">27</div>
       </div>
       <div class="week" b-bgn9u4guxz="">
-        <div part="day" class="day" aria-label="January 28" value="0001-01-28" blazor:onclick="31" b-bgn9u4guxz="">28</div>
-        <div part="day" class="day" aria-label="January 29" value="0001-01-29" blazor:onclick="32" b-bgn9u4guxz="">29</div>
-        <div part="day" class="day" aria-label="January 30" value="0001-01-30" blazor:onclick="33" b-bgn9u4guxz="">30</div>
-        <div part="day" class="day" aria-label="January 31" value="0001-01-31" blazor:onclick="34" b-bgn9u4guxz="">31</div>
-        <div part="day" class="day" inactive="" aria-label="February 1" value="0001-02-01" blazor:onclick="35" b-bgn9u4guxz="">1</div>
-        <div part="day" class="day" inactive="" aria-label="February 2" value="0001-02-02" blazor:onclick="36" b-bgn9u4guxz="">2</div>
-        <div part="day" class="day" inactive="" aria-label="February 3" value="0001-02-03" blazor:onclick="37" b-bgn9u4guxz="">3</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 28" value="0001-01-28" blazor:onkeydown="90" blazor:onclick="91" blazor:onmouseover="92" b-bgn9u4guxz="">28</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 29" value="0001-01-29" blazor:onkeydown="93" blazor:onclick="94" blazor:onmouseover="95" b-bgn9u4guxz="">29</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 30" value="0001-01-30" blazor:onkeydown="96" blazor:onclick="97" blazor:onmouseover="98" b-bgn9u4guxz="">30</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="January 31" value="0001-01-31" blazor:onkeydown="99" blazor:onclick="100" blazor:onmouseover="101" b-bgn9u4guxz="">31</div>
+        <div part="day" class="day" inactive="" aria-label="February 1" value="0001-02-01" blazor:onkeydown="102" blazor:onclick="103" blazor:onmouseover="104" b-bgn9u4guxz="">1</div>
+        <div part="day" class="day" inactive="" aria-label="February 2" value="0001-02-02" blazor:onkeydown="105" blazor:onclick="106" blazor:onmouseover="107" b-bgn9u4guxz="">2</div>
+        <div part="day" class="day" inactive="" aria-label="February 3" value="0001-02-03" blazor:onkeydown="108" blazor:onclick="109" blazor:onmouseover="110" b-bgn9u4guxz="">3</div>
       </div>
       <div class="week" b-bgn9u4guxz="">
-        <div part="day" class="day" inactive="" aria-label="February 4" value="0001-02-04" blazor:onclick="38" b-bgn9u4guxz="">4</div>
-        <div part="day" class="day" inactive="" aria-label="February 5" value="0001-02-05" blazor:onclick="39" b-bgn9u4guxz="">5</div>
-        <div part="day" class="day" inactive="" aria-label="February 6" value="0001-02-06" blazor:onclick="40" b-bgn9u4guxz="">6</div>
-        <div part="day" class="day" inactive="" aria-label="February 7" value="0001-02-07" blazor:onclick="41" b-bgn9u4guxz="">7</div>
-        <div part="day" class="day" inactive="" aria-label="February 8" value="0001-02-08" blazor:onclick="42" b-bgn9u4guxz="">8</div>
-        <div part="day" class="day" inactive="" aria-label="February 9" value="0001-02-09" blazor:onclick="43" b-bgn9u4guxz="">9</div>
-        <div part="day" class="day" inactive="" aria-label="February 10" value="0001-02-10" blazor:onclick="44" b-bgn9u4guxz="">10</div>
+        <div part="day" class="day" inactive="" aria-label="February 4" value="0001-02-04" blazor:onkeydown="111" blazor:onclick="112" blazor:onmouseover="113" b-bgn9u4guxz="">4</div>
+        <div part="day" class="day" inactive="" aria-label="February 5" value="0001-02-05" blazor:onkeydown="114" blazor:onclick="115" blazor:onmouseover="116" b-bgn9u4guxz="">5</div>
+        <div part="day" class="day" inactive="" aria-label="February 6" value="0001-02-06" blazor:onkeydown="117" blazor:onclick="118" blazor:onmouseover="119" b-bgn9u4guxz="">6</div>
+        <div part="day" class="day" inactive="" aria-label="February 7" value="0001-02-07" blazor:onkeydown="120" blazor:onclick="121" blazor:onmouseover="122" b-bgn9u4guxz="">7</div>
+        <div part="day" class="day" inactive="" aria-label="February 8" value="0001-02-08" blazor:onkeydown="123" blazor:onclick="124" blazor:onmouseover="125" b-bgn9u4guxz="">8</div>
+        <div part="day" class="day" inactive="" aria-label="February 9" value="0001-02-09" blazor:onkeydown="126" blazor:onclick="127" blazor:onmouseover="128" b-bgn9u4guxz="">9</div>
+        <div part="day" class="day" inactive="" aria-label="February 10" value="0001-02-10" blazor:onkeydown="129" blazor:onclick="130" blazor:onmouseover="131" b-bgn9u4guxz="">10</div>
       </div>
     </div>
   </div>

--- a/tests/Core/DateTime/FluentCalendarTests.FluentCalendar_Minimum_View-months.verified.razor.html
+++ b/tests/Core/DateTime/FluentCalendarTests.FluentCalendar_Minimum_View-months.verified.razor.html
@@ -1,11 +1,11 @@
 
-<div class="fluent-month" b-bgn9u4guxz="">
+<div id="xxx" class="fluent-month" b-bgn9u4guxz="">
   <div b-bgn9u4guxz="">
     <div class="title" part="title" aria-label="1" b-bgn9u4guxz="">
-      <div part="label" class="label animation-none" blazor:onclick="1" b-bgn9u4guxz="">1</div>
+      <div part="label" class="label animation-none" role="button" tabindex="0" blazor:onclick="1" blazor:onkeydown="2" b-bgn9u4guxz="">1</div>
       <div part="move" class="change-period" b-bgn9u4guxz="">
         <div class="previous" disabled="" b-bgn9u4guxz=""></div>
-        <div class="next" title="2" blazor:onclick="2" b-bgn9u4guxz="">
+        <div class="next" title="2" blazor:onclick="3" role="button" tabindex="0" blazor:onkeydown="4" b-bgn9u4guxz="">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="var(--neutral-fill-strong-focus)" xmlns="http://www.w3.org/2000/svg">
             <path d="M19.8 13.27a.75.75 0 00-1.1-1.04l-5.95 6.25V3.75a.75.75 0 10-1.5 0v14.73L5.3 12.23a.75.75 0 10-1.1 1.04l7.08 7.42a1 1 0 001.44 0l7.07-7.42z"></path>
           </svg>
@@ -13,18 +13,18 @@
       </div>
     </div>
     <div class="months" part="months" b-bgn9u4guxz="">
-      <div class="month animation-none" selected="" aria-label="January 0001" title="January 0001" value="0001-01" blazor:onclick="3" b-bgn9u4guxz="">Jan</div>
-      <div class="month animation-none" aria-label="February 0001" title="February 0001" value="0001-02" blazor:onclick="4" b-bgn9u4guxz="">Feb</div>
-      <div class="month animation-none" aria-label="March 0001" title="March 0001" value="0001-03" blazor:onclick="5" b-bgn9u4guxz="">Mar</div>
-      <div class="month animation-none" aria-label="April 0001" title="April 0001" value="0001-04" blazor:onclick="6" b-bgn9u4guxz="">Apr</div>
-      <div class="month animation-none" aria-label="May 0001" title="May 0001" value="0001-05" blazor:onclick="7" b-bgn9u4guxz="">May</div>
-      <div class="month animation-none" aria-label="June 0001" title="June 0001" value="0001-06" blazor:onclick="8" b-bgn9u4guxz="">Jun</div>
-      <div class="month animation-none" aria-label="July 0001" title="July 0001" value="0001-07" blazor:onclick="9" b-bgn9u4guxz="">Jul</div>
-      <div class="month animation-none" aria-label="August 0001" title="August 0001" value="0001-08" blazor:onclick="10" b-bgn9u4guxz="">Aug</div>
-      <div class="month animation-none" aria-label="September 0001" title="September 0001" value="0001-09" blazor:onclick="11" b-bgn9u4guxz="">Sep</div>
-      <div class="month animation-none" aria-label="October 0001" title="October 0001" value="0001-10" blazor:onclick="12" b-bgn9u4guxz="">Oct</div>
-      <div class="month animation-none" aria-label="November 0001" title="November 0001" value="0001-11" blazor:onclick="13" b-bgn9u4guxz="">Nov</div>
-      <div class="month animation-none" aria-label="December 0001" title="December 0001" value="0001-12" blazor:onclick="14" b-bgn9u4guxz="">Dec</div>
+      <div class="month animation-none" selected="" aria-label="January 0001" title="January 0001" value="0001-01" role="button" tabindex="0" blazor:onkeydown="5" blazor:onclick="6" b-bgn9u4guxz="">Jan</div>
+      <div class="month animation-none" aria-label="February 0001" title="February 0001" value="0001-02" role="button" tabindex="0" blazor:onkeydown="7" blazor:onclick="8" b-bgn9u4guxz="">Feb</div>
+      <div class="month animation-none" aria-label="March 0001" title="March 0001" value="0001-03" role="button" tabindex="0" blazor:onkeydown="9" blazor:onclick="10" b-bgn9u4guxz="">Mar</div>
+      <div class="month animation-none" aria-label="April 0001" title="April 0001" value="0001-04" role="button" tabindex="0" blazor:onkeydown="11" blazor:onclick="12" b-bgn9u4guxz="">Apr</div>
+      <div class="month animation-none" aria-label="May 0001" title="May 0001" value="0001-05" role="button" tabindex="0" blazor:onkeydown="13" blazor:onclick="14" b-bgn9u4guxz="">May</div>
+      <div class="month animation-none" aria-label="June 0001" title="June 0001" value="0001-06" role="button" tabindex="0" blazor:onkeydown="15" blazor:onclick="16" b-bgn9u4guxz="">Jun</div>
+      <div class="month animation-none" aria-label="July 0001" title="July 0001" value="0001-07" role="button" tabindex="0" blazor:onkeydown="17" blazor:onclick="18" b-bgn9u4guxz="">Jul</div>
+      <div class="month animation-none" aria-label="August 0001" title="August 0001" value="0001-08" role="button" tabindex="0" blazor:onkeydown="19" blazor:onclick="20" b-bgn9u4guxz="">Aug</div>
+      <div class="month animation-none" aria-label="September 0001" title="September 0001" value="0001-09" role="button" tabindex="0" blazor:onkeydown="21" blazor:onclick="22" b-bgn9u4guxz="">Sep</div>
+      <div class="month animation-none" aria-label="October 0001" title="October 0001" value="0001-10" role="button" tabindex="0" blazor:onkeydown="23" blazor:onclick="24" b-bgn9u4guxz="">Oct</div>
+      <div class="month animation-none" aria-label="November 0001" title="November 0001" value="0001-11" role="button" tabindex="0" blazor:onkeydown="25" blazor:onclick="26" b-bgn9u4guxz="">Nov</div>
+      <div class="month animation-none" aria-label="December 0001" title="December 0001" value="0001-12" role="button" tabindex="0" blazor:onkeydown="27" blazor:onclick="28" b-bgn9u4guxz="">Dec</div>
     </div>
   </div>
 </div>

--- a/tests/Core/DateTime/FluentCalendarTests.FluentCalendar_Minimum_View-years.verified.razor.html
+++ b/tests/Core/DateTime/FluentCalendarTests.FluentCalendar_Minimum_View-years.verified.razor.html
@@ -1,11 +1,11 @@
 
-<div class="fluent-year" b-bgn9u4guxz="">
+<div id="xxx" class="fluent-year" b-bgn9u4guxz="">
   <div b-bgn9u4guxz="">
     <div class="title" part="title" aria-label="1 - 12" b-bgn9u4guxz="">
-      <div part="label" class="label" blazor:onclick="1" b-bgn9u4guxz="">1 - 12</div>
+      <div part="label" class="label" role="button" tabindex="0" blazor:onclick="1" blazor:onkeydown="2" b-bgn9u4guxz="">1 - 12</div>
       <div part="move" class="change-period" b-bgn9u4guxz="">
         <div class="previous" disabled="" b-bgn9u4guxz=""></div>
-        <div class="next" title="13 - 24" blazor:onclick="2" b-bgn9u4guxz="">
+        <div class="next" title="13 - 24" blazor:onclick="3" role="button" tabindex="0" blazor:onkeydown="4" b-bgn9u4guxz="">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="var(--neutral-fill-strong-focus)" xmlns="http://www.w3.org/2000/svg">
             <path d="M19.8 13.27a.75.75 0 00-1.1-1.04l-5.95 6.25V3.75a.75.75 0 10-1.5 0v14.73L5.3 12.23a.75.75 0 10-1.1 1.04l7.08 7.42a1 1 0 001.44 0l7.07-7.42z"></path>
           </svg>
@@ -13,18 +13,18 @@
       </div>
     </div>
     <div class="years" part="years" b-bgn9u4guxz="">
-      <div class="year" selected="" aria-label="1" title="1" value="0001" blazor:onclick="3" b-bgn9u4guxz="">1</div>
-      <div class="year" aria-label="2" title="2" value="0002" blazor:onclick="4" b-bgn9u4guxz="">2</div>
-      <div class="year" aria-label="3" title="3" value="0003" blazor:onclick="5" b-bgn9u4guxz="">3</div>
-      <div class="year" aria-label="4" title="4" value="0004" blazor:onclick="6" b-bgn9u4guxz="">4</div>
-      <div class="year" aria-label="5" title="5" value="0005" blazor:onclick="7" b-bgn9u4guxz="">5</div>
-      <div class="year" aria-label="6" title="6" value="0006" blazor:onclick="8" b-bgn9u4guxz="">6</div>
-      <div class="year" aria-label="7" title="7" value="0007" blazor:onclick="9" b-bgn9u4guxz="">7</div>
-      <div class="year" aria-label="8" title="8" value="0008" blazor:onclick="10" b-bgn9u4guxz="">8</div>
-      <div class="year" aria-label="9" title="9" value="0009" blazor:onclick="11" b-bgn9u4guxz="">9</div>
-      <div class="year" aria-label="10" title="10" value="0010" blazor:onclick="12" b-bgn9u4guxz="">10</div>
-      <div class="year" aria-label="11" title="11" value="0011" blazor:onclick="13" b-bgn9u4guxz="">11</div>
-      <div class="year" aria-label="12" title="12" value="0012" blazor:onclick="14" b-bgn9u4guxz="">12</div>
+      <div class="year" selected="" aria-label="1" title="1" value="0001" tabindex="0" blazor:onkeydown="5" blazor:onclick="6" b-bgn9u4guxz="">1</div>
+      <div class="year" aria-label="2" title="2" value="0002" tabindex="0" blazor:onkeydown="7" blazor:onclick="8" b-bgn9u4guxz="">2</div>
+      <div class="year" aria-label="3" title="3" value="0003" tabindex="0" blazor:onkeydown="9" blazor:onclick="10" b-bgn9u4guxz="">3</div>
+      <div class="year" aria-label="4" title="4" value="0004" tabindex="0" blazor:onkeydown="11" blazor:onclick="12" b-bgn9u4guxz="">4</div>
+      <div class="year" aria-label="5" title="5" value="0005" tabindex="0" blazor:onkeydown="13" blazor:onclick="14" b-bgn9u4guxz="">5</div>
+      <div class="year" aria-label="6" title="6" value="0006" tabindex="0" blazor:onkeydown="15" blazor:onclick="16" b-bgn9u4guxz="">6</div>
+      <div class="year" aria-label="7" title="7" value="0007" tabindex="0" blazor:onkeydown="17" blazor:onclick="18" b-bgn9u4guxz="">7</div>
+      <div class="year" aria-label="8" title="8" value="0008" tabindex="0" blazor:onkeydown="19" blazor:onclick="20" b-bgn9u4guxz="">8</div>
+      <div class="year" aria-label="9" title="9" value="0009" tabindex="0" blazor:onkeydown="21" blazor:onclick="22" b-bgn9u4guxz="">9</div>
+      <div class="year" aria-label="10" title="10" value="0010" tabindex="0" blazor:onkeydown="23" blazor:onclick="24" b-bgn9u4guxz="">10</div>
+      <div class="year" aria-label="11" title="11" value="0011" tabindex="0" blazor:onkeydown="25" blazor:onclick="26" b-bgn9u4guxz="">11</div>
+      <div class="year" aria-label="12" title="12" value="0012" tabindex="0" blazor:onkeydown="27" blazor:onclick="28" b-bgn9u4guxz="">12</div>
     </div>
   </div>
 </div>

--- a/tests/Core/DateTime/FluentCalendarTests.FluentCalendar_TitleClick-days.verified.razor.html
+++ b/tests/Core/DateTime/FluentCalendarTests.FluentCalendar_TitleClick-days.verified.razor.html
@@ -1,16 +1,16 @@
 
-<div class="fluent-calendar" b-bgn9u4guxz="">
-  <div class="fluent-month" b-bgn9u4guxz="">
+<div id="xxx" class="fluent-calendar" b-bgn9u4guxz="">
+  <div id="xxx" class="fluent-month" b-bgn9u4guxz="">
     <div b-bgn9u4guxz="">
       <div class="title" part="title" aria-label="2022" b-bgn9u4guxz="">
-        <div part="label" class="label" blazor:onclick="46" b-bgn9u4guxz="">2022</div>
+        <div part="label" class="label" role="button" tabindex="0" blazor:onclick="134" blazor:onkeydown="135" b-bgn9u4guxz="">2022</div>
         <div part="move" class="change-period" b-bgn9u4guxz="">
-          <div class="previous" title="2021" blazor:onclick="47" b-bgn9u4guxz="">
+          <div class="previous" title="2021" blazor:onclick="136" role="button" tabindex="0" blazor:onkeydown="137" b-bgn9u4guxz="">
             <svg width="24" height="24" viewBox="0 0 24 24" fill="var(--neutral-fill-strong-focus)" xmlns="http://www.w3.org/2000/svg">
               <path d="M4.2 10.73a.75.75 0 001.1 1.04l5.95-6.25v14.73a.75.75 0 001.5 0V5.52l5.95 6.25a.75.75 0 001.1-1.04l-7.08-7.42a1 1 0 00-1.44 0L4.2 10.73z"></path>
             </svg>
           </div>
-          <div class="next" title="2023" blazor:onclick="48" b-bgn9u4guxz="">
+          <div class="next" title="2023" blazor:onclick="138" role="button" tabindex="0" blazor:onkeydown="139" b-bgn9u4guxz="">
             <svg width="24" height="24" viewBox="0 0 24 24" fill="var(--neutral-fill-strong-focus)" xmlns="http://www.w3.org/2000/svg">
               <path d="M19.8 13.27a.75.75 0 00-1.1-1.04l-5.95 6.25V3.75a.75.75 0 10-1.5 0v14.73L5.3 12.23a.75.75 0 10-1.1 1.04l7.08 7.42a1 1 0 001.44 0l7.07-7.42z"></path>
             </svg>
@@ -18,18 +18,18 @@
         </div>
       </div>
       <div class="months" part="months" b-bgn9u4guxz="">
-        <div class="month" aria-label="January 2022" title="January 2022" value="2022-01" blazor:onclick="49" b-bgn9u4guxz="">Jan</div>
-        <div class="month" aria-label="February 2022" title="February 2022" value="2022-02" blazor:onclick="50" b-bgn9u4guxz="">Feb</div>
-        <div class="month" aria-label="March 2022" title="March 2022" value="2022-03" blazor:onclick="51" b-bgn9u4guxz="">Mar</div>
-        <div class="month" selected="" aria-label="April 2022" title="April 2022" value="2022-04" blazor:onclick="52" b-bgn9u4guxz="">Apr</div>
-        <div class="month" aria-label="May 2022" title="May 2022" value="2022-05" blazor:onclick="53" b-bgn9u4guxz="">May</div>
-        <div class="month" aria-label="June 2022" title="June 2022" value="2022-06" blazor:onclick="54" b-bgn9u4guxz="">Jun</div>
-        <div class="month" aria-label="July 2022" title="July 2022" value="2022-07" blazor:onclick="55" b-bgn9u4guxz="">Jul</div>
-        <div class="month" aria-label="August 2022" title="August 2022" value="2022-08" blazor:onclick="56" b-bgn9u4guxz="">Aug</div>
-        <div class="month" aria-label="September 2022" title="September 2022" value="2022-09" blazor:onclick="57" b-bgn9u4guxz="">Sep</div>
-        <div class="month" aria-label="October 2022" title="October 2022" value="2022-10" blazor:onclick="58" b-bgn9u4guxz="">Oct</div>
-        <div class="month" aria-label="November 2022" title="November 2022" value="2022-11" blazor:onclick="59" b-bgn9u4guxz="">Nov</div>
-        <div class="month" aria-label="December 2022" title="December 2022" value="2022-12" blazor:onclick="60" b-bgn9u4guxz="">Dec</div>
+        <div class="month" aria-label="January 2022" title="January 2022" value="2022-01" role="button" tabindex="0" blazor:onkeydown="140" blazor:onclick="141" b-bgn9u4guxz="">Jan</div>
+        <div class="month" aria-label="February 2022" title="February 2022" value="2022-02" role="button" tabindex="0" blazor:onkeydown="142" blazor:onclick="143" b-bgn9u4guxz="">Feb</div>
+        <div class="month" aria-label="March 2022" title="March 2022" value="2022-03" role="button" tabindex="0" blazor:onkeydown="144" blazor:onclick="145" b-bgn9u4guxz="">Mar</div>
+        <div class="month" selected="" aria-label="April 2022" title="April 2022" value="2022-04" role="button" tabindex="0" blazor:onkeydown="146" blazor:onclick="147" b-bgn9u4guxz="">Apr</div>
+        <div class="month" aria-label="May 2022" title="May 2022" value="2022-05" role="button" tabindex="0" blazor:onkeydown="148" blazor:onclick="149" b-bgn9u4guxz="">May</div>
+        <div class="month" aria-label="June 2022" title="June 2022" value="2022-06" role="button" tabindex="0" blazor:onkeydown="150" blazor:onclick="151" b-bgn9u4guxz="">Jun</div>
+        <div class="month" aria-label="July 2022" title="July 2022" value="2022-07" role="button" tabindex="0" blazor:onkeydown="152" blazor:onclick="153" b-bgn9u4guxz="">Jul</div>
+        <div class="month" aria-label="August 2022" title="August 2022" value="2022-08" role="button" tabindex="0" blazor:onkeydown="154" blazor:onclick="155" b-bgn9u4guxz="">Aug</div>
+        <div class="month" aria-label="September 2022" title="September 2022" value="2022-09" role="button" tabindex="0" blazor:onkeydown="156" blazor:onclick="157" b-bgn9u4guxz="">Sep</div>
+        <div class="month" aria-label="October 2022" title="October 2022" value="2022-10" role="button" tabindex="0" blazor:onkeydown="158" blazor:onclick="159" b-bgn9u4guxz="">Oct</div>
+        <div class="month" aria-label="November 2022" title="November 2022" value="2022-11" role="button" tabindex="0" blazor:onkeydown="160" blazor:onclick="161" b-bgn9u4guxz="">Nov</div>
+        <div class="month" aria-label="December 2022" title="December 2022" value="2022-12" role="button" tabindex="0" blazor:onkeydown="162" blazor:onclick="163" b-bgn9u4guxz="">Dec</div>
       </div>
     </div>
   </div>

--- a/tests/Core/DateTime/FluentCalendarTests.FluentCalendar_TitleClick-months.verified.razor.html
+++ b/tests/Core/DateTime/FluentCalendarTests.FluentCalendar_TitleClick-months.verified.razor.html
@@ -1,16 +1,16 @@
 
-<div class="fluent-month" b-bgn9u4guxz="">
-  <div class="fluent-year" b-bgn9u4guxz="">
+<div id="xxx" class="fluent-month" b-bgn9u4guxz="">
+  <div id="xxx" class="fluent-year" b-bgn9u4guxz="">
     <div b-bgn9u4guxz="">
       <div class="title" part="title" aria-label="2022 - 2033" b-bgn9u4guxz="">
-        <div part="label" class="label" blazor:onclick="16" b-bgn9u4guxz="">2022 - 2033</div>
+        <div part="label" class="label" role="button" tabindex="0" blazor:onclick="31" blazor:onkeydown="32" b-bgn9u4guxz="">2022 - 2033</div>
         <div part="move" class="change-period" b-bgn9u4guxz="">
-          <div class="previous" title="2010 - 2021" blazor:onclick="17" b-bgn9u4guxz="">
+          <div class="previous" title="2010 - 2021" blazor:onclick="33" role="button" tabindex="0" blazor:onkeydown="34" b-bgn9u4guxz="">
             <svg width="24" height="24" viewBox="0 0 24 24" fill="var(--neutral-fill-strong-focus)" xmlns="http://www.w3.org/2000/svg">
               <path d="M4.2 10.73a.75.75 0 001.1 1.04l5.95-6.25v14.73a.75.75 0 001.5 0V5.52l5.95 6.25a.75.75 0 001.1-1.04l-7.08-7.42a1 1 0 00-1.44 0L4.2 10.73z"></path>
             </svg>
           </div>
-          <div class="next" title="2034 - 2045" blazor:onclick="18" b-bgn9u4guxz="">
+          <div class="next" title="2034 - 2045" blazor:onclick="35" role="button" tabindex="0" blazor:onkeydown="36" b-bgn9u4guxz="">
             <svg width="24" height="24" viewBox="0 0 24 24" fill="var(--neutral-fill-strong-focus)" xmlns="http://www.w3.org/2000/svg">
               <path d="M19.8 13.27a.75.75 0 00-1.1-1.04l-5.95 6.25V3.75a.75.75 0 10-1.5 0v14.73L5.3 12.23a.75.75 0 10-1.1 1.04l7.08 7.42a1 1 0 001.44 0l7.07-7.42z"></path>
             </svg>
@@ -18,18 +18,18 @@
         </div>
       </div>
       <div class="years" part="years" b-bgn9u4guxz="">
-        <div class="year" selected="" aria-label="2022" title="2022" value="2022" blazor:onclick="19" b-bgn9u4guxz="">2022</div>
-        <div class="year" aria-label="2023" title="2023" value="2023" blazor:onclick="20" b-bgn9u4guxz="">2023</div>
-        <div class="year" aria-label="2024" title="2024" value="2024" blazor:onclick="21" b-bgn9u4guxz="">2024</div>
-        <div class="year" aria-label="2025" title="2025" value="2025" blazor:onclick="22" b-bgn9u4guxz="">2025</div>
-        <div class="year" aria-label="2026" title="2026" value="2026" blazor:onclick="23" b-bgn9u4guxz="">2026</div>
-        <div class="year" aria-label="2027" title="2027" value="2027" blazor:onclick="24" b-bgn9u4guxz="">2027</div>
-        <div class="year" aria-label="2028" title="2028" value="2028" blazor:onclick="25" b-bgn9u4guxz="">2028</div>
-        <div class="year" aria-label="2029" title="2029" value="2029" blazor:onclick="26" b-bgn9u4guxz="">2029</div>
-        <div class="year" aria-label="2030" title="2030" value="2030" blazor:onclick="27" b-bgn9u4guxz="">2030</div>
-        <div class="year" aria-label="2031" title="2031" value="2031" blazor:onclick="28" b-bgn9u4guxz="">2031</div>
-        <div class="year" aria-label="2032" title="2032" value="2032" blazor:onclick="29" b-bgn9u4guxz="">2032</div>
-        <div class="year" aria-label="2033" title="2033" value="2033" blazor:onclick="30" b-bgn9u4guxz="">2033</div>
+        <div class="year" selected="" aria-label="2022" title="2022" value="2022" tabindex="0" blazor:onkeydown="37" blazor:onclick="38" b-bgn9u4guxz="">2022</div>
+        <div class="year" aria-label="2023" title="2023" value="2023" tabindex="0" blazor:onkeydown="39" blazor:onclick="40" b-bgn9u4guxz="">2023</div>
+        <div class="year" aria-label="2024" title="2024" value="2024" tabindex="0" blazor:onkeydown="41" blazor:onclick="42" b-bgn9u4guxz="">2024</div>
+        <div class="year" aria-label="2025" title="2025" value="2025" tabindex="0" blazor:onkeydown="43" blazor:onclick="44" b-bgn9u4guxz="">2025</div>
+        <div class="year" aria-label="2026" title="2026" value="2026" tabindex="0" blazor:onkeydown="45" blazor:onclick="46" b-bgn9u4guxz="">2026</div>
+        <div class="year" aria-label="2027" title="2027" value="2027" tabindex="0" blazor:onkeydown="47" blazor:onclick="48" b-bgn9u4guxz="">2027</div>
+        <div class="year" aria-label="2028" title="2028" value="2028" tabindex="0" blazor:onkeydown="49" blazor:onclick="50" b-bgn9u4guxz="">2028</div>
+        <div class="year" aria-label="2029" title="2029" value="2029" tabindex="0" blazor:onkeydown="51" blazor:onclick="52" b-bgn9u4guxz="">2029</div>
+        <div class="year" aria-label="2030" title="2030" value="2030" tabindex="0" blazor:onkeydown="53" blazor:onclick="54" b-bgn9u4guxz="">2030</div>
+        <div class="year" aria-label="2031" title="2031" value="2031" tabindex="0" blazor:onkeydown="55" blazor:onclick="56" b-bgn9u4guxz="">2031</div>
+        <div class="year" aria-label="2032" title="2032" value="2032" tabindex="0" blazor:onkeydown="57" blazor:onclick="58" b-bgn9u4guxz="">2032</div>
+        <div class="year" aria-label="2033" title="2033" value="2033" tabindex="0" blazor:onkeydown="59" blazor:onclick="60" b-bgn9u4guxz="">2033</div>
       </div>
     </div>
   </div>

--- a/tests/Core/DateTime/FluentCalendarTests.FluentCalendar_TitleClick-years.verified.razor.html
+++ b/tests/Core/DateTime/FluentCalendarTests.FluentCalendar_TitleClick-years.verified.razor.html
@@ -1,15 +1,15 @@
 
-<div class="fluent-year" b-bgn9u4guxz="">
+<div id="xxx" class="fluent-year" b-bgn9u4guxz="">
   <div b-bgn9u4guxz="">
     <div class="title" part="title" aria-label="2022 - 2033" b-bgn9u4guxz="">
-      <div part="label" class="label" blazor:onclick="16" b-bgn9u4guxz="">2022 - 2033</div>
+      <div part="label" class="label" role="button" tabindex="0" blazor:onclick="31" blazor:onkeydown="32" b-bgn9u4guxz="">2022 - 2033</div>
       <div part="move" class="change-period" b-bgn9u4guxz="">
-        <div class="previous" title="2010 - 2021" blazor:onclick="2" b-bgn9u4guxz="">
+        <div class="previous" title="2010 - 2021" blazor:onclick="3" role="button" tabindex="0" blazor:onkeydown="4" b-bgn9u4guxz="">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="var(--neutral-fill-strong-focus)" xmlns="http://www.w3.org/2000/svg">
             <path d="M4.2 10.73a.75.75 0 001.1 1.04l5.95-6.25v14.73a.75.75 0 001.5 0V5.52l5.95 6.25a.75.75 0 001.1-1.04l-7.08-7.42a1 1 0 00-1.44 0L4.2 10.73z"></path>
           </svg>
         </div>
-        <div class="next" title="2034 - 2045" blazor:onclick="3" b-bgn9u4guxz="">
+        <div class="next" title="2034 - 2045" blazor:onclick="5" role="button" tabindex="0" blazor:onkeydown="6" b-bgn9u4guxz="">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="var(--neutral-fill-strong-focus)" xmlns="http://www.w3.org/2000/svg">
             <path d="M19.8 13.27a.75.75 0 00-1.1-1.04l-5.95 6.25V3.75a.75.75 0 10-1.5 0v14.73L5.3 12.23a.75.75 0 10-1.1 1.04l7.08 7.42a1 1 0 001.44 0l7.07-7.42z"></path>
           </svg>
@@ -17,18 +17,18 @@
       </div>
     </div>
     <div class="years" part="years" b-bgn9u4guxz="">
-      <div class="year" selected="" aria-label="2022" title="2022" value="2022" blazor:onclick="17" b-bgn9u4guxz="">2022</div>
-      <div class="year" aria-label="2023" title="2023" value="2023" blazor:onclick="18" b-bgn9u4guxz="">2023</div>
-      <div class="year" aria-label="2024" title="2024" value="2024" blazor:onclick="19" b-bgn9u4guxz="">2024</div>
-      <div class="year" aria-label="2025" title="2025" value="2025" blazor:onclick="20" b-bgn9u4guxz="">2025</div>
-      <div class="year" aria-label="2026" title="2026" value="2026" blazor:onclick="21" b-bgn9u4guxz="">2026</div>
-      <div class="year" aria-label="2027" title="2027" value="2027" blazor:onclick="22" b-bgn9u4guxz="">2027</div>
-      <div class="year" aria-label="2028" title="2028" value="2028" blazor:onclick="23" b-bgn9u4guxz="">2028</div>
-      <div class="year" aria-label="2029" title="2029" value="2029" blazor:onclick="24" b-bgn9u4guxz="">2029</div>
-      <div class="year" aria-label="2030" title="2030" value="2030" blazor:onclick="25" b-bgn9u4guxz="">2030</div>
-      <div class="year" aria-label="2031" title="2031" value="2031" blazor:onclick="26" b-bgn9u4guxz="">2031</div>
-      <div class="year" aria-label="2032" title="2032" value="2032" blazor:onclick="27" b-bgn9u4guxz="">2032</div>
-      <div class="year" aria-label="2033" title="2033" value="2033" blazor:onclick="28" b-bgn9u4guxz="">2033</div>
+      <div class="year" selected="" aria-label="2022" title="2022" value="2022" tabindex="0" blazor:onkeydown="33" blazor:onclick="34" b-bgn9u4guxz="">2022</div>
+      <div class="year" aria-label="2023" title="2023" value="2023" tabindex="0" blazor:onkeydown="35" blazor:onclick="36" b-bgn9u4guxz="">2023</div>
+      <div class="year" aria-label="2024" title="2024" value="2024" tabindex="0" blazor:onkeydown="37" blazor:onclick="38" b-bgn9u4guxz="">2024</div>
+      <div class="year" aria-label="2025" title="2025" value="2025" tabindex="0" blazor:onkeydown="39" blazor:onclick="40" b-bgn9u4guxz="">2025</div>
+      <div class="year" aria-label="2026" title="2026" value="2026" tabindex="0" blazor:onkeydown="41" blazor:onclick="42" b-bgn9u4guxz="">2026</div>
+      <div class="year" aria-label="2027" title="2027" value="2027" tabindex="0" blazor:onkeydown="43" blazor:onclick="44" b-bgn9u4guxz="">2027</div>
+      <div class="year" aria-label="2028" title="2028" value="2028" tabindex="0" blazor:onkeydown="45" blazor:onclick="46" b-bgn9u4guxz="">2028</div>
+      <div class="year" aria-label="2029" title="2029" value="2029" tabindex="0" blazor:onkeydown="47" blazor:onclick="48" b-bgn9u4guxz="">2029</div>
+      <div class="year" aria-label="2030" title="2030" value="2030" tabindex="0" blazor:onkeydown="49" blazor:onclick="50" b-bgn9u4guxz="">2030</div>
+      <div class="year" aria-label="2031" title="2031" value="2031" tabindex="0" blazor:onkeydown="51" blazor:onclick="52" b-bgn9u4guxz="">2031</div>
+      <div class="year" aria-label="2032" title="2032" value="2032" tabindex="0" blazor:onkeydown="53" blazor:onclick="54" b-bgn9u4guxz="">2032</div>
+      <div class="year" aria-label="2033" title="2033" value="2033" tabindex="0" blazor:onkeydown="55" blazor:onclick="56" b-bgn9u4guxz="">2033</div>
     </div>
   </div>
 </div>

--- a/tests/Core/DateTime/FluentCalendarTests.cs
+++ b/tests/Core/DateTime/FluentCalendarTests.cs
@@ -40,12 +40,12 @@ public partial class FluentCalendarTests : TestContext
 
         // Assert
         title.MarkupMatches(@$"<div class=""title"" part=""title"" aria-label=""February 2022"">
-                                 <div part=""label"" class=""label"">February 2022</div>
+                                 <div part=""label"" class=""label"" role=""button"" tabindex=""0"">February 2022</div>
                                  <div part=""move"" class=""change-period"">
-                                   <div class=""previous"" title=""January"">
+                                   <div class=""previous"" title=""January"" role=""button"" tabindex=""0"">
                                      {FluentCalendar.ArrowUp}
                                    </div>
-                                   <div class=""next"" title=""March"">
+                                   <div class=""next"" title=""March"" role=""button"" tabindex=""0"">
                                      {FluentCalendar.ArrowDown}
                                    </div>
                                  </div>
@@ -70,12 +70,12 @@ public partial class FluentCalendarTests : TestContext
 
         // Assert
         title.MarkupMatches(@$"<div class=""title"" part=""title"" aria-label=""{monthNameWithYear}"">
-                                 <div part=""label"" class=""label"">{monthNameWithYear}</div>
+                                 <div part=""label"" class=""label"" role=""button"" tabindex=""0"">{monthNameWithYear}</div>
                                  <div part=""move"" class=""change-period"">
-                                   <div class=""previous"" title=""{prevMonthName}"">
+                                   <div class=""previous"" title=""{prevMonthName}"" role=""button"" tabindex=""0"">
                                      {FluentCalendar.ArrowUp}
                                    </div>
-                                   <div class=""next"" title=""{nextMonthName}"">
+                                   <div class=""next"" title=""{nextMonthName}"" role=""button"" tabindex=""0"">
                                      {FluentCalendar.ArrowDown}
                                    </div>
                                  </div>
@@ -151,6 +151,8 @@ public partial class FluentCalendarTests : TestContext
         // Assert
         day.MarkupMatches(@"<div part=""day""
                                  class=""day""
+                                 role=""button""
+                                 tabindex=""0""
                                  aria-label=""February 20""
                                  value=""2022-02-20"">20</div>");
     }

--- a/tests/Core/DateTime/FluentDatePickerTests.FluentCalendar_DisabledDate.verified.html
+++ b/tests/Core/DateTime/FluentDatePickerTests.FluentCalendar_DisabledDate.verified.html
@@ -1,84 +1,84 @@
 
-<div class="fluent-calendar" b-bgn9u4guxz="">
+<div id="xxx" class="fluent-calendar" b-bgn9u4guxz="">
   <div b-bgn9u4guxz="">
     <div class="title" part="title" aria-label="February 2022" b-bgn9u4guxz="">
-      <div part="label" class="label" blazor:onclick="6" b-bgn9u4guxz="">February 2022</div>
+      <div part="label" class="label" role="button" tabindex="0" blazor:onclick="8" blazor:onkeydown="9" b-bgn9u4guxz="">February 2022</div>
       <div part="move" class="change-period" b-bgn9u4guxz="">
-        <div class="previous" title="January" blazor:onclick="7" b-bgn9u4guxz="">
+        <div class="previous" title="January" blazor:onclick="10" role="button" tabindex="0" blazor:onkeydown="11" b-bgn9u4guxz="">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="var(--neutral-fill-strong-focus)" xmlns="http://www.w3.org/2000/svg">
             <path d="M4.2 10.73a.75.75 0 001.1 1.04l5.95-6.25v14.73a.75.75 0 001.5 0V5.52l5.95 6.25a.75.75 0 001.1-1.04l-7.08-7.42a1 1 0 00-1.44 0L4.2 10.73z"></path>
           </svg>
         </div>
-        <div class="next" title="March" blazor:onclick="8" b-bgn9u4guxz="">
+        <div class="next" title="March" blazor:onclick="12" role="button" tabindex="0" blazor:onkeydown="13" b-bgn9u4guxz="">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="var(--neutral-fill-strong-focus)" xmlns="http://www.w3.org/2000/svg">
             <path d="M19.8 13.27a.75.75 0 00-1.1-1.04l-5.95 6.25V3.75a.75.75 0 10-1.5 0v14.73L5.3 12.23a.75.75 0 10-1.1 1.04l7.08 7.42a1 1 0 001.44 0l7.07-7.42z"></path>
           </svg>
         </div>
       </div>
     </div>
-    <div class="days" part="days">
-      <div class="week-days" part="week-days">
-        <div class="week-day" part="week-day" title="Sunday" abbr="Sunday">S</div>
-        <div class="week-day" part="week-day" title="Monday" abbr="Monday">M</div>
-        <div class="week-day" part="week-day" title="Tuesday" abbr="Tuesday">T</div>
-        <div class="week-day" part="week-day" title="Wednesday" abbr="Wednesday">W</div>
-        <div class="week-day" part="week-day" title="Thursday" abbr="Thursday">T</div>
-        <div class="week-day" part="week-day" title="Friday" abbr="Friday">F</div>
-        <div class="week-day" part="week-day" title="Saturday" abbr="Saturday">S</div>
+    <div class="days" part="days" blazor:onmouseleave="14" b-bgn9u4guxz="">
+      <div class="week-days" part="week-days" b-bgn9u4guxz="">
+        <div class="week-day" part="week-day" title="Sunday" abbr="Sunday" b-bgn9u4guxz="">S</div>
+        <div class="week-day" part="week-day" title="Monday" abbr="Monday" b-bgn9u4guxz="">M</div>
+        <div class="week-day" part="week-day" title="Tuesday" abbr="Tuesday" b-bgn9u4guxz="">T</div>
+        <div class="week-day" part="week-day" title="Wednesday" abbr="Wednesday" b-bgn9u4guxz="">W</div>
+        <div class="week-day" part="week-day" title="Thursday" abbr="Thursday" b-bgn9u4guxz="">T</div>
+        <div class="week-day" part="week-day" title="Friday" abbr="Friday" b-bgn9u4guxz="">F</div>
+        <div class="week-day" part="week-day" title="Saturday" abbr="Saturday" b-bgn9u4guxz="">S</div>
       </div>
-      <div class="week">
-        <div part="day" class="day" inactive="" aria-label="January 30" value="2022-01-30">30</div>
-        <div part="day" class="day" inactive="" aria-label="January 31" value="2022-01-31">31</div>
-        <div part="day" class="day" aria-label="February 1" value="2022-02-01">1</div>
-        <div part="day" class="day" aria-label="February 2" value="2022-02-02">2</div>
-        <div part="day" class="day" aria-label="February 3" value="2022-02-03">3</div>
-        <div part="day" class="day" aria-label="February 4" value="2022-02-04">4</div>
-        <div part="day" class="day" aria-label="February 5" value="2022-02-05">5</div>
+      <div class="week" b-bgn9u4guxz="">
+        <div part="day" class="day" inactive="" aria-label="January 30" value="2022-01-30" blazor:onkeydown="15" blazor:onclick="16" blazor:onmouseover="17" b-bgn9u4guxz="">30</div>
+        <div part="day" class="day" inactive="" aria-label="January 31" value="2022-01-31" blazor:onkeydown="18" blazor:onclick="19" blazor:onmouseover="20" b-bgn9u4guxz="">31</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 1" value="2022-02-01" blazor:onkeydown="21" blazor:onclick="22" blazor:onmouseover="23" b-bgn9u4guxz="">1</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 2" value="2022-02-02" blazor:onkeydown="24" blazor:onclick="25" blazor:onmouseover="26" b-bgn9u4guxz="">2</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 3" value="2022-02-03" blazor:onkeydown="27" blazor:onclick="28" blazor:onmouseover="29" b-bgn9u4guxz="">3</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 4" value="2022-02-04" blazor:onkeydown="30" blazor:onclick="31" blazor:onmouseover="32" b-bgn9u4guxz="">4</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 5" value="2022-02-05" blazor:onkeydown="33" blazor:onclick="34" blazor:onmouseover="35" b-bgn9u4guxz="">5</div>
       </div>
-      <div class="week">
-        <div part="day" class="day" aria-label="February 6" value="2022-02-06">6</div>
-        <div part="day" class="day" aria-label="February 7" value="2022-02-07">7</div>
-        <div part="day" class="day" aria-label="February 8" value="2022-02-08">8</div>
-        <div part="day" class="day" aria-label="February 9" value="2022-02-09">9</div>
-        <div part="day" class="day" aria-label="February 10" value="2022-02-10">10</div>
-        <div part="day" class="day" aria-label="February 11" value="2022-02-11">11</div>
-        <div part="day" class="day" aria-label="February 12" value="2022-02-12">12</div>
+      <div class="week" b-bgn9u4guxz="">
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 6" value="2022-02-06" blazor:onkeydown="36" blazor:onclick="37" blazor:onmouseover="38" b-bgn9u4guxz="">6</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 7" value="2022-02-07" blazor:onkeydown="39" blazor:onclick="40" blazor:onmouseover="41" b-bgn9u4guxz="">7</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 8" value="2022-02-08" blazor:onkeydown="42" blazor:onclick="43" blazor:onmouseover="44" b-bgn9u4guxz="">8</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 9" value="2022-02-09" blazor:onkeydown="45" blazor:onclick="46" blazor:onmouseover="47" b-bgn9u4guxz="">9</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 10" value="2022-02-10" blazor:onkeydown="48" blazor:onclick="49" blazor:onmouseover="50" b-bgn9u4guxz="">10</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 11" value="2022-02-11" blazor:onkeydown="51" blazor:onclick="52" blazor:onmouseover="53" b-bgn9u4guxz="">11</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 12" value="2022-02-12" blazor:onkeydown="54" blazor:onclick="55" blazor:onmouseover="56" b-bgn9u4guxz="">12</div>
       </div>
-      <div class="week">
-        <div part="day" class="day" aria-label="February 13" value="2022-02-13">13</div>
-        <div part="day" class="day" disabled="" aria-label="February 14" value="2022-02-14">14</div>
-        <div part="day" class="day" selected="" aria-label="February 15" value="2022-02-15">15</div>
-        <div part="day" class="day" aria-label="February 16" value="2022-02-16">16</div>
-        <div part="day" class="day" aria-label="February 17" value="2022-02-17">17</div>
-        <div part="day" class="day" aria-label="February 18" value="2022-02-18">18</div>
-        <div part="day" class="day" aria-label="February 19" value="2022-02-19">19</div>
+      <div class="week" b-bgn9u4guxz="">
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 13" value="2022-02-13" blazor:onkeydown="57" blazor:onclick="58" blazor:onmouseover="59" b-bgn9u4guxz="">13</div>
+        <div part="day" class="day" disabled="" aria-label="February 14" value="2022-02-14" blazor:onkeydown="60" blazor:onclick="61" blazor:onmouseover="62" b-bgn9u4guxz="">14</div>
+        <div part="day" class="day" role="button" tabindex="0" selected="" aria-label="February 15" value="2022-02-15" blazor:onkeydown="63" blazor:onclick="64" blazor:onmouseover="65" b-bgn9u4guxz="">15</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 16" value="2022-02-16" blazor:onkeydown="66" blazor:onclick="67" blazor:onmouseover="68" b-bgn9u4guxz="">16</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 17" value="2022-02-17" blazor:onkeydown="69" blazor:onclick="70" blazor:onmouseover="71" b-bgn9u4guxz="">17</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 18" value="2022-02-18" blazor:onkeydown="72" blazor:onclick="73" blazor:onmouseover="74" b-bgn9u4guxz="">18</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 19" value="2022-02-19" blazor:onkeydown="75" blazor:onclick="76" blazor:onmouseover="77" b-bgn9u4guxz="">19</div>
       </div>
-      <div class="week">
-        <div part="day" class="day" aria-label="February 20" value="2022-02-20">20</div>
-        <div part="day" class="day" aria-label="February 21" value="2022-02-21">21</div>
-        <div part="day" class="day" aria-label="February 22" value="2022-02-22">22</div>
-        <div part="day" class="day" aria-label="February 23" value="2022-02-23">23</div>
-        <div part="day" class="day" aria-label="February 24" value="2022-02-24">24</div>
-        <div part="day" class="day" aria-label="February 25" value="2022-02-25">25</div>
-        <div part="day" class="day" aria-label="February 26" value="2022-02-26">26</div>
+      <div class="week" b-bgn9u4guxz="">
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 20" value="2022-02-20" blazor:onkeydown="78" blazor:onclick="79" blazor:onmouseover="80" b-bgn9u4guxz="">20</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 21" value="2022-02-21" blazor:onkeydown="81" blazor:onclick="82" blazor:onmouseover="83" b-bgn9u4guxz="">21</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 22" value="2022-02-22" blazor:onkeydown="84" blazor:onclick="85" blazor:onmouseover="86" b-bgn9u4guxz="">22</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 23" value="2022-02-23" blazor:onkeydown="87" blazor:onclick="88" blazor:onmouseover="89" b-bgn9u4guxz="">23</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 24" value="2022-02-24" blazor:onkeydown="90" blazor:onclick="91" blazor:onmouseover="92" b-bgn9u4guxz="">24</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 25" value="2022-02-25" blazor:onkeydown="93" blazor:onclick="94" blazor:onmouseover="95" b-bgn9u4guxz="">25</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 26" value="2022-02-26" blazor:onkeydown="96" blazor:onclick="97" blazor:onmouseover="98" b-bgn9u4guxz="">26</div>
       </div>
-      <div class="week">
-        <div part="day" class="day" aria-label="February 27" value="2022-02-27">27</div>
-        <div part="day" class="day" aria-label="February 28" value="2022-02-28">28</div>
-        <div part="day" class="day" inactive="" aria-label="March 1" value="2022-03-01">1</div>
-        <div part="day" class="day" inactive="" aria-label="March 2" value="2022-03-02">2</div>
-        <div part="day" class="day" inactive="" aria-label="March 3" value="2022-03-03">3</div>
-        <div part="day" class="day" inactive="" aria-label="March 4" value="2022-03-04">4</div>
-        <div part="day" class="day" inactive="" aria-label="March 5" value="2022-03-05">5</div>
+      <div class="week" b-bgn9u4guxz="">
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 27" value="2022-02-27" blazor:onkeydown="99" blazor:onclick="100" blazor:onmouseover="101" b-bgn9u4guxz="">27</div>
+        <div part="day" class="day" role="button" tabindex="0" aria-label="February 28" value="2022-02-28" blazor:onkeydown="102" blazor:onclick="103" blazor:onmouseover="104" b-bgn9u4guxz="">28</div>
+        <div part="day" class="day" inactive="" aria-label="March 1" value="2022-03-01" blazor:onkeydown="105" blazor:onclick="106" blazor:onmouseover="107" b-bgn9u4guxz="">1</div>
+        <div part="day" class="day" inactive="" aria-label="March 2" value="2022-03-02" blazor:onkeydown="108" blazor:onclick="109" blazor:onmouseover="110" b-bgn9u4guxz="">2</div>
+        <div part="day" class="day" inactive="" aria-label="March 3" value="2022-03-03" blazor:onkeydown="111" blazor:onclick="112" blazor:onmouseover="113" b-bgn9u4guxz="">3</div>
+        <div part="day" class="day" inactive="" aria-label="March 4" value="2022-03-04" blazor:onkeydown="114" blazor:onclick="115" blazor:onmouseover="116" b-bgn9u4guxz="">4</div>
+        <div part="day" class="day" inactive="" aria-label="March 5" value="2022-03-05" blazor:onkeydown="117" blazor:onclick="118" blazor:onmouseover="119" b-bgn9u4guxz="">5</div>
       </div>
-      <div class="week">
-        <div part="day" class="day" inactive="" aria-label="March 6" value="2022-03-06">6</div>
-        <div part="day" class="day" inactive="" aria-label="March 7" value="2022-03-07">7</div>
-        <div part="day" class="day" inactive="" aria-label="March 8" value="2022-03-08">8</div>
-        <div part="day" class="day" inactive="" aria-label="March 9" value="2022-03-09">9</div>
-        <div part="day" class="day" inactive="" aria-label="March 10" value="2022-03-10">10</div>
-        <div part="day" class="day" inactive="" aria-label="March 11" value="2022-03-11">11</div>
-        <div part="day" class="day" inactive="" aria-label="March 12" value="2022-03-12">12</div>
+      <div class="week" b-bgn9u4guxz="">
+        <div part="day" class="day" inactive="" aria-label="March 6" value="2022-03-06" blazor:onkeydown="120" blazor:onclick="121" blazor:onmouseover="122" b-bgn9u4guxz="">6</div>
+        <div part="day" class="day" inactive="" aria-label="March 7" value="2022-03-07" blazor:onkeydown="123" blazor:onclick="124" blazor:onmouseover="125" b-bgn9u4guxz="">7</div>
+        <div part="day" class="day" inactive="" aria-label="March 8" value="2022-03-08" blazor:onkeydown="126" blazor:onclick="127" blazor:onmouseover="128" b-bgn9u4guxz="">8</div>
+        <div part="day" class="day" inactive="" aria-label="March 9" value="2022-03-09" blazor:onkeydown="129" blazor:onclick="130" blazor:onmouseover="131" b-bgn9u4guxz="">9</div>
+        <div part="day" class="day" inactive="" aria-label="March 10" value="2022-03-10" blazor:onkeydown="132" blazor:onclick="133" blazor:onmouseover="134" b-bgn9u4guxz="">10</div>
+        <div part="day" class="day" inactive="" aria-label="March 11" value="2022-03-11" blazor:onkeydown="135" blazor:onclick="136" blazor:onmouseover="137" b-bgn9u4guxz="">11</div>
+        <div part="day" class="day" inactive="" aria-label="March 12" value="2022-03-12" blazor:onkeydown="138" blazor:onclick="139" blazor:onmouseover="140" b-bgn9u4guxz="">12</div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
# [DateTime] Accessibility - Add `role`, `tabindex` and catch Enter/Space

The user can navigate, using keyboard (`Tab` and `Enter`), into the Calendar or DatePicker components.
But not yet the arrows to navigate from day to day (or month to month).

![peek_5](https://github.com/user-attachments/assets/eb8b9111-8809-41f1-8065-ff5acf3d025b)


## Unit Tests

Updated