### PR TITLE
[InputFile] Make it work icw a loading Button

### DIFF
--- a/examples/Demo/Shared/Pages/InputFile/Examples/InputFileLoading.razor
+++ b/examples/Demo/Shared/Pages/InputFile/Examples/InputFileLoading.razor
@@ -1,0 +1,66 @@
+﻿<FluentInputFile @ref="@myFileUploader"
+                 DragDropZoneVisible="false"
+                 Mode="InputFileMode.SaveToTemporaryFolder"
+                 Multiple="true"
+                 AnchorId="MyUploadLoadingButton"
+                 MaximumFileSize="@(100 * 1024 * 1024)"
+                 Accept=".mp4, .mov, .avi"
+                 OnProgressChange="@(e =>
+                     {
+                         _formUploading = true;
+                         progressPercent = e.ProgressPercent;
+                         progressTitle = e.ProgressTitle;
+                     })"
+                 OnCompleted="@OnCompleted" />
+
+<FluentProgress Min="0" Max="100" Visible="@(progressPercent > 0)" Value="@progressPercent" />
+<FluentLabel Alignment="HorizontalAlignment.Center">
+    @progressTitle
+</FluentLabel>
+
+<FluentButton Id="MyUploadLoadingButton" Loading="_formUploading" Appearance="Appearance.Accent">
+    Upload files
+</FluentButton>
+
+@if (Files.Any())
+{
+    <h4>File(s) uploaded:</h4>
+    <ul>
+        @foreach (var file in Files)
+        {
+            <li>
+                <b>@file.Name</b> 🔹
+                @($"{Decimal.Divide(file.Size, 1024):N} KB") 🔹
+                @file.ContentType 🔹
+                @file.LocalFile?.FullName
+                @file.ErrorMessage
+            </li>
+        }
+    </ul>
+}
+
+
+@code
+{
+    bool _formUploading;
+    FluentInputFile? myFileUploader = default!;
+    int? progressPercent;
+    string? progressTitle;
+
+    FluentInputFileEventArgs[] Files = Array.Empty<FluentInputFileEventArgs>();
+
+    void OnCompleted(IEnumerable<FluentInputFileEventArgs> files)
+    {
+        Files = files.ToArray();
+        progressPercent = myFileUploader!.ProgressPercent;
+        progressTitle = myFileUploader!.ProgressTitle;
+
+        // For the demo, delete these files.
+        foreach (var file in Files)
+        {
+            file.LocalFile?.Delete();
+        }
+        _formUploading = false;
+        StateHasChanged();
+    }
+}

--- a/examples/Demo/Shared/Pages/InputFile/InputFilePage.razor
+++ b/examples/Demo/Shared/Pages/InputFile/InputFilePage.razor
@@ -33,6 +33,12 @@
         </Description>
     </DemoSection>
 
+    <DemoSection Title="Manual upload with loading indicator" Component="@typeof(InputFileLoading)">
+        <Description>
+
+        </Description>
+    </DemoSection>
+
     <DemoSection Title="Mode = InputFileMode.Buffer" Component="@typeof(InputFileBufferMode)">
         <Description>
 

--- a/src/Core/Components/InputFile/FluentInputFile.razor.cs
+++ b/src/Core/Components/InputFile/FluentInputFile.razor.cs
@@ -12,7 +12,7 @@ public partial class FluentInputFile : FluentComponentBase, IAsyncDisposable
     private ElementReference? _containerElement;
     private InputFile? _inputFile;
     private IJSObjectReference? _containerInstance;
-
+    
     public static string ResourceLoadingBefore = "Loading...";
     public static string ResourceLoadingCompleted = "Completed";
     public static string ResourceLoadingCanceled = "Canceled";
@@ -201,12 +201,12 @@ public partial class FluentInputFile : FluentComponentBase, IAsyncDisposable
         {
             Module ??= await JSRuntime.InvokeAsync<IJSObjectReference>("import", JAVASCRIPT_FILE.FormatCollocatedUrl(LibraryConfiguration));
 
-            if (!string.IsNullOrEmpty(AnchorId))
-            {
-                await Module.InvokeVoidAsync("attachClickHandler", AnchorId, Id);
-            }
-
             _containerInstance = await Module.InvokeAsync<IJSObjectReference>("initializeFileDropZone", _containerElement, _inputFile!.Element);
+        }
+
+        if (!string.IsNullOrEmpty(AnchorId) && Module is not null)
+        {
+            await Module.InvokeVoidAsync("attachClickHandler", AnchorId, Id);
         }
     }
 

--- a/src/Core/Components/InputFile/FluentInputFile.razor.js
+++ b/src/Core/Components/InputFile/FluentInputFile.razor.js
@@ -8,10 +8,14 @@ export function raiseFluentInputFile(fileInputId) {
 export function attachClickHandler(buttonId, fileInputId) {
     var button = document.getElementById(buttonId);
     var fileInput = document.getElementById(fileInputId);
-    if (button && fileInput) {
+
+    if (button && fileInput && !button.fluentuiBlazorFileInputHandlerAttached) {
+
         button.addEventListener("click", function (e) {
             fileInput.click();
         });
+
+        button.fluentuiBlazorFileInputHandlerAttached = true;
     }
 }
 


### PR DESCRIPTION

# Pull Request

## 📖 Description

When a `FluentButton` is being used as an anchor to trigger a `FluentInputFile` in combination with the property `Loading` then the registered event will be lost once the button renders again to display the loading style. This PR fixes this by reattaching the event when it's necessary.

### 🎫 Issues

* #2754

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [ ] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

Perhaps you might want to add a test-case for this. I sadly don't know how to do this but I will take a look on it when you add one to learn from it! 😀
