### PR TITLE
[MessageBox] Add settable primary action text for Show... methods

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -3816,32 +3816,36 @@
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.DialogService.ShowPanelAsync``1(System.Type,Microsoft.FluentUI.AspNetCore.Components.DialogParameters{``0})">
             <inheritdoc cref="M:Microsoft.FluentUI.AspNetCore.Components.IDialogService.ShowPanelAsync``1(System.Type,Microsoft.FluentUI.AspNetCore.Components.DialogParameters{``0})"/>
         </member>
-        <member name="M:Microsoft.FluentUI.AspNetCore.Components.DialogService.ShowSuccess(System.String,System.String)">
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.DialogService.ShowSuccess(System.String,System.String,System.String)">
             <summary>
             Shows a success message box. Does not have a callback function.
             </summary>
             <param name="message">The message to display.</param>
+            <param name="primaryAction">The text to display on the primary button.</param>
             <param name="title">The title to display on the dialog.</param>
         </member>
-        <member name="M:Microsoft.FluentUI.AspNetCore.Components.DialogService.ShowWarning(System.String,System.String)">
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.DialogService.ShowWarning(System.String,System.String,System.String)">
             <summary>
             Shows a warning message box. Does not have a callback function.
             </summary>
             <param name="message">The message to display.</param>
+            <param name="primaryAction">The text to display on the primary button.</param>
             <param name="title">The title to display on the dialog.</param>
         </member>
-        <member name="M:Microsoft.FluentUI.AspNetCore.Components.DialogService.ShowError(System.String,System.String)">
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.DialogService.ShowError(System.String,System.String,System.String)">
             <summary>
             Shows an error message box. Does not have a callback function.
             </summary>
             <param name="message">The message to display.</param>
+            <param name="primaryAction">The text to display on the primary button.</param>
             <param name="title">The title to display on the dialog.</param>
         </member>
-        <member name="M:Microsoft.FluentUI.AspNetCore.Components.DialogService.ShowInfo(System.String,System.String)">
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.DialogService.ShowInfo(System.String,System.String,System.String)">
             <summary>
             Shows an information message box. Does not have a callback function.
             </summary>
             <param name="message">The message to display.</param>
+            <param name="primaryAction">The text to display on the primary button.</param>
             <param name="title">The title to display on the dialog.</param>
         </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.DialogService.ShowConfirmation(System.Object,System.Func{Microsoft.FluentUI.AspNetCore.Components.DialogResult,System.Threading.Tasks.Task},System.String,System.String,System.String,System.String)">
@@ -3863,32 +3867,36 @@
             </summary>
             <param name="parameters">Parameters to pass to component being displayed.</param>
         </member>
-        <member name="M:Microsoft.FluentUI.AspNetCore.Components.DialogService.ShowSuccessAsync(System.String,System.String)">
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.DialogService.ShowSuccessAsync(System.String,System.String,System.String)">
             <summary>
             Shows a success message box. Does not have a callback function.
             </summary>
             <param name="message">The message to display.</param>
+            <param name="primaryAction">The text to display on the primary button.</param>
             <param name="title">The title to display on the dialog.</param>
         </member>
-        <member name="M:Microsoft.FluentUI.AspNetCore.Components.DialogService.ShowWarningAsync(System.String,System.String)">
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.DialogService.ShowWarningAsync(System.String,System.String,System.String)">
             <summary>
             Shows a warning message box. Does not have a callback function.
             </summary>
             <param name="message">The message to display.</param>
+            <param name="primaryAction">The text to display on the primary button.</param>
             <param name="title">The title to display on the dialog.</param>
         </member>
-        <member name="M:Microsoft.FluentUI.AspNetCore.Components.DialogService.ShowErrorAsync(System.String,System.String)">
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.DialogService.ShowErrorAsync(System.String,System.String,System.String)">
             <summary>
             Shows an error message box. Does not have a callback function.
             </summary>
             <param name="message">The message to display.</param>
+            <param name="primaryAction">The text to display on the primary button.</param>
             <param name="title">The title to display on the dialog.</param>
         </member>
