### PR TITLE
[dev-v5] Add Categories and Pages Order

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Counter/CounterPage.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Counter/CounterPage.md
@@ -1,5 +1,7 @@
 ---
 title: My Counter (Test)
+category: 0200|Labs
+icon: Regular.ArrowBetweenUp
 route: /Test/Counter
 ---
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/MigrationVersion5.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/MigrationVersion5.md
@@ -1,5 +1,8 @@
 ---
 title: Migration to v5
+order: 0020
+category: 10|Get Started
+icon: Regular.ArrowBetweenUp
 route: /MigrationV5
 ---
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/ReleaseNotes.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/ReleaseNotes.md
@@ -1,5 +1,8 @@
 ---
 title: What's New
+order: 0010
+category: 10|Get Started
+icon: Regular.Info
 route: /WhatsNew
 ---
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Home.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Home.md
@@ -1,5 +1,8 @@
 ---
 title: Home
+order: 0000
+category: 10|Get Started
+icon: Regular.Home
 route: /
 ---
 

--- a/examples/Demo/FluentUI.Demo.Client/Layout/DemoNavMenu.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Layout/DemoNavMenu.razor
@@ -3,10 +3,20 @@
 
 <div>
     <ul>
-        @foreach (var page in DocViewerService.Pages.Where(i => !i.Hidden).OrderBy(i => i.Route))
+        @* TODO: Need to manage multiple levels (not only 2) *@
+        @foreach (var category in NavItems)
         {
             <li>
-                <a href="@(page.Route)">@(page.Title)</a>
+                @category.Title
+
+                <ul>
+                    @foreach (var page in category.Items)
+                    {
+                        <li>
+                            <a href="@(page.Route)">@(page.Title)</a>
+                        </li>
+                    }
+                </ul>
             </li>
         }
     </ul>

--- a/examples/Demo/FluentUI.Demo.Client/Layout/DemoNavMenu.razor.cs
+++ b/examples/Demo/FluentUI.Demo.Client/Layout/DemoNavMenu.razor.cs
@@ -7,4 +7,30 @@ namespace FluentUI.Demo.Client.Layout;
 public partial class DemoNavMenu
 {
 
+    protected override void OnInitialized()
+    {
+        var pages = DocViewerService.Pages.Where(i => !i.Hidden);
+
+        var navItems = pages
+                .GroupBy(p => p.Category.Title)
+                .Select(g => new NavItem(
+                    Title: string.IsNullOrEmpty(g.Key) ? "Components" : g.Key,
+                    Route: string.Empty,
+                    Icon: string.Empty, // Assuming categories don't have icons
+                    Order: string.IsNullOrEmpty(g.Key) ? "0099" : "0000",
+                    Items: g.Select(p => new NavItem(
+                        Title: p.Title,
+                        Route: p.Route,
+                        Icon: p.Icon,
+                        Order: p.Order,
+                        Items: Enumerable.Empty<NavItem>())
+                    ).OrderBy(i => i.Order)))
+                .OrderBy(i => i.Order);
+
+        NavItems = navItems;
+    }
+
+    public IEnumerable<NavItem> NavItems { get; private set; } = Enumerable.Empty<NavItem>();
+
+    public record NavItem(string Title, string Route, string Icon, string Order, IEnumerable<NavItem> Items);
 }

--- a/examples/Demo/FluentUI.Demo.Client/Layout/DemoNavMenu.razor.css
+++ b/examples/Demo/FluentUI.Demo.Client/Layout/DemoNavMenu.razor.css
@@ -1,0 +1,25 @@
+ul {
+  list-style-type: none;
+  padding-left: 0;
+  font: var(--fontWeightRegular) var(--fontSizeBase300) / var(--lineHeightBase300) var(--fontFamilyBase);
+}
+
+li {
+  font-weight: 600;
+  padding: 8px 10px;
+}
+
+  li li {
+    font-weight: 400;
+    padding-left: 24px;
+  }
+
+    li li:hover {
+      background: var(--colorNeutralBackground1Hover);
+      color: var(--colorNeutralForeground2Hover);
+    }
+
+a {
+  text-decoration: none;
+  color: var(--colorNeutralForeground2);
+}

