### PR TITLE
fix: [FluentNavLink] An issue where empty strings were not allowed in Href

### DIFF
--- a/src/Core/Components/NavMenu/FluentNavLink.razor
+++ b/src/Core/Components/NavMenu/FluentNavLink.razor
@@ -7,7 +7,7 @@
 @if (Owner == null || Owner.Expanded || (HasIcon && (!Owner.CollapsedChildNavigation || SubMenu == null)))
 {
     <div id="@Id" @attributes="AdditionalAttributes" class="@ClassValue" disabled="@Disabled" style="@Style" role="menuitem">
-        @if (!OnClick.HasDelegate && !string.IsNullOrEmpty(Href))
+        @if (!OnClick.HasDelegate && Href is not null)
         {
             <NavLink class="@LinkClassValue"
                      @attributes="@Attributes"


### PR DESCRIPTION
# Pull Request

## 📖 Description

Fixed FluentNavLink not working correctly when Href was empty

## 👩‍💻 Reviewer Notes

So simple PR

## 📑 Test Plan

Verify that clicking on a FluentNavLink correctly navigates to the root page when the Href of the FluentNavLink is empty.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [ ] I have modified an existing component
- [ ] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component