### PR TITLE
[Docs] Add cookie consent 

### DIFF
--- a/examples/Demo/Client/Program.cs
+++ b/examples/Demo/Client/Program.cs
@@ -1,5 +1,9 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
 using FluentUI.Demo.Shared;
-using FluentUI.Demo.Shared.SampleData;
+
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.FluentUI.AspNetCore.Components;
@@ -12,7 +16,5 @@ builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.
 
 builder.Services.AddFluentUIComponents();
 builder.Services.AddFluentUIDemoClientServices();
-
-builder.Services.AddScoped<DataSource>();
 
 await builder.Build().RunAsync();

--- a/examples/Demo/Client/wwwroot/index.html
+++ b/examples/Demo/Client/wwwroot/index.html
@@ -11,23 +11,6 @@
     <link href="_content/FluentUI.Demo.Shared/css/site.css" rel="stylesheet" />
     <link href="FluentUI.Demo.Client.styles.css" rel="stylesheet" />
     <link href="_content/FluentUI.Demo.Shared/css/site.css" rel="stylesheet" />
-
-    <!-- Statistics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-VML6BZWWTC"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag() { dataLayer.push(arguments); }
-        gtag('js', new Date());
-
-        gtag('config', 'G-VML6BZWWTC');
-    </script>
-    <script type="text/javascript">
-        (function(c, l, a, r, i, t, y) {
-            c[a] = c[a] || function() { (c[a].q = c[a].q || []).push(arguments) };
-            t = l.createElement(r); t.async = 1; t.src = "https://www.clarity.ms/tag/" + i;
-            y = l.getElementsByTagName(r)[0]; y.parentNode.insertBefore(t, y);
-        })(window, document, "clarity", "script", "hnr14wvzj8");
-    </script>
 </head>
 
 <body>

--- a/examples/Demo/Server/FluentUI.Demo.Server.csproj
+++ b/examples/Demo/Server/FluentUI.Demo.Server.csproj
@@ -9,7 +9,7 @@
     <NoWarn>$(NoWarn);CS1591;CS1573</NoWarn>
 	</PropertyGroup>
 
-	<ItemGroup>
+    <ItemGroup>
 	  <ProjectReference Include="..\Shared\FluentUI.Demo.Shared.csproj" />
 	</ItemGroup>
 

--- a/examples/Demo/Server/Program.cs
+++ b/examples/Demo/Server/Program.cs
@@ -1,3 +1,7 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
 using FluentUI.Demo.Shared;
 using FluentUI.Demo.Shared.SampleData;
 using Microsoft.AspNetCore.Hosting.StaticWebAssets;

--- a/examples/Demo/Shared/Components/Cookies/CookieConsent.razor
+++ b/examples/Demo/Shared/Components/Cookies/CookieConsent.razor
@@ -1,0 +1,20 @@
+﻿@if (_showBanner)
+{
+    <div id="cookieconsent" role="alert">
+        <div class="info">
+            <div class="infoicon">
+                <FluentIcon Value="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size28.Info())" />
+            </div>
+            <p class="infomessage">
+                We use optional cookies to improve your experience on our websites, such as through social media connections, and to display personalized advertising based on your online activity. If you reject optional cookies, only cookies necessary to provide you the services will be used. You may change your selection by clicking “Manage Cookies”.
+                <a target="_blank" href="https://go.microsoft.com/fwlink/?LinkId=521839">Privacy Statement</a>
+                <a target="_blank" href="https://aka.ms/3rdpartycookies">Third-Party Cookies</a>
+            </p>
+        </div>
+        <div class="buttons">
+            <FluentButton Class="button" @onclick="AcceptPolicyAsync" Title="Accept" Appearance="Appearance.Outline">Accept</FluentButton>
+            <FluentButton Class="button" @onclick="RejectPolicyAsync" Title="Reject" Appearance="Appearance.Outline">Reject</FluentButton>
+            <FluentButton Class="button" @onclick="ManageCookiesAsync" Title="Manage cookies" Appearance="Appearance.Outline">Manage cookies</FluentButton>
+        </div>
+    </div>
+}

