### PR TITLE
[FluentSlider] [FluentNumberField] Fix #2948

### DIFF
--- a/src/Core/Components/NumberField/FluentNumberField.razor.cs
+++ b/src/Core/Components/NumberField/FluentNumberField.razor.cs
@@ -160,6 +160,17 @@ public partial class FluentNumberField<TValue> : FluentInputBase<TValue>, IAsync
         base.OnParametersSet();
     }
 
+    /// <summary>
+    /// set to true when value is changed by the fluent-number-field either by input or by the spin buttons.
+    /// </summary>
+    private bool inputChanged = false;
+
+    protected override Task InputHandlerAsync(ChangeEventArgs e)
+    {
+        inputChanged = true;
+        return base.InputHandlerAsync(e);
+    }
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         await base.OnAfterRenderAsync(firstRender);
@@ -175,8 +186,15 @@ public partial class FluentNumberField<TValue> : FluentInputBase<TValue>, IAsync
         }
         else
         {
-            Module ??= await JSRuntime.InvokeAsync<IJSObjectReference>("import", JAVASCRIPT_FILE.FormatCollocatedUrl(LibraryConfiguration));
-            await Module.InvokeVoidAsync("setNumberFieldValue", Element, Value!.ToString());
+            if (inputChanged)
+            {
+                inputChanged = false;
+            }
+            else
+            {
+                Module ??= await JSRuntime.InvokeAsync<IJSObjectReference>("import", JAVASCRIPT_FILE.FormatCollocatedUrl(LibraryConfiguration));
+                await Module.InvokeVoidAsync("setNumberFieldValue", Element, Value!.ToString());
+            }
         }
     }
 

--- a/src/Core/Components/NumberField/FluentNumberField.razor.cs
+++ b/src/Core/Components/NumberField/FluentNumberField.razor.cs
@@ -160,41 +160,20 @@ public partial class FluentNumberField<TValue> : FluentInputBase<TValue>, IAsync
         base.OnParametersSet();
     }
 
-    /// <summary>
-    /// set to true when value is changed by the fluent-number-field either by input or by the spin buttons.
-    /// </summary>
-    private bool inputChanged = false;
-
-    protected override Task InputHandlerAsync(ChangeEventArgs e)
-    {
-        inputChanged = true;
-        return base.InputHandlerAsync(e);
-    }
-
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         await base.OnAfterRenderAsync(firstRender);
 
         if (firstRender)
         {
+            Module ??= await JSRuntime.InvokeAsync<IJSObjectReference>("import", JAVASCRIPT_FILE.FormatCollocatedUrl(LibraryConfiguration));
+            await Module.InvokeVoidAsync("ensureCurrentValueMatch", Element);
+
             if (AutoComplete != null && !string.IsNullOrEmpty(Id))
             {
-                Module ??= await JSRuntime.InvokeAsync<IJSObjectReference>("import", JAVASCRIPT_FILE.FormatCollocatedUrl(LibraryConfiguration));
                 await Module.InvokeVoidAsync("setControlAttribute", Id, "autocomplete", AutoComplete);
             }
 
-        }
-        else
-        {
-            if (inputChanged)
-            {
-                inputChanged = false;
-            }
-            else
-            {
-                Module ??= await JSRuntime.InvokeAsync<IJSObjectReference>("import", JAVASCRIPT_FILE.FormatCollocatedUrl(LibraryConfiguration));
-                await Module.InvokeVoidAsync("setNumberFieldValue", Element, Value!.ToString());
-            }
         }
     }
 

--- a/src/Core/Components/NumberField/FluentNumberField.razor.cs
+++ b/src/Core/Components/NumberField/FluentNumberField.razor.cs
@@ -6,7 +6,7 @@ using Microsoft.JSInterop;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
-public partial class FluentNumberField<TValue> : FluentInputBase<TValue>
+public partial class FluentNumberField<TValue> : FluentInputBase<TValue>, IAsyncDisposable
 {
     private const string JAVASCRIPT_FILE = "./_content/Microsoft.FluentUI.AspNetCore.Components/Components/TextField/FluentTextField.razor.js";
 
@@ -177,6 +177,23 @@ public partial class FluentNumberField<TValue> : FluentInputBase<TValue>
         {
             Module ??= await JSRuntime.InvokeAsync<IJSObjectReference>("import", JAVASCRIPT_FILE.FormatCollocatedUrl(LibraryConfiguration));
             await Module.InvokeVoidAsync("setNumberFieldValue", Element, Value!.ToString());
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            if (Module is not null)
+            {
+                await Module.DisposeAsync();
+            }
+        }
+        catch (Exception ex) when (ex is JSDisconnectedException ||
+                                   ex is OperationCanceledException)
+        {
+            // The JSRuntime side may routinely be gone already if the reason we're disposing is that
+            // the client disconnected. This is not an error.
         }
     }
 }

--- a/src/Core/Components/NumberField/FluentNumberField.razor.cs
+++ b/src/Core/Components/NumberField/FluentNumberField.razor.cs
@@ -173,5 +173,10 @@ public partial class FluentNumberField<TValue> : FluentInputBase<TValue>
             }
 
         }
+        else
+        {
+            Module ??= await JSRuntime.InvokeAsync<IJSObjectReference>("import", JAVASCRIPT_FILE.FormatCollocatedUrl(LibraryConfiguration));
+            await Module.InvokeVoidAsync("setNumberFieldValue", Element, Value!.ToString());
+        }
     }
 }

--- a/src/Core/Components/Slider/FluentSlider.razor.cs
+++ b/src/Core/Components/Slider/FluentSlider.razor.cs
@@ -27,7 +27,6 @@ public partial class FluentSlider<TValue> : FluentInputBase<TValue>, IAsyncDispo
     private TValue? max;
     private TValue? min;
     private bool updateSliderThumb = false;
