### PR TITLE
[AutoComplete] Add KeepOpen property

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -5660,6 +5660,12 @@
             Default is false.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.KeepOpen">
+            <summary>
+            Gets or sets whether the drop-down panel stays open after selecting an item,
+            until the number of selected items reaches the maximum (only using the mouse).
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.ListStyleValue">
             <summary />
         </member>
@@ -5712,6 +5718,9 @@
             <summary />
         </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.RaiseValueTextChangedAsync(System.String)">
+            <summary />
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.MustBeClosed">
             <summary />
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentCombobox`1.LibraryConfiguration">

--- a/examples/Demo/Shared/Pages/List/Autocomplete/Examples/AutocompleteCustomized.razor
+++ b/examples/Demo/Shared/Pages/List/Autocomplete/Examples/AutocompleteCustomized.razor
@@ -7,6 +7,7 @@
                     Placeholder="search"
                     OnOptionsSearch="@OnSearch"
                     MaximumSelectedOptions="3"
+                    KeepOpen="true"
                     OptionText="@(item => item.FirstName)"
                     OptionStyle="min-height: 40px;"
                     @bind-SelectedOptions="@SelectedItems">

--- a/src/Core/Components/List/ListComponentBase.razor.cs
+++ b/src/Core/Components/List/ListComponentBase.razor.cs
@@ -22,7 +22,7 @@ public abstract partial class ListComponentBase<TOption> : FluentInputBase<strin
 
     private bool _multiple = false;
     private bool _hasInitializedParameters;
-    private List<TOption> _selectedOptions = [];
+    protected List<TOption> _selectedOptions = [];
     protected TOption? _currentSelectedOption;
     protected readonly RenderFragment _renderOptions;
 


### PR DESCRIPTION
# [AutoComplete] Add KeepOpen property

Currently, when the user selects an item, the popup closes automatically and the user has to reopen it to select a new item.

To avoid this, it is now possible to use a `KeepOpen =‘true’` attribute which keeps the popup open as long as possible: as long as the maximum number of selected items has not been reached (`MaximumSelectedOptions`) 
And as long as the selection is made with the mouse (not the keyboard).

For compatibility reasons, this attribute is set to `false' by default.

See #2819

![peek_5](https://github.com/user-attachments/assets/6cd9a9d8-d1f3-4d4a-b860-b0b093c76c50)