--- a/examples/Demo/Shared/Components/Cookies/CookieConsent.razor.cs
+++ b/examples/Demo/Shared/Components/Cookies/CookieConsent.razor.cs
@@ -1,0 +1,90 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.FluentUI.AspNetCore.Components;
+
+namespace FluentUI.Demo.Shared.Components.Cookies;
+
+public partial class CookieConsent()
+{
+    private const string GA_MEASUREMENT_ID = "G-VML6BZWWTC"; // Google Analytics measurement ID
+    private const string MC_PROIOJECT_ID = "hnr14wvzj8";     // Microsoft Clarity project ID
+
+    [Inject]
+    public required CookieConsentService CookieConsentService { get; set; }
+
+    [Inject]
+    public IDialogService DialogService { get; set; } = default!;
+
+    private IDialogReference? _dialog;
+    private bool _showBanner = false;
+    private CookieState? _cookieState;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _cookieState ??= await CookieConsentService.GetCookieStateAsync();
+            _showBanner = _cookieState is null;
+
+            if (!_showBanner && _cookieState?.AcceptAnalytics == true)
+            {
+                await InitAnalyticsAsync();
+            }
+            StateHasChanged();
+        }
+    }
+
+    private async Task AcceptPolicyAsync()
+    {
+        _cookieState = new CookieState(true);
+        await CookieConsentService.SetCookieStateAsync(_cookieState);
+        await InitAnalyticsAsync();
+
+        _showBanner = false;
+    }
+
+    private async Task RejectPolicyAsync()
+    {
+        await CookieConsentService.SetCookieStateAsync(new CookieState(false));
+
+        _showBanner = false;
+    }
+
+    public async Task ManageCookiesAsync()
+    {
+        _cookieState ??= await CookieConsentService.GetCookieStateAsync() ?? new();
+
+        _dialog = await DialogService.ShowDialogAsync(DialogHelper.From<ManageCookies>(), _cookieState, new DialogParameters()
+        {
+            Title = $"Manage cookie preferences",
+            PrimaryAction = "Save changes",
+            SecondaryAction = "Reset all",
+            ShowDismiss = true,
+            Width = "640px",
+            Height = "610px",
+            PreventDismissOnOverlayClick = true,
+            PreventScroll = true,
+
+        });
+        var result = await _dialog.Result;
+
+        if (!result.Cancelled && result.Data is not null)
+        {
+            _cookieState = (CookieState)result.Data;
+
+            await CookieConsentService.SetCookieStateAsync(_cookieState);
+            await InitAnalyticsAsync();
+        }
+    }
+
+    private async Task InitAnalyticsAsync()
+    {
+        if (_cookieState?.AcceptAnalytics == true)
+        {
+            await CookieConsentService.InitAnalyticsAsync(GA_MEASUREMENT_ID, MC_PROIOJECT_ID);
+        }
+    }
+}

--- a/examples/Demo/Shared/Components/Cookies/CookieConsent.razor.css
+++ b/examples/Demo/Shared/Components/Cookies/CookieConsent.razor.css
@@ -1,0 +1,43 @@
+#cookieconsent {
+    position: relative;
+    display: flex;
+    z-index: 998;
+    width: 100%;
+    justify-content: space-between;
+    text-align: left;
+    background-color: var(--neutral-layer-2);
+}
+
+.info {
+    margin: 0;
+    padding-left: 5%;
+    padding-top: 8px;
+    padding-bottom: 8px;
+}
+.infoicon {
+    display: table-cell;
+    padding: 12px;
+    width: 24px;
+    height: 24px;
+}
+
+.infomessage {
+    display: table-cell;
+    vertical-align: middle;
+    padding: 0;
+}
+
+.buttons {
+    display: inline-block;
+    margin-left: 5%;
+    margin-right: 5%;
+    min-width: 40%;
+    min-width: calc((150px + 3 * 4px) * 2 + 150px);
+    min-width: fit-content;
+    align-self: center;
+    position: relative;
+}
+
+.button {
+    min-width: 150px;
+}

