### PR TITLE
[Stack] Added 'Stretch' horizontal alignment option

### DIFF
--- a/src/Core/Components/Dialog/Parameters/DialogParameters.cs
+++ b/src/Core/Components/Dialog/Parameters/DialogParameters.cs
@@ -11,7 +11,22 @@ public class DialogParameters : ComponentParameters, IDialogParameters
     /// left (full height), right (full height)
     /// or screen middle (using Width and Height properties).
     /// </summary>
-    public virtual HorizontalAlignment Alignment { get; set; } = HorizontalAlignment.Center;
+    public virtual HorizontalAlignment Alignment
+    {
+        set
+        {
+            if (value == HorizontalAlignment.Stretch)
+            {
+                throw new ArgumentException("Alignment HorizontalAlignment.Stretch is not supported for DialogParameters");
+            }
+            _alignment = value;
+        }
+        get
+        {
+            return _alignment;
+        }
+    }
+    private HorizontalAlignment _alignment = HorizontalAlignment.Center;
 
     /// <summary>
     /// Gets or sets the title of the dialog.

--- a/src/Core/Components/Dialog/Parameters/DialogParameters.cs
+++ b/src/Core/Components/Dialog/Parameters/DialogParameters.cs
@@ -12,6 +12,7 @@ public class DialogParameters : ComponentParameters, IDialogParameters
     /// Gets or sets the dialog position:
     /// left (full height), right (full height)
     /// or screen middle (using Width and Height properties).
+    /// HorizontalAlignment.Stretch is not supported for this property.
     /// </summary>
     public virtual HorizontalAlignment Alignment
     {

--- a/src/Core/Components/Dialog/Parameters/DialogParameters.cs
+++ b/src/Core/Components/Dialog/Parameters/DialogParameters.cs
@@ -4,6 +4,8 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 
 public class DialogParameters : ComponentParameters, IDialogParameters
 {
+    private HorizontalAlignment _alignment = HorizontalAlignment.Center;
+
     public string Id { get; set; } = Identifier.NewId();
 
     /// <summary>
@@ -26,8 +28,7 @@ public class DialogParameters : ComponentParameters, IDialogParameters
             return _alignment;
         }
     }
-    private HorizontalAlignment _alignment = HorizontalAlignment.Center;
-
+    
     /// <summary>
     /// Gets or sets the title of the dialog.
     /// </summary>

--- a/src/Core/Components/Stack/FluentStack.razor.cs
+++ b/src/Core/Components/Stack/FluentStack.razor.cs
@@ -86,6 +86,7 @@ public partial class FluentStack : FluentComponentBase
             HorizontalAlignment.Center => "center",
             HorizontalAlignment.Right => "end",
             HorizontalAlignment.End => "end",
+            HorizontalAlignment.Stretch => "stretch",
             _ => "start",
         };
     }

--- a/src/Core/Enums/HorizontalAlignement.cs
+++ b/src/Core/Enums/HorizontalAlignement.cs
@@ -29,4 +29,9 @@ public enum HorizontalAlignment
     /// The content is aligned to the end.
     /// </summary>
     End,
+
+    /// <summary>
+    /// The content is stretched to fill the available space.
+    /// </summary>
+    Stretch,
 }

--- a/tests/Core/Dialog/FluentDialogServiceTests.razor
+++ b/tests/Core/Dialog/FluentDialogServiceTests.razor
@@ -1,4 +1,5 @@
 ﻿@using Xunit;
+@using HorizontalAlignment = Microsoft.FluentUI.AspNetCore.Components.HorizontalAlignment
 @inherits TestContext
 @code
 {
@@ -113,6 +114,27 @@
         // Assert
         Assert.Equal("My new title", cut.Find("h4").InnerHtml);
         Assert.Equal("Oh yes", cut.Find("fluent-button[appearance='accent']").InnerHtml);
+    }
+
+    [Fact]
+    public async Task FluentDialogService_AlignmentInvalid()
+    {
+        Services.AddFluentUIComponents();
+
+        // Arrange
+        var cut = Render(@<FluentDialogProvider/>   );
+        var dialogService = Services.GetRequiredService<IDialogService>();
+
+        // Act/Assert
+        var exception = await Assert.ThrowsAsync<ArgumentException>(async () =>
+        {
+            var dialog = await dialogService.ShowDialogAsync<TestDialogHeaderFooter>(new DialogParameters()
+            {
+                Alignment = HorizontalAlignment.Stretch, // Stretch is not supported
+            });
+        });
+
+        Assert.Equal("Alignment HorizontalAlignment.Stretch is not supported for DialogParameters", exception.Message);
     }
 
     private class UpdateDialogUser


### PR DESCRIPTION
Introduced a new horizontal alignment option, `Stretch`, to the `FluentStack` component. Updated the `HorizontalAlignment` enum in `HorizontalAlignment.cs` to include the `Stretch` value with a summary comment. Modified the `GetHorizontalAlignment` method in `FluentStack.razor.cs` to map `HorizontalAlignment.Stretch`  to the string "stretch".

# Pull Request

## 📖 Description

While using the FluentStack in vertical mode I found that I was unable to set the underlying flexbox "align-items"  style to "stretch" as this option was missing from the HorizontalAlignment enum. Therefore I have added "Stretch" to the enum and implemented the option in the GetHorizontalAlignment method of the FluentStack component.
I don't believe this is a breaking change as the default option is still "start".


### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

To view the change in action visit the /Stack page of the demo and in the "Using the FluentStack component" section select the "Stretch" option in the "Horizonal" options. 

This is my very first pull request so apologies if I haven't followed any procedures correctly. 

## 📑 Test Plan

There doesn't appear to be any existing test coverage for these areas.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x ] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x ] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x ] I have modified an existing component
- [ ] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
