### PR TITLE
[dev-v5] Add FluentText component

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Text/Examples/TextAlignExample.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Text/Examples/TextAlignExample.razor
@@ -1,0 +1,15 @@
+﻿<div style="display: flex; flex-direction: column; gap: 20px; width: 320px; border-left: 1px solid #000; border-right: 1px solid #000;">
+    <FluentText Block="true" Align="TextAlign.Start">
+       Start aligned Block="true".
+    </FluentText>
+    <FluentText Block="true" Align="TextAlign.End">
+       End aligned Block="true".
+    </FluentText>
+    <FluentText Block="true" Align="TextAlign.Center">
+       Center aligned Block="true".
+    </FluentText>
+    <FluentText Block="true" Align="TextAlign.Justify">
+            Justify aligned Block="true" text stretches wrapped lines to meet container
+            edges.
+    </FluentText>
+</div>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Text/Examples/TextColor.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Text/Examples/TextColor.razor
@@ -1,0 +1,4 @@
+﻿<FluentText Block="true" Color="Color.Primary">A text using the primary color</FluentText>
+
+<FluentText Block="true" Color="Color.Custom" CustomColor="gold">A text using a custom color</FluentText>
+

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Text/Examples/TextDefault.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Text/Examples/TextDefault.razor
@@ -1,0 +1,1 @@
+﻿<FluentText As="@TextTag.Span">text</FluentText>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Text/Examples/TextFontExample.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Text/Examples/TextFontExample.razor
@@ -1,0 +1,5 @@
+﻿<FluentText Block="true" Font="TextFont.Base">Font base.</FluentText>
+<FluentText Block="true" Font="TextFont.Numeric">
+    Font numeric 0123456789.
+</FluentText>
+<FluentText Block="true" Font="TextFont.Monospace">Font monospace.</FluentText>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Text/Examples/TextMakeup.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Text/Examples/TextMakeup.razor
@@ -1,0 +1,23 @@
+﻿<FluentText Block="true" Italic="true">
+    Italics are emphasized text.
+</FluentText>
+
+<FluentText Block="true" Underline="true">
+    Underlined text draws the reader's attention to the words.
+</FluentText>
+
+<FluentText Block="true" Strikethrough="true">
+        Strikethrough text is used to indicate something that is no longer relevant.
+</FluentText>
+
+<span>
+    <FluentText Style="background: var(--colorNeutralBackground6)">
+        Fluent text is inline by default. Setting
+    </FluentText>
+    <FluentText Block="true" Style="background: var(--colorNeutralBackground6)">
+        <span>block</span>
+    </FluentText>
+    <FluentText Style="background: var(--colorNeutralBackground6)">
+        <span>will make it behave as a block element.</span>
+    </FluentText>
+</span>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Text/Examples/TextNowrap.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Text/Examples/TextNowrap.razor
@@ -1,0 +1,5 @@
+﻿<FluentText Nowrap="true">
+    <div style="display: block; width: 320px; border: 1px solid black;">
+        This text will not wrap lines when it overflows the container.
+    </div>
+</FluentText>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Text/Examples/TextSizeExample.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Text/Examples/TextSizeExample.razor
@@ -1,0 +1,10 @@
+﻿<FluentText Block="true" Size="TextSize.Size100">100</FluentText>
+<FluentText Block="true" Size="TextSize.Size200">200</FluentText>
+<FluentText Block="true" Size="TextSize.Size300">300</FluentText>
+<FluentText Block="true" Size="TextSize.Size400">400</FluentText>
+<FluentText Block="true" Size="TextSize.Size500">500</FluentText>
+<FluentText Block="true" Size="TextSize.Size600">600</FluentText>
+<FluentText Block="true" Size="TextSize.Size700">700</FluentText>
+<FluentText Block="true" Size="TextSize.Size800">800</FluentText>
+<FluentText Block="true" Size="TextSize.Size900">900</FluentText>
+<FluentText Block="true" Size="TextSize.Size1000">1000</FluentText>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Text/Examples/TextTruncate.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Text/Examples/TextTruncate.razor
@@ -1,0 +1,9 @@
+﻿<FluentText Truncate="true" Nowrap="true">
+    <div style="display: block; width: 320px; border: 1px solid black;">
+        Setting
+        <code>truncate</code>
+        and
+        <code>nowrap</code>
+        will truncate when it overflows the container.
+    </div>
+</FluentText>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Text/Examples/TextWeightExample.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Text/Examples/TextWeightExample.razor
@@ -1,0 +1,12 @@
+﻿<FluentText Block="true" Weight="TextWeight.Regular">
+    This text is regular.
+</FluentText>
+<FluentText Block="true" Weight="TextWeight.Medium">
+    This text is medium.
+</FluentText>
+<FluentText Block="true" Weight="TextWeight.Semibold">
+    This text is semibold.
+</FluentText>
+<FluentText Block="true" Weight="TextWeight.Bold">
+    This text is bold.
+</FluentText>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Text/FluentText.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Text/FluentText.md
@@ -1,0 +1,65 @@
+---
+title: Text
+route: /Text
+---
+
+# Text
+
+The text component codifies Fluent's opinions on typography to make them easy to use and standardize across products.
+
+Use the text component for plain text. For hypertext, try a [link](todo) instead.
+
+## Font families
+Use the `Font` parameter to choose a font family. Use the monospace font to represent code.
+
+## Alignment
+The `Align` parameter allows you to change text alignment. In most cases, start aligned text is the easiest to read. Use other alignments sparingly.
+
+Avoid justified text in web pages. The consistent line length and inconsistent spacing might make scanning information more difficult.
+
+For more info, see our typography guidelines.
+
+## Accessibility
+By default, text components result in span elements. Use the as prop to produce semantic HTML.
+
+Avoid using the appearance of a font to convey meaning. Bold and italic text should be used only when necessary, as not all screen readers communicate when text is bold or italicized.
+
+## Example
+
+{{ TextDefault }}
+
+### Nowrap
+
+{{ TextNowrap }}
+
+### Truncate
+
+{{ TextTruncate }}
+
+### Text markup variations
+
+{{ TextMakeup }}
+
+### Size
+
+{{ TextSizeExample }}
+
+### Weight
+
+{{ TextWeightExample }}
+
+### Alignment
+
+{{ TextAlignExample }}
+
+### Font family
+
+{{ TextFontExample }}
+
+### Color
+
+{{ TextColor }}
+
+## API FluentLayout
+
+{{ API Type=FluentText }}

