### PR TITLE
[DesignTokens] Make `AccentBaseColor` and `NeutralBaseColor` work with WithDefault

### DIFF
--- a/examples/Demo/Shared/Pages/Design/DesignTokensPage.razor
+++ b/examples/Demo/Shared/Pages/Design/DesignTokensPage.razor
@@ -1,10 +1,33 @@
 ﻿@page "/DesignTokens"
+@using FluentUI.Demo.Shared.Pages.Design.Examples
 
 <PageTitle>@App.PageTitle("Design Tokens")</PageTitle>
 
 <h1>Design Tokens</h1>
 
 <MarkdownSection FromAsset="./_content/FluentUI.Demo.Shared/docs/DesignTokens.md" OnContentConverted="RefreshTableOfContents" />
+
+<DemoSection Component="@typeof(DesignTokensDefault)" Title="Example of working with DesignTokens programmatically">
+    <Description>
+        <p>Use the first button go swith bewteen dark and light mode. Click the second button to toggle the accent and neutral colors. The third button has a custom font, and the last one has a custom border width and corner radius.</p>
+        <p>
+            As can be seen in the code tab (with the `ref4.Element`), it is possible to apply multiple tokens to the same component.
+        </p>
+
+        <p>
+            For Design Tokens that work with a color value, you must call the <code>ToSwatch()</code> extension method* on a string value or use one of the Swatch constructors. This
+            makes sure the color is using a format that Design Tokens can handle. A Swatch has a lot of commonality with the <code>System.Drawing.Color</code> struct. Instead of
+            the values of the components being between 0 and 255, in a Swatch the components are expressed as a value between 0 and 1
+        </p>
+        <p><em>* except for the AccentBaseColor and NeutralBaseColor. These just take a hex value as a string for the color.</em></p>
+    </Description>
+</DemoSection>
+
+<h3>Colors for integration with specific Microsoft products</h3>
+<p>
+    If you are configuring the components for integration into a specific Microsoft product, the following table provides `AccentBaseColor` values you can use.
+    <strong>The specific accent colors for many Office applications are offered in the `OfficeColor` enumeration.</strong>
+</p>
 
 @if (refreshCount > 0)
 {

--- a/examples/Demo/Shared/Pages/Design/Examples/DesignTokensDefault.razor
+++ b/examples/Demo/Shared/Pages/Design/Examples/DesignTokensDefault.razor
@@ -1,0 +1,74 @@
+﻿@using Microsoft.FluentUI.AspNetCore.Components.DesignTokens
+
+<FluentButton @ref="ref1" @onclick="OnClickFirst">Dark/Light</FluentButton>
+<FluentButton @ref="ref2" @onclick="OnClickSecond" Appearance ="Appearance.Accent">Accent button</FluentButton>
+<FluentButton @ref="ref3">And one more</FluentButton>
+<FluentButton @ref="ref4" @onclick=OnClickLast>Last button</FluentButton>
+
+
+@code {
+    [Inject]
+    private BaseLayerLuminance BaseLayerLuminance { get; set; } = default!;
+
+    [Inject]
+    private AccentBaseColor AccentBaseColor { get; set; } = default!;
+
+    [Inject]
+    private NeutralBaseColor NeutralBaseColor { get; set; } = default!;
+
+    [Inject]
+    private BodyFont BodyFont { get; set; } = default!;
+
+    [Inject]
+    private StrokeWidth StrokeWidth { get; set; } = default!;
+
+    [Inject]
+    private ControlCornerRadius ControlCornerRadius { get; set; } = default!;
+
+    private FluentButton? ref1;
+    private FluentButton? ref2;
+    private FluentButton? ref3;
+    private FluentButton? ref4;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            //Set to dark mode
+            //await BaseLayerLuminance.SetValueFor(ref1!.Element, (float)0.15);
+
+            //Set the font
+            await BodyFont.SetValueFor(ref3!.Element, "Comic Sans MS");
+
+            //Set 'border' width for ref4
+            await StrokeWidth.SetValueFor(ref4!.Element, 7);
+            //And change conrner radius as well
+            await ControlCornerRadius.SetValueFor(ref4!.Element, 15);
+
+            StateHasChanged();
+        }
+    }
+
+    public async Task OnClickFirst()
+    {
+        float? value = await BaseLayerLuminance.GetValueFor(ref1!.Element);
+        //Set to light mode
+        await BaseLayerLuminance.WithDefault(value == 0.15f ? (float)1.0 : (float)0.15);
+    }
+
+    public async Task OnClickSecond()
+    {
+        Swatch accent = await AccentBaseColor.GetValueFor(ref2!.Element);
+        Swatch neutral = await NeutralBaseColor.GetValueFor(ref2!.Element);
+
+        await AccentBaseColor.WithDefault(accent.B == (float)0.274509817 ? "#0078D4" : "#217346");
+        await NeutralBaseColor.WithDefault(neutral.B == (float)0.3372549 ? "#808080" : "#c75656");
+    }
+
+    public async Task OnClickLast()
+    {
+        //Remove the wide border
+        await StrokeWidth.DeleteValueFor(ref4!.Element);
+    }
+
+}

