### PR TITLE
[DataGrid] Fix error in handling GridTemplateColumns

### DIFF
--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -505,9 +505,9 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
                 _internalGridTemplateColumns = GridTemplateColumns ?? string.Join(" ", Enumerable.Repeat("1fr", _columns.Count));
             }
 
-            if (_columns.Any(x => !string.IsNullOrWhiteSpace(x.Width) && x is not SelectColumn<TGridItem>))
+            if (_columns.Any(x => !string.IsNullOrWhiteSpace(x.Width)))
             {
-                _internalGridTemplateColumns = string.Join(" ", _columns.Select(x => x.Width ?? "auto"));
+                _internalGridTemplateColumns = GridTemplateColumns ?? string.Join(" ", _columns.Select(x => x.Width ?? "auto"));
             }
         }
 

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -505,7 +505,7 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
                 _internalGridTemplateColumns = GridTemplateColumns ?? string.Join(" ", Enumerable.Repeat("1fr", _columns.Count));
             }
 
-            if (_columns.Any(x => !string.IsNullOrWhiteSpace(x.Width)))
+            if (_columns.Any(x => !string.IsNullOrWhiteSpace(x.Width) && x is not SelectColumn<TGridItem>))
             {
                 _internalGridTemplateColumns = string.Join(" ", _columns.Select(x => x.Width ?? "auto"));
             }


### PR DESCRIPTION
When finished collecting the columns, the `GridTemplateColumns` value is re-evaluated. The logic was not taking the original `GridTemplateColumns` value into account.