### PR TITLE
[dev-v5] Add an obsolete FluentProgress component

### DIFF
--- a/src/Core/Components/Progress/FluentProgressBar.razor.cs
+++ b/src/Core/Components/Progress/FluentProgressBar.razor.cs
@@ -9,7 +9,7 @@ using Microsoft.FluentUI.AspNetCore.Components.Utilities;
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 /// <summary>
-/// 
+/// Visual representation of content being loaded or processed.
 /// </summary>
 public partial class FluentProgressBar : FluentComponentBase
 {

--- a/src/Core/Migration/FluentProgress.cs
+++ b/src/Core/Migration/FluentProgress.cs
@@ -1,0 +1,15 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// Visual representation of content being loaded or processed.
+/// This component is renamed to <see cref="FluentProgressBar"/> and will be removed in a future release.
+/// </summary>
+[Obsolete("This component is renamed to FluentProgressBar and will be removed in a future release.")]
+public class FluentProgress : FluentProgressBar
+{
+
+}

--- a/tests/Core/Components/Progress/FluentProgressBarTests.razor
+++ b/tests/Core/Components/Progress/FluentProgressBarTests.razor
@@ -152,6 +152,17 @@
         var actual = cut.Find("fluent-progress-bar").GetAttribute("thickness");
         Assert.Equal(expectedThickness, actual);
     }
+
+    [Fact]
+    public void FluentProgressBar_OldComponent()
+    {
+        // Act
+        var cut = Render(@<FluentProgress Value="10" />);
+
+        // Assert
+        var actual = cut.Find("fluent-progress-bar").GetAttribute("value");
+        Assert.Equal("10", actual);
+    }
 #pragma warning restore
 
 }


### PR DESCRIPTION
# Add an obsolete FluentProgress component

`<FluentProgress />` and `<FluentProgressBar />` are identical, but `FluentProgress` is tagged `Obsolete`.