### PR TITLE
[Popover] Go to the next focusable Element

### DIFF
--- a/src/Core/Components/AnchoredRegion/FluentAnchoredRegion.razor.js
+++ b/src/Core/Components/AnchoredRegion/FluentAnchoredRegion.razor.js
@@ -1,6 +1,9 @@
 export function goToNextFocusableElement(forContainer, toOriginal, delay) {
-
     const container = typeof forContainer === "string" ? document.getElementById(forContainer) : forContainer;
+
+    if (container == null || container == undefined) {
+        return;
+    }
 
     if (!!!container.focusableElement) {
         container.focusableElement = new FocusableElement(container);
@@ -28,6 +31,7 @@ export function goToNextFocusableElement(forContainer, toOriginal, delay) {
         }
     }
 }
+
 
 /**
  * Focusable Element


### PR DESCRIPTION
# [Popover] Go to the next focusable Element

Sometime, the `goToNextFocusableElement` JS method can receive an obsolete element.
This test verifies if this element is still there or not (in the DOM)

Will fix #3012
