### PR TITLE
[DatePicker] Add `PopupHorizontalPosition` property

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -2931,6 +2931,12 @@
             Gets or sets a value which will be set when double-clicking on the text field of date picker.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDatePicker.PopupHorizontalPosition">
+            <summary>
+            Gets or sets an <see cref="T:Microsoft.FluentUI.AspNetCore.Components.HorizontalPosition"/> for the popup displayed when the user open the calendar.
+            By default, this value is Left or Right, depending of the 'CurrentUICulture.TextInfo.IsRightToLeft' value.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentTimePicker.StyleValue">
             <summary />
         </member>

--- a/examples/Demo/Shared/Pages/DateTimes/Examples/DatePickerDefault.razor
+++ b/examples/Demo/Shared/Pages/DateTimes/Examples/DatePickerDefault.razor
@@ -12,7 +12,7 @@
         <FluentDatePicker Label="Months view" AriaLabel="To" @bind-Value="@SelectedValue" View="CalendarViews.Months" DoubleClickToDate="@DoubleClickToDate" />
     </div>
     <div>
-        <FluentDatePicker Label="Years view" AriaLabel="To" @bind-Value="@SelectedValue" View="CalendarViews.Years" DoubleClickToDate="@DoubleClickToDate" />
+        <FluentDatePicker Label="Years view" AriaLabel="To" @bind-Value="@SelectedValue" View="CalendarViews.Years" DoubleClickToDate="@DoubleClickToDate" PopupHorizontalPosition="@HorizontalPosition.Left" />
     </div>
 </div>
 <p>

--- a/src/Core/Components/DateTime/FluentDatePicker.razor
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor
@@ -27,7 +27,7 @@
     <FluentOverlay @bind-Visible="@Opened" Dismissable="true" FullScreen="true" Interactive="true" InteractiveExceptId="@PopupId" />
     <FluentAnchoredRegion Anchor="@Id"
                           Id="@PopupId"
-                          HorizontalDefaultPosition="@(System.Globalization.CultureInfo.CurrentUICulture.TextInfo.IsRightToLeft ? HorizontalPosition.Left : HorizontalPosition.Right)"
+                          HorizontalDefaultPosition="@(PopupHorizontalPosition ?? (System.Globalization.CultureInfo.CurrentUICulture.TextInfo.IsRightToLeft ? HorizontalPosition.Left : HorizontalPosition.Right))"
                           HorizontalInset="true"
                           VerticalDefaultPosition="@VerticalPosition.Unset"
                           Shadow="ElevationShadow.Flyout"

--- a/src/Core/Components/DateTime/FluentDatePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor.cs
@@ -65,6 +65,13 @@ public partial class FluentDatePicker : FluentCalendarBase
     [Parameter]
     public DateTime? DoubleClickToDate { get; set; }
 
+    /// <summary>
+    /// Gets or sets an <see cref="HorizontalPosition"/> for the popup displayed when the user open the calendar.
+    /// By default, this value is Left or Right, depending of the 'CurrentUICulture.TextInfo.IsRightToLeft' value.
+    /// </summary>
+    [Parameter]
+    public HorizontalPosition? PopupHorizontalPosition { get; set; }
+
     public bool Opened { get; set; } = false;
 
     protected override string? FormatValueAsString(DateTime? value)


### PR DESCRIPTION
# [DatePicker] Add `PopupHorizontalPosition` property

There is a situation where the developer would like to "force" the horizontal position of the displayed popup.
See #3000

## Before
![{ADA1233C-9D3C-433B-989D-E664438CA8C2}](https://github.com/user-attachments/assets/8fafe35e-2316-47c4-a82f-755b6a019278)


## After
using the new `PopupHorizontalPosition="@HorizontalPosition.Left"` attribute.

![{C3BE2C16-CC38-4752-BF76-3E712832E09D}](https://github.com/user-attachments/assets/299ce39d-5e37-4fda-81be-5366c95e6795)
