### PR TITLE
[dev-v5] Add FluentAvatar component

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Avatar/Examples/FluentAvatarActive.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Avatar/Examples/FluentAvatarActive.razor
@@ -1,0 +1,29 @@
+﻿@using System.Linq;
+
+<FluentStack HorizontalGap="12px"
+             Style="margin-bottom:15px;"
+             VerticalAlignment="VerticalAlignment.Bottom"
+             Orientation="Orientation.Horizontal">
+
+    <FluentSelect Label="Active"
+                  Items="@activeModes"
+                  @bind-Value="@active" />
+
+    <FluentSelect Label="Active appearance"
+                  Items="@(Enum.GetValues<AvatarActiveAppearance>())"
+                  @bind-Value="@activeAppearance" />
+</FluentStack>
+
+<FluentAvatar Active="@active"
+              ActiveAppearance="@activeAppearance" />
+
+@code
+{
+    List<bool?> activeModes = new List<bool?> {
+        null,
+        true,
+        false
+    };
+    bool? active;
+    AvatarActiveAppearance activeAppearance = AvatarActiveAppearance.Ring;
+}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Avatar/Examples/FluentAvatarColorful.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Avatar/Examples/FluentAvatarColorful.razor
@@ -1,0 +1,14 @@
+﻿<FluentStack Orientation="Orientation.Horizontal" HorizontalGap="12px">
+
+    <FluentAvatar Color="AvatarColor.Colorful" name="Katri Athokas" />
+    <FluentAvatar Color="AvatarColor.Colorful" name="Elvia Atkins" />
+    <FluentAvatar Color="AvatarColor.Colorful" name="Cameron Evans" />
+    <FluentAvatar Color="AvatarColor.Colorful" name="Wanda Howard" />
+    <FluentAvatar Color="AvatarColor.Colorful" name="Mona Kane" />
+    <FluentAvatar Color="AvatarColor.Colorful" name="Allan Munger" />
+    <FluentAvatar Color="AvatarColor.Colorful" name="Daisy Phillips" />
+    <FluentAvatar Color="AvatarColor.Colorful" name="Robert Tolbert" />
+    <FluentAvatar Color="AvatarColor.Colorful" name="Kevin Sturgis" />
+    <FluentAvatar Color="AvatarColor.Colorful" name="Elliot Woodward" />
+
+</FluentStack>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Avatar/Examples/FluentAvatarDefault.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Avatar/Examples/FluentAvatarDefault.razor
@@ -1,0 +1,1 @@
+﻿<FluentAvatar  />

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Avatar/Examples/FluentAvatarExample.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Avatar/Examples/FluentAvatarExample.razor
@@ -1,0 +1,30 @@
+﻿@using System.Linq;
+
+<FluentStack HorizontalGap="12px"
+             Style="margin-bottom:15px;"
+             VerticalAlignment="VerticalAlignment.Bottom"
+             Orientation="Orientation.Horizontal">
+
+    <FluentSelect Label="Color"
+                  Items="@(Enum.GetValues<AvatarColor>())"
+                  @bind-Value="@color" />
+
+    <FluentSelect Label="Shape"
+                  Items="@(Enum.GetValues<AvatarShape>())"
+                  @bind-Value="@shape" />
+
+    <FluentSelect Label="Size"
+                  Items="@(Enum.GetValues<AvatarSize>())"
+                  @bind-Value="@size" />
+</FluentStack>
+
+<FluentAvatar Color="@color"
+              Shape="@shape"
+              Size="@size" />
+
+@code
+{
+    AvatarColor color = AvatarColor.Neutral;
+    AvatarShape shape = AvatarShape.Circle;
+    AvatarSize size = AvatarSize.Size32;
+}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Avatar/Examples/FluentAvatarIcon.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Avatar/Examples/FluentAvatarIcon.razor
@@ -1,0 +1,1 @@
+﻿<FluentAvatar Icon="@(new Icons.Regular.Size32.Guest())"  />

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Avatar/Examples/FluentAvatarImage.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Avatar/Examples/FluentAvatarImage.razor
@@ -1,0 +1,1 @@
+﻿<FluentAvatar Image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/KatriAthokas.jpg" Name="" />

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Avatar/Examples/FluentAvatarName.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Avatar/Examples/FluentAvatarName.razor
@@ -1,0 +1,20 @@
+﻿
+<FluentStack HorizontalGap="12px"
+             Style="margin-bottom:15px;"
+             VerticalAlignment="VerticalAlignment.Bottom"
+             Orientation="Orientation.Horizontal">
+
+    <FluentTextInput Label="Name" @bind-Value="@name" />
+
+    <FluentTextInput Label="Initials" @bind-Value="@initials" />
+
+</FluentStack>
+
+<FluentAvatar Initials="@initials"
+              Name="@name" />
+
+@code
+{
+    string? name = "John Doe";
+    string? initials = null;
+}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Avatar/FluentAvatar.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Avatar/FluentAvatar.md
@@ -1,0 +1,76 @@
+---
+title: Avatar
+route: /Avatar
+---
+
+# Avatar 
+
+The `Avatar` component is used to represent a user or entity. It can display an image, initials, or an icon.
+
+The component is a wrapper for the <fluentui-avatar/> web component.
+
+View the [Usage Guidance](https://fluent2.microsoft.design/components/web/react/avatar/usage).
+
+## Appearance
+
+The Avatar component can be displayed in various predefined sizes (from 16px to 128px). It can be circular or square and filled with a color chosen by the component (`colorful`) or by the developer from a list of 32 colors adapted to the theme of the application.
+
+> If you want to specify your own colors (this is not recommended), you can use the CSS styles: `color: white; background-color: red;`.
+
+{{ FluentAvatarExample }}
+
+### Activity state
+
+By default, without any value of the `Active` property, the `FluentAvatar` component is displayed normally.
+
+You can set the `Active` property to `true`, the avatar will be decorated according to `ActiveAppearance` property.
+The `ActiveAppearance` property allows you to choose how to render this state: `Ring` (default), `Shadow` or both.
+
+The value can be set to `false`, the `FluentAvatar` will be displayed as inactive. The component will be reduced in size and partially transparent
+
+{{ FluentAvatarActive }}
+
+### Colorful
+
+You can set the value `AvatarColor.Colorful` to the parameter `Color` to display a colorful background for the `Avatar` .
+It picks a color from a set of pre-defined colors, based on a hash of the `Name`.
+
+{{ FluentAvatarColorful }}
+
+## Contents
+
+By default, the `Avatar` component will display an icon.
+
+{{ FluentAvatarDefault }}
+
+### Name and initials
+
+You can provide a `Name` parameter to display initials. The `Name` parameter will be used to generate the initials displayed in the `FluentAvatar`.
+
+You can override the initials calculated by providing an `Initials` property.
+
+{{ FluentAvatarName }}
+
+### Image
+
+You can provide an `image` URL in the `Image` attribute, to display an image in the `FluentAvatar`.
+
+Optional: you can set the `Name` property to alternative text for the image.
+
+{{ FluentAvatarImage }}
+
+### Content overriding
+
+The displayed content is following a priority order: `Image`, `Initials`, `Name`, `Icon`.
+
+> Best practice: when you provide an `Image` prop, you should also provide an `Initials` parameter to display the initials in case the image is not available or is loading.
+
+### Default icon
+
+You can provide an `Icon` to replace the default icon in the `FluentAvatar` when the `Initials`, `Image` or `Name` is not provided.
+
+{{ FluentAvatarIcon }}
+
+## API FluentButton
+
+{{ API Type=FluentAvatar }}

--- a/spelling.dic
+++ b/spelling.dic
@@ -17,3 +17,4 @@ tabindex
 textarea
 sourcecode
 summarydata
+currentcolor

--- a/src/Core/Components/Avatar/FluentAvatar.razor
+++ b/src/Core/Components/Avatar/FluentAvatar.razor
@@ -1,0 +1,35 @@
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Rendering;
+@using Microsoft.FluentUI.AspNetCore.Components.Extensions
+@inherits FluentComponentBase
+
+<fluent-avatar id="@Id"
+               role="@GetRoleValue"
+               tabindex="@GetTabIndexValue"
+               class="@ClassValue"
+               style="@StyleValue"
+               active="@GetActiveValue"
+               appearance="@ActiveAppearance.ToAttributeValue()"
+               color="@Color.ToAttributeValue()"
+               initials="@GetInitialsValue"
+               name="@GetNameValue"
+               shape="@Shape.ToAttributeValue()"
+               size="@Size.ToAttributeValue()"
+               @onclick="@OnClickHandlerAsync"
+               @onkeydown="@OnKeyDownHandlerAsync"
+               @attributes="AdditionalAttributes">
+
+    @if (DisplayImage)
+    {
+        <img alt="@Name"
+             role="presentation"
+             aria-hidden="true"
+             src="@Image" />
+    }
+
+    @if (DisplayIcon && Icon is not null)
+    {
+        @Icon.ToMarkup(size: GetAvatarSize, color: "currentcolor", backgroundColor: "unset")
+    }
+
+</fluent-avatar>

--- a/src/Core/Components/Avatar/FluentAvatar.razor.cs
+++ b/src/Core/Components/Avatar/FluentAvatar.razor.cs
@@ -1,0 +1,141 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// The FluentButton component allows users to commit a change or trigger an action via a single click or tap and is often found inside forms, dialogs, drawers (panels) and/or pages.
+/// </summary>
+public partial class FluentAvatar : FluentComponentBase
+{
+    /// <summary />
+    protected string? ClassValue => DefaultClassBuilder.Build();
+
+    /// <summary />
+    protected string? StyleValue => DefaultStyleBuilder
+        .AddStyle("cursor", "pointer", when: OnClick.HasDelegate)
+        .Build();
+
+    /// <summary>
+    /// Gets or sets activity indicator
+    /// </summary>
+    [Parameter]
+    public bool? Active { get; set; }
+
+    /// <summary>
+    /// Gets or sets the styled appearance of the avatar when the avatar is "active".
+    /// </summary>
+    [Parameter]
+    public AvatarActiveAppearance? ActiveAppearance { get; set; }
+
+    /// <summary>
+    /// Gets or sets the color of the avatar.
+    /// </summary>
+    [Parameter]
+    public AvatarColor? Color { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default icon. The icon will only be shown when there is no image or initials available.
+    /// </summary> 
+    [Parameter]
+    public Icon? Icon { get; set; }
+
+    /// <summary>
+    /// Gets or sets an avatar can display an image.
+    /// </summary>
+    [Parameter]
+    public string? Image { get; set; }
+
+    /// <summary>
+    /// Gets or sets custom initials rather than one generated via the name
+    /// </summary>
+    [Parameter]
+    public string? Initials { get; set; }
+
+    /// <summary>
+    /// The name of the person or entity represented by this Avatar. This should always be provided if it is available.
+    /// The name is used to determine the initials displayed when there is no image.It is also provided to accessibility tools.
+    /// </summary>
+    [Parameter]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the shape of the avatar.
+    /// </summary>
+    [Parameter]
+    public AvatarShape? Shape { get; set; }
+
+    /// <summary>
+    /// Gets or sets size of the avatar.
+    /// </summary>
+    [Parameter]
+    public AvatarSize? Size { get; set; }
+
+    /// <summary>
+    /// Gets or sets a command executed when the user clicks on the button.
+    /// </summary>
+    [Parameter]
+    public EventCallback<MouseEventArgs> OnClick { get; set; }
+
+    /// <summary />
+    protected async Task OnClickHandlerAsync(MouseEventArgs e)
+    {
+        if (OnClick.HasDelegate)
+        {
+            await OnClick.InvokeAsync(e);
+        }
+    }
+
+    /// <summary />
+    protected async Task OnKeyDownHandlerAsync(KeyboardEventArgs e)
+    {
+        if (string.Equals(e.Code, "Enter", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(e.Code, "Space", StringComparison.OrdinalIgnoreCase))
+        {
+            await OnClickHandlerAsync(new MouseEventArgs());
+        }
+    }
+
+    private string? GetInitialsValue =>
+        string.IsNullOrEmpty(Initials)
+        ? null
+        : Initials;
+
+    private string? GetNameValue =>
+        string.IsNullOrEmpty(Name)
+        ? null
+        : Name;
+
+    private bool DisplayIcon =>
+        Icon is not null
+        && string.IsNullOrEmpty(Name)
+        && string.IsNullOrEmpty(Initials);
+
+    private bool DisplayImage => !string.IsNullOrEmpty(Image);
+
+    private string GetAvatarSize =>
+        Size is not null
+        ? $"{(int)Size}px"
+        : "32px"; // Default component size
+
+    private string? GetActiveValue =>
+        Active.HasValue
+        ? Active.Value
+            ? "active"
+            : "inactive"
+        : null;
+
+    private string? GetRoleValue =>
+        OnClick.HasDelegate
+        ? "button"
+        : null;
+
+    private int? GetTabIndexValue =>
+        OnClick.HasDelegate && (!AdditionalAttributes?.ContainsKey("tabindex") ?? true)
+        ? 0
+        : null;
+}

--- a/src/Core/Components/Icons/Icon.cs
+++ b/src/Core/Components/Icons/Icon.cs
@@ -93,14 +93,15 @@ public class Icon : IconInfo
     /// <summary>
     /// Gets the HTML markup of the icon.
     /// </summary>
-    public virtual MarkupString ToMarkup(string? size = null, string? color = null)
+    public virtual MarkupString ToMarkup(string? size = null, string? color = null, string? backgroundColor = null)
     {
         if (Size != IconSize.Custom && ContainsSVG)
         {
             var sizeAsString = ((int)Size).ToString(CultureInfo.InvariantCulture);
             var styleWidth = size ?? $"{sizeAsString}px";
             var styleColor = color ?? Color ?? Components.Color.Primary.ToAttributeValue();
-            return new MarkupString($"<svg viewBox=\"0 0 {sizeAsString} {sizeAsString}\" width=\"{styleWidth}\" fill=\"{styleColor}\" style=\"background-color: var(--colorNeutralBackground1); width: {styleWidth};\" aria-hidden=\"true\">{Content}</svg>");
+            var styleBackgroundColor = backgroundColor ?? "var(--colorNeutralBackground1)";
+            return new MarkupString($"<svg viewBox=\"0 0 {sizeAsString} {sizeAsString}\" width=\"{styleWidth}\" fill=\"{styleColor}\" style=\"background-color: {styleBackgroundColor}; width: {styleWidth};\" aria-hidden=\"true\">{Content}</svg>");
         }
 
         if (string.IsNullOrEmpty(size) && string.IsNullOrEmpty(color))

--- a/src/Core/Enums/AvatarActiveAppearance.cs
+++ b/src/Core/Enums/AvatarActiveAppearance.cs
@@ -1,0 +1,32 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using System.ComponentModel;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// Indicates the styled appearance of the avatar when active is set to Active.
+/// </summary>
+public enum AvatarActiveAppearance
+{
+    /// <summary>
+    /// Default value, the avatar will be decorated with a ring.
+    /// </summary>
+    [Description("ring")]
+    Ring,
+
+    /// <summary>
+    /// The avatar will be decorated with a shadow.
+    /// </summary>
+    [Description("shadow")]
+    Shadow,
+
+    /// <summary>
+    /// The avatar will be decorated with a ring and shadow.
+    /// </summary>
+    [Description("ring-shadow")]
+    RingShadow,
+
+}

--- a/src/Core/Enums/AvatarColor.cs
+++ b/src/Core/Enums/AvatarColor.cs
@@ -1,0 +1,211 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using System.ComponentModel;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// Represents the color options for an avatar.
+/// </summary>
+public enum AvatarColor
+{
+    /// <summary>
+    /// Neutral color.
+    /// </summary>
+    [Description("neutral")]
+    Neutral,
+
+    /// <summary>
+    /// Colorful color.
+    /// </summary>
+    [Description("colorful")]
+    Colorful,
+
+    /// <summary>
+    /// Anchor color.
+    /// </summary>
+    [Description("anchor")]
+    Anchor,
+
+    /// <summary>
+    /// Beige color.
+    /// </summary>
+    [Description("beige")]
+    Beige,
+
+    /// <summary>
+    /// Blue color.
+    /// </summary>
+    [Description("blue")]
+    Blue,
+
+    /// <summary>
+    /// Brand color.
+    /// </summary>
+    [Description("brand")]
+    Brand,
+
+    /// <summary>
+    /// Brass color.
+    /// </summary>
+    [Description("brass")]
+    Brass,
+
+    /// <summary>
+    /// Brown color.
+    /// </summary>
+    [Description("brown")]
+    Brown,
+
+    /// <summary>
+    /// Cornflower color.
+    /// </summary>
+    [Description("cornflower")]
+    Cornflower,
+
+    /// <summary>
+    /// Cranberry color.
+    /// </summary>
+    [Description("cranberry")]
+    Cranberry,
+
+    /// <summary>
+    /// Dark green color.
+    /// </summary>
+    [Description("dark-green")]
+    DarkGreen,
+
+    /// <summary>
+    /// Dark red color.
+    /// </summary>
+    [Description("dark-red")]
+    DarkRed,
+
+    /// <summary>
+    /// Forest color.
+    /// </summary>
+    [Description("forest")]
+    Forest,
+
+    /// <summary>
+    /// Grape color.
+    /// </summary>
+    [Description("grape")]
+    Grape,
+
+    /// <summary>
+    /// Gold color.
+    /// </summary>
+    [Description("gold")]
+    Gold,
+
+    /// <summary>
+    /// Lavender color.
+    /// </summary>
+    [Description("lavender")]
+    Lavender,
+
+    /// <summary>
+    /// Light teal color.
+    /// </summary>
+    [Description("light-teal")]
+    LightTeal,
+
+    /// <summary>
+    /// Lilac color.
+    /// </summary>
+    [Description("lilac")]
+    Lilac,
+
+    /// <summary>
+    /// Magenta color.
+    /// </summary>
+    [Description("magenta")]
+    Magenta,
+
+    /// <summary>
+    /// Marigold color.
+    /// </summary>
+    [Description("marigold")]
+    Marigold,
+
+    /// <summary>
+    /// Mink color.
+    /// </summary>
+    [Description("mink")]
+    Mink,
+
+    /// <summary>
+    /// Navy color.
+    /// </summary>
+    [Description("navy")]
+    Navy,
+
+    /// <summary>
+    /// Peach color.
+    /// </summary>
+    [Description("peach")]
+    Peach,
+
+    /// <summary>
+    /// Pink color.
+    /// </summary>
+    [Description("pink")]
+    Pink,
+
+    /// <summary>
+    /// Platinum color.
+    /// </summary>
+    [Description("platinum")]
+    Platinum,
+
+    /// <summary>
+    /// Plum color.
+    /// </summary>
+    [Description("plum")]
+    Plum,
+
+    /// <summary>
+    /// Pumpkin color.
+    /// </summary>
+    [Description("pumpkin")]
+    Pumpkin,
+
+    /// <summary>
+    /// Purple color.
+    /// </summary>
+    [Description("purple")]
+    Purple,
+
+    /// <summary>
+    /// Red color.
+    /// </summary>
+    [Description("red")]
+    Red,
+
+    /// <summary>
+    /// Royal blue color.
+    /// </summary>
+    [Description("royal-blue")]
+    RoyalBlue,
+
+    /// <summary>
+    /// Seafoam color.
+    /// </summary>
+    [Description("seafoam")]
+    Seafoam,
+
+    /// <summary>
+    /// Steel color.
+    /// </summary>
+    [Description("steel")]
+    Steel,
+
+    /// <summary>
+    /// Teal color.
+    /// </summary>
+    [Description("teal")]
+    Teal
+}

--- a/src/Core/Enums/AvatarShape.cs
+++ b/src/Core/Enums/AvatarShape.cs
@@ -1,0 +1,24 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using System.ComponentModel;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// Indicates the shape of the avatar.
+/// </summary>
+public enum AvatarShape
+{
+    /// <summary>
+    /// The avatar is circular.
+    /// </summary>
+    [Description("circle")]
+    Circle,
+    /// <summary>
+    /// The avatar is square.
+    /// </summary>
+    [Description("square")]
+    Square,
+}

--- a/src/Core/Enums/AvatarSize.cs
+++ b/src/Core/Enums/AvatarSize.cs
@@ -1,0 +1,97 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using System.ComponentModel;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// Represents the size options for an avatar.
+/// </summary>
+public enum AvatarSize
+{
+    /// <summary>
+    /// Size 16.
+    /// </summary>
+    [Description("16")]
+    Size16 = 16,
+
+    /// <summary>
+    /// Size 20.
+    /// </summary>
+    [Description("20")]
+    Size20 = 20,
+
+    /// <summary>
+    /// Size 24.
+    /// </summary>
+    [Description("24")]
+    Size24 = 24,
+
+    /// <summary>
+    /// Size 28.
+    /// </summary>
+    [Description("28")]
+    Size28 = 28,
+
+    /// <summary>
+    /// Size 32.
+    /// </summary>
+    [Description("32")]
+    Size32 = 32,
+
+    /// <summary>
+    /// Size 36.
+    /// </summary>
+    [Description("36")]
+    Size36 = 36,
+
+    /// <summary>
+    /// Size 40.
+    /// </summary>
+    [Description("40")]
+    Size40 = 40,
+
+    /// <summary>
+    /// Size 48.
+    /// </summary>
+    [Description("48")]
+    Size48 = 48,
+
+    /// <summary>
+    /// Size 56.
+    /// </summary>
+    [Description("56")]
+    Size56 = 56,
+
+    /// <summary>
+    /// Size 64.
+    /// </summary>
+    [Description("64")]
+    Size64 = 64,
+
+    /// <summary>
+    /// Size 72.
+    /// </summary>
+    [Description("72")]
+    Size72 = 72,
+
+    /// <summary>
+    /// Size 96.
+    /// </summary>
+    [Description("96")]
+    Size96 = 96,
+
+    /// <summary>
+    /// Size 120.
+    /// </summary>
+    [Description("120")]
+    Size120 = 120,
+
+    /// <summary>
+    /// Size 128.
+    /// </summary>
+    [Description("128")]
+    Size128 = 128
+}

--- a/tests/Core/Components/Avatar/FluentAvatarTests.FluentAvatar_Default.verified.razor.html
+++ b/tests/Core/Components/Avatar/FluentAvatarTests.FluentAvatar_Default.verified.razor.html
@@ -1,0 +1,1 @@
+<fluent-avatar></fluent-avatar>

--- a/tests/Core/Components/Avatar/FluentAvatarTests.FluentAvatar_DefaultWithOnClick.verified.razor.html
+++ b/tests/Core/Components/Avatar/FluentAvatarTests.FluentAvatar_DefaultWithOnClick.verified.razor.html
@@ -1,0 +1,1 @@
+<fluent-avatar role="button" tabindex="0" style="cursor: pointer;"></fluent-avatar>

--- a/tests/Core/Components/Avatar/FluentAvatarTests.FluentAvatar_Icon.verified.razor.html
+++ b/tests/Core/Components/Avatar/FluentAvatarTests.FluentAvatar_Icon.verified.razor.html
@@ -1,0 +1,5 @@
+<fluent-avatar>
+    <svg viewBox="0 0 24 24" width="32px" fill="currentcolor" style="background-color: unset; width: 32px;" aria-hidden="true">
+        <path d="M12 2a10 10 0 1 1 0 20 10 10 0 0 1 0-20Zm0 8.25a1 1 0 0 0-1 .88v5.74a1 1 0 0 0 2 0v-5.62l-.01-.12a1 1 0 0 0-1-.88Zm0-3.75A1.25 1.25 0 1 0 12 9a1.25 1.25 0 0 0 0-2.5Z"></path>
+    </svg>
+</fluent-avatar>

--- a/tests/Core/Components/Avatar/FluentAvatarTests.FluentAvatar_Icon_WithSize.verified.razor.html
+++ b/tests/Core/Components/Avatar/FluentAvatarTests.FluentAvatar_Icon_WithSize.verified.razor.html
@@ -1,0 +1,5 @@
+<fluent-avatar size="96">
+    <svg viewBox="0 0 24 24" width="96px" fill="currentcolor" style="background-color: unset; width: 96px;" aria-hidden="true">
+        <path d="M12 2a10 10 0 1 1 0 20 10 10 0 0 1 0-20Zm0 8.25a1 1 0 0 0-1 .88v5.74a1 1 0 0 0 2 0v-5.62l-.01-.12a1 1 0 0 0-1-.88Zm0-3.75A1.25 1.25 0 1 0 12 9a1.25 1.25 0 0 0 0-2.5Z"></path>
+    </svg>
+</fluent-avatar>

--- a/tests/Core/Components/Avatar/FluentAvatarTests.razor
+++ b/tests/Core/Components/Avatar/FluentAvatarTests.razor
@@ -1,0 +1,276 @@
+﻿@using Microsoft.FluentUI.AspNetCore.Components;
+@using Microsoft.FluentUI.AspNetCore.Components.Tests.Extensions
+@using Microsoft.FluentUI.AspNetCore.Components.Utilities
+@using Xunit;
+@using static Microsoft.FluentUI.AspNetCore.Components.Tests.Samples.Icons;
+@inherits TestContext
+
+@code
+{
+    public FluentAvatarTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddFluentUIComponents();
+    }
+
+    [Fact]
+    public void FluentAvatar_Default()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentAvatar />);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentAvatar_DefaultWithOnClick()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentAvatar OnClick="@(e => {} )" />);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Theory]
+    [InlineData(true, "active")]
+    [InlineData(false, "inactive")]
+    [InlineData(null, "")]
+    public void FluentAvatar_Active(bool? active, string expectedValue)
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentAvatar Active="@active" />);
+
+        // Assert
+        var attribute = cut.Find("fluent-avatar").GetAttribute("active") ?? string.Empty;
+        Assert.Equal(expectedValue, attribute);
+    }
+
+    [Theory]
+    [InlineData(AvatarActiveAppearance.Shadow, "shadow")]
+    [InlineData(AvatarActiveAppearance.Ring, "ring")]
+    [InlineData(AvatarActiveAppearance.RingShadow, "ring-shadow")]
+    [InlineData((AvatarActiveAppearance)999, "")]
+    [InlineData(null, "")]
+    public void FluentAvatar_AvatarActiveAppearance(AvatarActiveAppearance? activeAppearance, string expectedValue)
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentAvatar ActiveAppearance="@activeAppearance" />);
+
+        // Assert
+        var attribute = cut.Find("fluent-avatar").GetAttribute("appearance") ?? string.Empty;
+        Assert.Equal(expectedValue, attribute);
+    }
+
+    [Theory]
+    [InlineData(AvatarColor.Neutral, "neutral")]
+    [InlineData(AvatarColor.Anchor, "anchor")]
+    [InlineData(AvatarColor.Beige, "beige")]
+    [InlineData(AvatarColor.Blue, "blue")]
+    [InlineData(AvatarColor.Brand, "brand")]
+    [InlineData(AvatarColor.Brass, "brass")]
+    [InlineData(AvatarColor.Brown, "brown")]
+    [InlineData(AvatarColor.Colorful, "colorful")]
+    [InlineData(AvatarColor.Cornflower, "cornflower")]
+    [InlineData(AvatarColor.Cranberry, "cranberry")]
+    [InlineData(AvatarColor.DarkGreen, "dark-green")]
+    [InlineData(AvatarColor.DarkRed, "dark-red")]
+    [InlineData(AvatarColor.Forest, "forest")]
+    [InlineData(AvatarColor.Grape, "grape")]
+    [InlineData(AvatarColor.Gold, "gold")]
+    [InlineData(AvatarColor.Lavender, "lavender")]
+    [InlineData(AvatarColor.LightTeal, "light-teal")]
+    [InlineData(AvatarColor.Lilac, "lilac")]
+    [InlineData(AvatarColor.Magenta, "magenta")]
+    [InlineData(AvatarColor.Marigold, "marigold")]
+    [InlineData(AvatarColor.Mink, "mink")]
+    [InlineData(AvatarColor.Navy, "navy")]
+    [InlineData(AvatarColor.Peach, "peach")]
+    [InlineData(AvatarColor.Pink, "pink")]
+    [InlineData(AvatarColor.Platinum, "platinum")]
+    [InlineData(AvatarColor.Plum, "plum")]
+    [InlineData(AvatarColor.Pumpkin, "pumpkin")]
+    [InlineData(AvatarColor.Purple, "purple")]
+    [InlineData(AvatarColor.Red, "red")]
+    [InlineData(AvatarColor.RoyalBlue, "royal-blue")]
+    [InlineData(AvatarColor.Seafoam, "seafoam")]
+    [InlineData(AvatarColor.Steel, "steel")]
+    [InlineData(AvatarColor.Teal, "teal")]
+    [InlineData((AvatarColor)999, "")]
+    [InlineData(null, "")]
+    public void FluentAvatar_Color(AvatarColor? color, string expectedValue)
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentAvatar Color="@color" />);
+
+        // Assert
+        var attribute = cut.Find("fluent-avatar").GetAttribute("color") ?? string.Empty;
+        Assert.Equal(expectedValue, attribute);
+    }
+
+    [Theory]
+    [InlineData(AvatarSize.Size16, "16")]
+    [InlineData(AvatarSize.Size20, "20")]
+    [InlineData(AvatarSize.Size24, "24")]
+    [InlineData(AvatarSize.Size28, "28")]
+    [InlineData(AvatarSize.Size32, "32")]
+    [InlineData(AvatarSize.Size36, "36")]
+    [InlineData(AvatarSize.Size40, "40")]
+    [InlineData(AvatarSize.Size48, "48")]
+    [InlineData(AvatarSize.Size56, "56")]
+    [InlineData(AvatarSize.Size64, "64")]
+    [InlineData(AvatarSize.Size72, "72")]
+    [InlineData(AvatarSize.Size96, "96")]
+    [InlineData(AvatarSize.Size120, "120")]
+    [InlineData(AvatarSize.Size128, "128")]
+    [InlineData((AvatarSize)999, "")]
+    [InlineData(null, "")]
+    public void FluentAvatar_Size(AvatarSize? size, string expectedValue)
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentAvatar Size="@size" />);
+
+        // Assert
+        var attribute = cut.Find("fluent-avatar").GetAttribute("size") ?? string.Empty;
+        Assert.Equal(expectedValue, attribute);
+    }
+
+    [Theory]
+    [InlineData(AvatarShape.Circle, "circle")]
+    [InlineData(AvatarShape.Square, "square")]
+    [InlineData((AvatarShape)999, "")]
+    [InlineData(null, "")]
+    public void FluentAvatar_Shape(AvatarShape? shape, string expectedValue)
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentAvatar Shape="@shape" />);
+
+        // Assert
+        var attribute = cut.Find("fluent-avatar").GetAttribute("shape") ?? string.Empty;
+        Assert.Equal(expectedValue, attribute);
+    }
+
+    [Fact]
+    public void FluentAvatar_Name()
+    {
+        // Arrange
+        string name = "John Doe";
+        string expectedValue = "John Doe";
+        // Act
+        var cut = Render(@<FluentAvatar Name="@name" />);
+
+        // Assert
+        var value = cut.Find("fluent-avatar").GetAttribute("name") ?? string.Empty;
+        Assert.Equal(expectedValue, value);
+    }
+
+    [Fact]
+    public void FluentAvatar_Initials()
+    {
+        // Arrange
+        string initials = "JD";
+        string expectedValue = "JD";
+        // Act
+        var cut = Render(@<FluentAvatar Initials="@initials" />);
+
+        // Assert
+        var value = cut.Find("fluent-avatar").GetAttribute("initials") ?? string.Empty;
+        Assert.Equal(expectedValue, value);
+    }
+
+    [Fact]
+    public void FluentAvatar_Image()
+    {
+        // Arrange
+        string imageUrl = "ImageUrl";
+        string expectedValue = "ImageUrl";
+
+        // Act
+        var cut = Render(@<FluentAvatar Image="@imageUrl" />);
+
+        // Assert
+        var value = cut.Find("fluent-avatar img").GetAttribute("src") ?? string.Empty;
+        Assert.Equal(expectedValue, value);
+    }
+
+    [Fact]
+    public void FluentAvatar_Icon()
+    {
+        // Arrange
+        Icon icon = new Samples.Info();
+
+        // Act
+        var cut = Render(@<FluentAvatar Icon="icon" />);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentAvatar_TabIndex()
+    {
+        // Arrange & Act
+        var tabIndex = "55";
+        var cut = Render(@<FluentAvatar OnClick="@(e => {})" tabindex="@tabIndex" />);
+
+        // Assert
+        cut.Find("fluent-avatar").HasAttribute("tabindex", tabIndex);
+    }
+
+    [Fact]
+    public void FluentAvatar_WithOnClick_WithoutTabIndex()
+    {
+        // Arrange & Act
+        var cut = Render(@<FluentAvatar OnClick="@(e => {})" />);
+
+        // Assert
+        cut.Find("fluent-avatar").HasAttribute("tabindex", "0");
+    }
+
+    [Fact]
+    public void FluentAvatar_Icon_WithSize()
+    {
+        // Arrange
+        Icon icon = new Samples.Info();
+
+        // Act
+        var cut = Render(@<FluentAvatar Icon="icon" Size="AvatarSize.Size96" />);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentAvatar_OnClick()
+    {
+        bool clicked = false;
+
+        // Arrange
+        var cut = Render(@<FluentAvatar OnClick="@(e => { clicked = true; } )"></FluentAvatar>);
+
+        // Act
+        cut.Find("fluent-avatar").Click();
+
+        // Assert
+        Assert.True(clicked);
+    }
+
+    [Theory]
+    [InlineData("Enter", true)]
+    [InlineData("Space", true)]
+    [InlineData("a", false)]
+
+    public async Task FluentAvatar_OnKressPress(string code, bool expectedValue)
+    {
+        bool clicked = false;
+        // Arrange
+        var cut = Render(@<FluentAvatar OnClick="@(e => { clicked = true; } )"></FluentAvatar>);
+
+        // Act
+        await cut.Find("fluent-avatar").KeyDownAsync(new KeyboardEventArgs { Code = code });
+
+        // Assert
+        Assert.Equal(expectedValue, clicked);
+    }
+}


### PR DESCRIPTION
# Add FluentAvatar component

The `Avatar` component is used to represent a user or entity. It can display an image, initials, or an icon.

## Default implementation

![image](https://github.com/user-attachments/assets/9dd179db-3662-4a5f-8a2b-b786b0719675)

## Colors

![image](https://github.com/user-attachments/assets/a218b6ad-094d-4a47-9a18-062b99f89b7d)

## Name and initials 

You can provide a name prop to display initials. The name prop will be used to generate the initials displayed in the Avatar.

![image](https://github.com/user-attachments/assets/1536f1c8-4939-4f19-927e-6a4cae30fafe)

## Image

![image](https://github.com/user-attachments/assets/516e96c0-9dd9-46f5-8c26-948107b51b4e)

## Default icon 
You can provide an icon prop to replace the default icon in the Avatar when the initials or name is not provided .

![image](https://github.com/user-attachments/assets/4709a91a-b935-4de4-9041-c03cac3ff27a)

# Missing features

Since the fluent-badge is not available in the dev-v5 branch, the component needs to be reviewed with these features to include the feature of status badge

# Documentation

- Appearance : Defines all appearance mode available
- Contents : Defines the way to control the content of the avatar 
   - Name and initials 
   - Image
   - Default icon

# Coverage & Testing

![image](https://github.com/user-attachments/assets/95553148-59da-47b2-aebc-ed6a0145e098)