-        <member name="M:Microsoft.FluentUI.AspNetCore.Components.DialogService.ShowInfoAsync(System.String,System.String)">
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.DialogService.ShowInfoAsync(System.String,System.String,System.String)">
             <summary>
             Shows an information message box. Does not have a callback function.
             </summary>
             <param name="message">The message to display.</param>
+            <param name="primaryAction">The text to display on the primary button.</param>
             <param name="title">The title to display on the dialog.</param>
         </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.DialogService.ShowConfirmationAsync(System.Object,System.Func{Microsoft.FluentUI.AspNetCore.Components.DialogResult,System.Threading.Tasks.Task},System.String,System.String,System.String,System.String)">

--- a/examples/Demo/Shared/Pages/MessageBox/Examples/DialogMessageBoxAsyncCustomPrimary.razor
+++ b/examples/Demo/Shared/Pages/MessageBox/Examples/DialogMessageBoxAsyncCustomPrimary.razor
@@ -21,42 +21,42 @@
 
     private async Task ShowSuccessAsync()
     {
-        var dialog = await DialogService.ShowSuccessAsync("The action was a success");
+        var dialog = await DialogService.ShowSuccessAsync("The action was a success", null, "Hooray!");
         var result = await dialog.Result;
         canceled = result.Cancelled;
     }
 
     private async Task ShowWarningAsync()
     {
-        var dialog = await DialogService.ShowWarningAsync("This is your final warning");
+        var dialog = await DialogService.ShowWarningAsync("This is your final warning", null, "Stop!");
         var result = await dialog.Result;
         canceled = result.Cancelled;
     }
 
     private async Task ShowErrorAsync()
     {
-        var dialog = await DialogService.ShowErrorAsync("This is an error");
+        var dialog = await DialogService.ShowErrorAsync("This is an error", null, "Oops");
         var result = await dialog.Result;
         canceled = result.Cancelled;
     }
 
     private async Task ShowInformationAsync()
     {
-        var dialog = await DialogService.ShowInfoAsync("This is a message");
+        var dialog = await DialogService.ShowInfoAsync("This is a message", null, "Confirm");
         var result = await dialog.Result;
         canceled = result.Cancelled;
     }
 
     private async Task ShowConfirmationAsync()
     {
-        var dialog = await DialogService.ShowConfirmationAsync("Do you have two eyes?");
+        var dialog = await DialogService.ShowConfirmationAsync("Do you have two eyes?", "Yup", "Nope", "Eyes on you");
         var result = await dialog.Result;
         canceled = result.Cancelled;
     }
 
     private async Task ShowMessageBoxLongAsync()
     {
-        var dialog = await DialogService.ShowInfoAsync("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum");
+        var dialog = await DialogService.ShowInfoAsync("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum", null, "Excepteur");
         var result = await dialog.Result;
         canceled = result.Cancelled;
     }
@@ -72,8 +72,8 @@
                     Icon = new Icons.Regular.Size24.Games(),
                     IconColor = Color.Success,
                 },
-                PrimaryAction = "Plus",
-                SecondaryAction = "Minus",
+                PrimaryAction = "OK",
+                SecondaryAction = "Cancel",
                 Width = "300px",
             });
         var result = await dialog.Result;

--- a/examples/Demo/Shared/Pages/MessageBox/MessageBoxPage.razor
+++ b/examples/Demo/Shared/Pages/MessageBox/MessageBoxPage.razor
@@ -50,6 +50,10 @@
     <p>The buttons below call the <strong>async</strong> MessageBox methods on the DialogService.</p>
 </DemoSection>
 
+<DemoSection Title="MessageBoxAsync" Component="@typeof(DialogMessageBoxAsyncCustomPrimary)">
+    <p>Same examples as above , but with custom primary botton texts</p>
+</DemoSection>
+
 <h2 id="documentation">Documentation</h2>
 
 <ApiDocumentation Component="typeof(MessageBoxContent)" />

--- a/examples/Demo/Shared/Pages/TreeView/TreeViewPage.razor
+++ b/examples/Demo/Shared/Pages/TreeView/TreeViewPage.razor
@@ -26,11 +26,14 @@
     </p>
 </blockquote>
 
