### PR TITLE
[Docs] Fix - Nullable reference types not always shown in API documentation

### DIFF
--- a/examples/Demo/Shared/ReflectionExtensions.cs
+++ b/examples/Demo/Shared/ReflectionExtensions.cs
@@ -181,9 +181,12 @@ public static class ReflectionExtensions
     public static string ToTypeNameString(this MethodInfo methodInfo, Func<Type, Queue<string>, string> typeNameConverter = null,
         bool invokeTypeNameConverterForGenericType = false)
     {
+        bool isNullableType = !methodInfo.ReturnType.IsValueType
+                && (new NullabilityInfoContext().Create(methodInfo.ReturnParameter).ReadState is NullabilityState.Nullable);
+
         return methodInfo.ReturnType.ToNameStringWithValueTupleNames(
             methodInfo.ReturnParameter?.GetCustomAttribute<TupleElementNamesAttribute>()?.TransformNames, typeNameConverter,
-            invokeTypeNameConverterForGenericType);
+            invokeTypeNameConverterForGenericType) + (isNullableType ? "?" : "");
     }
 
     /// <summary>
@@ -206,9 +209,12 @@ public static class ReflectionExtensions
     public static string ToTypeNameString(this PropertyInfo propertyInfo, Func<Type, Queue<string>, string> typeNameConverter = null,
         bool invokeTypeNameConverterForGenericType = false)
     {
+        bool isNullableType = !propertyInfo.PropertyType.IsValueType
+                && (new NullabilityInfoContext().Create(propertyInfo).WriteState is NullabilityState.Nullable);
+
         return propertyInfo.PropertyType.ToNameStringWithValueTupleNames(
             propertyInfo.GetCustomAttribute<TupleElementNamesAttribute>()?.TransformNames, typeNameConverter,
-            invokeTypeNameConverterForGenericType);
+            invokeTypeNameConverterForGenericType) + (isNullableType ? "?" : "");
     }
 
     /// <summary>


### PR DESCRIPTION
# Pull Request

## 📖 Description

API documentation did not always show nullable type for parameters or method return.

### 🎫 Issues

- Only the underlying type shown even though it was declared nullable. It does not match the [source code](https://github.com/microsoft/fluentui-blazor/blob/dev/src/Core/Components/Grid/FluentGridItem.razor.cs).

#### Before
![image](https://github.com/user-attachments/assets/3b72a811-e4f5-4ec9-80c8-1e4349931eb4)

#### After
![image](https://github.com/user-attachments/assets/ee3e8bf9-2cdc-4b50-8322-f3c27ea452c1)

## 👩‍💻 Reviewer Notes

Changes were made to the `ToTypeNameString` extensions instead of `APIDocumentation`. Only concern I have is that the original extensions were sourced from https://github.com/loxsmoke/DocXml.

## 📑 Test Plan

- I manually checked many of the components. 

## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [X] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps
