### PR TITLE
[DataGrid] Save paging state in URL

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -2002,6 +2002,17 @@
             Sets <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.GridTemplateColumns"/> to automatically fit the columns to the available width as best it can.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.SaveStateInUrl">
+            <summary>
+            Gets or sets a value indicating whether the grid should save its paging state in the URL.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.SaveStatePrefix">
+            <summary>
+            Gets or sets a prefix to use when saving the grid state in the URL.
+            </summary>
+            <remarks>Only relevant when <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.SaveStateInUrl"/> is set to <see langword="true"/> on multiple grids on a single page.</remarks>
+        </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.#ctor">
             <summary>
             Constructs an instance of <see cref="T:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1"/>.

--- a/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridTypical.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridTypical.razor
@@ -13,7 +13,9 @@
                 RowStyle="@rowStyle"
                 HeaderCellAsButtonWithMenu="true"
                 Style="height: 405px;overflow:auto;"
-                ColumnResizeLabels="@customLabels">
+                ColumnResizeLabels="@customLabels"
+                SaveStateInUrl="true"
+                SaveStatePrefix="g1">
     <TemplateColumn Tooltip="true" HeaderTooltip="Flag of each team" TooltipText="@(c => "Flag of " + c.Name)" Title="Rank" SortBy="@rankSort" Align="Align.Center" InitialSortDirection="SortDirection.Ascending" IsDefaultSortColumn=true>
         <img class="flag" src="_content/FluentUI.Demo.Shared/flags/@(context.Code).svg" alt="Flag of @(context.Code)" />
     </TemplateColumn>

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -258,6 +258,7 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     /// Gets or sets a prefix to use when saving the grid state in the URL.
     /// </summary>
     /// <remarks>Only relevant when <see cref="SaveStateInUrl"/> is set to <see langword="true"/> on multiple grids on a single page.</remarks>
+    [Parameter]
     public string? SaveStatePrefix { get; set; }
 
     private ElementReference? _gridReference;
