### PR TITLE
[Debounce] Fix the Debounce class with async methods

### DIFF
--- a/tests/Core/Utilities/DebounceActionTests.cs
+++ b/tests/Core/Utilities/DebounceActionTests.cs
@@ -199,15 +199,35 @@ public class DebounceActionTests
     [Fact]
     public async Task Debounce_Exception()
     {
-        // Act
-        Debounce.Run(50, async () =>
+        await Assert.ThrowsAsync<AggregateException>(async () =>
         {
-            await Task.CompletedTask;
-            throw new InvalidProgramException("Error");     // Simulate an exception
+            // Act
+            Debounce.Run(50, async () =>
+            {
+                await Task.CompletedTask;
+                throw new InvalidProgramException("Error");     // Simulate an exception
+            });
+
+            // Wait for the debounce to complete
+            await Debounce.CurrentTask;
         });
 
-        // Wait for the debounce to complete
-        await Debounce.CurrentTask;
+        // Assert
+        Assert.False(Debounce.Busy);
+    }
+
+    [Fact]
+    public async Task Debounce_AsyncException()
+    {
+        await Assert.ThrowsAsync<AggregateException>(async () =>
+        {
+            // Act
+            await Debounce.RunAsync(50, async () =>
+            {
+                await Task.CompletedTask;
+                throw new InvalidProgramException("Error");     // Simulate an exception
+            });
+        });
 
         // Assert
         Assert.False(Debounce.Busy);


### PR DESCRIPTION
# [Debounce] Fix the Debounce class with async methods

When the action being executed is asynchronous, `Debounce` can sometimes return a value without waiting for the task to finish.
This PR fixes that.

![Debounce](https://github.com/user-attachments/assets/926872f8-51fb-40b9-9c05-0155365f125f)


See #2751