### PR TITLE
[FluentRadioGroup] Fix binding error

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -8079,7 +8079,7 @@
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentRadio`1.Context">
             <summary>
-            Gets context for this <see cref="T:Microsoft.FluentUI.AspNetCore.Components.FluentRadio`1"/>. 
+            Gets context for this <see cref="T:Microsoft.FluentUI.AspNetCore.Components.FluentRadio`1"/>.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentRadio`1.ReadOnly">
@@ -8132,7 +8132,7 @@
             Gets or sets the content to be rendered inside the component.
             </summary>
         </member>
-        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentRadio`1.OnInitialized">
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentRadio`1.OnParametersSet">
             <inheritdoc />
         </member>
         <member name="T:Microsoft.FluentUI.AspNetCore.Components.FluentRadioContext">

--- a/src/Core/Components/List/FluentSelect.razor.cs
+++ b/src/Core/Components/List/FluentSelect.razor.cs
@@ -47,7 +47,9 @@ public partial class FluentSelect<TOption> : ListComponentBase<TOption> where TO
 
     private string? GetAriaLabelWithRequired()
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         var label = AriaLabel ?? Label ?? Title ?? string.Empty;
+#pragma warning restore CS0618 // Type or member is obsolete
 
         return label + (Required ? $", {RequiredAriaLabel}" : string.Empty);
     }

--- a/src/Core/Components/Radio/FluentRadio.razor.cs
+++ b/src/Core/Components/Radio/FluentRadio.razor.cs
@@ -6,7 +6,7 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 public partial class FluentRadio<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TValue> : FluentComponentBase
 {
     /// <summary>
-    /// Gets context for this <see cref="FluentRadio{TValue}"/>. 
+    /// Gets context for this <see cref="FluentRadio{TValue}"/>.
     /// </summary>
     internal FluentRadioContext? Context { get; private set; }
 
@@ -78,7 +78,7 @@ public partial class FluentRadio<[DynamicallyAccessedMembers(DynamicallyAccessed
     }
 
     /// <inheritdoc />
-    protected override void OnInitialized()
+    protected override void OnParametersSet()
     {
         Context = string.IsNullOrEmpty(Name) ? CascadedContext : CascadedContext?.FindContextInAncestors(Name);
 

--- a/src/Core/Components/Radio/FluentRadioGroup.razor
+++ b/src/Core/Components/Radio/FluentRadioGroup.razor
@@ -12,6 +12,7 @@
                         name="@_context!.GroupName"
                         orientation="@Orientation.ToAttributeValue()"
                         required="@Required"
+                        value="@CurrentValueAsString"
                         @onradiogroupchange="HandleChange"
                         @attributes="AdditionalAttributes">
         @ChildContent

--- a/src/Core/Components/Radio/FluentRadioGroup.razor.cs
+++ b/src/Core/Components/Radio/FluentRadioGroup.razor.cs
@@ -49,7 +49,7 @@ public partial class FluentRadioGroup<[DynamicallyAccessedMembers(DynamicallyAcc
         else if (_context.ParentContext != CascadedContext)
         {
             // This should never be possible in any known usage pattern, but if it happens, we want to know
-            throw new InvalidOperationException("An FluentRadioGroup cannot change context after creation");
+            throw new InvalidOperationException("A FluentRadioGroup cannot change context after creation");
         }
 
         // Mutate the FluentRadioContext instance in place. Since this is a non-fixed cascading parameter, the descendant
@@ -65,7 +65,7 @@ public partial class FluentRadioGroup<[DynamicallyAccessedMembers(DynamicallyAcc
 
     private void HandleChange(ChangeEventArgs e)
     {
-        if (CurrentValueAsString != e?.Value?.ToString())
+        if (CurrentValueAsString != e?.Value?.ToString() && e?.Value is not null)
         {
             CurrentValueAsString = e?.Value?.ToString();
         }

--- a/tests/Core/_ToDo/Radio/FluentRadioGroupTests.FluentRadioGroup_Default.verified.html
+++ b/tests/Core/_ToDo/Radio/FluentRadioGroupTests.FluentRadioGroup_Default.verified.html
@@ -1,4 +1,4 @@
 
-<fluent-radio-group id="xxx" name="xxx" blazor:onradiogroupclick="1" blazor:elementreference="xxx">
+<fluent-radio-group id="xxx" name="xxx" value="False" blazor:onradiogroupclick="1" blazor:elementreference="xxx">
   <b>render me</b>
 </fluent-radio-group>


### PR DESCRIPTION
Fix #2740 by adding value to fluent-radio-group and prevent handling a change when the arg value is empty.

![fix-iisue-#2740](https://github.com/user-attachments/assets/974c8b1d-9e27-4622-b3ce-54a53261b38c)

Note: Changed to use `OnParametersSet` instead of `OnInitialized` based on [ASP.NET Core source](https://github.com/dotnet/aspnetcore/blob/fe0fbff040c9f129ba3f5ee8cf15c8f6d96fb50e/src/Components/Web/src/Forms/InputRadioGroup.cs#L33)