### PR TITLE
[Lists] Add `ChangeOnEnterOnly` parameter to allow option focus change without selection

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -6226,6 +6226,12 @@
             ⚠️ Only available when Multiple = true.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.ListComponentBase`1.ChangeOnEnterOnly">
+            <summary>
+            Gets or sets whether using the up and down arrow keys should change focus and select immediately or that selection is done only on Enter.
+            ⚠️ Only applicable in single select scenarios.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.ListComponentBase`1.SelectedOptionsChanged">
             <summary>
             Called whenever the selection changed.

--- a/src/Core/Components/List/ListComponentBase.razor.cs
+++ b/src/Core/Components/List/ListComponentBase.razor.cs
@@ -168,6 +168,13 @@ public abstract partial class ListComponentBase<TOption> : FluentInputBase<strin
     public virtual IEnumerable<TOption>? SelectedOptions { get; set; }
 
     /// <summary>
+    /// Gets or sets whether using the up and down arrow keys should change focus and select immediately or that selection is done only on Enter.
+    /// ⚠️ Only applicable in single select scenarios.
+    /// </summary>
+    [Parameter]
+    public virtual bool ChangeOnEnterOnly { get; set; } = false;
+
+    /// <summary>
     /// Called whenever the selection changed.
     /// ⚠️ Only available when Multiple = true.
     /// </summary>
@@ -574,7 +581,11 @@ public abstract partial class ListComponentBase<TOption> : FluentInputBase<strin
 
         var item = _internalListContext.Options.FirstOrDefault(i => i.Id == id);
 
-        if (item is not null)
+        if (item is null)
+        {
+            return;
+        }
+        if (!ChangeOnEnterOnly || (ChangeOnEnterOnly && e.Code == "Enter"))
         {
             await item.OnClickHandlerAsync();
         }


### PR DESCRIPTION
Fix #3257 by adding `ChangeOnEnterOnly` parameter to list base class. This allows for the option having focus to change without immediately selecting the option.

Default value for the parameter is false so earlier behavior is not changed