### PR TITLE
[DataGrid] Restore OnRowFocus and OnCellFocus

### DIFF
--- a/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridTemplateColumns2.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridTemplateColumns2.razor
@@ -4,7 +4,9 @@
     GridTemplateColumns="1fr 1fr"
     TGridItem=SampleGridData
     OnRowClick="HandleRowClick"
+    OnRowFocus="HandleRowFocus"
     OnCellClick="HandleCellClick"
+    OnCellFocus="HandleCellFocus"
     RowSize="@DataGridRowSize.Medium">
     <TemplateColumn Title="Name">
         <FluentTextField @bind-Value="@context!.Name"/>
@@ -38,11 +40,21 @@
 
     private void HandleRowClick(FluentDataGridRow<SampleGridData> row)
     {
+        DemoLogger.WriteLine($"Row clicked: {row.RowIndex}");
+    }
+
+    private void HandleRowFocus(FluentDataGridRow<SampleGridData> row)
+    {
         DemoLogger.WriteLine($"Row focused: {row.RowIndex}");
     }
 
     private void HandleCellClick(FluentDataGridCell<SampleGridData> cell)
     {
-        DemoLogger.WriteLine($"Cell focused: {cell.GridColumn}");
+        DemoLogger.WriteLine($"Cell clicked: {cell.GridColumn}");
+    }
+
+    private void HandleCellFocus(FluentDataGridCell<SampleGridData> cell)
+    {
+        DemoLogger.WriteLine($"Cell focused : {cell.GridColumn}");
     }
 }

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -185,6 +185,7 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
 
     /// <summary>
     /// Gets or sets a callback when a row is focused.
+    /// As of 4.11 a row is a tr element with a 'display: contents'. Browsers can not focus such elements currently, but work is underway to fix that.
     /// </summary>
     [Parameter]
     public EventCallback<FluentDataGridRow<TGridItem>> OnRowFocus { get; set; }
@@ -918,18 +919,6 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
         stateParams.Add($"{SaveStatePrefix}page", Pagination?.CurrentPageIndex + 1 ?? null);
         stateParams.Add($"{SaveStatePrefix}top", Pagination?.ItemsPerPage ?? null);
         NavigationManager.NavigateTo(NavigationManager.GetUriWithQueryParameters(stateParams), replace: true);
-    }
-
-    private async Task HandleOnRowFocusAsync(DataGridRowFocusEventArgs args)
-    {
-        var rowId = args.RowId;
-        if (_internalGridContext.Rows.TryGetValue(rowId!, out var row))
-        {
-            if (row != null && row.RowType == DataGridRowType.Default)
-            {
-                await OnRowFocus.InvokeAsync(row);
-            }
-        }
     }
 
     public async Task OnKeyDownAsync(FluentKeyCodeEventArgs args)

--- a/src/Core/Components/DataGrid/FluentDataGridCell.razor
+++ b/src/Core/Components/DataGrid/FluentDataGridCell.razor
@@ -11,6 +11,7 @@
         tabindex="0"
         @onkeydown="@HandleOnCellKeyDownAsync"
         @onclick="@HandleOnCellClickAsync"
+        @onfocus="@HandleOnCellFocusAsync"
         @attributes="AdditionalAttributes">
         @ChildContent
     </td>
@@ -23,6 +24,7 @@ else
         @oncontextmenu:preventDefault="true"
         @onkeydown="@HandleOnCellKeyDownAsync"
         @onclick="@HandleOnCellClickAsync"
+        @onfocus="@HandleOnCellFocusAsync"
         @attributes="AdditionalAttributes">
         @ChildContent
     </th>

--- a/src/Core/Components/DataGrid/FluentDataGridCell.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGridCell.razor.cs
@@ -100,6 +100,14 @@ public partial class FluentDataGridCell<TGridItem> : FluentComponentBase
         }
     }
 
+    internal async Task HandleOnCellFocusAsync()
+    {
+        if (CellType == DataGridCellType.Default)
+        {
+            await Grid.OnCellFocus.InvokeAsync(this);
+        }
+    }
+
     internal async Task HandleOnCellKeyDownAsync(KeyboardEventArgs e)
     {
         if (!SelectColumn<TGridItem>.KEYBOARD_SELECT_KEYS.Contains(e.Code))

--- a/src/Core/Components/DataGrid/FluentDataGridRow.razor
+++ b/src/Core/Components/DataGrid/FluentDataGridRow.razor
@@ -11,6 +11,7 @@
         @onkeydown="@(e => HandleOnRowKeyDownAsync(RowId, e))"
         @onclick="@(e => HandleOnRowClickAsync(RowId))"
         @ondblclick="@(e => HandleOnRowDoubleClickAsync(RowId))"
+        @onfocus="@HandleOnRowFocusAsync"
         @attributes="AdditionalAttributes">
         @ChildContent
     </tr>

--- a/src/Core/Components/DataGrid/FluentDataGridRow.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGridRow.razor.cs
@@ -93,15 +93,11 @@ public partial class FluentDataGridRow<TGridItem> : FluentComponentBase, IHandle
         cells.Remove(cell.CellId!);
     }
 
-    private async Task HandleOnCellFocusAsync(DataGridCellFocusEventArgs args)
+    internal async Task HandleOnRowFocusAsync()
     {
-        var cellId = args.CellId;
-        if (cells.TryGetValue(cellId!, out var cell))
+        if (Grid.OnRowFocus.HasDelegate)
         {
-            if (cell != null && cell.CellType == DataGridCellType.Default)
-            {
-                await Grid.OnCellFocus.InvokeAsync(cell);
-            }
+            await Grid.OnRowFocus.InvokeAsync(this);
         }
     }
 


### PR DESCRIPTION
With the change to html table rendering, the DataGrid lost the `OnRowFocus` and `OnCellFocus` event callbacks. This PR restores them. (We added `OnRowClick` and `OnCellClick` event callbacks btw)

There is however one issue: rows are now `tr` elements with a `display: contents;` style. Currently, browser do not support setting focus to such elements but work is underway to add this. See also https://chromestatus.com/feature/6237396851228672 for more information.

This fixes #3096 