### PR TITLE
[Tooltip] Add role so screen reader can announce tooltip text

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -6468,6 +6468,12 @@
             Default is true.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentMessageBar.FadeIn">
+            <summary>
+            Gets or sets the fade in animation for the MessageBar.
+            Default is true.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentMessageBar.Link">
             <summary>
             A link can be shown after the message. 

--- a/src/Core/Components/Tooltip/FluentTooltip.razor
+++ b/src/Core/Components/Tooltip/FluentTooltip.razor
@@ -1,4 +1,4 @@
-@namespace Microsoft.FluentUI.AspNetCore.Components
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 @inherits FluentComponentBase
 
 @if (DrawTooltip)
@@ -13,6 +13,7 @@
                     auto-update-mode="@AutoUpdateMode"
                     horizontal-viewport-lock="@HorizontalViewportLock"
                     vertical-viewport-lock="@VerticalViewportLock"
+                    role="tooltip"
                     @ontooltipdismiss="HandleDismissed"
                     @attributes="AdditionalAttributes">
         @if (string.IsNullOrWhiteSpace(MaxWidth ?? GlobalOptions?.MaxWidth))

--- a/tests/Core/Dialog/FluentDialogTests.FluentDialog_HeaderFooter.verified.razor.html
+++ b/tests/Core/Dialog/FluentDialogTests.FluentDialog_HeaderFooter.verified.razor.html
@@ -9,7 +9,7 @@
         <path d="m4.09 4.22.06-.07a.5.5 0 0 1 .63-.06l.07.06L10 9.29l5.15-5.14a.5.5 0 0 1 .63-.06l.07.06c.18.17.2.44.06.63l-.06.07L10.71 10l5.14 5.15c.18.17.2.44.06.63l-.06.07a.5.5 0 0 1-.63.06l-.07-.06L10 10.71l-5.15 5.14a.5.5 0 0 1-.63.06l-.07-.06a.5.5 0 0 1-.06-.63l.06-.07L9.29 10 4.15 4.85a.5.5 0 0 1-.06-.63l.06-.07-.06.07Z"></path>
       </svg>
     </fluent-button>
-    <fluent-tooltip anchor="xxx" delay="300" blazor:ontooltipdismiss="2" placement="Placement.Bottom" blazor:elementreference=""></fluent-tooltip>
+    <fluent-tooltip anchor="xxx" role="tooltip" delay="300" blazor:ontooltipdismiss="2" placement="Placement.Bottom" blazor:elementreference=""></fluent-tooltip>
   </div>
   <div class="fluent-dialog-body">
     Body content

--- a/tests/Core/Tooltip/FluentTooltipTests.FluentTooltip_AllAttributes.verified.html
+++ b/tests/Core/Tooltip/FluentTooltipTests.FluentTooltip_AllAttributes.verified.html
@@ -1,4 +1,4 @@
 
-<fluent-tooltip visible="" anchor="button-id" delay="200" position="bottom" auto-update-mode="Auto" horizontal-viewport-lock="" vertical-viewport-lock="" blazor:ontooltipdismiss="1" blazor:elementreference="82c7cfb0-d639-4809-ada8-c06caa67273f">
-  <div style="max-width: 300px; text-wrap: wrap;">My help text</div>
+<fluent-tooltip visible="" anchor="button-id" delay="200" position="bottom" auto-update-mode="Auto" horizontal-viewport-lock="" vertical-viewport-lock="" role="tooltip" blazor:ontooltipdismiss="1" blazor:elementreference="82c7cfb0-d639-4809-ada8-c06caa67273f">
+    <div style="max-width: 300px; text-wrap: wrap;">My help text</div>
 </fluent-tooltip>

--- a/tests/Core/Tooltip/FluentTooltipTests.FluentTooltip_Default.verified.html
+++ b/tests/Core/Tooltip/FluentTooltipTests.FluentTooltip_Default.verified.html
@@ -1,2 +1,2 @@
 
-<fluent-tooltip anchor="button-id" delay="300" blazor:ontooltipdismiss="1" blazor:elementreference="ab13056b-5757-44df-bc3e-aab0ae2b20b4">My help text</fluent-tooltip>
+<fluent-tooltip anchor="button-id" delay="300" role="tooltip" blazor:ontooltipdismiss="1" blazor:elementreference="ab13056b-5757-44df-bc3e-aab0ae2b20b4">My help text</fluent-tooltip>


### PR DESCRIPTION
Add `role=tooltip` to the web component. This makes a screen reader (tested with NVDA) announce the tooltip content.