### PR TITLE
[Tabs] Fix missing bold highlighting in Firefox #3276

### DIFF
--- a/src/Core/Components/Tabs/FluentTab.razor.css
+++ b/src/Core/Components/Tabs/FluentTab.razor.css
@@ -35,3 +35,7 @@ fluent-tab {
     ::deep .fluent-tab-close:hover {
         fill: var(--neutral-fill-strong-hover) !important;
     }
+
+::deep fluent-tab[aria-selected="true"] {
+    font-variation-settings: normal;
+}


### PR DESCRIPTION
# Pull Request

## 📖 Description
Fixes missing bold highlighting for the active tab in Mozilla Firefox.

Before:
![grafik](https://github.com/user-attachments/assets/a8469169-71a5-4d6c-be1e-0314d6100f2a)


After:
![grafik](https://github.com/user-attachments/assets/a6c624c4-7847-4512-9595-80d1cafb82f3)


### 🎫 Issues

Discussion: #3276


## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.


