### PR TITLE
[MenuProvider] Check whether the FluentMenuProvider is included

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -6319,6 +6319,9 @@
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentMenuItem.OnClickHandlerAsync(Microsoft.AspNetCore.Components.Web.MouseEventArgs)">
             <summary />
         </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentMenuProvider.#ctor">
+            <summary />
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentMenuProvider.ClassValue">
             <summary />
         </member>
@@ -6342,6 +6345,11 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.IMenuService.OnMenuUpdated">
             <summary>
             Action to be called when the menu is updated.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.IMenuService.ProviderId">
+            <summary>
+            Gets or sets the FluentMenuProvider ID.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.IMenuService.Menus">
@@ -6381,6 +6389,11 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.MenuService.Menus">
             <summary>
             <see cref="P:Microsoft.FluentUI.AspNetCore.Components.IMenuService.Menus" />
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.MenuService.ProviderId">
+            <summary>
+            <see cref="P:Microsoft.FluentUI.AspNetCore.Components.IMenuService.ProviderId" />
             </summary>
         </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.MenuService.Add(Microsoft.FluentUI.AspNetCore.Components.FluentMenu)">

--- a/src/Core/Components/Menu/FluentMenu.razor.cs
+++ b/src/Core/Components/Menu/FluentMenu.razor.cs
@@ -183,6 +183,11 @@ public partial class FluentMenu : FluentComponentBase, IDisposable
         _menuService = ServiceProvider?.GetService<IMenuService>();
         if (MenuService != null && DrawMenuWithService)
         {
+            if (string.IsNullOrEmpty(MenuService.ProviderId))
+            {
+                throw new ArgumentNullException(nameof(UseMenuService), "<FluentMenuProvider /> needs to be added to the main layout of your application/site.");
+            }
+
             MenuService.Add(this);
         }
 

--- a/src/Core/Components/Menu/FluentMenuProvider.razor.cs
+++ b/src/Core/Components/Menu/FluentMenuProvider.razor.cs
@@ -13,6 +13,12 @@ public partial class FluentMenuProvider : FluentComponentBase
     private IMenuService? _menuService = null;
 
     /// <summary />
+    public FluentMenuProvider()
+    {
+        Id = Identifier.NewId();
+    }
+
+    /// <summary />
     internal string? ClassValue => new CssBuilder(Class)
         .AddClass("fluent-menu-provider")
         .Build();
@@ -42,6 +48,7 @@ public partial class FluentMenuProvider : FluentComponentBase
 
         if (MenuService != null)
         {
+            MenuService.ProviderId = Id;
             MenuService.OnMenuUpdated = () => InvokeAsync(StateHasChanged);
         }
     }

--- a/src/Core/Components/Menu/Services/IMenuService.cs
+++ b/src/Core/Components/Menu/Services/IMenuService.cs
@@ -12,6 +12,11 @@ public interface IMenuService : IDisposable
     Action OnMenuUpdated { get; set; }
 
     /// <summary>
+    /// Gets or sets the FluentMenuProvider ID.
+    /// </summary>
+    public string? ProviderId { get; set; }
+
+    /// <summary>
     /// Gets the list of menus.
     /// </summary>
     IEnumerable<FluentMenu> Menus { get; }

--- a/src/Core/Components/Menu/Services/MenuService.cs
+++ b/src/Core/Components/Menu/Services/MenuService.cs
@@ -35,6 +35,11 @@ public class MenuService : IMenuService, IDisposable
     }
 
     /// <summary>
+    /// <see cref="IMenuService.ProviderId" />
+    /// </summary>
+    public string? ProviderId { get; set; }
+
+    /// <summary>
     /// <see cref="IMenuService.Add(FluentMenu)" />
     /// </summary>
     public void Add(FluentMenu menu)


### PR DESCRIPTION
# Check whether the `FluentMenuProvider` is included

We've added a new `FluentMenuProvider` to manage menus more simply.
By default, it is used but requires the presence of `<FluentMenuProvider />` in the **MainLayout**. 
If this is not the case and the developer does not explicitly request `UseMenuService=‘false’`, an error is triggered.

![{BFE5C91C-1D07-4D9F-B136-F4E446B0FEFB}](https://github.com/user-attachments/assets/60bdab92-4e39-4fdc-a979-308efd78afdc)

