### PR TITLE
[MenuButton] Fix the MenuItem OnClick used with MenuButton

### DIFF
--- a/src/Core/Components/MenuButton/FluentMenuButton.razor.cs
+++ b/src/Core/Components/MenuButton/FluentMenuButton.razor.cs
@@ -92,10 +92,16 @@ public partial class FluentMenuButton : FluentComponentBase
 
     private async Task OnMenuChangeAsync(MenuChangeEventArgs args)
     {
+        if (!OnMenuChanged.HasDelegate)
+        {
+            return;
+        }
+
         if (args is not null && args.Id is not null)
         {
             await OnMenuChanged.InvokeAsync(args);
         }
+
         _visible = false;
     }
 

--- a/src/Core/Components/MenuButton/FluentMenuButton.razor.cs
+++ b/src/Core/Components/MenuButton/FluentMenuButton.razor.cs
@@ -71,6 +71,7 @@ public partial class FluentMenuButton : FluentComponentBase
 
     /// <summary>
     /// The callback to invoke when a menu item is chosen.
+    /// Using this event prevents the execution of any OnClick event on an included FluentMenuItem.
     /// </summary>
     [Parameter]
     public EventCallback<MenuChangeEventArgs> OnMenuChanged { get; set; }


### PR DESCRIPTION
# Fix the MenuItem OnClick used with MenuButton.

When the FluentMenuButton does not contain an `OnMenuChanged` event, clicking on the `FluentMenuItem` is not activated. This is because `OnMenuChanged` is executed anyway and renders the menu invisible, hiding the OnClick event.

This PR checks the presence of OnMenuChanged to use it or leave OnClick in other cases.

Doc updated.