+<p>
+    When using a TreeView with dynamic items, always use th <code>Items</code> collection to define the tree structure. The <code>FluentTreeItem</code> component should only be used to define the tree nodes when the tree structure is static.
+</p>
 <h2 id="example">Examples</h2>
 
 <DemoSection Title="Default with event handling" Component="@typeof(TreeViewDefault)" />
 
-<DemoSection Title="With Items" Component="@typeof(TreeViewWithItems)" />
+<DemoSection Title="Dynamic tree generation via Items" Component="@typeof(TreeViewWithItems)" />
 
 <DemoSection Title="With Unlimited Items" Component="@typeof(TreeViewWithUnlimitedItems)" />
 

--- a/src/Core/Components/Dialog/Services/DialogService-MessageBox.cs
+++ b/src/Core/Components/Dialog/Services/DialogService-MessageBox.cs
@@ -8,8 +8,9 @@ public partial class DialogService
     /// Shows a success message box. Does not have a callback function.
     /// </summary>
     /// <param name="message">The message to display.</param>
+    /// <param name="primaryAction">The text to display on the primary button.</param>
     /// <param name="title">The title to display on the dialog.</param>
-    public void ShowSuccess(string message, string? title = null) => ShowMessageBox(new DialogParameters<MessageBoxContent>()
+    public void ShowSuccess(string message, string? title = null, string? primaryAction = null) => ShowMessageBox(new DialogParameters<MessageBoxContent>()
     {
         Content = new MessageBoxContent()
         {
@@ -20,7 +21,7 @@ public partial class DialogService
             Message = message,
         },
         DialogType = DialogType.MessageBox,
-        PrimaryAction = "OK",
+        PrimaryAction = string.IsNullOrWhiteSpace(primaryAction) ? "OK" : primaryAction,
         SecondaryAction = string.Empty,
     });
 
@@ -28,8 +29,9 @@ public partial class DialogService
     /// Shows a warning message box. Does not have a callback function.
     /// </summary>
     /// <param name="message">The message to display.</param>
+    /// <param name="primaryAction">The text to display on the primary button.</param>
     /// <param name="title">The title to display on the dialog.</param>
-    public void ShowWarning(string message, string? title = null) => ShowMessageBox(new DialogParameters<MessageBoxContent>()
+    public void ShowWarning(string message, string? title = null, string? primaryAction = null) => ShowMessageBox(new DialogParameters<MessageBoxContent>()
     {
         Content = new MessageBoxContent()
         {
@@ -40,7 +42,7 @@ public partial class DialogService
             Message = message,
         },
         DialogType = DialogType.MessageBox,
-        PrimaryAction = "OK",
+        PrimaryAction = string.IsNullOrWhiteSpace(primaryAction) ? "OK" : primaryAction,
         SecondaryAction = string.Empty,
     });
 
@@ -48,8 +50,9 @@ public partial class DialogService
     /// Shows an error message box. Does not have a callback function.
     /// </summary>
     /// <param name="message">The message to display.</param>
+    /// <param name="primaryAction">The text to display on the primary button.</param>
     /// <param name="title">The title to display on the dialog.</param>
-    public void ShowError(string message, string? title = null) => ShowMessageBox(new DialogParameters<MessageBoxContent>()
+    public void ShowError(string message, string? title = null, string? primaryAction = null) => ShowMessageBox(new DialogParameters<MessageBoxContent>()
     {
         Content = new MessageBoxContent()
         {
@@ -60,7 +63,7 @@ public partial class DialogService
             Message = message,
         },
         DialogType = DialogType.MessageBox,
-        PrimaryAction = "OK",
+        PrimaryAction = string.IsNullOrWhiteSpace(primaryAction) ? "Close" : primaryAction,
         SecondaryAction = string.Empty,
     });
 
@@ -68,8 +71,9 @@ public partial class DialogService
     /// Shows an information message box. Does not have a callback function.
     /// </summary>
     /// <param name="message">The message to display.</param>
+    /// <param name="primaryAction">The text to display on the primary button.</param>
     /// <param name="title">The title to display on the dialog.</param>
-    public void ShowInfo(string message, string? title = null) => ShowMessageBox(new DialogParameters<MessageBoxContent>()
+    public void ShowInfo(string message, string? title = null, string? primaryAction = null) => ShowMessageBox(new DialogParameters<MessageBoxContent>()
     {
         Content = new MessageBoxContent()
         {
@@ -80,7 +84,7 @@ public partial class DialogService
             Message = message,
         },
         DialogType = DialogType.MessageBox,
-        PrimaryAction = "OK",
+        PrimaryAction = string.IsNullOrWhiteSpace(primaryAction) ? "OK" : primaryAction,
         SecondaryAction = string.Empty,
     });
 
@@ -142,8 +146,9 @@ public partial class DialogService
     /// Shows a success message box. Does not have a callback function.
     /// </summary>
     /// <param name="message">The message to display.</param>
+    /// <param name="primaryAction">The text to display on the primary button.</param>
     /// <param name="title">The title to display on the dialog.</param>
-    public async Task<IDialogReference> ShowSuccessAsync(string message, string? title = null)
+    public async Task<IDialogReference> ShowSuccessAsync(string message, string? title = null, string? primaryAction = null)
         => await ShowMessageBoxAsync(new DialogParameters<MessageBoxContent>()
         {
             Content = new MessageBoxContent()
@@ -155,7 +160,7 @@ public partial class DialogService
                 Message = message,
             },
             DialogType = DialogType.MessageBox,
-            PrimaryAction = "OK",
+            PrimaryAction = string.IsNullOrWhiteSpace(primaryAction) ? "OK" : primaryAction,
             SecondaryAction = string.Empty,
         });
 
@@ -163,8 +168,9 @@ public partial class DialogService
     /// Shows a warning message box. Does not have a callback function.
     /// </summary>
     /// <param name="message">The message to display.</param>
+    /// <param name="primaryAction">The text to display on the primary button.</param>
     /// <param name="title">The title to display on the dialog.</param>
-    public async Task<IDialogReference> ShowWarningAsync(string message, string? title = null)
+    public async Task<IDialogReference> ShowWarningAsync(string message, string? title = null, string? primaryAction = null)
         => await ShowMessageBoxAsync(new DialogParameters<MessageBoxContent>()
         {
             Content = new MessageBoxContent()
@@ -176,7 +182,7 @@ public partial class DialogService
                 Message = message,
             },
             DialogType = DialogType.MessageBox,
-            PrimaryAction = "OK",
+            PrimaryAction = string.IsNullOrWhiteSpace(primaryAction) ? "OK" : primaryAction,
             SecondaryAction = string.Empty,
         });
 
@@ -184,8 +190,9 @@ public partial class DialogService
     /// Shows an error message box. Does not have a callback function.
     /// </summary>
     /// <param name="message">The message to display.</param>
+    /// <param name="primaryAction">The text to display on the primary button.</param>
     /// <param name="title">The title to display on the dialog.</param>
-    public async Task<IDialogReference> ShowErrorAsync(string message, string? title = null)
+    public async Task<IDialogReference> ShowErrorAsync(string message, string? title = null, string? primaryAction = null)
         => await ShowMessageBoxAsync(new DialogParameters<MessageBoxContent>()
         {
             Content = new MessageBoxContent()
@@ -197,7 +204,7 @@ public partial class DialogService
                 Message = message,
             },
             DialogType = DialogType.MessageBox,
-            PrimaryAction = "OK",
+            PrimaryAction = string.IsNullOrWhiteSpace(primaryAction) ? "Close" : primaryAction,
             SecondaryAction = string.Empty,
         });
 
@@ -205,8 +212,9 @@ public partial class DialogService
     /// Shows an information message box. Does not have a callback function.
     /// </summary>
     /// <param name="message">The message to display.</param>
+    /// <param name="primaryAction">The text to display on the primary button.</param>
     /// <param name="title">The title to display on the dialog.</param>
-    public async Task<IDialogReference> ShowInfoAsync(string message, string? title = null)
+    public async Task<IDialogReference> ShowInfoAsync(string message, string? title = null, string? primaryAction = null)
         => await ShowMessageBoxAsync(new DialogParameters<MessageBoxContent>()
         {
             Content = new MessageBoxContent()
@@ -218,7 +226,7 @@ public partial class DialogService
                 Message = message,
             },
             DialogType = DialogType.MessageBox,
-            PrimaryAction = "OK",
+            PrimaryAction = string.IsNullOrWhiteSpace(primaryAction) ? "OK" : primaryAction,
             SecondaryAction = string.Empty,
         });
 
