### PR TITLE
[DataGrid] Fix script being to eager on processing arrow keys

### DIFF
--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.js
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.js
@@ -63,7 +63,8 @@ export function init(gridElement, autoFocus) {
             );
         }
 
-        if (start === document.activeElement) {
+        // check if start is a child of gridElement
+        if (start !== null && (gridElement.contains(start) || gridElement === start) && document.activeElement === start) {
             const idx = start.cellIndex;
 
             if (event.key === "ArrowUp") {


### PR DESCRIPTION
Fix #3087

The DataGrid script was too eager in processing arrow keys. This lead to unexpected/unwanted behavior in other components like when having to TextFields next to each other with focus in text field 1, arrow right would move focus from 1st text field to the second instead of moving through the letters in the text field.