### PR TITLE
[DataGrid] Fix disposed object access error in EntityFrameworkAdapter [#2769]

### DIFF
--- a/src/Extensions/DataGrid.EntityFrameworkAdapter/EntityFrameworkAsyncQueryExecutor.cs
+++ b/src/Extensions/DataGrid.EntityFrameworkAdapter/EntityFrameworkAsyncQueryExecutor.cs
@@ -19,15 +19,22 @@ internal class EntityFrameworkAsyncQueryExecutor : IAsyncQueryExecutor, IDisposa
 
     private async Task<TResult> ExecuteAsync<TResult>(Func<Task<TResult>> operation)
     {
-        await _lock.WaitAsync();
-
         try
         {
-            return await operation();
+            await _lock.WaitAsync();
+
+            try
+            {
+                return await operation();
+            }
+            finally
+            {
+                _lock.Release();
+            }
         }
-        finally
+        catch (ObjectDisposedException)
         {
-            _lock.Release();
+            return default!;
         }
     }
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

Fix for reported issue #2769

### 🎫 Issues

[FIX: Semphore slim disposed object access error in EntityFrameworkAdapter and FluentDataGrid](https://github.com/microsoft/fluentui-blazor/issues/2769)

## 📑 Test Plan

Use the scenario described in issue #2769 to manually test.

## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [ ] I have modified an existing component
- [ ] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component
