### PR TITLE
[Templates] More templates work

### DIFF
--- a/src/Templates/Microsoft.FluentUI.AspNetCore.Templates.csproj
+++ b/src/Templates/Microsoft.FluentUI.AspNetCore.Templates.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk" InitialTargets="AddTemplatesToPackageAsContent">
-
 	<PropertyGroup>
 		<TargetFramework>net9.0</TargetFramework>
 		<Authors>Microsoft</Authors>
@@ -40,18 +39,18 @@
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageOutputPath>$(SolutionDir)artifacts</PackageOutputPath>
 	</PropertyGroup>
-	
+
 	 <PropertyGroup>
 		<UsePublicApiAnalyzers>false</UsePublicApiAnalyzers>
-	</PropertyGroup>  
+	</PropertyGroup>
 
 	<ItemGroup>
 		<None Include="templates\**\*" />
 		<Content Include="content\**\*" Exclude="content\**\bin\**;content\**\obj\**" />
-		
+
 		<None Include="README.md" Pack="true" PackagePath="\" />
 		<None Include="..\..\icon.png" Pack="true" PackagePath="\" />
-		
+
 	</ItemGroup>
 
 	<ItemGroup>
@@ -75,7 +74,7 @@
 			<Content Include="%(_TemplatesForPackage.Identity)" PackagePath="content/content/%(_TemplatesForPackage.RecursiveDir)" />
 		</ItemGroup>
 	</Target>
-	
+
 	<!-- Replaces the versions referenced by the templates projects to use the version of the packages being live-built -->
 	<Target Name="ReplacePackageVersionOnTemplates" DependsOnTargets="CopyTemplatesToIntermediateOutputPath">
 
@@ -89,6 +88,7 @@
 		<WriteLinesToFile File="%(TemplateProjectFiles.DestinationFile)"
 											Lines="$([System.IO.File]::ReadAllText('%(TemplateProjectFiles.FullPath)')
 																								 .Replace('!!REPLACE_WITH_LATEST_VERSION!!', '$(PackageVersion)')
+                                                 .Replace('!!REPLACE_WITH_LATEST_ASPIRE_VERSION!!', '$(AspirePackageVersion)')
 																								 .Replace('!!REPLACE_WITH_ASPNETCORE_8_VERSION!!', '$(MicrosoftAspNetCorePackageVersionForNet8)')
 																								 .Replace('!!REPLACE_WITH_ASPNETCORE_9_VERSION!!', '$(MicrosoftAspNetCorePackageVersionForNet9)')
 																								 .Replace('!!REPLACE_WITH_DOTNET_EXTENSIONS_VERSION!!', '$(MicrosoftExtensionsHttpResiliencePackageVersion)'))"

--- a/src/Templates/templates/aspire-starter/8.2/Aspire-StarterApplication.1.Web/Aspire-StarterApplication.1.Web.csproj
+++ b/src/Templates/templates/aspire-starter/8.2/Aspire-StarterApplication.1.Web/Aspire-StarterApplication.1.Web.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\XmlEncodedProjectName.ServiceDefaults\XmlEncodedProjectName.ServiceDefaults.csproj" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="[4.11.0,)" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="[4.11.0,)" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
   </ItemGroup>
 
   <!--#if (UseRedisCache) -->

--- a/src/Templates/templates/aspire-starter/8.2/Aspire-StarterApplication.1.Web/Components/Pages/Weather.razor
+++ b/src/Templates/templates/aspire-starter/8.2/Aspire-StarterApplication.1.Web/Components/Pages/Weather.razor
@@ -1,7 +1,6 @@
 ﻿@page "/weather"
-@attribute [StreamRendering(true)]
+@rendermode InteractiveServer
 @attribute [OutputCache(Duration = 5)]
-
 @inject WeatherApiClient WeatherApi
 
 <PageTitle>Weather</PageTitle>

