### PR TITLE
[DataGrid] Remove padding for first column header

### DIFF
--- a/src/Core/Components/DataGrid/FluentDataGridCell.razor.css
+++ b/src/Core/Components/DataGrid/FluentDataGridCell.razor.css
@@ -49,10 +49,6 @@ td {
     padding: calc((var(--design-unit) + var(--focus-stroke-width) - var(--stroke-width)) * 1px) 1px calc((var(--design-unit) + var(--focus-stroke-width) - var(--stroke-width)) * 1px);
 }
 
-.column-header:not(.select-all):first-of-type {
-    padding-inline-start: calc(var(--design-unit) * 2px);
-}
-
 ::deep .col-sort-button {
     width: calc(100% - 20px);
     overflow: hidden;


### PR DESCRIPTION
Fix #3273 by removing padding for first column in css. See the issue for explanation.