### PR TITLE
[Lists] Trigger field changed when in multiple mode

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -6209,6 +6209,12 @@
             ⚠️ Only available when Multiple = false.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.ListComponentBase`1.SelectedOptionExpression">
+            <summary>
+            Gets or sets an expression that identifies the bound selected options.
+            ⚠️ Only available when Multiple = false.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.ListComponentBase`1.Multiple">
             <summary>
             If true, the user can select multiple elements.
@@ -6235,6 +6241,12 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.ListComponentBase`1.SelectedOptionsChanged">
             <summary>
             Called whenever the selection changed.
+            ⚠️ Only available when Multiple = true.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.ListComponentBase`1.SelectedOptionsExpression">
+            <summary>
+            Gets or sets an expression that identifies the bound selected options.
             ⚠️ Only available when Multiple = true.
             </summary>
         </member>

--- a/examples/Demo/Shared/Pages/List/Autocomplete/AutocompletePage.razor
+++ b/examples/Demo/Shared/Pages/List/Autocomplete/AutocompletePage.razor
@@ -6,12 +6,6 @@
 
 <h1>Autocomplete</h1>
 
-<blockquote>
-    @(new MarkupString(DemoNavProvider.EditFormOffIcon))
-    The <b>FluentAutocomplete</b> component is not yet fully compatible with the <code>EditForm</code> and <code>FluentEditForm</code> elements.
-    Some functionalities, such as error messages, the requirement message or the validation messages are missing.
-</blockquote>
-
 <h2 id="example">Examples</h2>
 
 <DemoSection Title="Default" Component="@typeof(AutocompleteDefault)" />

--- a/examples/Demo/Shared/SampleData/Starship.cs
+++ b/examples/Demo/Shared/SampleData/Starship.cs
@@ -20,6 +20,7 @@ public class Starship
     public string? Description { get; set; }
 
     [Required(ErrorMessage = "Countries are required")]
+    [MinLength(1, ErrorMessage = "Countries are required")]
     public IEnumerable<Country>? Countries { get; set; }
 
     [Required(ErrorMessage = "A classification is required")]

--- a/src/Core/Components/List/ListComponentBase.razor.cs
+++ b/src/Core/Components/List/ListComponentBase.razor.cs
@@ -527,19 +527,8 @@ public abstract partial class ListComponentBase<TOption> : FluentInputBase<strin
         {
             if (!Equals(item, SelectedOption))
             {
-                var value = GetOptionValue(item);
-
-                if (this is FluentListbox<TOption> ||
-                    this is FluentCombobox<TOption> ||
-                    (this is FluentSelect<TOption> && Value is null))
-                {
-                    await base.ChangeHandlerAsync(new ChangeEventArgs() { Value = value });
-                }
-
                 SelectedOption = item;
-
-                //InternalValue = Value = value;
-                InternalValue = value;
+                InternalValue = GetOptionValue(item);
                 await RaiseChangedEventsAsync();
             }
         }
@@ -562,6 +551,8 @@ public abstract partial class ListComponentBase<TOption> : FluentInputBase<strin
                 await SelectedOptionChanged.InvokeAsync(SelectedOption);
             }
         }
+
+        await base.ChangeHandlerAsync(new ChangeEventArgs() { Value = InternalValue });
     }
 
     protected virtual async Task OnKeydownHandlerAsync(KeyboardEventArgs e)

--- a/src/Core/Components/List/ListComponentBase.razor.cs
+++ b/src/Core/Components/List/ListComponentBase.razor.cs
@@ -3,6 +3,7 @@
 // ------------------------------------------------------------------------
 
 using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.Web;
@@ -36,7 +37,7 @@ public abstract partial class ListComponentBase<TOption> : FluentInputBase<strin
 
     // We cascade the _internalListContext to descendants, which in turn call it to add themselves to the options list
     internal InternalListContext<TOption> _internalListContext;
-    internal override bool FieldBound => Field is not null || ValueExpression is not null || ValueChanged.HasDelegate || SelectedOptionChanged.HasDelegate || SelectedOptionsChanged.HasDelegate;
+    internal override bool FieldBound => Field is not null || ValueExpression is not null || ValueChanged.HasDelegate || SelectedOptionChanged.HasDelegate || SelectedOptionExpression is not null || SelectedOptionsChanged.HasDelegate || SelectedOptionsExpression is not null;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -148,6 +149,13 @@ public abstract partial class ListComponentBase<TOption> : FluentInputBase<strin
     public virtual EventCallback<TOption?> SelectedOptionChanged { get; set; }
 
     /// <summary>
+    /// Gets or sets an expression that identifies the bound selected options.
+    /// ⚠️ Only available when Multiple = false.
+    /// </summary>
+    [Parameter]
+    public Expression<Func<TOption>>? SelectedOptionExpression { get; set; }
+
+    /// <summary>
     /// If true, the user can select multiple elements.
     /// ⚠️ Only available for the FluentSelect and FluentListbox components.
     /// </summary>
@@ -180,6 +188,13 @@ public abstract partial class ListComponentBase<TOption> : FluentInputBase<strin
     /// </summary>
     [Parameter]
     public virtual EventCallback<IEnumerable<TOption>?> SelectedOptionsChanged { get; set; }
+
+    /// <summary>
+    /// Gets or sets an expression that identifies the bound selected options.
+    /// ⚠️ Only available when Multiple = true.
+    /// </summary>
+    [Parameter]
+    public Expression<Func<IEnumerable<TOption>>>? SelectedOptionsExpression { get; set; }
 
     /// <summary />
     public ListComponentBase()
@@ -293,11 +308,19 @@ public abstract partial class ListComponentBase<TOption> : FluentInputBase<strin
 
         if (!_hasInitializedParameters)
         {
-            if (SelectedOptionChanged.HasDelegate)
+            if (SelectedOptionExpression is not null)
+            {
+                FieldIdentifier = FieldIdentifier.Create(SelectedOptionExpression);
+            }
+            else if (SelectedOptionChanged.HasDelegate)
             {
                 FieldIdentifier = FieldIdentifier.Create(() => SelectedOption);
             }
-            if (SelectedOptionsChanged.HasDelegate)
+            else if (SelectedOptionsExpression is not null)
+            {
+                FieldIdentifier = FieldIdentifier.Create(SelectedOptionsExpression);
+            }
+            else if (SelectedOptionsChanged.HasDelegate)
             {
                 FieldIdentifier = FieldIdentifier.Create(() => SelectedOptions);
             }


### PR DESCRIPTION
# Pull Request

## 📖 Description

autocomplete doesnt trigger the fieldchanged as the default ChangeHandler, which handles the validation/fieldchanged event of the editform, this was fixed by always triggering the event on selection changes for both single and multiple mode.

i also noticed that the list base didnt implement the binding expression property, so the fieldidentifier was always wrong.

### 🎫 Issues
Fix #3115 

## 👩‍💻 Reviewer Notes

this was tested using the form page from the demo project. i am currently going through the tests to check out if i missed anything

## 📑 Test Plan

none, i dont see how to put this in a test without adding a binding the bunit test and rendering a validator at the same time. not sure if its worth it?

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps
N/A