--- a/examples/Demo/Shared/Components/Cookies/CookieConsent.razor.js
+++ b/examples/Demo/Shared/Components/Cookies/CookieConsent.razor.js
@@ -1,0 +1,92 @@
+window.dataLayer = window.dataLayer || [];
+function gtag() { dataLayer.push(arguments) };
+
+const injectGAScript = (measurementId) => {
+    // Load the Google tag manager script dynamically
+    const script = document.createElement('script');
+    script.async = true;
+    script.src = `https://www.googletagmanager.com/gtag/js?id=${measurementId}`;
+    document.head.appendChild(script);
+
+    // Initialize GA4 once the script loads
+    script.onload = () => {
+        gtag('js', new Date());
+        gtag('config', measurementId);
+        console.log('Google Analytics 4 initialized successfully');
+    };
+
+    script.onerror = () => {
+        console.error('Failed to load Google Analytics 4');
+    };
+};
+function injectMCScript(projectId) {
+    try {
+        (function (c, l, a, r, i, t, y) {
+            if (l.getElementById("clarity-script")) {
+                return;
+            }
+            c[a] = c[a] ||
+                function () {
+                    (c[a].q = c[a].q || []).push(arguments);
+                };
+            t = l.createElement(r);
+            t.async = 1;
+            t.src = "https://www.clarity.ms/tag/" + i + "?ref=npm";
+            t.id = "clarity-script"
+            y = l.getElementsByTagName(r)[0];
+            y.parentNode.insertBefore(t, y);
+        })(window, document, "clarity", "script", projectId);
+        console.log('Microsoft Clarity initialized successfully');
+        return;
+    } catch (error) {
+        console.error('Failed to load Microsoft Clarity');
+        return;
+    }
+};
+
+const Clarity = {
+    init(projectId) {
+        injectMCScript(projectId, 'clarity-script');
+    },
+
+    setTag(key, value) {
+        window.clarity('set', key, value);
+    },
+
+    identify(customerId, customSessionId, customPageId, friendlyName) {
+        window.clarity('identify', customerId, customSessionId, customPageId, friendlyName);
+    },
+
+    consent(consent = true) {
+        window.clarity('consent', consent);
+    },
+
+    upgrade(reason) {
+        window.clarity('upgrade', reason);
+    },
+
+    event(eventName) {
+        window.clarity('event', eventName);
+    },
+};
+
+export async function getCookiePolicy() {
+    const cookiePolicy = localStorage.getItem("cookie-policy")
+
+    return JSON.parse(cookiePolicy)
+}
+
+export async function setCookiePolicy(state) {
+    localStorage.setItem("cookie-policy", JSON.stringify(state))
+}
+
+export async function initAnalytics(GAmeasurementId, MCprojectId) {
+    // Google Analytics initialization
+    injectGAScript(GAmeasurementId);
+
+    // Microsoft Clarity initialization
+    Clarity.init(MCprojectId)
+    Clarity.consent()
+
+    console.log("Analytics initialized")
+}

--- a/examples/Demo/Shared/Components/Cookies/CookieConsentService.cs
+++ b/examples/Demo/Shared/Components/Cookies/CookieConsentService.cs
@@ -1,0 +1,42 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using Microsoft.FluentUI.AspNetCore.Components.Utilities;
+using Microsoft.JSInterop;
+
+namespace FluentUI.Demo.Shared.Components.Cookies;
+
+public class CookieConsentService(IJSRuntime jsRuntime) : JSModule(jsRuntime, "./_content/FluentUI.Demo.Shared/Components/Cookies/CookieConsent.razor.js")
+{
+    private CookieState? _cookieState;
+
+    public async Task<bool> IsAnalyticsConsentedAsync() =>
+        (await GetCookieStateAsync())?.AcceptAnalytics == true;
+
+    public async Task<bool> IsSocialMediaConsentedAsync() =>
+        (await GetCookieStateAsync())?.AcceptSocialMedia == true;
+
+    public async Task<bool> IsAdvertisingConsentedAsync() =>
+        (await GetCookieStateAsync())?.AcceptAdvertising == true;
+
+    public async Task<bool> IsConsentGivenAsync() =>
+        await GetCookieStateAsync() != null;
+
+    public async Task<CookieState?> GetCookieStateAsync()
+    {
+        _cookieState ??= await InvokeAsync<CookieState>("getCookiePolicy");
+        return _cookieState;
+    }
+
+    public async Task SetCookieStateAsync(CookieState state)
+    {
+        await InvokeVoidAsync("setCookiePolicy", state);
+    }
+
+    public async Task InitAnalyticsAsync(string gaMeasurementID, string mcProjectID)
+    {
+        await InvokeVoidAsync("initAnalytics", gaMeasurementID, mcProjectID);
+    }
+
+}

