### PR TITLE
Fixed .NET typo in Templates.md file.  .NET was misspelled as .NAT.

### DIFF
--- a/examples/Demo/Shared/wwwroot/docs/Templates.md
+++ b/examples/Demo/Shared/wwwroot/docs/Templates.md
@@ -2,7 +2,7 @@ To make it easier to start a project that uses the Fluent UI Web Components for 
 - Fluent Blazor Web App
 - Fluent Blazor WebAssembly Standalone App
 - Fluent .NET MAUI Blazor Hybrid and Web App
-- Fluent .NAT Aspire Starter app
+- Fluent .NET Aspire Starter app
 
 
 All of these templates mimic their standard Blazor template counterpart but have the Fluent UI Blazor components already fully set up. If you choose to add sample pages when creating a project, all components have been replaced with Fluent UI components (and a few extra have been added). All Bootstrap styling is removed of course as well.


### PR DESCRIPTION

# Pull Request

## 📖 Description

Template.md had .NET misspelled as .NAT

### 🎫 Issues

I did not see any issues for this documentation fix, and I did not create an issue.  Let me know if this is something I need to do moving forward.

## 👩‍💻 Reviewer Notes

Only a documentation fix.  


## 📑 Test Plan

No test plan.  Just a documentation fix.  

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.  **Only doc markup change. No unit tests required.**
- [x ] I have tested my changes.  **I made markup change and viewed rendering in Live Preview**
- [ ] I have updated the project documentation to reflect my changes.  **Change was in the project documentation**
- [x ] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.


## ⏭ Next Steps

Just need documentation fix approved and merged.