--- a/src/Templates/templates/aspire-starter/9.0/Aspire-StarterApplication.1.AppHost/Aspire-StarterApplication.1.AppHost.csproj
+++ b/src/Templates/templates/aspire-starter/9.0/Aspire-StarterApplication.1.AppHost/Aspire-StarterApplication.1.AppHost.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Sdk Name="Aspire.AppHost.Sdk" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
+  <Sdk Name="Aspire.AppHost.Sdk" Version="!!REPLACE_WITH_LATEST_ASPIRE_VERSION!!" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -17,9 +17,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="!!REPLACE_WITH_LATEST_ASPIRE_VERSION!!" />
   <!--#if (UseRedisCache) -->
-    <PackageReference Include="Aspire.Hosting.Redis" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="!!REPLACE_WITH_LATEST_ASPIRE_VERSION!!" />
   <!--#endif -->
   </ItemGroup>
 

--- a/src/Templates/templates/aspire-starter/9.0/Aspire-StarterApplication.1.ServiceDefaults/Aspire-StarterApplication.1.ServiceDefaults.csproj
+++ b/src/Templates/templates/aspire-starter/9.0/Aspire-StarterApplication.1.ServiceDefaults/Aspire-StarterApplication.1.ServiceDefaults.csproj
@@ -11,7 +11,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="!!REPLACE_WITH_DOTNET_EXTENSIONS_VERSION!!" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="!!REPLACE_WITH_LATEST_ASPIRE_VERSION!!" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />

--- a/src/Templates/templates/aspire-starter/9.0/Aspire-StarterApplication.1.Tests/Aspire-StarterApplication.1.Tests.csproj
+++ b/src/Templates/templates/aspire-starter/9.0/Aspire-StarterApplication.1.Tests/Aspire-StarterApplication.1.Tests.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Testing" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
+    <PackageReference Include="Aspire.Hosting.Testing" Version="!!REPLACE_WITH_LATEST_ASPIRE_VERSION!!" />
     <PackageReference Include="coverlet.collector" Version="6.0.2" Condition=" $(TestFramework) == 'xUnit.net' " />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" Condition=" $(TestFramework) != 'MSTest' " />
     <PackageReference Include="MSTest" Version="3.4.3" Condition=" $(TestFramework) == 'MSTest' " />

--- a/src/Templates/templates/aspire-starter/9.0/Aspire-StarterApplication.1.Web/Aspire-StarterApplication.1.Web.csproj
+++ b/src/Templates/templates/aspire-starter/9.0/Aspire-StarterApplication.1.Web/Aspire-StarterApplication.1.Web.csproj
@@ -8,13 +8,13 @@
 
   <ItemGroup>
     <ProjectReference Include="..\XmlEncodedProjectName.ServiceDefaults\XmlEncodedProjectName.ServiceDefaults.csproj" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="[4.11.0,)" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="[4.11.0,)" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
   </ItemGroup>
 
   <!--#if (UseRedisCache) -->
   <ItemGroup>
-    <PackageReference Include="Aspire.StackExchange.Redis.OutputCaching" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
+    <PackageReference Include="Aspire.StackExchange.Redis.OutputCaching" Version="!!REPLACE_WITH_LATEST_ASPIRE_VERSION!!" />
   </ItemGroup>
 
   <!--#endif -->

--- a/src/Templates/templates/aspire-starter/9.0/Aspire-StarterApplication.1.Web/Components/Pages/Weather.razor
+++ b/src/Templates/templates/aspire-starter/9.0/Aspire-StarterApplication.1.Web/Components/Pages/Weather.razor
@@ -1,5 +1,5 @@
 ﻿@page "/weather"
-@attribute [StreamRendering(true)]
+@rendermode InteractiveServer
 @attribute [OutputCache(Duration = 5)]
 
 @inject WeatherApiClient WeatherApi

