### PR TITLE
[Autocomplete] Fix the Autocomplete search rendering on slow connections

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -3517,6 +3517,7 @@
             Gets or sets the dialog position:
             left (full height), right (full height)
             or screen middle (using Width and Height properties).
+            HorizontalAlignment.Stretch is not supported for this property.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.DialogParameters.Title">
@@ -5673,6 +5674,9 @@
             <summary />
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.SelectableItem">
+            <summary />
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.ShouldRender">
             <summary />
         </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.InputHandlerAsync(Microsoft.AspNetCore.Components.ChangeEventArgs)">
@@ -13867,6 +13871,11 @@
         <member name="F:Microsoft.FluentUI.AspNetCore.Components.HorizontalAlignment.End">
             <summary>
             The content is aligned to the end.
+            </summary>
+        </member>
+        <member name="F:Microsoft.FluentUI.AspNetCore.Components.HorizontalAlignment.Stretch">
+            <summary>
+            The content is stretched to fill the available space.
             </summary>
         </member>
         <member name="T:Microsoft.FluentUI.AspNetCore.Components.HorizontalPosition">

--- a/src/Core/Components/List/FluentAutocomplete.razor.cs
+++ b/src/Core/Components/List/FluentAutocomplete.razor.cs
@@ -19,6 +19,7 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
     public new FluentTextField? Element { get; set; } = default!;
     private Virtualize<TOption>? VirtualizationContainer { get; set; }
     private readonly Debounce _debounce = new();
+    private bool _shouldRender = true;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FluentAutocomplete{TOption}"/> class.
@@ -268,12 +269,17 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
     private TOption? SelectableItem { get; set; }
 
     /// <summary />
+    protected override bool ShouldRender() => _shouldRender;
+
+    /// <summary />
     protected override async Task InputHandlerAsync(ChangeEventArgs e)
     {
         if (ReadOnly || Disabled)
         {
             return;
         }
+
+        _shouldRender = false;
 
         ValueText = e.Value?.ToString() ?? string.Empty;
         await RaiseValueTextChangedAsync(ValueText);
@@ -312,6 +318,9 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
         {
             await VirtualizationContainer.RefreshDataAsync();
         }
+
+        _shouldRender = true;
+        StateHasChanged();
     }
 
     private ValueTask<ItemsProviderResult<TOption>> LoadFilteredItemsAsync(ItemsProviderRequest request)


### PR DESCRIPTION
# [Autocomplete] Fix the Autocomplete search rendering on slow connections

When a slow connection is used and the search takes a long time, some side effects may occur.
This PR blocks rendering during the search process.

## Before

![peek_3](https://github.com/user-attachments/assets/9e978b60-81b1-4042-942e-9f0ac16b784f)

## After

![peek_4](https://github.com/user-attachments/assets/12e82e9b-c3a5-4820-87a4-4278333c4925)
