### PR TITLE
[DesignTheme] Add support for setting/getting NuetralBaseColor

### DIFF
--- a/examples/Demo/Shared/Components/SiteSettingsPanel.razor
+++ b/examples/Demo/Shared/Components/SiteSettingsPanel.razor
@@ -6,6 +6,7 @@
     <FluentDesignTheme @ref=_theme
                        @bind-Mode="@Mode"
                        @bind-OfficeColor="@OfficeColor"
+                       @bind-NeutralBaseColor="@NeutralColor"
                        Direction="@Direction"
                        StorageName="theme" />
 
@@ -31,6 +32,20 @@
                 </FluentStack>
             </OptionTemplate>
         </FluentSelect>
+        <FluentLabel>Neutral base color</FluentLabel>
+        <FluentStack VerticalAlignment="VerticalAlignment.Center">
+            <FluentTextField TextFieldType="TextFieldType.Color" @bind-Value="@NeutralColor" Style="width:150px; margin-bottom: 10px;" />
+            <FluentIcon Id="neutralinfo" Value="@(new Icons.Regular.Size24.Info())" OnClick="@(() => _popNIVisible = !_popNIVisible)" />
+            <FluentPopover Style="width: 350px;" AnchorId="neutralinfo" FixedPlacement="true" @bind-Open="@_popNIVisible">
+                <Header>Neutral base color</Header>
+                <Body>
+                    <p>
+                        The <code>NeutralBaseColor</code> design token is used to determine the color for layers and other neutral components. It uses a recipe to make sure a high enough value for the contrast is maintained.
+                    </p>
+                </Body>
+            </FluentPopover>
+        </FluentStack>
+
 
         <FluentSwitch Label="Direction"
                       Style="margin-bottom: 30px;"

--- a/examples/Demo/Shared/Components/SiteSettingsPanel.razor.cs
+++ b/examples/Demo/Shared/Components/SiteSettingsPanel.razor.cs
@@ -12,9 +12,11 @@ namespace FluentUI.Demo.Shared.Components;
 
 public partial class SiteSettingsPanel
 {
+    private const string DEFAULT_NEUTRAL_COLOR = "#808080";
+
     private CookieConsent? _cookie;
     private string? _status;
-    private bool _popVisible;
+    private bool _popVisible, _popNIVisible;
     private bool _ltr = true;
     private FluentDesignTheme? _theme;
 
@@ -30,6 +32,8 @@ public partial class SiteSettingsPanel
     public DesignThemeModes Mode { get; set; }
 
     public OfficeColor? OfficeColor { get; set; }
+
+    public string? NeutralColor { get; set; }
 
     public LocalizationDirection? Direction { get; set; }
 
@@ -49,7 +53,12 @@ public partial class SiteSettingsPanel
         {
             Direction = GlobalState.Dir;
             _ltr = !Direction.HasValue || Direction.Value == LocalizationDirection.LeftToRight;
+
+            NeutralColor = GlobalState.NeutralColor;
+            // Same default values is used for light and dark theme
+            NeutralColor ??= DEFAULT_NEUTRAL_COLOR;
         }
+
     }
 
     protected void HandleDirectionChanged(bool isLeftToRight)
@@ -71,6 +80,7 @@ public partial class SiteSettingsPanel
 
         OfficeColor = OfficeColorUtilities.GetRandom();
         Mode = DesignThemeModes.System;
+        NeutralColor = DEFAULT_NEUTRAL_COLOR;
     }
 
     private async Task ManageCookieSettingsAsync()

--- a/src/Core.Assets/src/Design/ThemeStorage.ts
+++ b/src/Core.Assets/src/Design/ThemeStorage.ts
@@ -20,7 +20,7 @@ class ThemeStorage {
   }
 
 
