### PR TITLE
[Templates] Fix StreamRender error occurring in certain situations

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,17 +2,17 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <RuntimeVersion8>8.0.0</RuntimeVersion8>
-    <AspNetCoreVersion8>8.0.10</AspNetCoreVersion8>
-    <EfCoreVersion8>8.0.10</EfCoreVersion8>
+    <AspNetCoreVersion8>8.0.11</AspNetCoreVersion8>
+    <EfCoreVersion8>8.0.11</EfCoreVersion8>
     <RuntimeVersion9>9.0.0</RuntimeVersion9>
     <AspNetCoreVersion9>9.0.0</AspNetCoreVersion9>
     <EfCoreVersion9>9.0.0</EfCoreVersion9>
   </PropertyGroup>
   <ItemGroup>
     <!-- For Sample Apps -->
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.11.0-beta.1" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" version="4.11.0-beta.1" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="4.11.0-beta.1" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.11.0" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" version="4.11.0" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="4.11.0" />
     <!-- Test dependencies -->
     <PackageVersion Include="bunit" Version="1.31.3" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />

--- a/src/Templates/templates/blazorweb-csharp/BlazorWeb-CSharp/Components/Pages/Weather.razor
+++ b/src/Templates/templates/blazorweb-csharp/BlazorWeb-CSharp/Components/Pages/Weather.razor
@@ -9,29 +9,29 @@
 
 <p>This component demonstrates showing data.</p>
 
+@*#if (InteractiveAtRoot) -->
 @if (forecasts == null)
 {
     <p><em>Loading...</em></p>
 }
 else
 {
-    @*#if (InteractiveAtRoot) -->
     <FluentDataGrid Id="weathergrid" Items="@forecasts" GridTemplateColumns="1fr 1fr 1fr 2fr" TGridItem="WeatherForecast">
         <PropertyColumn Title="Date" Property="@(c => c!.Date)" Sortable="true" Align="Align.Start"/>
         <PropertyColumn Title="Temp. (C)" Property="@(c => c!.TemperatureC)" Sortable="true" Align="Align.Center"/>
         <PropertyColumn Title="Temp. (F)" Property="@(c => c!.TemperatureF)" Sortable="true" Align="Align.Center"/>
         <PropertyColumn Title="Summary" Property="@(c => c!.Summary)" Sortable="true" Align="Align.End"/>
     </FluentDataGrid>
-    ##else
-    <!-- This page is rendered in SSR mode, so the FluentDataGrid component does not offer any interactivity (like sorting). -->
-    <FluentDataGrid Id="weathergrid" Items="@forecasts" GridTemplateColumns="1fr 1fr 1fr 2fr" TGridItem="WeatherForecast">
-        <PropertyColumn Title="Date" Property="@(c => c!.Date)" Align="Align.Start"/>
-        <PropertyColumn Title="Temp. (C)" Property="@(c => c!.TemperatureC)" Align="Align.Center"/>
-        <PropertyColumn Title="Temp. (F)" Property="@(c => c!.TemperatureF)" Align="Align.Center"/>
-        <PropertyColumn Title="Summary" Property="@(c => c!.Summary)" Align="Align.End"/>
-    </FluentDataGrid>
-    ##endif*@
 }
+##else
+<!-- This page is rendered in SSR mode, so the FluentDataGrid component does not offer any interactivity (like sorting). -->
+<FluentDataGrid Id="weathergrid" Items="@forecasts" GridTemplateColumns="1fr 1fr 1fr 2fr" Loading="@(forecasts == null)" Style="height:204px;" TGridItem="WeatherForecast">
+    <PropertyColumn Title="Date" Property="@(c => c!.Date)" Align="Align.Start"/>
+    <PropertyColumn Title="Temp. (C)" Property="@(c => c!.TemperatureC)" Align="Align.Center"/>
+    <PropertyColumn Title="Temp. (F)" Property="@(c => c!.TemperatureF)" Align="Align.Center"/>
+    <PropertyColumn Title="Summary" Property="@(c => c!.Summary)" Align="Align.End"/>
+</FluentDataGrid>
+##endif*@
 
 @code {
     private IQueryable<WeatherForecast>? forecasts;

--- a/src/Templates/templates/maui-blazor-solution/MauiApp.1.Shared/Pages/Weather.razor
+++ b/src/Templates/templates/maui-blazor-solution/MauiApp.1.Shared/Pages/Weather.razor
@@ -9,6 +9,7 @@
 
 <p>This component demonstrates showing data.</p>
 
+@*#if (InteractiveAtRoot) -->
 @if (forecasts == null)
 {
     <p><em>Loading...</em></p>
@@ -22,6 +23,16 @@ else
         <PropertyColumn Title="Summary" Property="@(c => c!.Summary)" Sortable="true" Align="Align.End"/>
     </FluentDataGrid>
 }
+##else
+<!-- This page is rendered in SSR mode, so the FluentDataGrid component does not offer any interactivity (like sorting). -->
+<FluentDataGrid Id="weathergrid" Items="@forecasts" GridTemplateColumns="1fr 1fr 1fr 2fr" Loading="@(forecasts == null)" Style="height:204px;" TGridItem="WeatherForecast">
+    <PropertyColumn Title="Date" Property="@(c => c!.Date)" Align="Align.Start"/>
+    <PropertyColumn Title="Temp. (C)" Property="@(c => c!.TemperatureC)" Align="Align.Center"/>
+    <PropertyColumn Title="Temp. (F)" Property="@(c => c!.TemperatureF)" Align="Align.Center"/>
+    <PropertyColumn Title="Summary" Property="@(c => c!.Summary)" Align="Align.End"/>
+</FluentDataGrid>
+##endif*@
+
 
 @code {
     private IQueryable<WeatherForecast>? forecasts;


### PR DESCRIPTION
Fix #3068.

 `IQueryable` does not work great in combination with `StreamRendering` (see also https://github.com/dotnet/aspnetcore/issues/51749)

Our DataGrid (which is based on QuickGrid and mentioned in the other issue) needs an `IQueryable` to work. I tried the suggested fix from the other issue but it did not lead to the loading text being shown. This has to do with the fact that the DataGrid has it's own loading state as well. 
With the code below, we can use this internal loading state to show the Loading in the grid itself instead of using the if..else construct from the standard template. This PR changes the template to use this code (only in the situations where the error occurred).

After the change:
![Image](https://github.com/user-attachments/assets/8710c32d-3495-461b-b431-b0a0bbf53070)


You can see the `StreamRendering` is actually working as when you set it to false, the page will just not display until the `TaskDelay` has passed