### PR TITLE
[Accordion] Fix Expanded state not being set in OnAccordionItemChange

### DIFF
--- a/examples/Demo/Shared/Pages/Accordion/Examples/AccordionDefault.razor
+++ b/examples/Demo/Shared/Pages/Accordion/Examples/AccordionDefault.razor
@@ -23,7 +23,7 @@
     </FluentAccordionItem>
 </FluentAccordion>
 
-<p>Last changed accordion item: @(changed?.Heading ?? "item with HeaderTemplate")</p>
+<p>Last changed accordion item: @(changed?.Heading ?? "item with HeaderTemplate"), Expanded: @changed?.Expanded</p>
 
 
 @code {

--- a/src/Core/Components/Accordion/FluentAccordion.razor.cs
+++ b/src/Core/Components/Accordion/FluentAccordion.razor.cs
@@ -1,3 +1,7 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 
@@ -52,6 +56,7 @@ public partial class FluentAccordion : FluentComponentBase
             var Id = args.ActiveId;
             if (Id is not null && items.TryGetValue(Id!, out FluentAccordionItem? item))
             {
+                item.Expanded = args.Expanded;
                 await OnAccordionItemChange.InvokeAsync(item);
                 await ActiveIdChanged.InvokeAsync(Id);
             }

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.js
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.js
@@ -63,7 +63,8 @@ export function init(gridElement, autoFocus) {
             );
         }
 
-        if (start === document.activeElement) {
+        // check if start is a child of gridElement
+        if (start !== null && (gridElement.contains(start) || gridElement === start) && document.activeElement === start) {
             const idx = start.cellIndex;
 
             if (event.key === "ArrowUp") {


### PR DESCRIPTION
Fix #3086
In `HandleOnAccordionChangedAsync(AccordionChangeEventArgs args)` arg contains the expanded state of the active Id. This value was not being used by the found `AccordionItem` used in the invocation of `OnAccordionItemChange`

After this change Expanded shows state of the changed item:
![accordionexpanded](https://github.com/user-attachments/assets/7bb07b4d-d626-42d2-b497-ca0d4216282b)
