### PR TITLE
[Autocomplete] Fix the second unnecessary call

### DIFF
--- a/src/Core/Components/List/FluentAutocomplete.razor.cs
+++ b/src/Core/Components/List/FluentAutocomplete.razor.cs
@@ -430,14 +430,15 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
             }
 
             // Remove last char
-            if (!string.IsNullOrEmpty(ValueText))
-            {
-                await InputHandlerAsync(new ChangeEventArgs()
-                {
-                    Value = ValueText[..^1],
-                });
-                return;
-            }
+            // -> Commented to fix #3359
+            // if (!string.IsNullOrEmpty(ValueText))
+            // {
+            //     await InputHandlerAsync(new ChangeEventArgs()
+            //     {
+            //         Value = ValueText[..^1],
+            //     });
+            //     return;
+            // }
         }
 
         // ArrowUp


### PR DESCRIPTION
# [Autocomplete] Fix the second unnecessary call

> When using backspace within the FluentAutocomplete component the method bound to OnOptionsSearch will be executed twice.

This PR fixes this issue.