--- a/examples/Tools/FluentUI.Demo.DocViewer.Tests/PageTests.cs
+++ b/examples/Tools/FluentUI.Demo.DocViewer.Tests/PageTests.cs
@@ -193,4 +193,17 @@ public class PageTests
 
         Assert.Equal(string.Empty, page.Order);
     }
+
+    [Fact]
+    public void Page_Icon_Default()
+    {
+        var fileContent = @"---
+                           icon: Regular.ControlButton
+                           ---
+                           My content";
+
+        var page = new Page(DocViewerService, "file.md", fileContent.RemoveLeadingBlanks());
+
+        Assert.Equal("Regular.ControlButton", page.Icon);
+    }
 }

--- a/examples/Tools/FluentUI.Demo.DocViewer.Tests/PageTests.cs
+++ b/examples/Tools/FluentUI.Demo.DocViewer.Tests/PageTests.cs
@@ -125,4 +125,72 @@ public class PageTests
         Assert.Equal(SectionType.Html, sections.ElementAt(0).Type);
         Assert.Equal(SectionType.Code, sections.ElementAt(1).Type);
     }
+
+    [Fact]
+    public void Page_Category_NoOrder()
+    {
+        var fileContent = @"---
+                           category: Get started
+                           ---
+                           My content";
+
+        var page = new Page(DocViewerService, "file.md", fileContent.RemoveLeadingBlanks());
+
+        Assert.Equal("Get started", page.Category.Title);
+        Assert.Equal("", page.Category.Key);
+    }
+
+    [Fact]
+    public void Page_Category_KeyTitle()
+    {
+        var fileContent = @"---
+                           category: 10 | Get started
+                           ---
+                           My content";
+
+        var page = new Page(DocViewerService, "file.md", fileContent.RemoveLeadingBlanks());
+
+        Assert.Equal("Get started", page.Category.Title);
+        Assert.Equal("10", page.Category.Key);
+    }
+
+    [Fact]
+    public void Page_Category_MultipleKeys()
+    {
+        var fileContent = @"---
+                           category: 10|Get started#Invalid
+                           ---
+                           My content";
+
+        var page = new Page(DocViewerService, "file.md", fileContent.RemoveLeadingBlanks());
+
+        Assert.Equal("Get started", page.Category.Title);
+        Assert.Equal("10", page.Category.Key);
+    }
+
+    [Fact]
+    public void Page_Order_Default()
+    {
+        var fileContent = @"---
+                           order: 10
+                           ---
+                           My content";
+
+        var page = new Page(DocViewerService, "file.md", fileContent.RemoveLeadingBlanks());
+
+        Assert.Equal("10", page.Order);
+    }
+
+    [Fact]
+    public void Page_Order_Undefined()
+    {
+        var fileContent = @"---
+                           title: My title
+                           ---
+                           My content";
+
+        var page = new Page(DocViewerService, "file.md", fileContent.RemoveLeadingBlanks());
+
+        Assert.Equal(string.Empty, page.Order);
+    }
 }

--- a/examples/Tools/FluentUI.Demo.DocViewer/Models/Page.cs
+++ b/examples/Tools/FluentUI.Demo.DocViewer/Models/Page.cs
@@ -40,6 +40,7 @@ public record Page
         Headers = items.Where(i => i.Key != "content").ToDictionary();
         Title = GetItem(items, "title");
         Order = GetItem(items, "order");
+        Icon = GetItem(items, "icon");
         Route = GetItem(items, "route");
         Hidden = GetItem(items, "hidden") == "true";
 