--- a/examples/Demo/Shared/Pages/Lab/IssueTester.razor
+++ b/examples/Demo/Shared/Pages/Lab/IssueTester.razor
@@ -1,14 +1,12 @@
 ﻿@using Microsoft.FluentUI.AspNetCore.Components.DesignTokens
 
-<FluentButton @ref="ref1">A button</FluentButton>
-<FluentButton @ref="ref2" Appearance="Appearance.Accent">Another button</FluentButton>
+<FluentButton @ref="ref1" @onclick=OnClickFirst>Dark/Light</FluentButton>
+<FluentButton @ref="ref2" Appearance="Appearance.Accent">Accent button</FluentButton>
 <FluentButton @ref="ref3">And one more</FluentButton>
-<FluentButton @ref="ref4" @onclick=OnClick>Last button</FluentButton>
+<FluentButton @ref="ref4" @onclick=OnClickLast>Last button</FluentButton>
 
 
 @code {
-
-
     [Inject]
     private BaseLayerLuminance BaseLayerLuminance { get; set; } = default!;
 
@@ -37,10 +35,7 @@
         if (firstRender)
         {
             //Set to dark mode
-            await BaseLayerLuminance.SetValueFor(ref1!.Element, (float)0.15);
-
-            //Set to Excel color
-            //await AccentBaseColor.SetValueFor(ref2!.Element, "#217346".ToSwatch());
+            //await BaseLayerLuminance.SetValueFor(ref1!.Element, (float)0.15);
 
             //Set the font
             await BodyFont.SetValueFor(ref3!.Element, "Comic Sans MS");
@@ -50,20 +45,21 @@
             //And change conrner radius as well
             await ControlCornerRadius.SetValueFor(ref4!.Element, 15);
 
-            // If you would like to change the BaseLayerLuminance  value for the whole site, you can use the WithDefault method
-            //await BaseLayerLuminance.WithDefault((float)0.15);
-
             await AccentBaseColor.WithDefault("#217346");
             await NeutralBaseColor.WithDefault("#c75656");
-
-
-
 
             StateHasChanged();
         }
     }
 
