### PR TITLE
[DataGrid] Add mechanism to not fire single click when a row is double clicked

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -3517,6 +3517,7 @@
             Gets or sets the dialog position:
             left (full height), right (full height)
             or screen middle (using Width and Height properties).
+            HorizontalAlignment.Stretch is not supported for this property.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.DialogParameters.Title">
@@ -13867,6 +13868,11 @@
         <member name="F:Microsoft.FluentUI.AspNetCore.Components.HorizontalAlignment.End">
             <summary>
             The content is aligned to the end.
+            </summary>
+        </member>
+        <member name="F:Microsoft.FluentUI.AspNetCore.Components.HorizontalAlignment.Stretch">
+            <summary>
+            The content is stretched to fill the available space.
             </summary>
         </member>
         <member name="T:Microsoft.FluentUI.AspNetCore.Components.HorizontalPosition">

--- a/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridRemoteData.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridRemoteData.razor
@@ -4,7 +4,7 @@
 @inject NavigationManager NavManager
 
 <div style="height: 434px; overflow:auto;" tabindex="-1">
-    <FluentDataGrid style="height: 100%;" Loading="@(numResults == null)" ItemsProvider="foodRecallProvider" OnRowDoubleClick="@((e)=>DemoLogger.WriteLine($"Row double clicked! ({e.RowIndex})"))" OnRowClick="@((e)=>DemoLogger.WriteLine($"Row clicked! ({e.RowIndex})"))" Virtualize="true" ItemSize="46" GenerateHeader="GenerateHeaderOption.Sticky" TGridItem="FoodRecall" >
+    <FluentDataGrid style="height: 100%;" Loading="@(numResults == null)" ItemsProvider="foodRecallProvider" OnRowDoubleClick="@(()=>DemoLogger.WriteLine($"Row double clicked!"))" OnRowClick="@(()=>DemoLogger.WriteLine($"Row clicked!"))" Virtualize="true" ItemSize="46" GenerateHeader="GenerateHeaderOption.Sticky" TGridItem="FoodRecall" >
         <PropertyColumn Title="ID" Property="@(c => c!.Event_Id)" />
         <PropertyColumn Property="@(c => c!.State)" Style="color: #af5f00 ;" />
         <PropertyColumn Property="@(c => c!.City)" />

--- a/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridRemoteData.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridRemoteData.razor
@@ -4,7 +4,7 @@
 @inject NavigationManager NavManager
 
 <div style="height: 434px; overflow:auto;" tabindex="-1">
-    <FluentDataGrid style="height: 100%;" Loading="@(numResults == null)" ItemsProvider="foodRecallProvider" OnRowDoubleClick="@(()=>DemoLogger.WriteLine("Row double clicked!"))" Virtualize="true" ItemSize="46" GenerateHeader="GenerateHeaderOption.Sticky" TGridItem="FoodRecall" >
+    <FluentDataGrid style="height: 100%;" Loading="@(numResults == null)" ItemsProvider="foodRecallProvider" OnRowDoubleClick="@((e)=>DemoLogger.WriteLine($"Row double clicked! ({e.RowIndex})"))" OnRowClick="@((e)=>DemoLogger.WriteLine($"Row clicked! ({e.RowIndex})"))" Virtualize="true" ItemSize="46" GenerateHeader="GenerateHeaderOption.Sticky" TGridItem="FoodRecall" >
         <PropertyColumn Title="ID" Property="@(c => c!.Event_Id)" />
         <PropertyColumn Property="@(c => c!.State)" Style="color: #af5f00 ;" />
         <PropertyColumn Property="@(c => c!.City)" />


### PR DESCRIPTION
Add delay on single click to prevent it from firing when double clicked. Remote data example has been updated to show the working of the new feature. Fixes #2789 

After:
![fix-issue-#2789](https://github.com/user-attachments/assets/447d1210-c2cb-4fcc-bef1-37b6dd241d15)