@@ -88,6 +89,11 @@ public record Page
     /// Gets the page order defined in the <see cref="Headers"/>
     /// </summary>
     public string Order { get; } = string.Empty;
+
+    /// <summary>
+    /// Gets the page icon defined in the <see cref="Headers"/>
+    /// </summary>
+    public string Icon { get; } = string.Empty;
 
     /// <summary>
     /// Gets the page category defined in the <see cref="Headers"/>

--- a/examples/Tools/FluentUI.Demo.DocViewer/Models/Page.cs
+++ b/examples/Tools/FluentUI.Demo.DocViewer/Models/Page.cs
@@ -19,6 +19,7 @@ public record Page
     /// <summary>
     /// 
     ///   ---
+    ///   category: 20|Components
     ///   title: Button
     ///   route: /Button
     ///   hidden: true
@@ -38,8 +39,23 @@ public record Page
         Content = ReplaceIncludes(GetItem(items, "content"));
         Headers = items.Where(i => i.Key != "content").ToDictionary();
         Title = GetItem(items, "title");
+        Order = GetItem(items, "order");
         Route = GetItem(items, "route");
         Hidden = GetItem(items, "hidden") == "true";
+
+        var category = GetItem(items, "category");
+        if (!string.IsNullOrEmpty(category))
+        {
+            var parts = category.Split(['|'], 2);
+            if (parts.Length == 2)
+            {
+                Category = (parts[0].Trim(), parts[1].Trim());
+            }
+            else
+            {
+                Category = (string.Empty, category.Trim());
+            }
+        }
     }
 
     /// <summary>
@@ -67,6 +83,16 @@ public record Page
     /// Gets the page title defined in the <see cref="Headers"/>
     /// </summary>
     public string Title { get; } = string.Empty;
+
+    /// <summary>
+    /// Gets the page order defined in the <see cref="Headers"/>
+    /// </summary>
+    public string Order { get; } = string.Empty;
+
+    /// <summary>
+    /// Gets the page category defined in the <see cref="Headers"/>
+    /// </summary>
+    public (string Key, string Title) Category { get; } = (string.Empty, string.Empty);
 
     /// <summary>
     /// Gets or sets the visibility of the page, defined in the <see cref="Headers"/>.

--- a/examples/Tools/FluentUI.Demo.DocViewer/ReadMe.md
+++ b/examples/Tools/FluentUI.Demo.DocViewer/ReadMe.md
@@ -46,7 +46,7 @@ into equivalent HTML pages.
    }
    ```
 
-## Header: Title and Routing
+## Header: Title, Routing and Category
 
 Each markdown file contains a header that defines the page title and the
 the route to this documentation page.
@@ -65,6 +65,19 @@ You can also hide the page from the navigation menu using the `hidden` attribute
 title: Button
 route: /Button
 hidden: true
+---
+```
+
+You can classify pages into categories using the `category` attribute.
+This allows you to present the navigation structure with these categories, possibly sorted on the basis of the key
+(to avoid alphabetical classification). Similarly, pages can be classified using the `order` parameter.
+
+```markdown
+---
+category: 10|Getting Started
+title: Button
+order: 20
+route: /Button
 ---
 ```
 


### PR DESCRIPTION
# [dev-v5] Add Categories and Pages Order

Update the Markdown headers to classify pages into categories using the `category` attribute.
This allows you to present the navigation structure with these categories, possibly sorted on the basis of the key
(to avoid alphabetical classification). Similarly, pages can be classified using the `order` parameter.

```markdown
---
category: 10|Getting Started
title: Button
order: 20
route: /Button
---
```

Temporary update of the `DemoNavMenu.razor` to have an acceptable result for the DotNetConf demo.
(Waiting the future NavMenu element)

![{67477D55-2AFF-4819-B039-68F184DD836C}](https://github.com/user-attachments/assets/3d018f04-5b66-4bab-86da-3fe2c0f455de)
