### PR TITLE
[DataGrid] Fix styling when using `Virtualize` with `DataGridDisplayMode.Table`

### DIFF
--- a/examples/Demo/Client/wwwroot/index.html
+++ b/examples/Demo/Client/wwwroot/index.html
@@ -48,9 +48,10 @@
         <div class="loading-progress-text"></div>
 
         <div class="loading-info">
-            <h1>Fluent UI Blazor</h1>
-            <em style="display: block; margin-bottom: 1em;">Welcom to the Fluent UI Blazor component library demo and documentation site!</em>
-            <a href="https://github.com/microsoft/fluentui-blazor" target="_blank">GitHub repository</a>
+            <em style="display: block;">Welcome to the</em>
+            <h1 style="margin: 1em 0;">Fluent UI Blazor</h1>
+            <em style="display: block; margin-bottom: 1em;">demo and documentation site!</em>
+            <a style="font-size: initial;" href="https://github.com/microsoft/fluentui-blazor" target="_blank">GitHub repository</a>
         </div>
     </div>
 

--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -15268,22 +15268,6 @@
             Releases all resources used by the DebounceTask dispatcher.
             </summary>
         </member>
-        <member name="M:Microsoft.FluentUI.AspNetCore.Components.Utilities.InternalDebounce.DebounceAction`1.Run(System.Int32,System.Func{System.Threading.Tasks.Task{`0}})">
-            <summary>
-            Delays the invocation of an action until a predetermined interval has elapsed since the last call.
-            </summary>
-            <param name="milliseconds"></param>
-            <param name="action"></param>
-            <exception cref="T:System.ArgumentOutOfRangeException"></exception>
-        </member>
-        <member name="M:Microsoft.FluentUI.AspNetCore.Components.Utilities.InternalDebounce.DebounceAction`1.RunAsync(System.Int32,System.Func{System.Threading.Tasks.Task{`0}})">
-            <summary>
-            Delays the invocation of an action until a predetermined interval has elapsed since the last call.
-            </summary>
-            <param name="milliseconds"></param>
-            <param name="action"></param>
-            <exception cref="T:System.ArgumentOutOfRangeException"></exception>
-        </member>
         <member name="T:Microsoft.FluentUI.AspNetCore.Components.Utilities.InternalDebounce.DebounceTask">
             <summary>
             The DebounceTask dispatcher delays the invocation of an action until a predetermined interval has elapsed since the last call.

--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -2042,6 +2042,15 @@
             Automatically fit the number of items per page to the available height.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.DisplayMode">
+            <summary>
+            Gets or set the <see cref="T:Microsoft.FluentUI.AspNetCore.Components.DataGridDisplayMode"/> of the grid.
+            Default is 'Grid'.
+            When set to Grid, <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.GridTemplateColumns" /> can be used to specify column widths.
+            When set to Table, widths need to be specified at the column level.
+            When using <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.Virtualize"/>, it is recommended to use Table.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.RowSize">
             <summary>
             Gets or sets the size of each row in the grid based on the <see cref="T:Microsoft.FluentUI.AspNetCore.Components.DataGridRowSize"/> enum.
@@ -15258,6 +15267,22 @@
             <summary>
             Releases all resources used by the DebounceTask dispatcher.
             </summary>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.Utilities.InternalDebounce.DebounceAction`1.Run(System.Int32,System.Func{System.Threading.Tasks.Task{`0}})">
+            <summary>
+            Delays the invocation of an action until a predetermined interval has elapsed since the last call.
+            </summary>
+            <param name="milliseconds"></param>
+            <param name="action"></param>
+            <exception cref="T:System.ArgumentOutOfRangeException"></exception>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.Utilities.InternalDebounce.DebounceAction`1.RunAsync(System.Int32,System.Func{System.Threading.Tasks.Task{`0}})">
+            <summary>
+            Delays the invocation of an action until a predetermined interval has elapsed since the last call.
+            </summary>
+            <param name="milliseconds"></param>
+            <param name="action"></param>
+            <exception cref="T:System.ArgumentOutOfRangeException"></exception>
         </member>
         <member name="T:Microsoft.FluentUI.AspNetCore.Components.Utilities.InternalDebounce.DebounceTask">
             <summary>

--- a/examples/Demo/Shared/Pages/DataGrid/DataGridPage.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/DataGridPage.razor
@@ -67,6 +67,18 @@
     When using <code>Virtualize</code>, the <code>ItemSize</code> value isused is still used to indicate the row height.
 </p>
 