--- a/examples/Demo/Shared/Components/Cookies/CookieState.cs
+++ b/examples/Demo/Shared/Components/Cookies/CookieState.cs
@@ -1,0 +1,20 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+namespace FluentUI.Demo.Shared.Components.Cookies;
+
+public class CookieState(bool? acceptAnalysis, bool? acceptSocialMedia, bool? acceptAdvertising)
+{
+    public bool? AcceptAnalytics { get; set; } = acceptAnalysis;
+    public bool? AcceptSocialMedia { get; set; } = acceptSocialMedia;
+    public bool? AcceptAdvertising { get; set; } = acceptAdvertising;
+
+    public CookieState() : this(null, null, null)
+    {
+    }
+
+    public CookieState(bool acceptAll) : this(acceptAll, acceptAll, acceptAll)
+    {
+    }
+}

--- a/examples/Demo/Shared/Components/Cookies/ManageCookies.razor
+++ b/examples/Demo/Shared/Components/Cookies/ManageCookies.razor
@@ -52,12 +52,12 @@
     public CookieState Content { get; set; } = default!;
 
     [CascadingParameter]
-    public FluentDialog? Dialog { get; set; }
+    public FluentDialog? Dialog { get; set; } = default!;
 
 
     private async Task HandleSaveAsync()
     {
-        await Dialog!.CloseAsync(Content);
+        await Dialog.CloseAsync(Content);
     }
 
     private async Task HandleCancelAsync()
@@ -65,6 +65,6 @@
         Content.AcceptAnalytics = null;
         Content.AcceptSocialMedia = null;
         Content.AcceptAdvertising = null;
-        await Dialog!.CancelAsync();
+        await Dialog.CancelAsync();
     }
 }

--- a/examples/Demo/Shared/Components/Cookies/ManageCookies.razor
+++ b/examples/Demo/Shared/Components/Cookies/ManageCookies.razor
@@ -1,0 +1,70 @@
+﻿@namespace FluentUI.Demo.Shared.Components.Cookies
+@implements IDialogContentComponent<CookieState>
+
+<FluentDialogBody Style="height: 446px; overflow: auto;">
+    <p class="_20_nXDf6uFs9Q6wxRXG-I- w8hcgFksdo30C8w-bygqu">
+        Most Microsoft websites use cookies. Cookies are small text files placed on your device to store data so web servers can use it later. Microsoft and our third-party partners use cookies to remember your preferences and settings, help you sign in, show you personalized ads, and analyze how well our websites are working. For more info, see the Cookies and similar technologies section of the <a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=845480">Privacy Statement</a>.
+    </p>
+
+    <dl>
+        <dt>
+            <h4>Required</h4>
+            <p class="explainer">We use required cookies to perform essential website functions. For example, they're used to log you in, save your language preferences, provide a shopping cart experience, improve performance, route traffic between web servers, detect the size of your screen, determine page load times, improve user experience, and for audience measurement. These cookies are necessary for our websites to work.</p>
+        </dt>
+
+        <dt aria-label="Analytics">
+            <h4>Analytics</h4>
+            <p class="explainer">We allow third parties to use analytics cookies to understand how you use our websites so we can make them better and the third parties can develop and improve their products, which they may use on websites that are not owned or operated by Microsoft. For example, they're used to gather information about the pages you visit and how many clicks you need to accomplish a task. We use some analytics cookies for advertising.</p>
+            <FluentRadioGroup Class="choices" Name="AcceptAnalytics" @bind-Value="@Content.AcceptAnalytics">
+                <FluentRadio Value="true">Accept</FluentRadio>
+                <FluentRadio Value="false">Reject</FluentRadio>
+            </FluentRadioGroup>
+        </dt>
+
+        <dt aria-label="Social Media">
+            <h4>Social Media</h4>
+            <p class="explainer">We and third parties use social media cookies to show you ads and content based on your social media profiles and activity on our websites. They’re used to connect your activity on our websites to your social media profiles so the ads and content you see on our websites and on social media will better reflect your interests.</p>
+            <FluentRadioGroup Class="choices" Name="AcceptAnalytics" @bind-Value="@Content.AcceptSocialMedia">
+                <FluentRadio Value="true">Accept</FluentRadio>
+                <FluentRadio Value="false">Reject</FluentRadio>
+            </FluentRadioGroup>
+        </dt>
+
+        <dt aria-label="Advertising">
+            <h4>Advertising</h4>
+            <p class="explainer">We and third parties use advertising cookies to show you new ads by recording which ads you've already seen. They're also used to track which ads you click on or purchases you make after clicking on an ad for payment purposes, and to show you ads that are more relevant to you. For example, they're used to detect when you click on an ad and show you ads based on your social media interests and website browsing history.</p>
+            <FluentRadioGroup Class="choices" Name="AcceptAnalytics" @bind-Value="@Content.AcceptAdvertising">
+                <FluentRadio Value="true">Accept</FluentRadio>
+                <FluentRadio Value="false">Reject</FluentRadio>
+            </FluentRadioGroup>
+        </dt>
+    </dl>
+</FluentDialogBody>
+<FluentDialogFooter>
+    <FluentButton Style="min-width: 150px;" Disabled="@_buttonsDisabled" @onclick="HandleSaveAsync" Appearance="Appearance.Accent">Save changes</FluentButton>
+    <FluentButton Style="min-width: 150px;" Disabled="@_buttonsDisabled" @onclick="HandleCancelAsync">Cancel</FluentButton>
+</FluentDialogFooter>
+
+@code {
+    private bool _buttonsDisabled => Content.AcceptAnalytics is null && Content.AcceptSocialMedia is null && Content.AcceptAdvertising is null;
+
+    [Parameter]
+    public CookieState Content { get; set; } = default!;
+
+    [CascadingParameter]
+    public FluentDialog? Dialog { get; set; }
+
+
+    private async Task HandleSaveAsync()
+    {
+        await Dialog!.CloseAsync(Content);
+    }
+
+    private async Task HandleCancelAsync()
+    {
+        Content.AcceptAnalytics = null;
+        Content.AcceptSocialMedia = null;
+        Content.AcceptAdvertising = null;
+        await Dialog!.CancelAsync();
+    }
+}

