### PR TITLE
[TreeView] Fix OnSelectedChange when using Items

### DIFF
--- a/src/Core/Components/TreeView/FluentTreeItem.razor.cs
+++ b/src/Core/Components/TreeView/FluentTreeItem.razor.cs
@@ -197,6 +197,7 @@ public partial class FluentTreeItem : FluentComponentBase, IDisposable
 
         if (Owner != null)
         {
+            Selected = args.Selected.Value;
             await Owner.ItemSelectedChangeAsync(this);
         }
     }


### PR DESCRIPTION
Set a `FluentTreeItem`'s `Selected` value before calling `FluentTreeView.ItemSelectedChangeAsync`. Fixes #2810