+<h2 id="displaymode">DisplayMode</h2>
+<p>
+    The DataGrid supports 2 different display modes through the <code>DisplayMode</code> parameter: <code>DataGridDisplayMode.Grid</code> (default) and
+    <code>DataGridDisplayMode.Table</code>. When set to <code>Grid</code>, the <code>GridTableColumns</code> parameter cam be used set specify column
+    widths in fractions. It basically provides an HTML table element with a <code>display: grid;</code> style. The <code>Table</code> mode uses standard
+    HTML table elements and rendering. Column widths in that mode are best specified through the <code>Width</code> parameter of the columns.
+</p>
+<p>
+    Specifically when using <code>Virtualize</code>, it is <strong>higly recommended</strong> to use the <code>Table</code> display mode as the <code>Grid</code> mode
+    can exhibit some odd behaviour when scrolling.
+</p>
+
 
 <h2 id="changeuistrings">Change strings used in the UI</h2>
 <p>

--- a/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridRemoteData2.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridRemoteData2.razor
@@ -27,12 +27,12 @@
     </FluentAccordionItem>
 </FluentAccordion>
 <br />
-<div style="height: 370px; overflow:auto;" tabindex="-1">
+<div style="height: 484px; overflow:auto;" tabindex="-1">
     <FluentDataGrid @ref="dataGrid"
                     Items="foodRecallItems"
                     RefreshItems="RefreshItemsAsync"
                     OnRowDoubleClick="@(()=>DemoLogger.WriteLine("Row double clicked!"))"
-                    ItemSize="46"
+                    RowSize="DataGridRowSize.Small"
                     GenerateHeader="GenerateHeaderOption.Sticky"
                     TGridItem="FoodRecall"
                     Loading="loading"
@@ -88,6 +88,7 @@
 
         loading = false;
         await InvokeAsync(StateHasChanged);
+
     }
 
     public void ClearFilters()

--- a/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridVirtualize.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridVirtualize.razor
@@ -1,5 +1,5 @@
 ﻿<div style="height: 400px; max-width: 800px; overflow-y: scroll;">
-    <FluentDataGrid @ref="grid" Items=@items Virtualize="true" ItemSize="54" GenerateHeader="@GenerateHeaderOption.Sticky">
+    <FluentDataGrid @ref="grid" Items=@items Virtualize="true" DisplayMode="DataGridDisplayMode.Table" Style="width: 100%;" ItemSize="54" GenerateHeader="@GenerateHeaderOption.Sticky">
         <ChildContent>
             <PropertyColumn Width="25%" Property="@(c => c.Item1)" Sortable="true" />
             <PropertyColumn Width="25%" Property="@(c => c.Item2)" />

