### PR TITLE
[Calendar] Add DisabledCheckAllDaysOfMonthYear

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -2731,6 +2731,14 @@
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentCalendar.OnSelectDayMouseOverAsync(System.DateTime,System.Boolean)">
             <summary />
         </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentCalendar.AllDaysAreDisabled(System.DateTime,System.DateTime)">
+            <summary>
+            Check if all days between two dates are disabled.
+            </summary>
+            <param name="start"></param>
+            <param name="end"></param>
+            <returns></returns>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentCalendarBase.Culture">
             <summary>
             Gets or sets the culture of the component.
@@ -2740,6 +2748,12 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentCalendarBase.DisabledDateFunc">
             <summary>
             Function to know if a specific day must be disabled.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentCalendarBase.DisabledCheckAllDaysOfMonthYear">
+            <summary>
+            By default, the <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentCalendarBase.DisabledDateFunc" /> check only the first day of the month and the first day of the year for the Month and Year views.
+            Set this property to `true` to check if all days of the month and year are disabled (more time consuming).
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentCalendarBase.DisabledSelectable">
@@ -14595,6 +14609,14 @@
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.Extensions.DateTimeExtensions.StartOfYear(System.DateTime,System.Globalization.CultureInfo)">
             <summary>
             Returns the first day of the year
+            </summary>
+            <param name="self"></param>
+            <param name="culture"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.Extensions.DateTimeExtensions.EndOfYear(System.DateTime,System.Globalization.CultureInfo)">
+            <summary>
+            Returns the last day of the year.
             </summary>
             <param name="self"></param>
             <param name="culture"></param>

--- a/src/Core/Components/DateTime/FluentCalendar.razor
+++ b/src/Core/Components/DateTime/FluentCalendar.razor
@@ -163,6 +163,7 @@
                         Culture="@Culture"
                         DisabledSelectable="@DisabledSelectable"
                         AnimatePeriodChanges="@AnimatePeriodChanges"
+                        DisabledCheckAllDaysOfMonthYear="@DisabledCheckAllDaysOfMonthYear"
                         DisabledDateFunc="@(e => DisabledDateFunc != null ? DisabledDateFunc(e) : false)" />
     }
 
@@ -177,6 +178,7 @@
                         Culture="@Culture"
                         DisabledSelectable="@DisabledSelectable"
                         AnimatePeriodChanges="@AnimatePeriodChanges"
+                        DisabledCheckAllDaysOfMonthYear="@DisabledCheckAllDaysOfMonthYear"
                         DisabledDateFunc="@(e => DisabledDateFunc != null ? DisabledDateFunc(e) : false)" />
     }
 

--- a/src/Core/Components/DateTime/FluentCalendar.razor.cs
+++ b/src/Core/Components/DateTime/FluentCalendar.razor.cs
@@ -445,4 +445,28 @@ public partial class FluentCalendar : FluentCalendarBase
 
         return Task.CompletedTask;
     }
