### PR TITLE
[Autocomplete]: Apply invalid css to autocomplete #3407

### DIFF
--- a/src/Core.Assets/src/index.ts
+++ b/src/Core.Assets/src/index.ts
@@ -56,7 +56,8 @@ fluent-number-field.invalid,
 [role='combobox'].invalid::part(control),
 fluent-combobox.invalid::part(control),
 fluent-text-area.invalid::part(control),
-fluent-text-field.invalid::part(root)
+fluent-text-field.invalid::part(root),
+.fluent-autocomplete-multiselect.invalid > fluent-text-field::part(root)
 {
     outline: calc(var(--stroke-width) * 1px)  solid var(--error);
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description
applies the error css to the autocomplete when invalid

### 🎫 Issues

#3407

## 👩‍💻 Reviewer Notes
can be tested with the form example and putting in a country & disabling it again

## 📑 Test Plan

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- x ] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps
N/A