--- a/src/Core/Components/Text/FluentText.razor
+++ b/src/Core/Components/Text/FluentText.razor
@@ -1,0 +1,21 @@
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components
+@using Microsoft.FluentUI.AspNetCore.Components.Extensions
+@inherits FluentComponentBase
+
+<fluent-text id="@Id"
+             class="@ClassValue"
+             style="@StyleValue"
+             as="@As.ToAttributeValue()"
+             size="@Size.ToAttributeValue()"
+             weight="@Weight.ToAttributeValue()"
+             align="@Align.ToAttributeValue()"
+             font="@Font.ToAttributeValue()"
+             nowrap="@Nowrap"
+             truncate="@Truncate"
+             block="@Block"
+             italic="@Italic"
+             underline="@Underline"
+             strikethrough="@Strikethrough"
+             @attributes=AdditionalAttributes>
+    @ChildContent
+</fluent-text>

--- a/src/Core/Components/Text/FluentText.razor.cs
+++ b/src/Core/Components/Text/FluentText.razor.cs
@@ -1,0 +1,138 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+using Microsoft.AspNetCore.Components;
+using Microsoft.FluentUI.AspNetCore.Components.Extensions;
+using Microsoft.FluentUI.AspNetCore.Components.Utilities;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// FluentText component, codifies Fluent's opinions on typography to make them easy to use and standardize across products.
+/// </summary>
+public partial class FluentText : FluentComponentBase
+{
+    /// <summary />
+    protected string? ClassValue => new CssBuilder(Class)
+        .Build();
+
+    /// <summary />
+    protected string? StyleValue => new StyleBuilder(Style)
+        .AddStyle("color", GetTextColor(), when: (value) => !string.IsNullOrEmpty(value))
+        .Build();
+
+    /// <summary>
+    /// Gets or sets the tag to be rendered.
+    /// </summary>
+    [Parameter]
+    public TextTag As { get; set; }
+
+    /// <summary>
+    /// Gets or sets the size of the text.
+    /// </summary>
+    [Parameter]
+    public TextSize? Size { get; set; }
+
+    /// <summary>
+    /// Gets or sets the weight of the text.
+    /// </summary>
+    [Parameter]
+    public TextWeight? Weight { get; set; }
+
+    /// <summary>
+    /// Gets or sets the alignment of the text.
+    /// </summary>
+    [Parameter]
+    public TextAlign? Align { get; set; }
+
+    /// <summary>
+    /// Gets or sets the font family of the text.
+    /// </summary>
+    [Parameter]
+    public TextFont? Font { get; set; }
+
+    /// <summary>
+    /// Gets or sets if the texts is set to no-wrap.
+    /// </summary>
+    [Parameter]
+    public bool Nowrap { get; set; }
+
+    /// <summary>
+    /// Gets or sets if the text should truncate. 
+    /// </summary>
+    [Parameter]
+    public bool Truncate { get; set; }
+
+    /// <summary>
+    /// Gets or sets if the text is set to block.
+    /// </summary>
+    [Parameter]
+    public bool Block { get; set; }
+
+    /// <summary>
+    /// Gets or sets if the text is shown in italic.
+    /// </summary>
+    [Parameter]
+    public bool Italic { get; set; }
+
+    /// <summary>
+    /// Gets or sets is shown underlined .
+    /// </summary>
+    [Parameter]
+    public bool Underline { get; set; }
+
+    /// <summary>
+    /// Gets or sets if the text is shown as strikethrough.
+    /// </summary>
+    [Parameter]
+    public bool Strikethrough { get; set; }
+
+    /// <summary>
+    /// Gets or sets the text drawing color.
+    /// Value comes from the <see cref="AspNetCore.Components.Color"/> enumeration. Defaults to Accent.
+    /// </summary>
+    [Parameter]
+    public Color? Color { get; set; }
+
+    /// <summary>
+    /// Gets or sets the text drawing color to a custom value.
+    /// Needs to be formatted as an HTML hex color string (#RRGGBB or #RGB) or CSS variable.
+    /// ⚠️ Only available when Color is set to Color.Custom.
+    /// </summary>
+    [Parameter]
+    public string? CustomColor { get; set; }
+
+    /// <summary>
+    /// Gets or sets the content to be shown.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    /// <summary />
+    protected override void OnParametersSet()
+    {
+        if (!string.IsNullOrEmpty(CustomColor) && Color != Components.Color.Custom)
+        {
+            throw new ArgumentException("CustomColor can only be used when Color is set to Color.Custom.", nameof(CustomColor));
+        }
+    }
+
+    /// <summary>
+    /// Returns CustomColor, or Color.
+    /// </summary>
+    /// <returns></returns>
+    private string? GetTextColor()
+    {
+        if (Color == Components.Color.Custom && !string.IsNullOrEmpty(CustomColor))
+        {
+            return CustomColor;
+        }
+
+        if (Color != null)
+        {
+            return Color.ToAttributeValue();
+        }
+
+        return null;
+    }
+}

