### PR TITLE
Expose data grid query executor for entity framework

### DIFF
--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -289,6 +289,11 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     [Parameter]
     public bool AutoFocus{ get; set; } = false;
 
+    /// <summary>
+    /// Gets the grids' current query executor.
+    /// </summary>
+    public IAsyncQueryExecutor? AsyncQueryExecutor => _asyncQueryExecutor;
+
     private ElementReference? _gridReference;
     private Virtualize<(int, TGridItem)>? _virtualizeComponent;
 

--- a/src/Extensions/DataGrid.EntityFrameworkAdapter/EntityFrameworkAsyncQueryExecutor.cs
+++ b/src/Extensions/DataGrid.EntityFrameworkAdapter/EntityFrameworkAsyncQueryExecutor.cs
@@ -4,7 +4,7 @@ using Microsoft.FluentUI.AspNetCore.Components.DataGrid.Infrastructure;
 
 namespace Microsoft.FluentUI.AspNetCore.Components.DataGrid.EntityFrameworkAdapter;
 
-internal class EntityFrameworkAsyncQueryExecutor : IAsyncQueryExecutor, IDisposable
+internal class EntityFrameworkAsyncQueryExecutor : IAsyncQueryExecutor, IEntityFrameworkAsyncQueryExecutor, IDisposable
 {
     private readonly SemaphoreSlim _lock = new(1);
 
@@ -17,7 +17,7 @@ internal class EntityFrameworkAsyncQueryExecutor : IAsyncQueryExecutor, IDisposa
     public Task<T[]> ToArrayAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken)
         => ExecuteAsync(() => queryable.ToArrayAsync(cancellationToken));
 
-    private async Task<TResult> ExecuteAsync<TResult>(Func<Task<TResult>> operation)
+    public async Task<TResult> ExecuteAsync<TResult>(Func<Task<TResult>> operation)
     {
         try
         {

--- a/src/Extensions/DataGrid.EntityFrameworkAdapter/IEntityFrameworkAsyncQueryExecutor.cs
+++ b/src/Extensions/DataGrid.EntityFrameworkAdapter/IEntityFrameworkAsyncQueryExecutor.cs
@@ -1,0 +1,15 @@
+namespace Microsoft.FluentUI.AspNetCore.Components.DataGrid.Infrastructure;
+
+/// <summary>
+/// Defines methods for executing asynchronous operations serially within an Entity Framework database context.
+/// </summary>
+public interface IEntityFrameworkAsyncQueryExecutor
+{
+    /// <summary>
+    /// Schedules an asynchronous operation to be executed serially against the database context associated with the grid.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the result returned by the operation.</typeparam>
+    /// <param name="operation">A function representing the asynchronous operation to execute.</param>
+    /// <returns>A task representing the result of the operation.</returns>
+    Task<TResult> ExecuteAsync<TResult>(Func<Task<TResult>> operation);
+}


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

The IAsyncQueryExecutor owned by FluentDataGrid ensures that operations against an Entity Framework DbContext are executed serially. When the data grid is used to both display and edit data within the same DbContext (with change tracking), such as presenting a list of editable entities, the data grid handles data presentation, while editing occurs outside of the grid. In such cases, it is essential to ensure that both query operations and save operations are executed serially against the DbContext to avoid conflicts.

This PR exposes the IAsyncQueryExecutor owned by FluentDataGrid, allowing callers to cast it to IEntityFrameworkAsyncQueryExecutor and execute additional Entity Framework operations serially.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

Please let me know if this is the preferred approach for exposing the query executor for EF operations, or if the team has alternative recommendations.

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [ ] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
