### PR TITLE
[Calendar] Fix the Calendar disabled day in RTL direction

### DIFF
--- a/src/Core/Components/DateTime/FluentCalendar.razor.css
+++ b/src/Core/Components/DateTime/FluentCalendar.razor.css
@@ -190,6 +190,10 @@
         animation: none;
     }
 
+[dir="rtl"] .fluent-calendar ::deep .day[disabled]::before {
+    transform: translate(4px, 0px) rotate(45deg);
+}
+
 /*
     "Months" View
 */


### PR DESCRIPTION
# [Calendar] Fix the Calendar disabled day in RTL direction

## LTR

![{AC9910EA-E5C7-45A3-BF93-2F69F8829DA3}](https://github.com/user-attachments/assets/288aff66-2ec1-44f4-9339-1608984be370)

## RTL

![{4B899595-BE57-4D8F-BB5D-F4FAF079FFC8}](https://github.com/user-attachments/assets/4e500f76-7beb-4c7c-8b2b-4e7fab4fd8a9)

## Solution

```css
[dir="rtl"] .fluent-calendar ::deep .day[disabled]::before {
    transform: translate(4px, 0px) rotate(45deg);
}
```

See #2897 