--- a/src/Core/Enums/TextAlign.cs
+++ b/src/Core/Enums/TextAlign.cs
@@ -1,0 +1,37 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using System.ComponentModel;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// Indicates the alignment of the text shown in the <see cref="FluentText"/>.
+/// </summary>
+public enum TextAlign
+{
+    /// <summary>
+    /// Start alignment
+    /// </summary>
+    [Description("start")]
+    Start,
+
+    /// <summary>
+    /// End alignment
+    /// </summary>
+    [Description("end")]
+    End,
+
+    /// <summary>
+    /// Center alignment
+    /// </summary>
+    [Description("center")]
+    Center,
+
+    /// <summary>
+    /// Justify alignment
+    /// </summary>
+    [Description("justify")]
+    Justify,
+}

--- a/src/Core/Enums/TextFont.cs
+++ b/src/Core/Enums/TextFont.cs
@@ -1,0 +1,31 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using System.ComponentModel;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// Indicates the font family of the text shown in the <see cref="FluentText"/>.
+/// </summary>
+public enum TextFont
+{
+    /// <summary>
+    /// Default font
+    /// </summary>
+    [Description("base")]
+    Base,
+
+    /// <summary>
+    /// Numeric font
+    /// </summary>
+    [Description("numeric")]
+    Numeric,
+
+    /// <summary>
+    /// Monospace font
+    /// </summary>
+    [Description("monospace")]
+    Monospace,
+}

