### PR TITLE
[NavMenu] Make submenu in collapsed state work again

### DIFF
--- a/src/Core/Components/NavMenu/FluentNavGroup.razor
+++ b/src/Core/Components/NavMenu/FluentNavGroup.razor
@@ -50,7 +50,8 @@
                     HorizontalPosition="@HorizontalPosition.End"
                     HorizontalInset="@false"
                     VerticalPosition="@VerticalPosition.Bottom"
-                    VerticalInset="@true">
+                    VerticalInset="@true"
+                    UseMenuService="false">
             @ChildContent
         </FluentMenu>
     }


### PR DESCRIPTION
Fix #2765 by not using the `MenuService` for the `NavMenu` sub-menu. Result:

![image](https://github.com/user-attachments/assets/3330ad79-50c6-4570-b4b9-aaa88a60c125)
