### PR TITLE
[Overlay] Fix the detection of ExcludedElement for WASM

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -13959,6 +13959,12 @@
             Light variant of FluentUI System Icons
             </summary>
         </member>
+        <member name="F:Microsoft.FluentUI.AspNetCore.Components.IconVariant.Color">
+            <summary>
+            Color variant of FluentUI System Icons
+            > Note: FOR TESTING ONLY. This variant is not supported yet in the FluentUI System Icons.
+            </summary>
+        </member>
         <member name="T:Microsoft.FluentUI.AspNetCore.Components.InputFileMode">
             <summary>
             How to handle the input file(s).

--- a/src/Core/Components/List/FluentAutocomplete.razor.cs
+++ b/src/Core/Components/List/FluentAutocomplete.razor.cs
@@ -302,8 +302,6 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
             await OnOptionsSearch.InvokeAsync(args);
         }
 
-        Console.WriteLine($"args.Items: {args.Items?.Count()}");
-
         Items = args.Items?.Take(MaximumOptionsSearch);
 
         SelectableItem = Items != null

--- a/src/Core/Components/Overlay/FluentOverlay.razor.js
+++ b/src/Core/Components/Overlay/FluentOverlay.razor.js
@@ -18,12 +18,11 @@ export function overlayInitialize(dotNetHelper, containerId, id) {
 
         // Click event handler
         clickHandler: async function (event) {
-            const excludeElement = document.getElementById(id);
-            const isExcludeElement = excludeElement && excludeElement.contains(event.target);
-            const isInsideContainer = isClickInsideContainer(event, containerId);
+            const isInsideContainer = isClickInsideContainer(event, document.getElementById(containerId));
+            const isInsideExcludedElement = !!document.getElementById(id) && isClickInsideContainer(event, document.getElementById(id));
 
-            if (isInsideContainer && !isExcludeElement) {
-                dotNetHelper.invokeMethodAsync('OnCloseInteractiveAsync', event);
+            if (isInsideContainer && !isInsideExcludedElement) {
+                dotNetHelper.invokeMethodAsync('OnCloseInteractiveAsync', event); 
             }
         }
     };
@@ -48,11 +47,10 @@ export function overlayDispose(id) {
 }
 
 /**
- * Determines whether a mouse click event occurred inside a specific HTML element identified by its `id`.
+ * Determines whether a mouse click event occurred inside a specific HTML element.
  */
-function isClickInsideContainer(event, id) {
-    if (id && document.getElementById(id)) {
-        const container = document.getElementById(id);
+function isClickInsideContainer(event, container) {
+    if (!!container) {
         const rect = container.getBoundingClientRect();
 
         return (


### PR DESCRIPTION
# [Overlay] Fix the detection of ExcludedElement for WASM

A problem seems occured with the current way of detecting when a user clicks in a FluentOverlay exclusion zone: 
- Currently, when the user clicks on an element, we calculate the `isExcludeElement` variable based on `event.target`. 
`const isExcludeElement = excludeElement && excludeElement.contains(event.target);`
However, Blazor WASM refreshes HTML DOM faster than Blazor Server, making `target` invalid in this test.

- We correct this problem by calculating `isInsideExcludedElement` using the coordinates of the mouse click.
`const isInsideExcludedElement = !!document.getElementById(id) && isClickInsideContainer(event, document.getElementById(id));`

## Before
![Before](https://github.com/user-attachments/assets/c079e66d-0cd0-43fd-8d52-bd8d710dd39a)


## After
![After](https://github.com/user-attachments/assets/d3b15ad4-3ad6-4678-972c-eecea8cc7a0b)