--- a/src/Core/Enums/TextSize.cs
+++ b/src/Core/Enums/TextSize.cs
@@ -1,0 +1,73 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using System.ComponentModel;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// Indicates the size of the text shown in the <see cref="FluentText"/>.
+/// </summary>
+public enum TextSize
+{
+    /// <summary>
+    /// Size 100
+    /// </summary>
+    [Description("100")]
+    Size100,
+
+    /// <summary>
+    /// Size 200
+    /// </summary>
+    [Description("200")]
+    Size200,
+
+    /// <summary>
+    /// Size 300
+    /// </summary>
+    [Description("300")]
+    Size300,
+
+    /// <summary>
+    /// Size 400
+    /// </summary>
+    [Description("400")]
+    Size400,
+
+    /// <summary>
+    /// Size 500
+    /// </summary>
+    [Description("500")]
+    Size500,
+
+    /// <summary>
+    /// Size 600
+    /// </summary>
+    [Description("600")]
+    Size600,
+
+    /// <summary>
+    /// Size 700
+    /// </summary>
+    [Description("700")]
+    Size700,
+
+    /// <summary>
+    /// Size 800
+    /// </summary>
+    [Description("800")]
+    Size800,
+
+    /// <summary>
+    /// Size 900
+    /// </summary>
+    [Description("900")]
+    Size900,
+
+    /// <summary>
+    /// Size 1000
+    /// </summary>
+    [Description("1000")]
+    Size1000,
+}

--- a/src/Core/Enums/TextTag.cs
+++ b/src/Core/Enums/TextTag.cs
@@ -1,0 +1,67 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using System.ComponentModel;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// Indicates the tag to render in the <see cref="FluentText"/>.
+/// </summary>
+public enum TextTag
+{
+    /// <summary>
+    /// Span tag
+    /// </summary>
+    [Description("span")]
+    Span,
+
+    /// <summary>
+    /// Paragraph tag
+    /// </summary>
+    [Description("p")]
+    Paragraph,
+
+    /// <summary>
+    /// Pre tag
+    /// </summary>
+    [Description("pre")]
+    Pre,
+
+    /// <summary>
+    /// H1 tag
+    /// </summary>
+    [Description("h1")]
+    H1,
+
+    /// <summary>
+    /// H2 tag
+    /// </summary>
+    [Description("h2")]
+    H2,
+
+    /// <summary>
+    /// H3 tag
+    /// </summary>
+    [Description("h3")]
+    H3,
+
+    /// <summary>
+    /// H4 tag
+    /// </summary>
+    [Description("h4")]
+    H4,
+
+    /// <summary>
+    /// H5 tag
+    /// </summary>
+    [Description("h5")]
+    H5,
+
+    /// <summary>
+    /// H6 tag
+    /// </summary>
+    [Description("h6")]
+    H6,
+}

--- a/src/Core/Enums/TextWeight.cs
+++ b/src/Core/Enums/TextWeight.cs
@@ -1,0 +1,37 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using System.ComponentModel;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// Indicates the weight of the text shown in the <see cref="FluentText"/>.
+/// </summary>
+public enum TextWeight
+{
+    /// <summary>
+    /// Medium weight
+    /// </summary>
+    [Description("medium")]
+    Medium,
+
+    /// <summary>
+    /// Regular weight
+    /// </summary>
+    [Description("regular")]
+    Regular,
+
+    /// <summary>
+    /// Semibold weight
+    /// </summary>
+    [Description("semibold")]
+    Semibold,
+
+    /// <summary>
+    /// Bold weight
+    /// </summary>
+    [Description("bold")]
+    Bold,
+}

--- a/src/Core/Microsoft.FluentUI.AspNetCore.Components.csproj
+++ b/src/Core/Microsoft.FluentUI.AspNetCore.Components.csproj
@@ -115,8 +115,5 @@
       <LastGenOutput>%(ParentFile).Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Components\Text\" />
-  </ItemGroup>
 
 </Project>

--- a/src/Core/Microsoft.FluentUI.AspNetCore.Components.csproj
+++ b/src/Core/Microsoft.FluentUI.AspNetCore.Components.csproj
@@ -115,5 +115,8 @@
       <LastGenOutput>%(ParentFile).Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Components\Text\" />
+  </ItemGroup>
 
 </Project>

