### PR TITLE
[DataGrid] Only add Selectable items when using Select All

### DIFF
--- a/src/Core/Components/DataGrid/Columns/SelectColumn.cs
+++ b/src/Core/Components/DataGrid/Columns/SelectColumn.cs
@@ -534,9 +534,8 @@ public class SelectColumn<TGridItem> : ColumnBase<TGridItem>
         {
             // Only add selectable items
             _selectedItems.AddRange((InternalGridContext.Grid.Items?.ToList() ?? InternalGridContext.Items)
-                .Where(item => Selectable?.Invoke(item) ?? false)
-                .ToArray()
-);
+                .Where(item => Selectable?.Invoke(item) ?? true)
+            );
         }
 
         if (SelectedItemsChanged.HasDelegate)

--- a/src/Core/Components/DataGrid/Columns/SelectColumn.cs
+++ b/src/Core/Components/DataGrid/Columns/SelectColumn.cs
@@ -1,3 +1,7 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.Web;
@@ -528,7 +532,11 @@ public class SelectColumn<TGridItem> : ColumnBase<TGridItem>
         _selectedItems.Clear();
         if (SelectAll == true)
         {
-            _selectedItems.AddRange(InternalGridContext.Grid.Items?.ToArray() ?? InternalGridContext.Items);
+            // Only add selectable items
+            _selectedItems.AddRange((InternalGridContext.Grid.Items?.ToList() ?? InternalGridContext.Items)
+                .Where(item => Selectable?.Invoke(item) ?? false)
+                .ToArray()
+);
         }
 
         if (SelectedItemsChanged.HasDelegate)


### PR DESCRIPTION
Fix #3447 

Add extra check when selecting all items so only items that are actually selectable get selected.