@@ -232,7 +240,7 @@ public partial class DialogService
     /// <param name="primaryText">The text to display on the primary button.</param>
     /// <param name="secondaryText">The text to display on the secondary button.</param>
     /// <param name="title">The title to display on the dialog.</param>
-    public async Task<IDialogReference> ShowConfirmationAsync(object receiver, Func<DialogResult, Task> callback, string message, string primaryText = "Yes", string secondaryText = "No", string? title = null)
+    public async Task<IDialogReference> ShowConfirmationAsync(object receiver, Func<DialogResult, Task> callback, string message, string? primaryText = "Yes", string? secondaryText = "No", string? title = null)
         => await ShowMessageBoxAsync(new DialogParameters<MessageBoxContent>()
         {
             Content = new MessageBoxContent()
@@ -257,7 +265,7 @@ public partial class DialogService
     /// <param name="primaryText">The text to display on the primary button.</param>
     /// <param name="secondaryText">The text to display on the secondary button.</param>
     /// <param name="title">The title to display on the dialog.</param>
-    public async Task<IDialogReference> ShowConfirmationAsync(string message, string primaryText = "Yes", string secondaryText = "No", string? title = null)
+    public async Task<IDialogReference> ShowConfirmationAsync(string message, string? primaryText = "Yes", string? secondaryText = "No", string? title = null)
         => await ShowMessageBoxAsync(new DialogParameters<MessageBoxContent>()
         {
             Content = new MessageBoxContent()

--- a/src/Core/Components/Dialog/Services/IDialogService-MessageBox.cs
+++ b/src/Core/Components/Dialog/Services/IDialogService-MessageBox.cs
@@ -2,25 +2,26 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 
 public partial interface IDialogService
 {
-    void ShowSuccess(string message, string? title = null);
 
-    void ShowWarning(string message, string? title = null);
+    void ShowSuccess(string message, string? title = null, string? primaryText = null);
 
-    void ShowError(string message, string? title = null);
+    void ShowWarning(string message, string? title = null, string? primaryText = null);
 
-    void ShowInfo(string message, string? title = null);
+    void ShowError(string message, string? title = null, string? primaryText = null);
+
+    void ShowInfo(string message, string? title = null, string? primaryText = null);
 
     void ShowConfirmation(object receiver, Func<DialogResult, Task> callback, string message, string primaryText = "Yes", string secondaryText = "No", string? title = null);
 
     void ShowMessageBox(DialogParameters<MessageBoxContent> parameters);
 
-    Task<IDialogReference> ShowSuccessAsync(string message, string? title = null);
+    Task<IDialogReference> ShowSuccessAsync(string message, string? title = null, string? primaryText = null);
 
-    Task<IDialogReference> ShowWarningAsync(string message, string? title = null);
+    Task<IDialogReference> ShowWarningAsync(string message, string? title = null, string? primaryText = null);
 
-    Task<IDialogReference> ShowErrorAsync(string message, string? title = null);
+    Task<IDialogReference> ShowErrorAsync(string message, string? title = null, string? primaryText = null);
 
-    Task<IDialogReference> ShowInfoAsync(string message, string? title = null);
+    Task<IDialogReference> ShowInfoAsync(string message, string? title = null, string? primaryText = null);
 
     Task<IDialogReference> ShowConfirmationAsync(object receiver, Func<DialogResult, Task> callback, string message, string primaryText = "Yes", string secondaryText = "No", string? title = null);
 


### PR DESCRIPTION
Fix #2805 by adding primary action parameter to message box shortcut methods. Changed existing examples to use default value. Added new examples for new parameter.

The new parameter has been added as the last (nullable) parameter in the method calls to not break current implementations