### PR TITLE
[TreeView] prevent runtime errors in change handeling

### DIFF
--- a/src/Core/Components/Menu/FluentMenuProvider.razor.cs
+++ b/src/Core/Components/Menu/FluentMenuProvider.razor.cs
@@ -20,6 +20,7 @@ public partial class FluentMenuProvider : FluentComponentBase
     /// <summary />
     internal string? StyleValue => new StyleBuilder(Style)
         .AddStyle("display", "fixed")   // To prevent the menu from displaying a scrollbar in body
+        .AddStyle("z-index", ZIndex.Menu.ToString())
         .Build();
 
     /// <summary>

--- a/src/Core/Components/TreeView/FluentTreeView.razor
+++ b/src/Core/Components/TreeView/FluentTreeView.razor
@@ -8,7 +8,7 @@
                       class="@Class"
                       style="@Style"
                       render-collapsed-nodes="@RenderCollapsedNodes"
-                      @onselectedchange="@HandleCurrentSelectedChangeAsync"
+                      @onselectedchange="@HandleCurrentSelectedChange"
                       @attributes="AdditionalAttributes">
         @ChildContent
 

--- a/src/Core/Components/TreeView/FluentTreeView.razor.cs
+++ b/src/Core/Components/TreeView/FluentTreeView.razor.cs
@@ -120,7 +120,7 @@ public partial class FluentTreeView : FluentComponentBase, IDisposable
                 {
                     await currentTreeItem.OnExpandedAsync(new TreeViewItemExpandedEventArgs(currentTreeItem, item.Expanded));
                 }
-                
+
                 await InvokeAsync(StateHasChanged);
             }
         }
@@ -146,7 +146,7 @@ public partial class FluentTreeView : FluentComponentBase, IDisposable
         _allItems.Remove(fluentTreeItem.Id!);
     }
 