-    public async Task OnClick()
+    public async Task OnClickFirst()
+    {
+        float? value = await BaseLayerLuminance.GetValueFor(ref1!.Element);
+        //Set to light mode
+        await BaseLayerLuminance.WithDefault(value == 0.15f ? (float)1.0 : (float)0.15);
+    }
+
+    public async Task OnClickLast()
     {
         //Remove the wide border
         await StrokeWidth.DeleteValueFor(ref4!.Element);

--- a/examples/Demo/Shared/Pages/Lab/IssueTester.razor
+++ b/examples/Demo/Shared/Pages/Lab/IssueTester.razor
@@ -1,1 +1,72 @@
-﻿
+﻿@using Microsoft.FluentUI.AspNetCore.Components.DesignTokens
+
+<FluentButton @ref="ref1">A button</FluentButton>
+<FluentButton @ref="ref2" Appearance="Appearance.Accent">Another button</FluentButton>
+<FluentButton @ref="ref3">And one more</FluentButton>
+<FluentButton @ref="ref4" @onclick=OnClick>Last button</FluentButton>
+
+
+@code {
+
+
+    [Inject]
+    private BaseLayerLuminance BaseLayerLuminance { get; set; } = default!;
+
+    [Inject]
+    private AccentBaseColor AccentBaseColor { get; set; } = default!;
+
+    [Inject]
+    private NeutralBaseColor NeutralBaseColor { get; set; } = default!;
+
+    [Inject]
+    private BodyFont BodyFont { get; set; } = default!;
+
+    [Inject]
+    private StrokeWidth StrokeWidth { get; set; } = default!;
+
+    [Inject]
+    private ControlCornerRadius ControlCornerRadius { get; set; } = default!;
+
+    private FluentButton? ref1;
+    private FluentButton? ref2;
+    private FluentButton? ref3;
+    private FluentButton? ref4;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            //Set to dark mode
+            await BaseLayerLuminance.SetValueFor(ref1!.Element, (float)0.15);
+
+            //Set to Excel color
+            //await AccentBaseColor.SetValueFor(ref2!.Element, "#217346".ToSwatch());
+
+            //Set the font
+            await BodyFont.SetValueFor(ref3!.Element, "Comic Sans MS");
+
+            //Set 'border' width for ref4
+            await StrokeWidth.SetValueFor(ref4!.Element, 7);
+            //And change conrner radius as well
+            await ControlCornerRadius.SetValueFor(ref4!.Element, 15);
+
+            // If you would like to change the BaseLayerLuminance  value for the whole site, you can use the WithDefault method
+            //await BaseLayerLuminance.WithDefault((float)0.15);
+
+            await AccentBaseColor.WithDefault("#217346");
+            await NeutralBaseColor.WithDefault("#c75656");
+
+
+
+
+            StateHasChanged();
+        }
+    }
+
+    public async Task OnClick()
+    {
+        //Remove the wide border
+        await StrokeWidth.DeleteValueFor(ref4!.Element);
+    }
+
+}

