### PR TITLE
Add Support to the DataGrid Control for Complex Layout Rendering. Wit…

### DIFF
--- a/examples/Demo/Shared/Pages/DataGrid/DataGridPage.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/DataGridPage.razor
@@ -334,6 +334,14 @@ fluent-data-grid-row:has([row-selected]) {
     </Description>
 </DemoSection>
 
+<DemoSection Title="Complex Layout Example" Component="@typeof(DataGridComplexLayout)">
+    <Description>
+        Use can use nested <code>FluentDataGrid</code> components to create complex layouts.
+        <br />
+        So you can create some kind of column generator if needed. This example shows how to create a grid which is wrapped into an own component and has an static column generator.
+    </Description>
+</DemoSection>
+
 <h2 id="documentation">Documentation</h2>
 
 <ApiDocumentation Component="typeof(FluentDataGrid<>)" GenericLabel="TGridItem" />

--- a/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridComplexLayout.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridComplexLayout.razor
@@ -1,0 +1,9 @@
+﻿<DataGridComplexLayoutWrapper>
+    <Columns>
+        <DataGridComplexLayoutGenerator TGridItem="Person"></DataGridComplexLayoutGenerator>
+    </Columns>
+</DataGridComplexLayoutWrapper>
+
+@code {
+
+}

--- a/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridComplexLayoutGenerator.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridComplexLayoutGenerator.razor
@@ -1,0 +1,9 @@
+﻿@typeparam TGridItem
+
+<PropertyColumn TGridItem="Person" TProp="int" Property="@(p => p.PersonId)" Sortable="true" />
+<PropertyColumn TGridItem="Person" TProp="String" Property="@(p => p.FirstName)" Sortable="true" />
+<PropertyColumn TGridItem="Person" TProp="DateOnly" Property="@(p => p.BirthDate)" Format="yyyy-MM-dd" Sortable="true" />
+
+@code {
+
+}

--- a/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridComplexLayoutWrapper.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridComplexLayoutWrapper.razor
@@ -1,0 +1,13 @@
+﻿<FluentDataGrid Items="@people">
+    @Columns
+</FluentDataGrid>
+
+@code {
+
+
+    IQueryable<Person> people = new DataSource().People;
+
+
+    [Parameter]
+    public RenderFragment Columns { get; set; }
+}

--- a/src/Core/Components/DataGrid/Columns/ColumnBase.razor
+++ b/src/Core/Components/DataGrid/Columns/ColumnBase.razor
@@ -2,9 +2,8 @@
 @using Microsoft.FluentUI.AspNetCore.Components.DataGrid.Infrastructure
 @namespace Microsoft.FluentUI.AspNetCore.Components
 @typeparam TGridItem
-@{
-    Grid.AddColumn(this, InitialSortDirection, IsDefaultSortColumn);
-}
+@implements IDisposable
+
 @code
 {
     private void RenderDefaultHeaderContent(RenderTreeBuilder __builder)
@@ -171,4 +170,18 @@
             @PlaceholderTemplate(placeholderContext)
         }
     }
+
+    protected override void OnParametersSet()
+    {
+        base.OnParametersSet();
+        Grid.AddColumn(this, InitialSortDirection, IsDefaultSortColumn);
+    }
+
+    public void Dispose()
+    {
+        if (Grid != null)
+            Grid.RemoveColumn(this);
+
+    }
+
 }

--- a/src/Core/Components/DataGrid/Columns/PropertyColumn.cs
+++ b/src/Core/Components/DataGrid/Columns/PropertyColumn.cs
@@ -51,6 +51,8 @@ public class PropertyColumn<TGridItem, TProp> : ColumnBase<TGridItem>, IBindable
     /// <inheritdoc />
     protected override void OnParametersSet()
     {
+        base.OnParametersSet();
+
         // We have to do a bit of pre-processing on the lambda expression. Only do that if it's new or changed.
         if (_lastAssignedProperty != Property)
         {

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor
@@ -4,9 +4,7 @@
 @inherits FluentComponentBase
 @typeparam TGridItem
 <CascadingValue TValue="InternalGridContext<TGridItem>" IsFixed="true" Value="@_internalGridContext">
-    @{
-        StartCollectingColumns();
-    }
+
     @if (!_manualGrid)
     {
         @ChildContent


### PR DESCRIPTION
# Pull Request

## 📖 Description

Currently the FluentDataGrid has problem to collect all the columns if the rendering structure is nested with some wrapper component. The Target of this PR is to unbound the Grid from internal rendering logic of blazor by using the well known apis.
On bigger projects the dev always try to wrap components to integrate there own extensions an logics. 

### 🎫 Issues

I found no issue for this topic

## 👩‍💻 Reviewer Notes

Reviewer can check the updated DataGrid example page. There is now a Example which generate the columns in a nested way

## 📑 Test Plan

I think the wohle DataGrid Control need to be tested. I have dont only the minimal change to dont intercept other functions but i am not sure about side effects

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [ ] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

