### PR TITLE
[ListComponentsBase] Fix SelectedOptionsChanged being Invoked twice

### DIFF
--- a/src/Core/Components/List/ListComponentBase.razor.cs
+++ b/src/Core/Components/List/ListComponentBase.razor.cs
@@ -337,7 +337,7 @@ public abstract partial class ListComponentBase<TOption> : FluentInputBase<strin
             }
         }
 
-        if (Value is not null && (InternalValue is null || InternalValue != Value))
+        if (!string.IsNullOrWhiteSpace(Value) && (InternalValue is null || InternalValue != Value))
         {
             InternalValue = Value;
         }


### PR DESCRIPTION
Fix #3111 

`InternalValue` was being set in `OnParametersSet` even when `Value` was an empty string. This led to the `RaiseChangedEventsAsync` event being invoked twice in.