@@ -816,12 +817,17 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
 
     private void LoadStateFromQueryString(string queryString)
     {
+        if (!SaveStateInUrl)
+        {
+            return;
+        }
+
         var query = System.Web.HttpUtility.ParseQueryString(queryString);
         if (query.AllKeys.Contains($"{SaveStatePrefix}orderby"))
         {
             var orderBy = query[$"{SaveStatePrefix}orderby"]!.Split(' ',2);
             var title = orderBy[0];
-            
+
             var column = _columns.FirstOrDefault(c => c.Title == title);
             if (column is not null)
             {
@@ -846,18 +852,20 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
 
     private void SaveStateToQueryString()
     {
-        if (SaveStateInUrl)
+        if (!SaveStateInUrl)
         {
-            var stateParams = new Dictionary<string, object?>();
-            if (_sortByColumn is not null)
-            {
-                var order = _sortByAscending ? "asc" : "desc";
-                stateParams.Add($"{SaveStatePrefix}orderby", $"{_sortByColumn.Title} {order}");
-            }
-            stateParams.Add($"{SaveStatePrefix}page", Pagination?.CurrentPageIndex + 1 ?? null);
-            stateParams.Add($"{SaveStatePrefix}top", Pagination?.ItemsPerPage ?? null);
-            NavigationManager.NavigateTo(NavigationManager.GetUriWithQueryParameters(stateParams), replace: true);
+            return;
         }
+
+        var stateParams = new Dictionary<string, object?>();
+        if (_sortByColumn is not null)
+        {
+            var order = _sortByAscending ? "asc" : "desc";
+            stateParams.Add($"{SaveStatePrefix}orderby", $"{_sortByColumn.Title} {order}");
+        }
+        stateParams.Add($"{SaveStatePrefix}page", Pagination?.CurrentPageIndex + 1 ?? null);
+        stateParams.Add($"{SaveStatePrefix}top", Pagination?.ItemsPerPage ?? null);
+        NavigationManager.NavigateTo(NavigationManager.GetUriWithQueryParameters(stateParams), replace: true);
     }
 
     private async Task HandleOnRowFocusAsync(DataGridRowFocusEventArgs args)

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -28,6 +28,9 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     private LibraryConfiguration LibraryConfiguration { get; set; } = default!;
 
     [Inject]
+    private NavigationManager NavigationManager { get; set; } = default!;
+
+    [Inject]
     private IServiceScopeFactory ScopeFactory { get; set; } = default!;
 
     [Inject]
@@ -245,6 +248,18 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     [Parameter]
     public bool AutoFit { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether the grid should save its paging state in the URL.
+    /// </summary>
+    [Parameter]
+    public bool SaveStateInUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets a prefix to use when saving the grid state in the URL.
+    /// </summary>
+    /// <remarks>Only relevant when <see cref="SaveStateInUrl"/> is set to <see langword="true"/> on multiple grids on a single page.</remarks>
+    public string? SaveStatePrefix { get; set; }
+
     private ElementReference? _gridReference;
     private Virtualize<(int, TGridItem)>? _virtualizeComponent;
 
@@ -322,6 +337,10 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     protected override void OnInitialized()
     {
         KeyCodeService.RegisterListener(OnKeyDownAsync);
+        if (SaveStateInUrl)
+        {
+            LoadStateFromQueryString(new Uri(NavigationManager.Uri).Query);
+        }
     }
 
     /// <inheritdoc />
@@ -795,6 +814,52 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
         StateHasChanged();
     }
 
+    private void LoadStateFromQueryString(string queryString)
+    {
+        var query = System.Web.HttpUtility.ParseQueryString(queryString);
+        if (query.AllKeys.Contains($"{SaveStatePrefix}orderby"))
+        {
+            var orderBy = query[$"{SaveStatePrefix}orderby"]!.Split(' ',2);
+            var title = orderBy[0];
+            
+            var column = _columns.FirstOrDefault(c => c.Title == title);
+            if (column is not null)
+            {
+                _sortByColumn = column;
+                _sortByAscending = orderBy.Length == 2 && orderBy[1] == "asc";
+            }
+        }
+
+        if (Pagination is not null)
+        {
+            if (query.AllKeys.Contains($"{SaveStatePrefix}page") && int.TryParse(query[$"{SaveStatePrefix}page"]!, out int page))
+            {
+                Pagination.SetCurrentPageIndexAsync(page - 1);
+            }
+
+            if (query.AllKeys.Contains($"{SaveStatePrefix}top") && int.TryParse(query[$"{SaveStatePrefix}top"]!, out int itemsPerPage))
+            {
+                Pagination.ItemsPerPage = itemsPerPage;
+            }
+        }
+    }
+
+    private void SaveStateToQueryString()
+    {
+        if (SaveStateInUrl)
+        {
+            var stateParams = new Dictionary<string, object?>();
+            if (_sortByColumn is not null)
+            {
+                var order = _sortByAscending ? "asc" : "desc";
+                stateParams.Add($"{SaveStatePrefix}orderby", $"{_sortByColumn.Title} {order}");
+            }
+            stateParams.Add($"{SaveStatePrefix}page", Pagination?.CurrentPageIndex + 1 ?? null);
+            stateParams.Add($"{SaveStatePrefix}top", Pagination?.ItemsPerPage ?? null);
+            NavigationManager.NavigateTo(NavigationManager.GetUriWithQueryParameters(stateParams), replace: true);
+        }
+    }
+
     private async Task HandleOnRowFocusAsync(DataGridRowFocusEventArgs args)
     {
         var rowId = args.RowId;
@@ -865,5 +930,11 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
         {
             await Module.InvokeVoidAsync("resetColumnWidths", _gridReference);
         }
+    }
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        base.OnAfterRender(firstRender);
+        SaveStateToQueryString();
     }
 }


### PR DESCRIPTION
Fixed #2839

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

Paging or sorting for a data grid will now save the state in the url, if the developer opt-ed in for this on that grid. It also supports a prefix, in case you would have multiple grids on a single page.

### 🎫 Issues

* #2839 

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [X] I have modified an existing component
- [X] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component `404`

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
