### PR TITLE
[DataGrid] Small optimization to the number of times data needs to be refreshed

### DIFF
--- a/examples/Demo/Shared/Pages/DataGrid/Pages/DataGridAutoItemsPerPagePage.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/Pages/DataGridAutoItemsPerPagePage.razor
@@ -41,6 +41,7 @@
         }
 
         .demo-section-example {
+            min-height: 135px!important;
             height: 100%;
         }
 
@@ -74,6 +75,7 @@
     }
 
     .demo-section-example {
+        min-height: 135px !important;
         height: 100%;
     }
 

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -421,7 +421,7 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
             Pagination?.ItemsPerPage != _lastRefreshedPaginationState?.ItemsPerPage
             || Pagination?.CurrentPageIndex != _lastRefreshedPaginationState?.CurrentPageIndex;
 
-        var mustRefreshData = dataSourceHasChanged || paginationStateHasChanged || Loading is null;
+        var mustRefreshData = dataSourceHasChanged || paginationStateHasChanged || EffectiveLoadingValue;
 
         // We don't want to trigger the first data load until we've collected the initial set of columns,
         // because they might perform some action like setting the default sort order, so it would be wasteful


### PR DESCRIPTION
Fix #3261 3261 by fine tunning a change that was made in PR #3064 which only took `ItemsProvider` into account

+ a small fix in a datagrid example