-    internal async Task HandleCurrentSelectedChangeAsync(TreeChangeEventArgs args)
+    internal void HandleCurrentSelectedChange(TreeChangeEventArgs args)
     {
         if (!_allItems.TryGetValue(args.AffectedId!, out FluentTreeItem? treeItem))
         {
@@ -154,7 +154,7 @@ public partial class FluentTreeView : FluentComponentBase, IDisposable
         }
 
         var previouslySelected = CurrentSelected;
-        await _currentSelectedChangedDebounce.RunAsync(50, () => InvokeAsync(async () =>
+        _currentSelectedChangedDebounce.Run(50, () => InvokeAsync(async () =>
         {
             CurrentSelected = treeItem?.Selected == true ? treeItem : null;
             if (CurrentSelected != previouslySelected && CurrentSelectedChanged.HasDelegate)

--- a/tests/Core/TreeView/FluentTreeViewItemsTests.FluentTreeViewItems_SelectedItem_Change.verified.razor.html
+++ b/tests/Core/TreeView/FluentTreeViewItemsTests.FluentTreeViewItems_SelectedItem_Change.verified.razor.html
@@ -1,27 +1,27 @@
 
-<fluent-tree-view blazor:onselectedchange="1" blazor:elementreference="">
-  <fluent-tree-item aria-label="Item 1" aria-expanded="false" id="xxx" blazor:onselectedchange="2" blazor:onexpandedchange="3" b-toee5o4b4e="" blazor:elementreference="">
-    <span class="treeitem-text" b-toee5o4b4e="">Item 1</span>
-    <fluent-tree-item aria-label="Item 1.1" aria-expanded="false" id="xxx" blazor:onselectedchange="6" blazor:onexpandedchange="7" b-toee5o4b4e="" blazor:elementreference="xxx">
-      <span class="treeitem-text" b-toee5o4b4e="">Item 1.1</span>
+<fluent-tree-view blazor:onselectedchange="1" blazor:elementreference="xxx">
+    <fluent-tree-item aria-label="Item 1" aria-expanded="false" id="xxx" blazor:onselectedchange="2" blazor:onexpandedchange="3" b-toee5o4b4e="" blazor:elementreference="xxx">
+        <span class="treeitem-text" b-toee5o4b4e="">Item 1</span>
+        <fluent-tree-item aria-label="Item 1.1" aria-expanded="false" id="xxx" blazor:onselectedchange="6" blazor:onexpandedchange="7" b-toee5o4b4e="" blazor:elementreference="xxx">
+            <span class="treeitem-text" b-toee5o4b4e="">Item 1.1</span>
+        </fluent-tree-item>
+        <fluent-tree-item aria-label="Item 1.2" aria-expanded="false" id="xxx" selected="" blazor:onselectedchange="8" blazor:onexpandedchange="9" b-toee5o4b4e="" blazor:elementreference="xxx">
+            <span class="treeitem-text" b-toee5o4b4e="">Item 1.2</span>
+        </fluent-tree-item>
+        <fluent-tree-item aria-label="Item 1.3" aria-expanded="false" id="xxx" blazor:onselectedchange="10" blazor:onexpandedchange="11" b-toee5o4b4e="" blazor:elementreference="xxx">
+            <span class="treeitem-text" b-toee5o4b4e="">Item 1.3</span>
+        </fluent-tree-item>
     </fluent-tree-item>
-    <fluent-tree-item aria-label="Item 1.2" aria-expanded="false" id="xxx" blazor:onselectedchange="8" blazor:onexpandedchange="9" b-toee5o4b4e="" blazor:elementreference="">
-      <span class="treeitem-text" b-toee5o4b4e="">Item 1.2</span>
+    <fluent-tree-item aria-label="Item 2" aria-expanded="false" id="xxx" blazor:onselectedchange="4" blazor:onexpandedchange="5" b-toee5o4b4e="" blazor:elementreference="xxx">
+        <span class="treeitem-text" b-toee5o4b4e="">Item 2</span>
+        <fluent-tree-item aria-label="Item 2.1" aria-expanded="false" id="xxx" blazor:onselectedchange="12" blazor:onexpandedchange="13" b-toee5o4b4e="" blazor:elementreference="xxx">
+            <span class="treeitem-text" b-toee5o4b4e="">Item 2.1</span>
+        </fluent-tree-item>
+        <fluent-tree-item aria-label="Item 2.2" aria-expanded="false" id="xxx" blazor:onselectedchange="14" blazor:onexpandedchange="15" b-toee5o4b4e="" blazor:elementreference="xxx">
+            <span class="treeitem-text" b-toee5o4b4e="">Item 2.2</span>
+        </fluent-tree-item>
+        <fluent-tree-item aria-label="Item 2.3" aria-expanded="false" id="xxx" blazor:onselectedchange="16" blazor:onexpandedchange="17" b-toee5o4b4e="" blazor:elementreference="xxx">
+            <span class="treeitem-text" b-toee5o4b4e="">Item 2.3</span>
+        </fluent-tree-item>
     </fluent-tree-item>
-    <fluent-tree-item aria-label="Item 1.3" aria-expanded="false" id="xxx" blazor:onselectedchange="10" blazor:onexpandedchange="11" b-toee5o4b4e="" blazor:elementreference="xxx">
-      <span class="treeitem-text" b-toee5o4b4e="">Item 1.3</span>
-    </fluent-tree-item>
-  </fluent-tree-item>
-  <fluent-tree-item aria-label="Item 2" aria-expanded="false" id="xxx" blazor:onselectedchange="4" blazor:onexpandedchange="5" b-toee5o4b4e="" blazor:elementreference="">
-    <span class="treeitem-text" b-toee5o4b4e="">Item 2</span>
-    <fluent-tree-item aria-label="Item 2.1" aria-expanded="false" id="xxx" blazor:onselectedchange="12" blazor:onexpandedchange="13" b-toee5o4b4e="" blazor:elementreference="xxx">
-      <span class="treeitem-text" b-toee5o4b4e="">Item 2.1</span>
-    </fluent-tree-item>
-    <fluent-tree-item aria-label="Item 2.2" aria-expanded="false" id="xxx" selected="" blazor:onselectedchange="14" blazor:onexpandedchange="15" b-toee5o4b4e="" blazor:elementreference="">
-      <span class="treeitem-text" b-toee5o4b4e="">Item 2.2</span>
-    </fluent-tree-item>
-    <fluent-tree-item aria-label="Item 2.3" aria-expanded="false" id="xxx" blazor:onselectedchange="16" blazor:onexpandedchange="17" b-toee5o4b4e="" blazor:elementreference="xxx">
-      <span class="treeitem-text" b-toee5o4b4e="">Item 2.3</span>
-    </fluent-tree-item>
-  </fluent-tree-item>
 </fluent-tree-view>

--- a/tests/Core/TreeView/FluentTreeViewItemsTests.razor
+++ b/tests/Core/TreeView/FluentTreeViewItemsTests.razor
@@ -55,7 +55,7 @@
     }
 
     [Fact]
-    public async Task FluentTreeViewItems_SelectedItem_Change()
+    public void FluentTreeViewItems_SelectedItem_Change()
     {
         // Arrange
         var selectedItem = Items.ElementAt(0).Items?.ElementAt(1);  // Item 1.2
@@ -63,16 +63,16 @@
 
         // Act
         var tree = cut.FindComponent<FluentTreeView>();
-        await tree.Instance.HandleCurrentSelectedChangeAsync(new TreeChangeEventArgs()
-            {
-                AffectedId = "id22",
-                Selected = true,
-            });
+        tree.Instance.HandleCurrentSelectedChange(new TreeChangeEventArgs()
+        {
+            AffectedId = "id12",
+            Selected = true,
+        });
 
         tree.Render();
 
         // Assert
-        Assert.Equal("id22", selectedItem?.Id);
+        Assert.Equal("id12", selectedItem?.Id);
         cut.Verify();
     }
 


### PR DESCRIPTION
Change HandleCurrentSelectedChangeAsync to non-async to prevent runtime errors