### PR TITLE
[Tabs] Only render Label if Header is null

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -2028,7 +2028,7 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.SaveStateInUrl">
             <summary>
             Gets or sets a value indicating whether the grid should save its paging state in the URL.
-            <para>This is an **experimental** feature, which might cause unwanted jumping in the page when you change something in the grid.</para>
+            <para>This is an experimental feature, which might cause unwanted jumping in the page when you change something in the grid.</para>
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.SaveStatePrefix">

--- a/examples/Demo/Shared/Pages/Lab/IssueTester.razor
+++ b/examples/Demo/Shared/Pages/Lab/IssueTester.razor
@@ -1,1 +1,31 @@
-﻿
+﻿<div style="width: 175px;">
+<FluentTabs ActiveTabId="tab-1">
+    <FluentTab Id="tab-1" Label="All">
+        <Header>
+            <FluentIcon Value="@(new Icons.Regular.Size16.LeafOne())" />
+            All
+        </Header>
+        <Content>
+            Content 0
+        </Content>
+    </FluentTab>
+    <FluentTab Id="tab-2" Label="January">
+        <Header>
+            <FluentIcon Value="@(new Icons.Regular.Size16.LeafTwo())" Color="@Color.Success" />
+            January
+        </Header>
+        <Content>
+            Content 1
+        </Content>
+    </FluentTab>
+    <FluentTab Id="tab-3" Label="February">
+        <Header>
+            <FluentIcon Value="@(new Icons.Regular.Size16.LeafThree())" Color="@Color.Error" />
+            <span style="color:forestgreen;">February</span>
+        </Header>
+        <Content>
+            Content 2
+        </Content>
+    </FluentTab>
+</FluentTabs>
+</div>

--- a/src/Core/Components/Tabs/FluentTab.razor
+++ b/src/Core/Components/Tabs/FluentTab.razor
@@ -13,15 +13,18 @@
         {
             <FluentIcon Value="@Icon" Width="20px" Class="fluent-tab-icon" />
         }
-        @if (LabelEditable)
+        @if (Header is null)
         {
-            <span contenteditable="true" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" Title="Click to edit this tab name" style="padding: 3px 5px;">
+            @if (LabelEditable)
+            {
+                <span contenteditable="true" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" Title="Click to edit this tab name" style="padding: 3px 5px;">
+                    @Label
+                </span>
+            }
+            else
+            {
                 @Label
-            </span>
-        }
-        else
-        {
-            @Label
+            }
         }
 
         @Header


### PR DESCRIPTION
Fix #2988. See the issue for more context. Gist is that with this PR you can now use both `Header` and `Label` at the same time while only `Header` will be rendered. `Label` can be used in overflow menu

