### PR TITLE
[DataGrid] Remove optimalization check as it can break in certain scenarios

### DIFF
--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.js
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.js
@@ -1,5 +1,4 @@
 let initialColumnsWidths = {};
-var latestGridElement = null;
 
 export function init(gridElement) {
     if (gridElement === undefined || gridElement === null) {
@@ -159,9 +158,6 @@ export function checkColumnPopupPosition(gridElement, selector) {
     }
 }
 export function enableColumnResizing(gridElement) {
-    if (gridElement === latestGridElement)
-        return;
-    latestGridElement = gridElement;
     const columns = [];
     let min = 75;
     let headerBeingResized;
@@ -224,7 +220,9 @@ export function enableColumnResizing(gridElement) {
             resizeHandle = target;
             headerBeingResized = target.parentNode;
 
-            resizeHandle.setPointerCapture(pointerId);
+            if (resizeHandle) {
+                resizeHandle.setPointerCapture(pointerId);
+            }
         };
 
         const dragHandle = header.querySelector('.col-width-draghandle');


### PR DESCRIPTION
Fixes #2868. When `StateHasChanged()` is called in the data refresh logic, the script would detect that it is running for the same grid and then return. In some cases however re-running the script code is actually necessary. 