### PR TITLE
[DesignTheme] Fix the document.body.dataset.theme from the web component

### DIFF
--- a/src/Core.Assets/src/DesignTheme.ts
+++ b/src/Core.Assets/src/DesignTheme.ts
@@ -53,11 +53,13 @@ class DesignTheme extends HTMLElement {
       // Dark mode - Luminance = 0.15
       case "dark":
         baseLayerLuminance.withDefault(StandardLuminance.DarkMode);
+        document.body.dataset.theme = "dark";
         break;
 
       // Light mode - Luminance = 0.98
       case "light":
         baseLayerLuminance.withDefault(StandardLuminance.LightMode);
+        document.body.dataset.theme = "light";
         break;
 
       // System mode
@@ -65,9 +67,11 @@ class DesignTheme extends HTMLElement {
         const isDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
         if (isDark) {
           baseLayerLuminance.withDefault(StandardLuminance.DarkMode);
+          document.body.dataset.theme = "dark";
         }
         else {
           baseLayerLuminance.withDefault(StandardLuminance.LightMode);
+          document.body.dataset.theme = "light";
         }
         break;
     }


### PR DESCRIPTION
# Fix the document.body.dataset.theme from the web component

Example using 
```css
@media (prefers-color-scheme: dark) {
    body:not([data-theme="light"]) {
        background-color: pink;
    }
}
```

## Before
A “flash” occurs during reload in “light mode”.
![01](https://github.com/user-attachments/assets/0d71a1ce-05e6-4522-99c2-1d147688e2d5)

## After
![02](https://github.com/user-attachments/assets/367d7bcc-eb13-443a-91c1-cfdd7a6e3415)

See #3502