### PR TITLE
[TreeItem] Only pass initially selected state to the web component

### DIFF
--- a/examples/Demo/Shared/Pages/Lab/IssueTester.razor
+++ b/examples/Demo/Shared/Pages/Lab/IssueTester.razor
@@ -1,1 +1,10 @@
-﻿
+﻿<FluentTreeView Items="@list" @bind-SelectedItem="this.selectedItem">
+
+</FluentTreeView>
+
+@code
+{
+    private ITreeViewItem? selectedItem;
+    private List<TreeViewItem> list = new List<TreeViewItem>() { new TreeViewItem() { Expanded = true, Text = "test 1", Items = new List<TreeViewItem>() { new TreeViewItem() { Text = "sub test 2" } } },
+        new TreeViewItem() { Text = "test 2" } };
+}

--- a/examples/Demo/Shared/Pages/Lab/IssueTester.razor
+++ b/examples/Demo/Shared/Pages/Lab/IssueTester.razor
@@ -1,10 +1,1 @@
-﻿<FluentTreeView Items="@list" @bind-SelectedItem="this.selectedItem">
 
-</FluentTreeView>
-
-@code
-{
-    private ITreeViewItem? selectedItem;
-    private List<TreeViewItem> list = new List<TreeViewItem>() { new TreeViewItem() { Expanded = true, Text = "test 1", Items = new List<TreeViewItem>() { new TreeViewItem() { Text = "sub test 2" } } },
-        new TreeViewItem() { Text = "test 2" } };
-}

--- a/src/Core/Components/TreeView/FluentTreeItem.razor
+++ b/src/Core/Components/TreeView/FluentTreeItem.razor
@@ -7,7 +7,7 @@
                   style="@Style"
                   id="@Id"
                   expanded="@Expanded"
-                  selected="@Selected"
+                  selected="@InitiallySelected"
                   disabled="@Disabled"
                   @onselectedchange="@HandleSelectedChangeAsync"
                   @onexpandedchange="@HandleExpandedChangeAsync"

--- a/src/Core/Components/TreeView/FluentTreeItem.razor.cs
+++ b/src/Core/Components/TreeView/FluentTreeItem.razor.cs
@@ -211,7 +211,7 @@ public partial class FluentTreeItem : FluentComponentBase, IDisposable
             builder.AddAttribute(i++, "Id", item.Id);
             builder.AddAttribute(i++, "Items", item.Items);
             builder.AddAttribute(i++, "Text", item.Text);
-            builder.AddAttribute(i++, "Selected", owner.SelectedItem == item);
+            builder.AddAttribute(i++, "InitiallySelected", owner.SelectedItem == item);
             builder.AddAttribute(i++, "Expanded", item.Expanded);
             builder.AddAttribute(i++, "Disabled", item.Disabled);
             builder.AddAttribute(i++, "IconCollapsed", item.IconCollapsed);


### PR DESCRIPTION
Fixes #2911 

When using 
```
<fluent-tree-item @ref=Element
   :
     selected="@Selected"
   :
```

and using a tree item collection, setting `Selected` leads to a looping situation where the value keeps flipping form true to false. To fix this I've changed this to only set `selected` to the `InitiallySelected` value. Selecting an item still works as expected as it will be handled by the web component and the event handler sets the state on the Blazor side.

Do not auto merge this. Need to clear issue tester first!