-  public updateLocalStorage(mode: string | null, primaryColor: string | null, neutralBaseColor: string | null): void {
+  public updateLocalStorage(mode: string | null, primaryColor: string | null, neutralColor: string | null): void {
 
     // If LocalStorage is not available, do nothing.
     if (localStorage == null) {
@@ -41,11 +41,11 @@ class ThemeStorage {
     localStorage.setItem(this.storageName, JSON.stringify({
       mode: ThemeStorage.getValueOrNull(mode),
       primaryColor: ThemeStorage.getValueOrNull(primaryColor),
-      neutralBaseColor: ThemeStorage.getValueOrNull(neutralBaseColor),
+      neutralColor: ThemeStorage.getValueOrNull(neutralColor),
     }));
   }
 
-  public readLocalStorage(): { mode: string | null, primaryColor: string | null, neutralBaseColor: string | null } | null {
+  public readLocalStorage(): { mode: string | null, primaryColor: string | null, neutralColor: string | null } | null {
 
     // If LocalStorage is not available, do nothing.
     if (localStorage == null) {
@@ -70,7 +70,7 @@ class ThemeStorage {
     return {
       mode: ThemeStorage.getValueOrNull(storageItems?.mode),
       primaryColor: ThemeStorage.getValueOrNull(storageItems?.primaryColor),
-      neutralBaseColor: ThemeStorage.getValueOrNull(storageItems?.neutralBaseColor),
+      neutralColor: ThemeStorage.getValueOrNull(storageItems?.neutralColor),
     }
   }
 

--- a/src/Core.Assets/src/Design/ThemeStorage.ts
+++ b/src/Core.Assets/src/Design/ThemeStorage.ts
@@ -20,7 +20,7 @@ class ThemeStorage {
   }
 
 
-  public updateLocalStorage(mode: string | null, primaryColor: string | null): void {
+  public updateLocalStorage(mode: string | null, primaryColor: string | null, neutralBaseColor: string | null): void {
 
     // If LocalStorage is not available, do nothing.
     if (localStorage == null) {
@@ -41,10 +41,11 @@ class ThemeStorage {
     localStorage.setItem(this.storageName, JSON.stringify({
       mode: ThemeStorage.getValueOrNull(mode),
       primaryColor: ThemeStorage.getValueOrNull(primaryColor),
+      neutralBaseColor: ThemeStorage.getValueOrNull(neutralBaseColor),
     }));
   }
 
-  public readLocalStorage(): { mode: string | null, primaryColor: string | null } | null {
+  public readLocalStorage(): { mode: string | null, primaryColor: string | null, neutralBaseColor: string | null } | null {
 
     // If LocalStorage is not available, do nothing.
     if (localStorage == null) {
@@ -69,6 +70,7 @@ class ThemeStorage {
     return {
       mode: ThemeStorage.getValueOrNull(storageItems?.mode),
       primaryColor: ThemeStorage.getValueOrNull(storageItems?.primaryColor),
+      neutralBaseColor: ThemeStorage.getValueOrNull(storageItems?.neutralBaseColor),
     }
   }
 

--- a/src/Core.Assets/src/DesignTheme.ts
+++ b/src/Core.Assets/src/DesignTheme.ts
@@ -116,14 +116,14 @@ class DesignTheme extends HTMLElement {
   * Gets the current neutral base color attribute value.
   */
   get neutralColor(): string | null {
-    return this.getAttribute("neutral-base-color");
+    return this.getAttribute("neutral-color");
   }
 
   /**
   *  Sets the current neutral base color attribute value.
   */
   set neutralColor(value: string | null) {
-    this.updateAttribute("neutral-base-color", value);
+    this.updateAttribute("neutral-color", value);
 
     // Apply the color
     if (value != null) {
@@ -173,7 +173,7 @@ class DesignTheme extends HTMLElement {
     if (existingComponent != null) {
       const mode = ThemeStorage.getValueOrNull(existingComponent.getAttribute("mode"));
       const color = ThemeStorage.getValueOrNull(existingComponent.getAttribute("primary-color"))
-      const neutralColor = ThemeStorage.getValueOrNull(existingComponent.getAttribute("neutral-base-color"));
+      const neutralColor = ThemeStorage.getValueOrNull(existingComponent.getAttribute("neutral-color"));
 
       // Mode can be null in other components
       this.attributeChangedCallback("mode", this.mode, mode);
@@ -185,7 +185,7 @@ class DesignTheme extends HTMLElement {
 
       // Neutral color cannot be null in other components
       if (neutralColor != null) {
-        this.attributeChangedCallback("neutral-base-color", this.neutralColor, neutralColor);
+        this.attributeChangedCallback("neutral-color", this.neutralColor, neutralColor);
       }
     }
 
@@ -196,7 +196,7 @@ class DesignTheme extends HTMLElement {
       if (theme != null) {
         this.attributeChangedCallback("mode", this.mode, theme.mode);
         this.attributeChangedCallback("primary-color", this.primaryColor, theme.primaryColor);
-        this.attributeChangedCallback("neutral-base-color", this.neutralColor, theme.neutralBaseColor);
+        this.attributeChangedCallback("neutral-color", this.neutralColor, theme.neutralColor);
       }
     }
 
@@ -235,7 +235,7 @@ class DesignTheme extends HTMLElement {
 
   // Attributes to observe
   static get observedAttributes() {
-    return ["mode", "primary-color", "neutral-base-color", "storage-name"];
+    return ["mode", "primary-color", "neutral-color", "storage-name"];
   }
 
   // Attributes has changed.
@@ -267,7 +267,7 @@ class DesignTheme extends HTMLElement {
         this.primaryColor = newValue;
         break;
 
-      case "neutral-base-color":
+      case "neutral-color":
         this.dispatchAttributeChanged(name, oldValue, newValue);
         this.neutralColor = newValue;
         break;

--- a/src/Core.Assets/src/DesignTheme.ts
+++ b/src/Core.Assets/src/DesignTheme.ts
@@ -113,6 +113,32 @@ class DesignTheme extends HTMLElement {
   }
 
   /**
+  * Gets the current neutral base color attribute value.
+  */
+  get neutralColor(): string | null {
+    return this.getAttribute("neutral-base-color");
+  }
+
+  /**
+  *  Sets the current neutral base color attribute value.
+  */
+  set neutralColor(value: string | null) {
+    this.updateAttribute("neutral-base-color", value);
+
+    // Apply the color
+    if (value != null) {
+      const rgb = parseColorHexRGB(value);
+      if (rgb != null) {
+        const swatch = SwatchRGB.from(rgb);
+        neutralBaseColor.withDefault(swatch);
+      }
+
+      // Synchronization
+      this._synchronization.synchronizeOtherComponents("neutral-color", value);
+    }
+  }
+
+  /**
   * Gets the current storage-name key, to persist the theme/color between sessions.
   */
   get storageName(): string | null {
@@ -147,6 +173,7 @@ class DesignTheme extends HTMLElement {
     if (existingComponent != null) {
       const mode = ThemeStorage.getValueOrNull(existingComponent.getAttribute("mode"));
       const color = ThemeStorage.getValueOrNull(existingComponent.getAttribute("primary-color"))
+      const neutralColor = ThemeStorage.getValueOrNull(existingComponent.getAttribute("neutral-base-color"));
 
       // Mode can be null in other components
       this.attributeChangedCallback("mode", this.mode, mode);
@@ -154,6 +181,11 @@ class DesignTheme extends HTMLElement {
       // Color cannot be null in other components
       if (color != null) {
         this.attributeChangedCallback("primary-color", this.primaryColor, color);
+      }
+
+      // Neutral color cannot be null in other components
+      if (neutralColor != null) {
+        this.attributeChangedCallback("neutral-base-color", this.neutralColor, neutralColor);
       }
     }
 
@@ -164,6 +196,7 @@ class DesignTheme extends HTMLElement {
       if (theme != null) {
         this.attributeChangedCallback("mode", this.mode, theme.mode);
         this.attributeChangedCallback("primary-color", this.primaryColor, theme.primaryColor);
+        this.attributeChangedCallback("neutral-base-color", this.neutralColor, theme.neutralBaseColor);
       }
     }
 
@@ -202,7 +235,7 @@ class DesignTheme extends HTMLElement {
 
   // Attributes to observe
   static get observedAttributes() {
-    return ["mode", "primary-color", "storage-name"];
+    return ["mode", "primary-color", "neutral-base-color", "storage-name"];
   }
 
   // Attributes has changed.
@@ -232,6 +265,11 @@ class DesignTheme extends HTMLElement {
       case "primary-color":
         this.dispatchAttributeChanged(name, oldValue, newValue);
         this.primaryColor = newValue;
+        break;
+
+      case "neutral-base-color":
+        this.dispatchAttributeChanged(name, oldValue, newValue);
+        this.neutralColor = newValue;
         break;
 
       case "storage-name":
@@ -298,7 +336,7 @@ class DesignTheme extends HTMLElement {
       }
     }
     if (this.storageName != null) {
-      this._themeStorage.updateLocalStorage(this.mode, this.primaryColor);
+      this._themeStorage.updateLocalStorage(this.mode, this.primaryColor, this.neutralColor);
     }
 
     this._isInternalChange = false;

--- a/src/Core/Components/DesignSystemProvider/FluentDesignTheme.razor
+++ b/src/Core/Components/DesignSystemProvider/FluentDesignTheme.razor
@@ -1,4 +1,4 @@
 ﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 
-<fluent-design-theme id="@Id" mode="@GetMode()" primary-color="@GetColor()" neutral-base-color="@NeutralBaseColor" storage-name="@StorageName" />
+<fluent-design-theme id="@Id" mode="@GetMode()" primary-color="@GetColor()" neutral-color="@NeutralBaseColor" storage-name="@StorageName" />
 @ChildContent

--- a/src/Core/Components/DesignSystemProvider/FluentDesignTheme.razor
+++ b/src/Core/Components/DesignSystemProvider/FluentDesignTheme.razor
@@ -1,4 +1,4 @@
-@namespace Microsoft.FluentUI.AspNetCore.Components
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 
-<fluent-design-theme id="@Id" mode="@GetMode()" primary-color="@GetColor()" storage-name="@StorageName" />
+<fluent-design-theme id="@Id" mode="@GetMode()" primary-color="@GetColor()" neutral-base-color="@NeutralBaseColor" storage-name="@StorageName" />
 @ChildContent

--- a/src/Core/Components/DesignSystemProvider/FluentDesignTheme.razor.cs
+++ b/src/Core/Components/DesignSystemProvider/FluentDesignTheme.razor.cs
@@ -182,7 +182,7 @@ public partial class FluentDesignTheme : ComponentBase
                 }
 
                 break;
-            case "neutral-base-color":
+            case "neutral-color":
                 if (value.StartsWith('#'))
                 {
                     GlobalDesign.SetNeutralColor(value);

--- a/src/Core/Components/DesignSystemProvider/FluentDesignTheme.razor.cs
+++ b/src/Core/Components/DesignSystemProvider/FluentDesignTheme.razor.cs
@@ -77,6 +77,12 @@ public partial class FluentDesignTheme : ComponentBase
     [Parameter]
     public EventCallback<OfficeColor?> OfficeColorChanged { get; set; }
 
+    [Parameter]
+    public string? NeutralBaseColor { get; set; }
+
+    [Parameter]
+    public EventCallback<string?> NeutralBaseColorChanged { get; set; }
+
     /// <summary>
     /// Gets or sets the local storage name to save and retrieve the <see cref="Mode"/> and the <see cref="OfficeColor"/> / <see cref="CustomColor"/>.
     /// </summary> 
@@ -176,6 +182,12 @@ public partial class FluentDesignTheme : ComponentBase
                 }
 
                 break;
+            case "neutral-base-color":
+                if (value.StartsWith('#'))
+                {
+                    GlobalDesign.SetNeutralColor(value);
+                }
+                break;
         }
     }
 
@@ -256,6 +268,16 @@ public partial class FluentDesignTheme : ComponentBase
                 await OnChangeRaisedAsync("primary-color", theme.PrimaryColor);
             }
         }
+
+        // Neutral base color
+        if (!string.IsNullOrEmpty(theme?.NeutralBaseColor))
+        {
+            if (theme.NeutralBaseColor.StartsWith('#'))
+            {
+                GlobalDesign.SetNeutralColor(theme.NeutralBaseColor);
+            }
+            await OnChangeRaisedAsync("neutral-base-color", theme.NeutralBaseColor);
+        }
     }
 
     /// <summary />
@@ -263,6 +285,7 @@ public partial class FluentDesignTheme : ComponentBase
     {
         public string? Mode { get; set; }
         public string? PrimaryColor { get; set; }
+        public string? NeutralBaseColor { get; set; }
     }
 
     /// <summary />

--- a/src/Core/GlobalState.cs
+++ b/src/Core/GlobalState.cs
@@ -1,3 +1,7 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
 using Microsoft.AspNetCore.Components;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
@@ -15,6 +19,8 @@ public class GlobalState
     public ElementReference Container { get; set; } = default!;
 
     public string? Color { get; set; }
+
+    public string? NeutralColor { get; set; }
 
     public event Action? OnChange;
 
@@ -39,6 +45,12 @@ public class GlobalState
     public void SetColor(string? color)
     {
         Color = color;
+        NotifyStateHasChanged();
+    }
+
+    public void SetNeutralColor(string? neutralColor)
+    {
+        NeutralColor = neutralColor;
         NotifyStateHasChanged();
     }
 


### PR DESCRIPTION
The `FluentDesignTheme` component (and accompanying web component) dit not support setting/getting the `NeutralBaseColor` design token yet. This PR adds that.

To demonstrate this is now possible, a color picker to change this value has been added to the Settings panel:

![image](https://github.com/user-attachments/assets/6d3bf567-65e4-4809-b1b4-8925eb71ca7f)


This allows for drastically changing the way the demo site looks...:
![image](https://github.com/user-attachments/assets/4c481937-a883-4688-b9a8-ec62153305ab)

and 

![image](https://github.com/user-attachments/assets/ddff056b-25be-4896-84d5-53a709d5fe7a)
