### PR TITLE
[FluentInputFile] [Docs] Add null check on initialization

### DIFF
--- a/examples/Demo/Shared/Components/CodeSnippet.razor.js
+++ b/examples/Demo/Shared/Components/CodeSnippet.razor.js
@@ -21,7 +21,9 @@ export function addCopyButton() {
 }
 
 export function highlightElement(id) {
-    if (hljs) {
-        hljs.highlightElement(id);
+    try {
+        hljs?.highlightElement(id);
+    } catch (e) {
+        // highlightJS may fail when the user navigates away from the page quickly. Which when not catched will result in a crash.
     }
 }

--- a/src/Core/Components/InputFile/FluentInputFile.razor.js
+++ b/src/Core/Components/InputFile/FluentInputFile.razor.js
@@ -57,20 +57,20 @@ export function initializeFileDropZone(containerElement, inputFile) {
     //}
 
     // Register all events
-    containerElement.addEventListener("dragenter", onDragHover);
-    containerElement.addEventListener("dragover", onDragHover);
-    containerElement.addEventListener("dragleave", onDragLeave);
-    containerElement.addEventListener("drop", onDrop);
-    //containerElement.addEventListener('paste', onPaste);
+    containerElement?.addEventListener("dragenter", onDragHover);
+    containerElement?.addEventListener("dragover", onDragHover);
+    containerElement?.addEventListener("dragleave", onDragLeave);
+    containerElement?.addEventListener("drop", onDrop);
+    //containerElement?.addEventListener('paste', onPaste);
 
     // The returned object allows to unregister the events when the Blazor component is destroyed
     return {
         dispose: () => {
-            containerElement.removeEventListener('dragenter', onDragHover);
-            containerElement.removeEventListener('dragover', onDragHover);
-            containerElement.removeEventListener('dragleave', onDragLeave);
-            containerElement.removeEventListener("drop", onDrop);
-            //containerElement.removeEventListener('paste', onPaste);
+            containerElement?.removeEventListener('dragenter', onDragHover);
+            containerElement?.removeEventListener('dragover', onDragHover);
+            containerElement?.removeEventListener('dragleave', onDragLeave);
+            containerElement?.removeEventListener("drop", onDrop);
+            //containerElement?.removeEventListener('paste', onPaste);
         }
     }
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR adds a null check to `FluentInputFile.razor.js` to prevent a crash which happens when the user leaves the page before the `FluentInputFile` has been fully initialized. Without this null check the app might eventually crash.

In addition this PR also adds a `try/catch` for the `CodeSnippet` component for the demo sites. Which has the same problem on fast navigations. Here a null check is not possible because `hljs` is not null and the javascript which is being executed is a third party library.

### 🎫 Issues
Fixes #3061 


## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component (FluentInputFile & CodeSnippet)
- [ ] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component


