### PR TITLE
[DesignThemen] Fix the DesignTheme with no Storage

### DIFF
--- a/src/Core/Components/DesignSystemProvider/FluentDesignTheme.razor.js
+++ b/src/Core/Components/DesignSystemProvider/FluentDesignTheme.razor.js
@@ -18,7 +18,7 @@ export function addThemeChangeEvent(dotNetHelper, id) {
             // This can fail when localStorage does not contain a valid JSON object
             const theme = element.themeStorage.readLocalStorage();
             if (theme == null) {
-                return theme;
+                return null;
             }
             else {
                 UpdateBodyDataSetTheme(theme.mode);

--- a/src/Core/Components/DesignSystemProvider/FluentDesignTheme.razor.js
+++ b/src/Core/Components/DesignSystemProvider/FluentDesignTheme.razor.js
@@ -17,8 +17,13 @@ export function addThemeChangeEvent(dotNetHelper, id) {
         try {
             // This can fail when localStorage does not contain a valid JSON object
             const theme = element.themeStorage.readLocalStorage();
-            UpdateBodyDataSetTheme(theme.mode);
-            return theme == null ? theme : JSON.stringify(theme);
+            if (theme == null) {
+                return theme;
+            }
+            else {
+                UpdateBodyDataSetTheme(theme.mode);
+                return JSON.stringify(theme);
+            }
         } catch (error) {
             ClearLocalStorage(id);
             console.error(`FluentDesignTheme: failing to load theme from localStorage.`, error);


### PR DESCRIPTION
# [DesignThemen] Fix the DesignTheme with no Storage

After updating the package from version 4.10.1 to version 4.10.3 or if the StorageName is not defined in the FluentDesignTheme, this error may be displayed. This is a non-blocking error, but it is annoying for the Console logs.

![{88B70F5A-4795-453A-9144-D7E02B6B52E2}](https://github.com/user-attachments/assets/97b780d7-d401-4213-b76c-8fd53260f6c4)

See #2952 and in the [DotNetConf 2024 Demo](https://github.com/dvoituron/dotnetconf-2024-fluentui-blazor)