--- a/examples/Demo/Shared/wwwroot/css/site.css
+++ b/examples/Demo/Shared/wwwroot/css/site.css
@@ -347,6 +347,7 @@ kbd {
 .loading-info {
     margin-top: 1em;
     text-align: center;
+    font-size: 1.5em;
 }
 
     .loading-info a {

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor
@@ -1,5 +1,6 @@
 ﻿@using Microsoft.AspNetCore.Components.Rendering
 @using Microsoft.FluentUI.AspNetCore.Components.DataGrid.Infrastructure
+@using System.Globalization
 @namespace Microsoft.FluentUI.AspNetCore.Components
 @inherits FluentComponentBase
 @typeparam TGridItem
@@ -241,7 +242,7 @@
         }
         else
         {
-            colspan = _columns.Count.ToString();
+            colspan = _columns.Count.ToString(CultureInfo.InvariantCulture);
         }
 
         <FluentDataGridRow Class="@LOADING_CONTENT_ROW_CLASS" TGridItem="TGridItem">

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor
@@ -200,13 +200,24 @@
 
     private void RenderEmptyContent(RenderTreeBuilder __builder)
     {
-        @if (_manualGrid)
+        if (_manualGrid)
         {
             return;
         }
 
+        string? style = null;
+        string? colspan = null;
+        if (DisplayMode == DataGridDisplayMode.Grid)
+        {
+            style = $"grid-column: 1 / {_columns.Count + 1}";
+        }
+        else
+        {
+            colspan = _columns.Count.ToString();
+        }
+
         <FluentDataGridRow Class="@EMPTY_CONTENT_ROW_CLASS" TGridItem="TGridItem">
-            <FluentDataGridCell Class="empty-content-cell" Style="@($"grid-column: 1 / {_columns.Count + 1}")">
+            <FluentDataGridCell Class="empty-content-cell" Style="@style" colspan="@colspan">
                 @if (EmptyContent is null)
                 {
                     @("No data to show!")
@@ -222,8 +233,19 @@
 
     private void RenderLoadingContent(RenderTreeBuilder __builder)
     {
+        string? style = null;
+        string? colspan = null;
+        if (DisplayMode == DataGridDisplayMode.Grid)
+        {
+            style = $"grid-column: 1 / {_columns.Count + 1}";
+        }
+        else
+        {
+            colspan = _columns.Count.ToString();
+        }
+
         <FluentDataGridRow Class="@LOADING_CONTENT_ROW_CLASS" TGridItem="TGridItem">
-            <FluentDataGridCell Class="loading-content-cell" Style="@($"grid-column: 1 / {_columns.Count + 1}")">
+            <FluentDataGridCell Class="loading-content-cell" Style="@style" colspan="@colspan">
                 @if (LoadingContent is null)
                 {
                     <FluentStack HorizontalGap="3" HorizontalAlignment="@HorizontalAlignment.Center">

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -369,8 +369,6 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
 
     private GridItemsProviderRequest<TGridItem>? _lastRequest;
     private bool _forceRefreshData;
-    private readonly Debounce<ItemsProviderResult<(int, TGridItem)>> _debounce = new();
-    //private readonly Debounce _debounce = new();
 
     // If the PaginationState mutates, it raises this event. We use it to trigger a re-render.
     private readonly EventCallbackSubscriber<PaginationState> _currentPageItemsChanged;

--- a/src/Core/Components/DataGrid/FluentDataGridCell.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGridCell.razor.cs
@@ -68,14 +68,14 @@ public partial class FluentDataGridCell<TGridItem> : FluentComponentBase
         .Build();
 
     protected string? StyleValue => new StyleBuilder(Style)
-        .AddStyle("grid-column", GridColumn.ToString(), () => (!Grid.EffectiveLoadingValue && (Grid.Items is not null || Grid.ItemsProvider is not null)) || Grid.Virtualize)
+        .AddStyle("grid-column", GridColumn.ToString(), () => (!Grid.EffectiveLoadingValue && (Grid.Items is not null || Grid.ItemsProvider is not null)) || (Grid.Virtualize && Grid.DisplayMode == DataGridDisplayMode.Grid))
         .AddStyle("text-align", "center", Column is SelectColumn<TGridItem>)
         .AddStyle("align-content", "center", Column is SelectColumn<TGridItem>)
         .AddStyle("padding-inline-start", "calc(((var(--design-unit)* 3) + var(--focus-stroke-width) - var(--stroke-width))* 1px)", Column is SelectColumn<TGridItem> && Owner.RowType == DataGridRowType.Default)
         .AddStyle("padding-top", "calc(var(--design-unit) * 2.5px)", Column is SelectColumn<TGridItem> && (Grid.RowSize == DataGridRowSize.Medium || Owner.RowType == DataGridRowType.Header))
         .AddStyle("padding-top", "calc(var(--design-unit) * 1.5px)", Column is SelectColumn<TGridItem> && Grid.RowSize == DataGridRowSize.Small && Owner.RowType == DataGridRowType.Default)
         .AddStyle("width", Column?.Width, !string.IsNullOrEmpty(Column?.Width) && Grid.DisplayMode == DataGridDisplayMode.Table)
-        .AddStyle("height", $"{Grid.ItemSize:0}px", () => !Grid.EffectiveLoadingValue && Grid.Virtualize && Owner.RowType == DataGridRowType.Default)
+        .AddStyle("height", $"{Grid.ItemSize:0}px", () => !Grid.EffectiveLoadingValue && Grid.Virtualize && Owner.RowType == DataGridRowType.Default && Grid.DisplayMode == DataGridDisplayMode.Grid)
         .AddStyle("height", $"{(int)Grid.RowSize}px", () => !Grid.EffectiveLoadingValue && !Grid.Virtualize && !Grid.MultiLine && (Grid.Items is not null || Grid.ItemsProvider is not null))
         .AddStyle("height", "100%", Grid.MultiLine)
         .AddStyle("min-height", "44px", Owner.RowType != DataGridRowType.Default)


### PR DESCRIPTION
When using `Virtualize` on a `FluentDataGrid`, the 'DisplayMode=DataGridDisplayMode.Table` should be used. 

Several fixes in styling have been applied to address the changes needed when using this `DisplayMode`.

Fixes #3485