--- a/tests/Core/Components/Text/FluentTextTests.FluentText_AdditionalAttribute.verified.razor.html
+++ b/tests/Core/Components/Text/FluentTextTests.FluentText_AdditionalAttribute.verified.razor.html
@@ -1,0 +1,2 @@
+
+<fluent-text as="span" additional-attribute-name="additional-attribute-value">fluent-text</fluent-text>

--- a/tests/Core/Components/Text/FluentTextTests.FluentText_AdditionalAttributes.verified.razor.html
+++ b/tests/Core/Components/Text/FluentTextTests.FluentText_AdditionalAttributes.verified.razor.html
@@ -1,0 +1,2 @@
+
+<fluent-text as="span" additional-attribute1-name="additional-attribute1-value" additional-attribute2-name="additional-attribute2-value">fluent-text</fluent-text>

--- a/tests/Core/Components/Text/FluentTextTests.FluentText_Block.verified.razor.html
+++ b/tests/Core/Components/Text/FluentTextTests.FluentText_Block.verified.razor.html
@@ -1,0 +1,2 @@
+
+<fluent-text as="span" block="">This is a fluent text.</fluent-text>

--- a/tests/Core/Components/Text/FluentTextTests.FluentText_ClassAttribute.verified.razor.html
+++ b/tests/Core/Components/Text/FluentTextTests.FluentText_ClassAttribute.verified.razor.html
@@ -1,0 +1,2 @@
+
+<fluent-text class="custom-class" as="span">This is a fluent text with class.</fluent-text>

--- a/tests/Core/Components/Text/FluentTextTests.FluentText_Default.verified.razor.html
+++ b/tests/Core/Components/Text/FluentTextTests.FluentText_Default.verified.razor.html
@@ -1,0 +1,2 @@
+
+<fluent-text as="span">This is a fluent text.</fluent-text>

--- a/tests/Core/Components/Text/FluentTextTests.FluentText_IdAttribute-[empty].verified.razor.html
+++ b/tests/Core/Components/Text/FluentTextTests.FluentText_IdAttribute-[empty].verified.razor.html
@@ -1,0 +1,2 @@
+
+<fluent-text id="" as="span">fluent-text</fluent-text>

--- a/tests/Core/Components/Text/FluentTextTests.FluentText_IdAttribute-[null].verified.razor.html
+++ b/tests/Core/Components/Text/FluentTextTests.FluentText_IdAttribute-[null].verified.razor.html
@@ -1,0 +1,2 @@
+
+<fluent-text as="span">fluent-text</fluent-text>

--- a/tests/Core/Components/Text/FluentTextTests.FluentText_IdAttribute-[space].verified.razor.html
+++ b/tests/Core/Components/Text/FluentTextTests.FluentText_IdAttribute-[space].verified.razor.html
@@ -1,0 +1,2 @@
+
+<fluent-text id=" " as="span">fluent-text</fluent-text>

--- a/tests/Core/Components/Text/FluentTextTests.FluentText_IdAttribute-id-value.verified.razor.html
+++ b/tests/Core/Components/Text/FluentTextTests.FluentText_IdAttribute-id-value.verified.razor.html
@@ -1,0 +1,2 @@
+
+<fluent-text id="xxx" as="span">fluent-text</fluent-text>

--- a/tests/Core/Components/Text/FluentTextTests.FluentText_Italic.verified.razor.html
+++ b/tests/Core/Components/Text/FluentTextTests.FluentText_Italic.verified.razor.html
@@ -1,0 +1,2 @@
+
+<fluent-text as="span" italic="">This is a fluent text.</fluent-text>

--- a/tests/Core/Components/Text/FluentTextTests.FluentText_Nowrap.verified.razor.html
+++ b/tests/Core/Components/Text/FluentTextTests.FluentText_Nowrap.verified.razor.html
@@ -1,0 +1,2 @@
+
+<fluent-text as="span" nowrap="">This is a fluent text.</fluent-text>

--- a/tests/Core/Components/Text/FluentTextTests.FluentText_Strikethrough.verified.razor.html
+++ b/tests/Core/Components/Text/FluentTextTests.FluentText_Strikethrough.verified.razor.html
@@ -1,0 +1,2 @@
+
+<fluent-text as="span" strikethrough="">This is a fluent text.</fluent-text>