-    private bool userChangedValue = false;
 
     /// <summary>
     /// Gets or sets the slider's minimal value.
@@ -71,14 +70,7 @@ public partial class FluentSlider<TValue> : FluentInputBase<TValue>, IAsyncDispo
             if (base.Value != value)
             {
                 base.Value = value;
-                if (userChangedValue)
-                {
-                    userChangedValue = false;
-                }
-                else
-                {
-                    updateSliderThumb = true;
-                }
+                updateSliderThumb = true;
             }
         }
     }
@@ -124,12 +116,6 @@ public partial class FluentSlider<TValue> : FluentInputBase<TValue>, IAsyncDispo
                 }
             }
         }
-    }
-
-    protected override Task ChangeHandlerAsync(ChangeEventArgs e)
-    {
-        userChangedValue = true;
-        return base.ChangeHandlerAsync(e);
     }
 
     protected override string? ClassValue

--- a/src/Core/Components/Slider/FluentSlider.razor.cs
+++ b/src/Core/Components/Slider/FluentSlider.razor.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components.Extensions;
 using Microsoft.FluentUI.AspNetCore.Components.Utilities;
+using Microsoft.FluentUI.AspNetCore.Components.Utilities.InternalDebounce;
 using Microsoft.JSInterop;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
@@ -27,6 +28,11 @@ public partial class FluentSlider<TValue> : FluentInputBase<TValue>, IAsyncDispo
     private TValue? max;
     private TValue? min;
     private bool updateSliderThumb = false;
+    private DebounceAction Debounce { get; init; }
+    public FluentSlider()
+    {
+        Debounce = new DebounceAction();
+    }
 
     /// <summary>
     /// Gets or sets the slider's minimal value.
@@ -112,7 +118,10 @@ public partial class FluentSlider<TValue> : FluentInputBase<TValue>, IAsyncDispo
                 updateSliderThumb = false;
                 if (Module is not null)
                 {
-                    await Module!.InvokeVoidAsync("updateSlider", Element);
+                    Debounce.Run(100, async () =>
+                    {
+                        await Module!.InvokeVoidAsync("updateSlider", Element);
+                    });
                 }
             }
         }

--- a/src/Core/Components/TextField/FluentTextField.razor.js
+++ b/src/Core/Components/TextField/FluentTextField.razor.js
@@ -17,3 +17,11 @@ export function setDataList(id, datalistid) {
     }
     shadowRoot.appendChild(dataList);
 }
+
+export function setNumberFieldValue(ref, value) {
+    if (ref !== undefined && ref != null) {
+        if (ref.value !== value) {
+            ref.value = value;
+        }
+    }
+}

--- a/src/Core/Components/TextField/FluentTextField.razor.js
+++ b/src/Core/Components/TextField/FluentTextField.razor.js
@@ -18,10 +18,19 @@ export function setDataList(id, datalistid) {
     shadowRoot.appendChild(dataList);
 }
 
-export function setNumberFieldValue(ref, value) {
+export function ensureCurrentValueMatch(ref) {
     if (ref !== undefined && ref != null) {
-        if (ref.value !== value) {
-            ref.value = value;
-        }
+        const observer = new MutationObserver((mutations) => {
+            mutations.forEach((mutation) => {
+                if (mutation.type === "attributes") {
+                    ref.value = mutation.target.getAttribute("value");
+                }
+            });
+        });
+        observer.observe(ref, {
+            attributes: true,
+            attributeFilter: ["value"],
+        });
     }
 }
+

--- a/tests/Core/NumberField/FluentNumberFieldTests.cs
+++ b/tests/Core/NumberField/FluentNumberFieldTests.cs
@@ -14,6 +14,7 @@ public class FluentNumberFieldTests : TestBase
     public FluentNumberFieldTests()
     {
         TestContext.Services.AddSingleton(LibraryConfiguration);
+        TestContext.JSInterop.Mode = JSRuntimeMode.Loose;
     }
 
     [Fact]

--- a/tests/Core/Wizard/FluentWizardTests.razor
+++ b/tests/Core/Wizard/FluentWizardTests.razor
@@ -10,6 +10,7 @@
     public FluentWizardTests()
     {
         this.Services.AddSingleton(LibraryConfiguration);
+        JSInterop.Mode = JSRuntimeMode.Loose;
     }
 
     [Fact]


### PR DESCRIPTION
# Pull Request

## 📖 Description

Fixes issues reported in #2948. Two issue reported both related to changing the value of the control programatically.

### 🎫 Issues

The underlying issue is that the web components being wrapped were designed to have there states only changed interactively.  `bind-value` does not behave as expected. Inward binding works only on for initialization. Outward binding works as expected.

This gives the appearance of a *sync* issue.

## 👩‍💻 Reviewer Notes

`FluentSlider` - #2665 did not fully fix #2609. The original fix was to prevent the [flickering when the slider was moved rapidly](https://github.com/microsoft/fluentui-blazor/issues/2609#issuecomment-2326339496) originally reported. I was not able to reproduce this problem with the current implementation of `FluentDataGrid`. I did end up adding debouncing with the `DebounceAction`.  I believe I did this correctly.

`FluentNumberField` - The fix was to ensure the underlying web component reflected the correct value. I could not find a way of distinguishing if the value was changed by manipulating the control or if it was changed programatically. I opted to use some javascript to force the value in the web component. I also added a `DisposeAsync`. It was missing.

I've also included an `issue-tester` page as part of this draft

## 📑 Test Plan

## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [X] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [ ] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component