--- a/examples/Demo/Shared/Components/Cookies/ManageCookies.razor
+++ b/examples/Demo/Shared/Components/Cookies/ManageCookies.razor
@@ -2,7 +2,7 @@
 @implements IDialogContentComponent<CookieState>
 
 <FluentDialogBody Style="height: 446px; overflow: auto;">
-    <p class="_20_nXDf6uFs9Q6wxRXG-I- w8hcgFksdo30C8w-bygqu">
+    <p class="explainer">
         Most Microsoft websites use cookies. Cookies are small text files placed on your device to store data so web servers can use it later. Microsoft and our third-party partners use cookies to remember your preferences and settings, help you sign in, show you personalized ads, and analyze how well our websites are working. For more info, see the Cookies and similar technologies section of the <a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=845480">Privacy Statement</a>.
     </p>
 

--- a/examples/Demo/Shared/Components/Cookies/ManageCookies.razor.css
+++ b/examples/Demo/Shared/Components/Cookies/ManageCookies.razor.css
@@ -1,0 +1,47 @@
+dl {
+    margin-top: 36px;
+    margin-bottom: 0;
+    padding: 0;
+    list-style: none;
+    text-transform: none;
+}
+
+dt {
+    margin-top: 20px;
+    float: none;
+    font-family: Segoe UI, SegoeUI, Arial, sans-serif;
+    font-style: normal;
+    font-weight: 600;
+    font-size: 18px;
+    line-height: 24px;
+    list-style: none;
+}
+
+dt > h4 {
+    margin: 0;
+    padding: 0;
+}
+
+form {
+    height: 446px;
+    overflow: auto;
+}
+
+.explainer, .choices {
+    margin-bottom: 13px;
+}
+
+.buttons {
+    display: inline-block;
+    margin-left: 5%;
+    margin-right: 5%;
+    min-width: 40%;
+    min-width: calc((150px + 3 * 4px) * 2 + 150px);
+    min-width: fit-content;
+    align-self: center;
+    position: relative;
+}
+
+.button {
+    min-width: 150px;
+}

--- a/examples/Demo/Shared/Components/SiteSettingsPanel.razor
+++ b/examples/Demo/Shared/Components/SiteSettingsPanel.razor
@@ -1,5 +1,7 @@
-﻿@implements IDialogContentComponent
+﻿@using FluentUI.Demo.Shared.Components.Cookies
+@implements IDialogContentComponent
 