--- a/tests/Core/Components/Text/FluentTextTests.FluentText_StyleAttribute.verified.razor.html
+++ b/tests/Core/Components/Text/FluentTextTests.FluentText_StyleAttribute.verified.razor.html
@@ -1,0 +1,2 @@
+
+<fluent-text style="color: red;" as="span">This is a fluent text with style.</fluent-text>

--- a/tests/Core/Components/Text/FluentTextTests.FluentText_Underline.verified.razor.html
+++ b/tests/Core/Components/Text/FluentTextTests.FluentText_Underline.verified.razor.html
@@ -1,0 +1,2 @@
+
+<fluent-text as="span" underline="">This is a fluent text.</fluent-text>

--- a/tests/Core/Components/Text/FluentTextTests.razor
+++ b/tests/Core/Components/Text/FluentTextTests.razor
@@ -1,0 +1,251 @@
+﻿@using Microsoft.FluentUI.AspNetCore.Components.Extensions
+@using Microsoft.FluentUI.AspNetCore.Components.Tests.Extensions
+@using Microsoft.FluentUI.AspNetCore.Components.Utilities
+@using System.ComponentModel.DataAnnotations
+@using Xunit;
+@inherits TestContext
+
+@code
+{
+    public FluentTextTests()
+    {
+
+    }
+
+    [Fact]
+    public void FluentText_Default()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentText>This is a fluent text.</FluentText>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentText_ClassAttribute()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentText Class="custom-class">This is a fluent text with class.</FluentText>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentText_StyleAttribute()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentText Style="color: red;">This is a fluent text with style.</FluentText>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Theory]
+    [InlineData("id-value")]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void FluentText_IdAttribute(string? id)
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentText Id="@id">fluent-text</FluentText>);
+
+        // Assert
+        cut.Verify(suffix: id);
+    }
+
+    [Fact]
+    public void FluentText_AdditionalAttribute()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentText additional-attribute-name="additional-attribute-value">fluent-text</FluentText>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentText_AdditionalAttributes()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentText additional-attribute1-name="additional-attribute1-value" additional-attribute2-name="additional-attribute2-value">fluent-text</FluentText>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Theory]
+    [InlineData(TextAlign.Start, "start")]
+    [InlineData(TextAlign.End, "end")]
+    [InlineData(TextAlign.Center, "center")]
+    [InlineData(TextAlign.Justify, "justify")]
+    public void FluentText_Align(TextAlign align, string expectedAttribute)
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentText Align="@align">fluent text</FluentText>);
+
+        // Assert
+        cut.MarkupMatches($"<fluent-text as=\"span\" align=\"{expectedAttribute}\">fluent text</fluent-text>");
+    }
+
+    [Theory]
+    [InlineData(TextWeight.Regular, "regular")]
+    [InlineData(TextWeight.Bold, "bold")]
+    public void FluentText_Weight(TextWeight weight, string expectedAttribute)
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentText Weight="@weight">fluent text</FluentText>);
+
+        // Assert
+        cut.MarkupMatches($"<fluent-text as=\"span\" weight=\"{expectedAttribute}\">fluent text</fluent-text>");
+    }
+
+    [Theory]
+    [InlineData(TextTag.Span, "span")]
+    [InlineData(TextTag.Paragraph, "p")]
+    [InlineData(TextTag.Pre, "pre")]
+    [InlineData(TextTag.H1, "h1")]
+    [InlineData(TextTag.H2, "h2")]
+    [InlineData(TextTag.H3, "h3")]
+    [InlineData(TextTag.H4, "h4")]
+    [InlineData(TextTag.H5, "h5")]
+    [InlineData(TextTag.H6, "h6")]
+    public void FluentText_Tag(TextTag tag, string expectedAttribute)
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentText As="@tag">fluent text</FluentText>);
+
+        // Assert
+        cut.MarkupMatches($"<fluent-text as=\"{expectedAttribute}\">fluent text</fluent-text>");
+    }
+
+    [Theory]
+    [InlineData(TextSize.Size100, "100")]
+    [InlineData(TextSize.Size200, "200")]
+    [InlineData(TextSize.Size300, "300")]
+    [InlineData(TextSize.Size400, "400")]
+    [InlineData(TextSize.Size500, "500")]
+    [InlineData(TextSize.Size600, "600")]
+    [InlineData(TextSize.Size700, "700")]
+    [InlineData(TextSize.Size800, "800")]
+    [InlineData(TextSize.Size900, "900")]
+    [InlineData(TextSize.Size1000, "1000")]
+    public void FluentText_Size(TextSize size, string expectedAttribute)
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentText Size="@size">fluent text</FluentText>);
+
+        // Assert
+        cut.MarkupMatches($"<fluent-text as=\"span\" size=\"{expectedAttribute}\">fluent text</fluent-text>");
+    }
+
+    [Theory]
+    [InlineData(TextFont.Base, "base")]
+    [InlineData(TextFont.Numeric,"numeric")]
+    [InlineData(TextFont.Monospace,"monospace")]
+    public void FluentText_Font(TextFont font, string expectedAttribute)
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentText Font="@font">fluent text</FluentText>);
+
+        // Assert
+        cut.MarkupMatches($"<fluent-text as=\"span\" font=\"{expectedAttribute}\">fluent text</fluent-text>");
+    }
+
+    [Fact]
+    public void FluentText_Nowrap()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentText Nowrap="true">This is a fluent text.</FluentText>);
+
+        // Assert
+        cut.Verify();
+    }
+
+
+    [Fact]
+    public void FluentText_Italic()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentText Italic="true">This is a fluent text.</FluentText>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentText_Underline()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentText Underline="true">This is a fluent text.</FluentText>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentText_Strikethrough()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentText Strikethrough="true">This is a fluent text.</FluentText>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentText_Block()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentText Block="true">This is a fluent text.</FluentText>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Theory]
+    [InlineData(Color.Primary, "var(--colorBrandForeground1)")]
+    [InlineData(Color.Default, "var(--colorNeutralForeground1)")]
+    [InlineData(Color.Lightweight, "var(--colorNeutralForegroundInverted)")]
+    [InlineData(Color.Disabled, "var(--colorNeutralForegroundDisabled)")]
+    [InlineData(Color.Warning, "var(--warning)")]
+    [InlineData(Color.Info, "var(--info)")]
+    [InlineData(Color.Error, "var(--error)")]
+    [InlineData(Color.Success, "var(--success)")]
+    [InlineData(Color.Custom, "var(--colorNeutralForeground1)")]
+    public void FluentText_Color(Color color, string expectedAttribute)
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentText Color="@color">fluent text</FluentText>   );
+
+        // Assert
+        cut.MarkupMatches($"<fluent-text as=\"span\" style=\"color: {expectedAttribute};\">fluent text</fluent-text>");
+    }
+
+    [Theory]
+    [InlineData("#FF5733")]
+    [InlineData("rgb(255, 87, 51)")]
+    [InlineData("hsl(9, 100%, 60%)")]
+    public void FluentText_CustomColor(string customColor)
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentText Color="Color.Custom" CustomColor="@customColor">fluent text</FluentText>);
+
+        // Assert
+        cut.MarkupMatches($"<fluent-text as=\"span\" style=\"color: {customColor};\">fluent text</fluent-text>");
+    }
+
+    [Fact]
+    public void FluentText_CustomColor_RequiresColorAttribute()
+    {
+        Assert.Throws<ArgumentException>(() =>
+        {
+            // Arrange & Act
+            var cut = Render(@<FluentText CustomColor="#ff0000">This is a text</FluentText>);
+
+            // Assert an exception because Color=Color.Custom is required
+        });
+    }
+}

--- a/tests/Core/Microsoft.FluentUI.AspNetCore.Components.Tests.csproj
+++ b/tests/Core/Microsoft.FluentUI.AspNetCore.Components.Tests.csproj
@@ -58,4 +58,8 @@
       <DependentUpon>%(ParentFile).razor</DependentUpon>
     </None>
   </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Components\Text\" />
+  </ItemGroup>
 </Project>

--- a/tests/Core/Microsoft.FluentUI.AspNetCore.Components.Tests.csproj
+++ b/tests/Core/Microsoft.FluentUI.AspNetCore.Components.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -57,9 +57,5 @@
       <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0])</ParentFile>
       <DependentUpon>%(ParentFile).razor</DependentUpon>
     </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Components\Text\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Adds the FluentText component. This is a replacement for the v4 Label component.

![image](https://github.com/user-attachments/assets/0a8fd44e-37f6-411c-881e-9ffef4cd31cc)


Unit Test added with 100% line coverage