--- a/examples/Demo/Shared/wwwroot/docs/DesignTokens.md
+++ b/examples/Demo/Shared/wwwroot/docs/DesignTokens.md
@@ -237,78 +237,7 @@ There are a couple of methods available **per design token** to get or set its v
 - `{DesignTokenName}.WithDefault(T value)` - Sets the default value for the whole design system use.
 - `{DesignTokenName}.GetValueFor(ElementReference element)` - Gets the value for the given element.- `
 
-#### Example
-Given the following `.razor` page fragment:
 
-```cshtml
-<FluentButton @ref="ref1">A button</FluentButton>
-<FluentButton @ref="ref2" Appearance="Appearance.Accent">Another button</FluentButton>
-<FluentButton @ref="ref3">And one more</FluentButton>
-<FluentButton @ref="ref4" @onclick=OnClick>Last button</FluentButton>
-```
-
-You can use Design Tokens to manipulate the styles from C# code as follows:
-
-```csharp
-@using Microsoft.FluentUI.AspNetCore.Components.DesignTokens
-
-[Inject]
-private BaseLayerLuminance BaseLayerLuminance { get; set; } = default!;
-
-[Inject]
-private AccentBaseColor AccentBaseColor { get; set; } = default!;
-
-[Inject]
-private BodyFont BodyFont { get; set; } = default!;
-
-[Inject]
-private StrokeWidth StrokeWidth { get; set; } = default!;
-
-[Inject]
-private ControlCornerRadius ControlCornerRadius { get; set; } = default!;
-
-private FluentButton? ref1;
-private FluentButton? ref2;
-private FluentButton? ref3;
-private FluentButton? ref4;
-
-protected override async Task OnAfterRenderAsync(bool firstRender)
-{
-	if (firstRender)
-	{
-		//Set to dark mode
-		await BaseLayerLuminance.SetValueFor(ref1!.Element, (float)0.15);
-
-		//Set to Excel color
-		await AccentBaseColor.SetValueFor(ref2!.Element, "#217346".ToSwatch());
-
-		//Set the font
-		await BodyFont.SetValueFor(ref3!.Element, "Comic Sans MS");
-
-		//Set 'border' width for ref4
-		await StrokeWidth.SetValueFor(ref4!.Element, 7);
-		//And change conrner radius as well
-		await ControlCornerRadius.SetValueFor(ref4!.Element, 15);
-
-		// If you would like to change the BaseLayerLuminance  value for the whole site, you can use the WithDefault method
-		await BaseLayerLuminance.WithDefault((float)0.15);
-
-		StateHasChanged();
-	}
-}
-
-public async Task OnClick()
-{
-	//Remove the wide border
-	await StrokeWidth.DeleteValueFor(ref4!.Element);
-}
-```
-
-As can be seen in the code above (with the `ref4.Element`), it is possible to apply multiple tokens to the same component.
- 
-For Design Tokens that work with a color value, you must call the `ToSwatch()` extension method on a string value or use one of the Swatch constructors. This 
-makes sure the color is using a format that Design Tokens can handle. A Swatch has a lot of commonality with the `System.Drawing.Color` struct. Instead of 
-the values of the components being between 0 and 255, in a Swatch the components are expressed as a value between 0 and 1.
 
 ### Using Design Tokens as components
 The Design Tokens can also be used as components in a `.razor` page directely. It looks like this:
@@ -334,6 +263,3 @@ To make this work, a link needs to be created between the Design Token component
 > Only one Design Token component at a time can be used this way. If you need to set more tokens, use the code approach as described in Option 1 above.
 
 
-## Colors for integration with specific Microsoft products
-If you are configuring the components for integration into a specific Microsoft product, the following table provides `AccentBaseColor` values you can use. 
-*The specific accent colors for many Office applications are offered in the `OfficeColor` enumeration.*

--- a/src/Core.Assets/src/Design/ColorsUtils.ts
+++ b/src/Core.Assets/src/Design/ColorsUtils.ts
@@ -5,53 +5,6 @@ class ColorsUtils {
   }
 
   /**
-   * See https://github.com/microsoft/fast -> packages/utilities/fast-colors/src/parse-color.ts
-   */
-  public static parseColorHexRGB(raw: string | null): ColorRGB | null {
-    // Matches #RGB and #RRGGBB, where R, G, and B are [0-9] or [A-F]
-    const hexRGBRegex: RegExp = /^#((?:[0-9a-f]{6}|[0-9a-f]{3}))$/i;
-    const result: string[] | null = hexRGBRegex.exec(raw ?? ColorsUtils.DEFAULT_COLOR);
-
-    if (result === null) {
-      return null;
-    }
-
-    let digits: string = result[1];
-
-    if (digits.length === 3) {
-      const r: string = digits.charAt(0);
-      const g: string = digits.charAt(1);
-      const b: string = digits.charAt(2);
-
-      digits = r.concat(r, g, g, b, b);
-    }
-
-    const rawInt: number = parseInt(digits, 16);
-
-    if (isNaN(rawInt)) {
-      return null;
-    }
-
-    return new ColorRGB(
-      this.normalized((rawInt & 0xff0000) >>> 16, 0, 255),
-      this.normalized((rawInt & 0x00ff00) >>> 8, 0, 255),
-      this.normalized(rawInt & 0x0000ff, 0, 255),
-    );
-  }
-
-  /**
-   * Scales an input to a number between 0 and 1
-   */
-  public static normalized(i: number, min: number, max: number): number {
-    if (isNaN(i) || i <= min) {
-      return 0.0;
-    } else if (i >= max) {
-      return 1.0;
-    }
-    return i / (max - min);
-  }
-
-  /**
    * Convert to named color to an equivalent Hex color
    * @param name Office color name
    * @returns Hexadecimal color
@@ -92,18 +45,6 @@ class ColorsUtils {
     { App: "Yamme", Color: "#106ebe" },
     { App: "Word", Color: "" },
   ];
-}
-
-class ColorRGB {
-  constructor(red: number, green: number, blue: number) {
-    this.r = red;
-    this.g = green;
-    this.b = blue;
-  }
-
-  public readonly r: number;
-  public readonly g: number;
-  public readonly b: number;
 }
 
 export { ColorsUtils };

--- a/src/Core.Assets/src/DesignTheme.ts
+++ b/src/Core.Assets/src/DesignTheme.ts
@@ -3,6 +3,7 @@
 // ********************
 
 import { ColorsUtils } from "./Design/ColorsUtils";
+import { parseColorHexRGB } from '@microsoft/fast-colors'
 import {
   baseLayerLuminance,
   StandardLuminance,
@@ -77,8 +78,8 @@ class DesignTheme extends HTMLElement {
 
   /**
   * Gets the current color or office name attribute value.
-  * Access, Booking, Exchange, Excel, GroupMe, Office, OneDrive, OneNote, Outlook, 
-  * Planner, PowerApps, PowerBI, PowerPoint, Project, Publisher, SharePoint, Skype, 
+  * Access, Booking, Exchange, Excel, GroupMe, Office, OneDrive, OneNote, Outlook,
+  * Planner, PowerApps, PowerBI, PowerPoint, Project, Publisher, SharePoint, Skype,
   * Stream, Sway, Teams, Visio, Windows, Word, Yammer
   */
   get primaryColor(): string | null {
@@ -97,7 +98,7 @@ class DesignTheme extends HTMLElement {
       : value;
 
     // Apply the color
-    const rgb = ColorsUtils.parseColorHexRGB(color);
+    const rgb = parseColorHexRGB(color);
     if (rgb != null) {
       const swatch = SwatchRGB.from(rgb);
       accentBaseColor.withDefault(swatch);
@@ -246,7 +247,7 @@ class DesignTheme extends HTMLElement {
     // If not, the dev already "forced" the mode to "dark" or "light"
     if (currentMode == null) {
 
-      // console.log(` ** colorSchemeListener = "${currentMode}"`) 
+      // console.log(` ** colorSchemeListener = "${currentMode}"`)
 
       // Dark
       if (e.matches) {

--- a/src/Core.Assets/src/index.ts
+++ b/src/Core.Assets/src/index.ts
@@ -1,5 +1,9 @@
 export * from '@fluentui/web-components/dist/web-components'
 export { parseColorHexRGB } from '@microsoft/fast-colors'
+
+import { accentBaseColor, neutralBaseColor, SwatchRGB, } from '@fluentui/web-components/dist/web-components'
+import { parseColorHexRGB } from '@microsoft/fast-colors'
+import { ColorsUtils } from './Design/ColorsUtils'
 import { SplitPanels } from './SplitPanels'
 import { DesignTheme } from './DesignTheme'
 import { FluentPageScript, onEnhancedLoad } from './FluentPageScript'
@@ -27,7 +31,6 @@ interface FluentUIEventType {
   _readOnly: any;
   type: string;
 }
-
 
 var styleSheet = new CSSStyleSheet();
 
@@ -301,7 +304,7 @@ export function afterStarted(blazor: Blazor, mode: string) {
     browserEventName: 'change',
     createEventArgs: event => {
       return {
-        value: event.target._selectedOptions[0] ? event.target._selectedOptions[0].value : event.target.value 
+        value: event.target._selectedOptions[0] ? event.target._selectedOptions[0].value : event.target.value
       }
     }
   });
@@ -330,4 +333,22 @@ export function beforeStart(options: any) {
   customElements.define("split-panels", SplitPanels);
 
   beforeStartCalled = true;
+}
+
+export function updateAccentBaseColor(value: string | null) {
+  const color = value == null || !value.startsWith("#") ? ColorsUtils.getHexColor(value) : value;
+  const rgb = parseColorHexRGB(color);
+  if (rgb != null) {
+    const swatch = SwatchRGB.from(rgb);
+    accentBaseColor.withDefault(swatch);
+  }
+}
+
+export function updateNeutralBaseColor(value: string | null) {
+  const color = value == null || !value.startsWith("#") ? ColorsUtils.getHexColor(value) : value;
+  const rgb = parseColorHexRGB(color);
+  if (rgb != null) {
+    const swatch = SwatchRGB.from(rgb);
+    neutralBaseColor.withDefault(swatch);
+  }
 }

--- a/src/Core/Components/DesignSystemProvider/FluentDesignTheme.razor.cs
+++ b/src/Core/Components/DesignSystemProvider/FluentDesignTheme.razor.cs
@@ -1,3 +1,7 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
 using System.Globalization;
 using System.Text.Json;
 using Microsoft.AspNetCore.Components;
@@ -175,7 +179,7 @@ public partial class FluentDesignTheme : ComponentBase
         }
     }
 
-    protected async override Task OnAfterRenderAsync(bool firstRender)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
         {

--- a/src/Core/DesignTokens/DesignToken.razor.cs
+++ b/src/Core/DesignTokens/DesignToken.razor.cs
@@ -1,3 +1,7 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
@@ -84,7 +88,19 @@ public partial class DesignToken<T> : ComponentBase, IDesignToken<T>, IAsyncDisp
     public async ValueTask<DesignToken<T>> WithDefault(string value)
     {
         await InitJSReferenceAsync();
-        await _jsModule.InvokeVoidAsync(Name + ".withDefault", value);
+
+        if (Name == "accentBaseColor")
+        {
+            await _jsModule.InvokeVoidAsync("updateAccentBaseColor", value);
+        }
+        else if (Name == "neutralBaseColor")
+        {
+            await _jsModule.InvokeVoidAsync("updateNeutralBaseColor", value);
+        }
+        else
+        {
+            await _jsModule.InvokeVoidAsync(Name + ".withDefault", value);
+        }
         return this;
     }
 
@@ -147,7 +163,6 @@ public partial class DesignToken<T> : ComponentBase, IDesignToken<T>, IAsyncDisp
     /// Convert a hex color string to a value the DesignToken can work with
     /// </summary>
     /// <returns>the value</returns>
-    [SuppressMessage("Style", "VSTHRD200:Use `Async` suffix for async methods", Justification = "#vNext: To update in the next version")]
     public async ValueTask<object> ParseColorHex(string color)
     {
         await InitJSReferenceAsync();

--- a/src/Core/DesignTokens/DesignTokenHelpers.cs
+++ b/src/Core/DesignTokens/DesignTokenHelpers.cs
@@ -1,3 +1,7 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
 using System.Drawing;
 
 namespace Microsoft.FluentUI.AspNetCore.Components.DesignTokens;


### PR DESCRIPTION
Fix #3511, Fix #2158

Both `AccentBaseColor` and `NeutralBaseColor` require some special handling to make it possible to assign a new color value with the `WithDefault` method. This PR adds that.

So by using the following code:
```
@using Microsoft.FluentUI.AspNetCore.Components.DesignTokens