+
+    /// <summary>
+    /// Check if all days between two dates are disabled.
+    /// </summary>
+    /// <param name="start"></param>
+    /// <param name="end"></param>
+    /// <returns></returns>
+    internal bool AllDaysAreDisabled(DateTime start, DateTime end)
+    {
+        if (DisabledDateFunc is null)
+        {
+            return false;
+        }
+
+        for (var day = start; day <= end; day = day.AddDays(1))
+        {
+            if (!DisabledDateFunc.Invoke(day))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/src/Core/Components/DateTime/FluentCalendarBase.cs
+++ b/src/Core/Components/DateTime/FluentCalendarBase.cs
@@ -19,6 +19,13 @@ public abstract class FluentCalendarBase : FluentInputBase<DateTime?>
     public virtual Func<DateTime, bool>? DisabledDateFunc { get; set; }
 
     /// <summary>
+    /// By default, the <see cref="DisabledDateFunc" /> check only the first day of the month and the first day of the year for the Month and Year views.
+    /// Set this property to `true` to check if all days of the month and year are disabled (more time consuming).
+    /// </summary>
+    [Parameter]
+    public virtual bool DisabledCheckAllDaysOfMonthYear { get; set; }
+
+    /// <summary>
     /// Apply the disabled style to the <see cref="DisabledDateFunc"/> days.
     /// If this is not the case, the days are displayed like the others, but cannot be selected.
     /// </summary>

--- a/src/Core/Components/DateTime/FluentCalendarMonth.cs
+++ b/src/Core/Components/DateTime/FluentCalendarMonth.cs
@@ -20,7 +20,14 @@ internal class FluentCalendarMonth
         _calendar = calendar;
         Month = month.GetDay(_calendar.Culture) == 1 ? month : month.StartOfMonth(_calendar.Culture);
 
-        _isInDisabledList = calendar.DisabledDateFunc?.Invoke(Month) ?? false;
+        if (calendar.DisabledCheckAllDaysOfMonthYear)
+        {
+            _isInDisabledList = calendar.AllDaysAreDisabled(month.StartOfMonth(_calendar.Culture), month.EndOfMonth(_calendar.Culture));
+        }
+        else
+        {
+            _isInDisabledList = calendar.DisabledDateFunc?.Invoke(Month) ?? false;
+        }
     }
 
     /// <summary>

--- a/src/Core/Components/DateTime/FluentCalendarYear.cs
+++ b/src/Core/Components/DateTime/FluentCalendarYear.cs
@@ -20,7 +20,14 @@ internal class FluentCalendarYear
         _calendar = calendar;
         Year = year.GetDay(_calendar.Culture) == 1 && year.GetMonth(_calendar.Culture) == 1 ? year : year.StartOfYear(_calendar.Culture);
 
-        _isInDisabledList = calendar.DisabledDateFunc?.Invoke(Year) ?? false;
+        if (calendar.DisabledCheckAllDaysOfMonthYear)
+        {
+            _isInDisabledList = calendar.AllDaysAreDisabled(year.StartOfYear(_calendar.Culture), year.EndOfYear(_calendar.Culture));
+        }
+        else
+        {
+            _isInDisabledList = calendar.DisabledDateFunc?.Invoke(Year) ?? false;
+        }
     }
 
     /// <summary>

--- a/src/Core/Components/DateTime/FluentDatePicker.razor
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor
@@ -37,6 +37,7 @@
                         View="@View"
                         DayFormat="@DayFormat"
                         DisabledDateFunc="@DisabledDateFunc"
+                        DisabledCheckAllDaysOfMonthYear="@DisabledCheckAllDaysOfMonthYear"
                         DisabledSelectable="@DisabledSelectable"
                         Value="@Value"
                         ValueChanged="@OnSelectedDateAsync"

--- a/src/Core/Extensions/DateTimeExtensions.cs
+++ b/src/Core/Extensions/DateTimeExtensions.cs
@@ -48,6 +48,17 @@ public static class DateTimeExtensions
     }
 
     /// <summary>
+    /// Returns the last day of the year.
+    /// </summary>
+    /// <param name="self"></param>
+    /// <param name="culture"></param>
+    /// <returns></returns>
+    public static DateTime EndOfYear(this DateTime self, CultureInfo culture)
+    {
+        return self.StartOfYear(culture).AddYears(1, culture).AddDays(-1, culture);
+    }
+
+    /// <summary>
     /// Returns the last day of the month.
     /// </summary>
     /// <param name="self"></param>


### PR DESCRIPTION
# [Calendar] Add DisabledCheckAllDaysOfMonthYear

By default, the `FluentCalendar` and `FluentDateTime` components have a `DisabledDateFunc` attribute which is called with the **day** (Day view) or the **first day** of the month (Month) or the **first day** of the year (Year view).

A new `DisabledCheckAllDaysOfMonthYear` option asks the calendar to check whether **ALL the days** of the month or year are disabled, in order to grey out the month or year.
This parameter forces the component to execute the `DisabledDateFunc` method 31 times or 365 times, which can be costly in terms of performance. The default setting is therefore `DisabledCheckAllDaysOfMonthYear = False`.

See #3348

## Unit Tests

Validated