### PR TITLE
[Accessibility] Fix of the unannounced `Required` keyword with FluentSelect

### DIFF
--- a/src/Core/Components/List/FluentSelect.razor
+++ b/src/Core/Components/List/FluentSelect.razor
@@ -3,7 +3,7 @@
 @typeparam TOption
 <CascadingValue Value="_internalListContext" Name="ListContext" TValue="InternalListContext<TOption>" IsFixed="true">
     @InlineStyleValue
-    <FluentInputLabel ForId="@Id" Label="@Label" AriaLabel="@AriaLabel" Required="@Required" ChildContent="@LabelTemplate" />
+    <FluentInputLabel ForId="@Id" Label="@Label" AriaLabel="@GetAriaLabelWithRequired()" Required="@Required" ChildContent="@LabelTemplate" />
     <fluent-select @ref=Element
                    id=@Id
                    class="@ClassValue"

--- a/src/Core/Components/List/FluentSelect.razor.cs
+++ b/src/Core/Components/List/FluentSelect.razor.cs
@@ -6,6 +6,11 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 [CascadingTypeParameter(nameof(TOption))]
 public partial class FluentSelect<TOption> : ListComponentBase<TOption> where TOption : notnull
 {
+    /// <summary>
+    /// Gets the `Required` aria label.
+    /// </summary>
+    public static string RequiredAriaLabel = "Required";
+
     /// <summary />
     protected virtual MarkupString InlineStyleValue => new InlineStyleBuilder()
         .AddStyle($"#{Id}::part(listbox)", "max-height", Height, !string.IsNullOrWhiteSpace(Height))
@@ -39,4 +44,11 @@ public partial class FluentSelect<TOption> : ListComponentBase<TOption> where TO
     /// </summary>
     [Parameter]
     public Appearance? Appearance { get; set; }
+
+    private string? GetAriaLabelWithRequired()
+    {
+        var label = AriaLabel ?? Label ?? Title ?? string.Empty;
+
+        return label + (Required ? $", {RequiredAriaLabel}" : string.Empty);
+    }
 }


### PR DESCRIPTION
# [Accessibility] Fix of the unannounced `Required` keyword with FluentSelect

Fix this issue: #2701, adding a `Required`keyword when the FluentSelect composant is **required**.

https://github.com/user-attachments/assets/bed000fa-6d41-4a04-ada0-198d20440611

