### PR TITLE
[DataGrid] Always re-evaluate GridTemplateColumns after collecting columns

### DIFF
--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -490,7 +490,8 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
             throw new Exception("You can use either the 'GridTemplateColumns' parameter on the grid or the 'Width' property at the column level, not both.");
         }
 
-        if (string.IsNullOrWhiteSpace(_internalGridTemplateColumns))
+        // Always re-evaluate after collecting columns when using displaymode grid. A column might be added or hidden and the _internalGridTemplateColumns needs to reflect that.
+        if (DisplayMode == DataGridDisplayMode.Grid)
         {
             if (!AutoFit)
             {
@@ -501,7 +502,6 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
             {
                 _internalGridTemplateColumns = string.Join(" ", _columns.Select(x => x.Width ?? "auto"));
             }
-
         }
 
         if (ResizableColumns)


### PR DESCRIPTION
Fix #3178

The value of GridTemplateColumns was only being set if it had not been set before. This PR fixes that and always re-evaluates that value after collecting columns when using displaymode grid. This means it now correctly responds to hiding or showing columns.
![fix-issue-#3178](https://github.com/user-attachments/assets/3a8746df-dbfb-473a-92e7-28ef1a3b1ff7)
