### PR TITLE
[ProfileMenu] Add `Open` attribute

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -7780,6 +7780,11 @@
             Default is Small.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentProfileMenu.Open">
+            <summary>
+            Gets or sets the Menu status.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentProfileMenu.TopCorner">
             <summary>
             Gets or sets whether popover should be forced to top right or top left (RTL).

--- a/src/Core/Components/ProfileMenu/FluentProfileMenu.razor
+++ b/src/Core/Components/ProfileMenu/FluentProfileMenu.razor
@@ -2,7 +2,7 @@
 @inherits FluentComponentBase
 
 <div id="@Id" class="@ClassValue" style="@StyleValue" top-corner="@TopCorner"
-     @onclick="@(e => PopoverVisible = !PopoverVisible)">
+     @onclick="@(e => Open = !Open)">
     @StartTemplate
     <FluentPersona Id="@PersonaId"
                    Image="@Image"
@@ -19,7 +19,7 @@
                Class="@PopoverClass"
                Style="@PopoverStyle"
                HorizontalPosition="@HorizontalPosition.Start"
-               @bind-Open="@PopoverVisible"
+               @bind-Open="@Open"
                @attributes="@AdditionalAttributes">
     <Header>
         @if (HeaderTemplate is null && (!string.IsNullOrEmpty(HeaderLabel) || !string.IsNullOrEmpty(HeaderButton)))

--- a/src/Core/Components/ProfileMenu/FluentProfileMenu.razor.cs
+++ b/src/Core/Components/ProfileMenu/FluentProfileMenu.razor.cs
@@ -21,7 +21,11 @@ public partial class FluentProfileMenu : FluentComponentBase
     protected string? StyleValue => new StyleBuilder(Style)
         .Build();
 
-    private bool PopoverVisible { get; set; } = false;
+    /// <summary>
+    /// Gets or sets the Menu status.
+    /// </summary>
+    [Parameter]
+    public bool Open { get; set; } = false;
 
     /// <summary>
     /// Gets or sets whether popover should be forced to top right or top left (RTL).

--- a/tests/Core/ProfileMenu/FluentProfileMenuTests.razor
+++ b/tests/Core/ProfileMenu/FluentProfileMenuTests.razor
@@ -48,12 +48,12 @@
                    FooterLink="Account"
                    OnHeaderButtonClick="@(e => signOutClicked = true)"
                    OnFooterLinkClick="@(e => viewAccountClicked = true)" />
-    );
+        );
 
         // Open the Popover
         var button = cut.Find(".fluent-profile-menu");
         button.Click();
-        
+
         // sign out
         var signOut = cut.Find("fluent-button");
         signOut.Click();
@@ -74,11 +74,11 @@
     {
         // Arrange && Act
         var cut = Render(
-            @<FluentProfileMenu Initials="DV">
-                <HeaderTemplate>Header</HeaderTemplate>
-                <ChildContent>Body</ChildContent>
-                <FooterTemplate>Footer</FooterTemplate>
-            </FluentProfileMenu>);
+    @<FluentProfileMenu Initials="DV">
+        <HeaderTemplate>Header</HeaderTemplate>
+        <ChildContent>Body</ChildContent>
+        <FooterTemplate>Footer</FooterTemplate>
+    </FluentProfileMenu>);
 
         // Open the Popover
         var button = cut.Find(".initials");
@@ -93,12 +93,30 @@
     {
         // Arrange && Act
         var cut = Render(
-            @<FluentProfileMenu Image="@SamplePicture">
-                <StartTemplate>Before</StartTemplate>
-                <EndTemplate>After</EndTemplate>
-            </FluentProfileMenu>);
+    @<FluentProfileMenu Image="@SamplePicture">
+        <StartTemplate>Before</StartTemplate>
+        <EndTemplate>After</EndTemplate>
+    </FluentProfileMenu>);
 
         // Assert
         cut.Verify();
+    }
+
+    [Fact]
+    public void FluentProfileMenu_OpenTrue()
+    {
+        var opened = true;
+
+        // Arrange
+        var cut = Render(@<FluentProfileMenu Open="@opened" />).FindComponent<FluentProfileMenu>();
+
+        // Assert: Opened
+        Assert.Contains("fluent-anchored-region", cut.Markup);
+
+        // Assert: Closed
+        opened = false;
+        cut.SetParametersAndRender(parameters => parameters.Add(p => p.Open, opened));
+
+        Assert.DoesNotContain("fluent-anchored-region", cut.Markup);
     }
 }


### PR DESCRIPTION
# [ProfileMenu] Add `Open` attribute

In certain situations, the developer may wish to open or close the profile menu. 
This can be done by adding the `Open` attribute.

See #2737