### PR TITLE
[General] Apply global color-scheme to reflect theme in use

### DIFF
--- a/src/Core/Components/DesignSystemProvider/FluentDesignTheme.razor.js
+++ b/src/Core/Components/DesignSystemProvider/FluentDesignTheme.razor.js
@@ -3,6 +3,7 @@ export function addThemeChangeEvent(dotNetHelper, id) {
 
     if (element) {
         element.addEventListener("onchange", (e) => {
+            UpdateBodyDataSetTheme(e.detail.newValue);
             try {
                 // setTimeout: https://github.com/dotnet/aspnetcore/issues/26809
                 setTimeout(() => {
@@ -15,7 +16,8 @@ export function addThemeChangeEvent(dotNetHelper, id) {
 
         try {
             // This can fail when localStorage does not contain a valid JSON object
-            const theme = element.themeStorage.readLocalStorage()
+            const theme = element.themeStorage.readLocalStorage();
+            UpdateBodyDataSetTheme(theme.mode);
             return theme == null ? theme : JSON.stringify(theme);
         } catch (error) {
             ClearLocalStorage(id);
@@ -44,5 +46,14 @@ export function ClearLocalStorage(id) {
 
     if (element) {
         element.themeStorage.clearLocalStorage();
+    }
+}
+
+function UpdateBodyDataSetTheme(theme) {
+    if (theme) {
+        document.body.dataset.theme = theme;
+    } else {
+        const isSystemDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+        document.body.dataset.theme = isSystemDark ? 'dark' : 'light';
     }
 }

--- a/src/Core/wwwroot/css/reboot.css
+++ b/src/Core/wwwroot/css/reboot.css
@@ -34,6 +34,16 @@ body, .body {
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 
+body[data-theme="light"],
+body[data-theme="system-light"] {
+    color-scheme: light;
+}
+
+body[data-theme="dark"],
+body[data-theme="system-dark"] {
+    color-scheme: dark;
+}
+
 hr {
     margin: 1rem 0;
     color: inherit;


### PR DESCRIPTION
# Pull Request

## 📖 Description

This pull request includes changes to improve theme management in the `FluentDesignTheme` component and updates to the CSS to support these changes. 

A new data attribute (`data-theme`) is added to body and updated every time theme changes.

In `reboot.css` this attribute is used to control the value of `color-scheme`: this ensure all browser-managed components (like scrollbars) matches theme in use.

Before:

![no_dark_mode_recognized](https://github.com/user-attachments/assets/a1aa21b0-ee4a-43a4-aa19-7f483ccdbe82)

After:

![all_dark](https://github.com/user-attachments/assets/fd056743-5a41-43f1-be43-8aa4ea7cd122)

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