--- a/src/Templates/templates/blazorweb-csharp/BlazorWeb-CSharp.Client/BlazorWeb-CSharp.Client.csproj
+++ b/src/Templates/templates/blazorweb-csharp/BlazorWeb-CSharp.Client/BlazorWeb-CSharp.Client.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="!!REPLACE_WITH_ASPNETCORE_9_VERSION!!" Condition="'$(Framework)' == 'net9.0'" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="!!REPLACE_WITH_ASPNETCORE_8_VERSION!!" Condition="'$(IndividualLocalAuth)' == 'True' AND '$(Framework)' == 'net8.0'" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="!!REPLACE_WITH_ASPNETCORE_9_VERSION!!" Condition="'$(IndividualLocalAuth)' == 'True' AND '$(Framework)' == 'net9.0'" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="[4.11.0,)" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="[4.11.0,)" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
   </ItemGroup>
 
 </Project>

--- a/src/Templates/templates/blazorweb-csharp/BlazorWeb-CSharp/BlazorWeb-CSharp.csproj
+++ b/src/Templates/templates/blazorweb-csharp/BlazorWeb-CSharp/BlazorWeb-CSharp.csproj
@@ -35,7 +35,7 @@
 
   <!--#endif -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="[4.11.0,)" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="[4.11.0,)" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
   </ItemGroup>
 </Project>

--- a/src/Templates/templates/blazorweb-csharp/BlazorWeb-CSharp/Components/_Imports.razor
+++ b/src/Templates/templates/blazorweb-csharp/BlazorWeb-CSharp/Components/_Imports.razor
@@ -14,6 +14,8 @@
 @using BlazorWeb_CSharp
 @*#if (UseWebAssembly) -->
 @using BlazorWeb_CSharp.Client
+##endif*@
+@*#if (UseWebAssembly && SampleContent) -->
 @using BlazorWeb_CSharp.Client.Layout
 ##endif*@
 @using BlazorWeb_CSharp.Components

--- a/src/Templates/templates/componentswebassembly-csharp/ComponentsWebAssembly-CSharp.csproj
+++ b/src/Templates/templates/componentswebassembly-csharp/ComponentsWebAssembly-CSharp.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="9.0.0" Condition="'$(IndividualLocalAuth)' == 'true'" />
     <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="9.0.0" Condition="'$(OrganizationalAuth)' == 'true' OR '$(IndividualB2CAuth)' == 'true'" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="[4.11.0,)" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="[4.11.0,)" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
   </ItemGroup>
 
   <!--#if PWA -->

--- a/src/Templates/templates/maui-blazor-solution/MauiApp.1.Shared/MauiApp.1.Shared.csproj
+++ b/src/Templates/templates/maui-blazor-solution/MauiApp.1.Shared/MauiApp.1.Shared.csproj
@@ -12,8 +12,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="[4.11.0,)" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="[4.11.0,)" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
   </ItemGroup>
 
 </Project>

--- a/src/Templates/templates/maui-blazor-solution/MauiApp.1.Web.Client/MauiApp.1.Web.Client.csproj
+++ b/src/Templates/templates/maui-blazor-solution/MauiApp.1.Web.Client/MauiApp.1.Web.Client.csproj
@@ -11,8 +11,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="9.0.0" Condition="'$(IndividualLocalAuth)' == 'True'" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.*-*" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.*-*" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Templates/templates/maui-blazor-solution/MauiApp.1.Web/MauiApp.1.Web.csproj
+++ b/src/Templates/templates/maui-blazor-solution/MauiApp.1.Web/MauiApp.1.Web.csproj
@@ -31,8 +31,8 @@
   </ItemGroup>
   <!--#endif -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="[4.11.0,)" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="[4.11.0,)" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Make `PackageReference`s use PackageVersion
Now all projects will always reference same version as being built
- Fix `PackageReference`s for Aspire version
Aspire 9 projects were using library's package version in generated solution
- Use InteractiveServer for Weather page in Aspire starter
The grid needs interactivity to make sorting work