<FluentButton @ref="ref1" @onclick=OnClickFirst>Dark/Light</FluentButton>
<FluentButton @ref="ref2" Appearance="Appearance.Accent">Accent button</FluentButton>
<FluentButton @ref="ref3">And one more</FluentButton>
<FluentButton @ref="ref4" @onclick=OnClickLast>Last button</FluentButton>

@code {
    [Inject]
    private BaseLayerLuminance BaseLayerLuminance { get; set; } = default!;

    [Inject]
    private AccentBaseColor AccentBaseColor { get; set; } = default!;

    [Inject]
    private NeutralBaseColor NeutralBaseColor { get; set; } = default!;

    [Inject]
    private BodyFont BodyFont { get; set; } = default!;

    [Inject]
    private StrokeWidth StrokeWidth { get; set; } = default!;

    [Inject]
    private ControlCornerRadius ControlCornerRadius { get; set; } = default!;

    private FluentButton? ref1;
    private FluentButton? ref2;
    private FluentButton? ref3;
    private FluentButton? ref4;

    protected override async Task OnAfterRenderAsync(bool firstRender)
    {
        if (firstRender)
        {
             //Set the font on button 3
            await BodyFont.SetValueFor(ref3!.Element, "Comic Sans MS");

            //Set 'border' width for button 4
            await StrokeWidth.SetValueFor(ref4!.Element, 7);
            //And change conrner radius as well
            await ControlCornerRadius.SetValueFor(ref4!.Element, 15);

            await AccentBaseColor.WithDefault("#217346");
            await NeutralBaseColor.WithDefault("#c75656");

            StateHasChanged();
        }
    }

    public async Task OnClickFirst()
    {
        float? value = await BaseLayerLuminance.GetValueFor(ref1!.Element);
        //Set to light/dark mode
        await BaseLayerLuminance.WithDefault(value == 0.15f ? (float)1.0 : (float)0.15);
    }

    public async Task OnClickLast()
    {
        //Remove the wide border
        await StrokeWidth.DeleteValueFor(ref4!.Element);
    }
}
```

You will now see the correct value outputted for the `--accent-base-color` and `--neutral-base-color` CSS variables:

![image](https://github.com/user-attachments/assets/23f0e693-a29b-4c32-ab9a-b2394ec6ae33)

and

![image](https://github.com/user-attachments/assets/53b8e8b6-59f0-4437-9ad3-8ce747d3c92d)

This means now all related accent buttons, checkboxes, etc. and layers and other neutral components will use the correct colors as well (calculated with a recipe defined by the web components script).

Using the values provided above will give you this (horrendous) result:

Light mode:
![image](https://github.com/user-attachments/assets/6082d40b-c36a-4771-a321-dddc1d076fca)

DarkMode:
![image](https://github.com/user-attachments/assets/3ef63f16-bb12-4744-8138-ad7e49ecc97d)


**NOTE** If you are using the `FluentDesignTheme` component, the `AccentBaseColor` will be reset to whatever primary color value you have specified there. 

