### PR TITLE
[Select] Fix positioning when multiple is true

### DIFF
--- a/examples/Demo/Shared/Pages/List/Select/Examples/SelectMultipleWithFunctions.razor
+++ b/examples/Demo/Shared/Pages/List/Select/Examples/SelectMultipleWithFunctions.razor
@@ -3,7 +3,7 @@
 <p>All people whose first name starts with a "J" are initialy selected through the <code>OptionSelected</code> (Func delegate) parameter.</p>
 <p>All people with a birth year greater than 1990 are disabled through the <code>OptionDisabled</code> (Func delegate) parameter.</p>
 
-<div style="display: block; height: 300px;">
+
     <FluentSelect TOption="Person"
                   Label="Select persons"
                   Items="@Data.People"
@@ -15,7 +15,7 @@
                   OptionSelected="@(p => p.FirstName.StartsWith("J"))"
                   @bind-Value="@SelectedValue"
                   @bind-SelectedOptions="@SelectedOptions" />
-</div>
+
 
 <p>
     Selected value: @SelectedValue <br />

--- a/src/Core/Components/List/FluentSelect.razor.cs
+++ b/src/Core/Components/List/FluentSelect.razor.cs
@@ -1,3 +1,7 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components.Utilities;
 
@@ -13,6 +17,7 @@ public partial class FluentSelect<TOption> : ListComponentBase<TOption> where TO
 
     /// <summary />
     protected virtual MarkupString InlineStyleValue => new InlineStyleBuilder()
+        .AddStyle($"#{Id}::part(listbox)", "position", "relative", Multiple)
         .AddStyle($"#{Id}::part(listbox)", "max-height", Height, !string.IsNullOrWhiteSpace(Height))
         .AddStyle($"#{Id}::part(listbox)", "height", "fit-content", !string.IsNullOrWhiteSpace(Height))
         .AddStyle($"#{Id}::part(listbox)", "z-index", ZIndex.SelectPopup.ToString())


### PR DESCRIPTION
Fix #3379 

Now, when `Multiple="true"` the generated inline style will correctly set the position to `relative` for the `.listbox` part.

![image](https://github.com/user-attachments/assets/d15073f0-bb04-4988-a130-d87db783b5c0)
