### PR TITLE
[DataGrid] Add method to close column options programmatically

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -2141,6 +2141,11 @@
             <param name="index">The column index whose options UI is to be displayed.</param>
             <returns>A <see cref="T:System.Threading.Tasks.Task"/> representing the completion of the operation.</returns>
         </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.CloseColumnOptionsAsync">
+            <summary>
+            Closes the <see cref="P:Microsoft.FluentUI.AspNetCore.Components.ColumnBase`1.ColumnOptions"/> UI that was previously displayed.
+            </summary>
+        </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.ShowColumnResizeAsync(Microsoft.FluentUI.AspNetCore.Components.ColumnBase{`0})">
             <summary>
             Displays the column resize UI for the specified column, closing any other column

--- a/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridTypical.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridTypical.razor
@@ -4,7 +4,8 @@
 <p>Remove the parameter completely to get the original behavior</p>
 
 <div style="height: 380px; overflow-x:auto; display:flex;">
-    <FluentDataGrid Items="@FilteredItems"
+    <FluentDataGrid @ref="grid"
+                    Items="@FilteredItems"
                     ResizableColumns=true
                     ResizeType="DataGridResizeType.Discrete"
                     GridTemplateColumns="0.3fr 1fr 0.2fr 0.2fr 0.2fr 0.2fr"
@@ -19,7 +20,7 @@
         <PropertyColumn Property="@(c => c.Name)" Sortable="true" Filtered="!string.IsNullOrWhiteSpace(nameFilter)" Tooltip="true" Title="Name of the country">
             <ColumnOptions>
                 <div class="search-box">
-                    <FluentSearch Autofocus=true @bind-Value=nameFilter @oninput="HandleCountryFilter" @bind-Value:after="HandleClear" Placeholder="Country name..." Style="width: 100%;" Label="Filter" />
+                    <FluentSearch Autofocus=true @bind-Value=nameFilter @oninput="HandleCountryFilter" @onkeydown="HandleCloseFilterAsync" @bind-Value:after="HandleClear" Placeholder="Country name..." Style="width: 100%;" Label="Filter" />
                 </div>
             </ColumnOptions>
         </PropertyColumn>
@@ -57,6 +58,7 @@
 </FluentSwitch>
 
 @code {
+    FluentDataGrid<Country>? grid;
     bool _clearItems = false;
     IQueryable<Country>? items;
     PaginationState pagination = new PaginationState { ItemsPerPage = 10 };
@@ -114,6 +116,18 @@
         if (string.IsNullOrWhiteSpace(nameFilter))
         {
             nameFilter = string.Empty;
+        }
+    }
+
+    private async Task HandleCloseFilterAsync(KeyboardEventArgs args)
+    {
+        if (args.Key == "Escape")
+        {
+            nameFilter = string.Empty;
+        }
+        if (args.Key == "Enter" && grid is not null)
+        {
+            await grid.CloseColumnOptionsAsync();
         }
     }
 

--- a/examples/Demo/Shared/Pages/DataGrid/Pages/DataGridTypicalPage.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/Pages/DataGridTypicalPage.razor
@@ -18,5 +18,9 @@
             <code>TooltipText</code> is a lambda function that takes the current item as input and returns the text to show in the tooltip (and <code>aria-label</code>).
             Look at the Razor tab to see how this is done and how it can be customized.
         </p>
+        <p>
+            The Country filter option can be used to quickly filter the list of countries shown. Pressing the ESC key just closes the option popup without changing the filtering currently being used.
+            Pressing enter finishes the filter action by the current input to filter on and closes the option popup.
+        </p>
     </Description>
 </DemoSection>

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -636,6 +636,16 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     }
 
     /// <summary>
+    /// Closes the <see cref="ColumnBase{TGridItem}.ColumnOptions"/> UI that was previously displayed.
+    /// </summary>
+    public Task CloseColumnOptionsAsync()
+    {
+        _displayOptionsForColumn = null;
+        StateHasChanged();
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
     /// Displays the column resize UI for the specified column, closing any other column
     /// resize UI that was previously displayed.
     /// </summary>


### PR DESCRIPTION
This PR adds a new method to the `FluentDataGrid` component that allows closing the column options UI programmatically. The new method, `CloseColumnOptionsAsync`, closes the UI that was previously displayed for a column.

The 'Typical Grid Usage' page has been updated to include the new method and handle the `Enter` key press event to close the column options UI.

_This is a copy of the method that was added to the QuickGrid component in .NET 10 (preview 2)_