### PR TITLE
[Providers] To prevent the menu and tooltip from displaying a scrollbar in body

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -9667,6 +9667,9 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentTooltipProvider.ClassValue">
             <summary />
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentTooltipProvider.StyleValue">
+            <summary />
+        </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentTreeItem.#ctor">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.FluentUI.AspNetCore.Components.FluentTreeItem"/> class.

--- a/src/Core/Components/Menu/FluentMenuProvider.razor.cs
+++ b/src/Core/Components/Menu/FluentMenuProvider.razor.cs
@@ -19,6 +19,7 @@ public partial class FluentMenuProvider : FluentComponentBase
 
     /// <summary />
     internal string? StyleValue => new StyleBuilder(Style)
+        .AddStyle("display", "fixed")   // To prevent the menu from displaying a scrollbar in body
         .Build();
 
     /// <summary>

--- a/src/Core/Components/Tooltip/FluentTooltipProvider.razor
+++ b/src/Core/Components/Tooltip/FluentTooltipProvider.razor
@@ -1,7 +1,7 @@
-@namespace Microsoft.FluentUI.AspNetCore.Components
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 @inherits FluentComponentBase
 
-<div @attributes="AdditionalAttributes" class="@ClassValue" style="@Style">
+<div @attributes="AdditionalAttributes" class="@ClassValue" style="@StyleValue">
     @if (Tooltips != null)
     {
         @foreach (var item in Tooltips)

--- a/src/Core/Components/Tooltip/FluentTooltipProvider.razor.cs
+++ b/src/Core/Components/Tooltip/FluentTooltipProvider.razor.cs
@@ -11,6 +11,11 @@ public partial class FluentTooltipProvider : FluentComponentBase, IDisposable
         => new CssBuilder(Class).AddClass("fluent-tooltip-provider")
                                  .Build();
 
+    /// <summary />
+    internal string? StyleValue => new StyleBuilder(Style)
+        .AddStyle("display", "fixed")   // To prevent the tooltip from displaying a scrollbar in body
+        .Build();
+
     [Inject]
     private ITooltipService TooltipService { get; set; } = default!;
 


### PR DESCRIPTION
# [Providers] To prevent the menu and tooltip from displaying a scrollbar in body

Sometimes (see #2736) the `FluentMenuProvider` or the `FluentTooltipProvider` can create an HTML tag which interferes with the body's scrollbars. This PR solves this problem.