### PR TITLE
[Wizard] Unregister EditForms in FluentWizardStep when DeferredLoading is enabled

### DIFF
--- a/src/Core/Components/Wizard/FluentWizard.razor.cs
+++ b/src/Core/Components/Wizard/FluentWizard.razor.cs
@@ -223,6 +223,11 @@ public partial class FluentWizard : FluentComponentBase
             await _steps[Value].OnChange.InvokeAsync(args);
         }
 
+        if (_steps[Value].DeferredLoading && !args.IsCancelled)
+        {
+            _steps[Value].ClearEditFormAndContext();
+        }
+
         return args;
     }
 

--- a/src/Core/Components/Wizard/FluentWizardStep.razor.cs
+++ b/src/Core/Components/Wizard/FluentWizardStep.razor.cs
@@ -147,6 +147,11 @@ public partial class FluentWizardStep : FluentComponentBase
         }
     }
 
+    public void ClearEditFormAndContext()
+    {
+        _editForms.Clear();
+    }
+
     public bool ValidateEditContexts()
     {
         var isValid = true;


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR fixes the EditForms functionality within the `FluentWizardStep` component when the DeferredLoading parameter is set to `true`.

The `DeferredLoading` parameter causes the component to create a new instance of all `EditForm` components within it each time the component is rendered. These `EditForm` instances are subsequently registered and invoked. This PR ensures that these `EditForm` instances are cleared when the user navigates away from the current step within the wizard.

### 🎫 Issues

#3014 


## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [ ] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