+<CookieConsent @ref="@_cookie"/>
 <div>
     <FluentDesignTheme @ref=_theme
                        @bind-Mode="@Mode"
@@ -7,7 +9,7 @@
                        Direction="@Direction"
                        StorageName="theme" />
 
-    <FluentStack Orientation="Orientation.Vertical" VerticalGap="0">
+    <FluentStack Orientation="Orientation.Vertical" VerticalGap="5">
         <FluentSelect Label="Theme"
                       Width="100%"
                       Style="margin-bottom: 30px;"
@@ -65,10 +67,10 @@
         </FluentPopover>
 
         <FluentStack VerticalAlignment="VerticalAlignment.Center">
-            <FluentButton OnClick="@ResetSiteAsync">Reset settings</FluentButton>
+            <FluentButton Style="width: 125px;" OnClick="@ResetSiteAsync">Reset settings</FluentButton>
             <FluentIcon Id="info" Value="@(new Icons.Regular.Size24.Info())" OnClick="@(() => _popVisible = !_popVisible)" />
         </FluentStack>
-
+        <FluentButton Style="width: 125px;" OnClick="@ManageCookieSettingsAsync">Manage cookies</FluentButton>
         <p style="margin-top: 1rem;">
             <em><strong>@_status</strong></em>
         </p>

--- a/examples/Demo/Shared/Components/SiteSettingsPanel.razor.cs
+++ b/examples/Demo/Shared/Components/SiteSettingsPanel.razor.cs
@@ -1,3 +1,8 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using FluentUI.Demo.Shared.Components.Cookies;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 using Microsoft.FluentUI.AspNetCore.Components;
@@ -7,6 +12,7 @@ namespace FluentUI.Demo.Shared.Components;
 
 public partial class SiteSettingsPanel
 {
+    private CookieConsent? _cookie;
     private string? _status;
     private bool _popVisible;
     private bool _ltr = true;
@@ -65,6 +71,14 @@ public partial class SiteSettingsPanel
 
         OfficeColor = OfficeColorUtilities.GetRandom();
         Mode = DesignThemeModes.System;
+    }
+
+    private async Task ManageCookieSettingsAsync()
+    {
+        if (_cookie != null)
+        {
+            await _cookie.ManageCookiesAsync();
+        }
     }
 
     private static string? GetCustomColor(OfficeColor? color)

--- a/examples/Demo/Shared/FluentUI.Demo.Shared.csproj
+++ b/examples/Demo/Shared/FluentUI.Demo.Shared.csproj
@@ -39,7 +39,7 @@
 	<ItemGroup>
 		<PackageReference Include="Markdig.Signed" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.Web" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" />
+        <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" />
 		<PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" />
 	</ItemGroup>
 

--- a/examples/Demo/Shared/Infrastructure/HttpBasedStaticAssetService.cs
+++ b/examples/Demo/Shared/Infrastructure/HttpBasedStaticAssetService.cs
@@ -1,3 +1,7 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
 using Microsoft.AspNetCore.Components;
 
 namespace FluentUI.Demo.Shared;
