### PR TITLE
[ComboBox] Fix OnValueChanged being called multiple times

### DIFF
--- a/examples/Demo/Shared/Pages/Lab/IssueTester.razor
+++ b/examples/Demo/Shared/Pages/Lab/IssueTester.razor
@@ -1,2 +1,1 @@
-﻿@using FluentUI.Demo.Shared.Pages.List.Select.Examples
-<SelectMultiple />
+﻿

--- a/src/Core.Assets/src/index.ts
+++ b/src/Core.Assets/src/index.ts
@@ -314,6 +314,15 @@ export function afterStarted(blazor: Blazor, mode: string) {
     }
   });
 
+  blazor.registerCustomEventType('comboboxchange', {
+    browserEventName: 'change',
+    createEventArgs: event => {
+      return {
+        value: event.target._selectedOptions[0] ? event.target._selectedOptions[0].value : event.target.value 
+      }
+    }
+  });
+
   blazor.theme = {
     isSystemDark: () => {
       return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;

--- a/src/Core/Components/List/FluentCombobox.razor
+++ b/src/Core/Components/List/FluentCombobox.razor
@@ -20,7 +20,7 @@
                      disabled=@Disabled
                      appearance="@Appearance.ToAttributeValue()"
                      required="@Required"
-                     @onchange="@ChangeHandlerAsync"
+                     @oncomboboxchange="@ChangeHandlerAsync"
                      @oncontrolinput="@InputHandlerAsync"
                      autofocus="@Autofocus"
                      name="@Name"

--- a/src/Core/Components/List/FluentCombobox.razor.cs
+++ b/src/Core/Components/List/FluentCombobox.razor.cs
@@ -138,15 +138,19 @@ public partial class FluentCombobox<TOption> : ListComponentBase<TOption> where 
             if (item is null)
             {
                 SelectedOption = default;
-                await base.ChangeHandlerAsync(e);
             }
             else
             {
                 await OnSelectedItemChangedHandlerAsync(item);
             }
-
         }
     }
+
+    protected override async Task InputHandlerAsync(ChangeEventArgs e)
+    {
+        await base.ChangeHandlerAsync(e);
+    }
+
 
     protected override string? GetOptionValue(TOption? item)
     {

--- a/src/Core/Components/List/FluentCombobox.razor.cs
+++ b/src/Core/Components/List/FluentCombobox.razor.cs
@@ -143,14 +143,13 @@ public partial class FluentCombobox<TOption> : ListComponentBase<TOption> where 
             {
                 await OnSelectedItemChangedHandlerAsync(item);
             }
+
+            if (Value != value)
+            {
+                await base.ChangeHandlerAsync(e);
+            }
         }
     }
-
-    protected override async Task InputHandlerAsync(ChangeEventArgs e)
-    {
-        await base.ChangeHandlerAsync(e);
-    }
-
 
     protected override string? GetOptionValue(TOption? item)
     {

--- a/src/Core/Events/EventHandlers.cs
+++ b/src/Core/Events/EventHandlers.cs
@@ -22,6 +22,7 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 [EventHandler("onsplitterresized", typeof(SplitterResizedEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
 [EventHandler("onsplittercollapsed", typeof(SplitterCollapsedEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
 [EventHandler("oncontrolinput", typeof(ChangeEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
+[EventHandler("oncomboboxchange", typeof(ChangeEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
 public static class EventHandlers
 {
 }


### PR DESCRIPTION
Fix #2851 by not calling `base.ChangeHandlerAsync` when no item selected. This could happen if the  Value and the Text of an option differed.

See original issue for before output. Now all test situations render as expected.