@@ -18,7 +22,7 @@ public class HttpBasedStaticAssetService : IStaticAssetService
     {
         string? result = null;
 
-        HttpRequestMessage? message = CreateMessage(assetUrl);
+        var message = CreateMessage(assetUrl);
 
         if (useCache)
         {
@@ -29,7 +33,7 @@ public class HttpBasedStaticAssetService : IStaticAssetService
         if (string.IsNullOrEmpty(result))
         {
             //It not in the cache (or cache not used), download the asset
-            HttpResponseMessage? response = await _httpClient.SendAsync(message);
+            var response = await _httpClient.SendAsync(message);
 
             // If successful, store the response in the cache and get the result
             if (response.IsSuccessStatusCode)

--- a/examples/Demo/Shared/Infrastructure/ServiceCollectionExtensions.cs
+++ b/examples/Demo/Shared/Infrastructure/ServiceCollectionExtensions.cs
@@ -2,7 +2,9 @@
 // MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
 // ------------------------------------------------------------------------
 
+using FluentUI.Demo.Shared.Components.Cookies;
 using FluentUI.Demo.Shared.Infrastructure;
+using FluentUI.Demo.Shared.SampleData;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace FluentUI.Demo.Shared;
@@ -15,8 +17,10 @@ public static class ServiceCollectionExtensions
     /// <param name="services">Service collection</param>
     public static IServiceCollection AddFluentUIDemoClientServices(this IServiceCollection services)
     {
+        services.AddScoped<DataSource>();
         services.AddSingleton<IAppVersionService, AppVersionService>();
-        services.AddSingleton<CacheStorageAccessor>();
+        services.AddScoped<CacheStorageAccessor>();
+        services.AddScoped<CookieConsentService>();
         services.AddHttpClient<IStaticAssetService, HttpBasedStaticAssetService>();
         services.AddSingleton<DemoNavProvider>();
 
@@ -29,8 +33,10 @@ public static class ServiceCollectionExtensions
     /// <param name="services">Service collection</param>
     public static IServiceCollection AddFluentUIDemoServerServices(this IServiceCollection services)
     {
+        services.AddScoped<DataSource>();
         services.AddScoped<IAppVersionService, AppVersionService>();
         services.AddScoped<CacheStorageAccessor>();
+        services.AddScoped<CookieConsentService>();
         services.AddHttpClient<IStaticAssetService, ServerStaticAssetService>();
         services.AddSingleton<DemoNavProvider>();
 

--- a/examples/Demo/Shared/Shared/DemoMainLayout.razor
+++ b/examples/Demo/Shared/Shared/DemoMainLayout.razor
@@ -1,4 +1,5 @@
-﻿@using FluentUI.Demo.Shared.Shared
+﻿@using FluentUI.Demo.Shared.Components.Cookies
+@using FluentUI.Demo.Shared.Shared
 @using FluentUI.Demo.Shared.Pages.MessageBar.Examples
 @using Microsoft.AspNetCore.Components
 @using System.Runtime.InteropServices
@@ -6,6 +7,7 @@
 
 <PageTitle>@App.PageTitle("Demo")</PageTitle>
 
+<CookieConsent />
 <div>
     <FluentLayout>
         <FluentHeader Class="siteheader">

--- a/examples/Demo/Shared/Shared/DemoMainLayout.razor.cs
+++ b/examples/Demo/Shared/Shared/DemoMainLayout.razor.cs
@@ -1,3 +1,7 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
 using FluentUI.Demo.Shared.Components;
 using FluentUI.Demo.Shared.Infrastructure;
 using Microsoft.AspNetCore.Components;

--- a/src/Core/Utilities/JSModule.cs
+++ b/src/Core/Utilities/JSModule.cs
@@ -1,3 +1,7 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.JSInterop;
 using static Microsoft.FluentUI.AspNetCore.Components.Utilities.LinkerFlags;
@@ -72,7 +76,7 @@ public abstract class JSModule : IAsyncDisposable
         {
             try
             {
-                IJSObjectReference? module = await _moduleTask.Value;
+                var module = await _moduleTask.Value;
                 await module.DisposeAsync().ConfigureAwait(false);
             }
             catch (InvalidOperationException)


### PR DESCRIPTION
This PR adds a cookie consent banner and functionality to the Demo & Documentation site, both for the (live) Wasm site and for the Server version of the site. The content and options are according to the Microsoft guidelines. 

![image](https://github.com/user-attachments/assets/fee5f3e9-cd86-46cb-a6ec-1fe4b9c1d3ab)

There are three categories that can be consented to: analytic cookies, social media cookies and advertising cookies (as per the Microsoft standard) The settings following the choices made will be put in local storage. When consent is provided for analytics, the Google Analytics and Microsoft Clarity scripts will be added to the page and cookies will be written. Currently, we do not do anything with the social media and advertising consent.
`Accept` gives consent for all three categories. `Reject` does not provide consent  to any of the categories. `Manage cookies` allows for providing consent to each category individually:

![image](https://github.com/user-attachments/assets/a67e9f5f-ad0f-40db-a147-91af0472c46b)

When later, a user wants to revise their consent settings, the Settings panel now offers a `Manage cookies` option as well:

![image](https://github.com/user-attachments/assets/afe1c562-02c1-4610-8776-23d0738c707e)


 