### PR TITLE
[dev-v5] FluentTooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ These providers are used by associated services to display Toasts, Dialog boxes,
 ```
 > **note:** You can remove providers that are not used in your application.
 
+You can also add all available providers in your `MainLayout.razor` file by using the `FluentProviders` component:
+```xml
+<FluentProviders />
+```
+
 ## 🔹Working with Icons and Emoji
 We have additional packages available that include the complete **Fluent UI System icons** and **Fluent UI Emoji** collections. 
 Please refer to the [Icons and Emoji](https://www.fluentui-blazor.net/IconsAndEmoji) page for more information.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/Examples/TooltipCustomized.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/Examples/TooltipCustomized.razor
@@ -4,7 +4,9 @@
     <FluentTooltip Anchor="MyCustomizedButton"
                    Delay="700"
                    Positioning="@Positioning.BelowStart"
-                   MaxWidth="200px"
+                   MaxWidth="300px"
+                   SpacingHorizontal="20px"
+                   SpacingVertical="10px"
                    Style="background-color: var(--colorBrandBackground); color: var(--colorNeutralForegroundInverted)">
         <FluentGrid>
             <FluentGridItem>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/Examples/TooltipCustomized.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/Examples/TooltipCustomized.razor
@@ -1,0 +1,18 @@
+﻿<FluentStack HorizontalAlignment="HorizontalAlignment.Center">
+    <FluentButton Id="MyCustomizedButton" IconStart="@(new Icons.Regular.Size20.Globe())">Hover me</FluentButton>
+
+    <FluentTooltip Anchor="MyCustomizedButton"
+                   Delay="700"
+                   Positioning="@Positioning.BelowStart"
+                   Style="background-color: var(--colorBrandBackground); color: var(--colorNeutralForegroundInverted)">
+        <FluentGrid>
+            <FluentGridItem>
+                <FluentIcon Value="@(new Icons.Regular.Size20.Info().WithColor(Color.FillInverse))" />
+            </FluentGridItem>
+            <FluentGridItem>
+                Really long <b>tooltip</b> content goes here.
+                Lorem ipsum dolor sit amet.
+            </FluentGridItem>
+        </FluentGrid>
+    </FluentTooltip>
+</FluentStack>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/Examples/TooltipCustomized.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/Examples/TooltipCustomized.razor
@@ -2,6 +2,8 @@
     <FluentButton Id="MyCustomizedButton" IconStart="@(new Icons.Regular.Size20.Globe())">Hover me</FluentButton>
 
     <FluentTooltip Anchor="MyCustomizedButton"
+                   OnToggle="@OnToggleAsync"
+                   OnDismissed="@OnDismissAsync"
                    Delay="700"
                    Positioning="@Positioning.BelowStart"
                    MaxWidth="300px"
@@ -14,8 +16,21 @@
             </FluentGridItem>
             <FluentGridItem>
                 Really long <b>tooltip</b> content goes here.
-                Lorem ipsum dolor sit amet.
+                Lorem ipsum dolor sit a met.
             </FluentGridItem>
         </FluentGrid>
     </FluentTooltip>
 </FluentStack>
+
+@code
+{
+    void OnToggleAsync(TooltipEventArgs args)
+    {
+        Console.WriteLine($"Tooltip is open: {args.Opened}.");
+    }
+
+    void OnDismissAsync(EventArgs args)
+    {
+        Console.WriteLine($"Tooltip is dismissed.");
+    }
+}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/Examples/TooltipCustomized.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/Examples/TooltipCustomized.razor
@@ -10,15 +10,15 @@
                    SpacingHorizontal="20px"
                    SpacingVertical="10px"
                    Style="background-color: var(--colorBrandBackground); color: var(--colorNeutralForegroundInverted)">
-        <FluentGrid>
-            <FluentGridItem>
-                <FluentIcon Value="@(new Icons.Regular.Size20.Info().WithColor(Color.Lightweight))" />
-            </FluentGridItem>
-            <FluentGridItem>
+        <FluentStack>
+            <FluentIcon Value="@(new Icons.Regular.Size20.Info().WithColor(Color.Lightweight))"
+                        Width="32px"
+                        Margin="@(Margin.Vertical2 + Margin.Right2)" />
+            <div>
                 Really long <b>tooltip</b> content goes here.
                 Lorem ipsum dolor sit a met.
-            </FluentGridItem>
-        </FluentGrid>
+            </div>
+        </FluentStack>
     </FluentTooltip>
 </FluentStack>
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/Examples/TooltipCustomized.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/Examples/TooltipCustomized.razor
@@ -4,6 +4,7 @@
     <FluentTooltip Anchor="MyCustomizedButton"
                    Delay="700"
                    Positioning="@Positioning.BelowStart"
+                   MaxWidth="200px"
                    Style="background-color: var(--colorBrandBackground); color: var(--colorNeutralForegroundInverted)">
         <FluentGrid>
             <FluentGridItem>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/Examples/TooltipCustomized.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/Examples/TooltipCustomized.razor
@@ -12,7 +12,7 @@
                    Style="background-color: var(--colorBrandBackground); color: var(--colorNeutralForegroundInverted)">
         <FluentGrid>
             <FluentGridItem>
-                <FluentIcon Value="@(new Icons.Regular.Size20.Info().WithColor(Color.FillInverse))" />
+                <FluentIcon Value="@(new Icons.Regular.Size20.Info().WithColor(Color.Lightweight))" />
             </FluentGridItem>
             <FluentGridItem>
                 Really long <b>tooltip</b> content goes here.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/Examples/TooltipDefault.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/Examples/TooltipDefault.razor
@@ -1,7 +1,7 @@
 ﻿<FluentStack HorizontalAlignment="HorizontalAlignment.Center">
-    <FluentButton Id="MyButton" IconStart="@(new Icons.Regular.Size20.Globe())" />
+    <FluentButton Id="MyButton" IconStart="@(new Icons.Regular.Size20.Globe())">Hover me</FluentButton>
 
     <FluentTooltip Anchor="MyButton">
-        Example tooltip
+        This is the description of the button
     </FluentTooltip>
 </FluentStack>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/Examples/TooltipDefault.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/Examples/TooltipDefault.razor
@@ -1,0 +1,7 @@
+﻿<FluentStack HorizontalAlignment="HorizontalAlignment.Center">
+    <FluentButton Id="MyButton" IconStart="@(new Icons.Regular.Size20.Globe())" />
+
+    <FluentTooltip Anchor="MyButton">
+        Example tooltip
+    </FluentTooltip>
+</FluentStack>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/FluentTooltip.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/FluentTooltip.md
@@ -17,6 +17,7 @@ Hover or focus the buttons in the examples to see their tooltips.
 
 ## Customized
 The tooltip can be customized with a custom template,
-adapting the delay to `700 ms`, the position of the tooltip to `BelowStart` and the style "Inverted".
+adapting the delay to `700 ms`, the position of the tooltip to `BelowStart` (including spacings to `20px` and `10px`)
+and the style "Inverted".
 
 {{ TooltipCustomized }}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/FluentTooltip.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/FluentTooltip.md
@@ -24,6 +24,30 @@ Each time the tooltip is shown or hidden, a message is logged in the console. Cl
 
 {{ TooltipCustomized }}
 
+## Using Tooltip Service Provider
+
+We advise you to always use this service when working with tooltips so all definitions will be generated with global options
+and will be written **at the end** of the HTML page to support different z-index levels.
+
+In the `Program.cs`, inject the Tooltip service with global options.
+You can also use the `Services.AddFluentUIComponents` method to register **all** required FluentUI services, including this one.
+
+```csharp
+builder.Services.AddScoped<ITooltipService, TooltipService>();
+```
+
+At the end of your MainLayout.razor page, include the provider:
+
+```xml
+<FluentTooltipProvider />
+```
+
+For the `<FluentTooltipProvider />` to work properly, it needs interactivity!
+If you are using "per page" interactivity, make sure to add a `@rendermode` to either the provider itself or the component the provider is placed in.
+
+In some use cases, you may want to render a tooltip without the provider. For example when the child content is dynamic.
+This is possible setting the `UseTooltipService` parameter to `false` in the component.
+
 ## API FluentTooltip
 
 {{ API Type=FluentTooltip }}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/FluentTooltip.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/FluentTooltip.md
@@ -1,3 +1,4 @@
+
 ---
 title: Tooltip
 route: /Tooltip
@@ -5,7 +6,8 @@ route: /Tooltip
 
 # Tooltip
 
-A `FluentTooltip` displays additional information about another component. The information is displayed above and near the target component.
+A `FluentTooltip` displays additional information about another component.
+The information is displayed near the target component by using `Positioning` it can also be placed **Above**, **Below**, etc.
 
 **Tooltip** is not expected to handle interactive content. If this is necessary behavior, an expand/collapse button + popover should be used instead.
 
@@ -30,7 +32,7 @@ We advise you to always use this service when working with tooltips so all defin
 and will be written **at the end** of the HTML page to support different z-index levels.
 
 In the `Program.cs`, inject the Tooltip service with global options.
-You can also use the `Services.AddFluentUIComponents` method to register **all** required FluentUI services, including this one.
+For more convenience, you should use the `Services.AddFluentUIComponents()` method to register all required Fluent UI services (including this one).
 
 ```csharp
 builder.Services.AddScoped<ITooltipService, TooltipService>();

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/FluentTooltip.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/FluentTooltip.md
@@ -23,3 +23,8 @@ and the style "Inverted".
 Each time the tooltip is shown or hidden, a message is logged in the console. Click on the top/right button to open the **Console**.
 
 {{ TooltipCustomized }}
+
+## API FluentTooltip
+
+{{ API Type=FluentTooltip }}
+

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/FluentTooltip.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/FluentTooltip.md
@@ -20,4 +20,6 @@ The tooltip can be customized with a custom template,
 adapting the delay to `700 ms`, the position of the tooltip to `BelowStart` (including spacings to `20px` and `10px`)
 and the style "Inverted".
 
+Each time the tooltip is shown or hidden, a message is logged in the console. Click on the top/right button to open the **Console**.
+
 {{ TooltipCustomized }}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/FluentTooltip.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/FluentTooltip.md
@@ -11,6 +11,12 @@ A `FluentTooltip` displays additional information about another component. The i
 
 Hover or focus the buttons in the examples to see their tooltips.
 
-## Appearance
+## Default
 
 {{ TooltipDefault }}
+
+## Customized
+The tooltip can be customized with a custom template,
+adapting the delay to `700 ms`, the position of the tooltip to `BelowStart` and the style "Inverted".
+
+{{ TooltipCustomized }}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/FluentTooltip.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/FluentTooltip.md
@@ -1,0 +1,16 @@
+---
+title: Tooltip
+route: /Tooltip
+---
+
+# Tooltip
+
+A `FluentTooltip` displays additional information about another component. The information is displayed above and near the target component.
+
+**Tooltip** is not expected to handle interactive content. If this is necessary behavior, an expand/collapse button + popover should be used instead.
+
+Hover or focus the buttons in the examples to see their tooltips.
+
+## Appearance
+
+{{ TooltipDefault }}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/FluentTooltip.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/FluentTooltip.md
@@ -47,6 +47,13 @@ If you are using "per page" interactivity, make sure to add a `@rendermode` to e
 
 In some use cases, you may want to render a tooltip without the provider. For example when the child content is dynamic.
 This is possible setting the `UseTooltipService` parameter to `false` in the component.
+You can also configure it globally in the `Program.cs` file:
+```csharp
+builder.Services.AddFluentUIComponents(options =>
+{
+    options.Tooltip.UseTooltipService = false;
+});
+```
 
 ## API FluentTooltip
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/FluentTooltip.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/FluentTooltip.md
@@ -59,3 +59,6 @@ builder.Services.AddFluentUIComponents(options =>
 
 {{ API Type=FluentTooltip }}
 
+## Migrating to v5
+
+{{ INCLUDE File=MigrationFluentTooltip }}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/FluentTooltip.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tooltip/FluentTooltip.md
@@ -51,7 +51,7 @@ You can also configure it globally in the `Program.cs` file:
 ```csharp
 builder.Services.AddFluentUIComponents(options =>
 {
-    options.Tooltip.UseTooltipService = false;
+    options.Tooltip.UseServiceProvider = false;
 });
 ```
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentTooltip.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentTooltip.md
@@ -1,0 +1,56 @@
+---
+title: Migration FluentTooltip
+route: /Migration/Tooltip
+hidden: true
+---
+
+### New properties
+  `SpacingHorizontal`,  `SpacingVertical`, `OnToggle` are new properties.
+
+### Removed properties💥
+  The `Visible` property has been removed. The tooltip is now visible when the user hovers over the target element.
+  The `OnToggle` event is triggered when the tooltip is shown or hidden.
+
+### Position 💥
+  The `Position` property has been updated to use the `Positioning` property name and the `Positioning` enum
+  instead of `TooltipPosition` enum.
+
+    `Positioning` enum has the following values:
+    - `AboveEnd`
+    - `AboveStart`
+    - `Above`
+    - `BelowStart`
+    - `Below`
+    - `BelowEnd`
+    - `BeforeTop`
+    - `Before`
+    - `BeforeBottom`
+    - `AfterTop`
+    - `After`
+    - `AfterBottom`
+    - `CenterCenter`
+
+### TooltipGlobalOptions
+
+The `TooltipGlobalOptions` class has been removed. The `Tooltip` component now uses the default options.
+
+### Migrating to v5
+
+You can use the `ToPositioning()` method to convert the `Position` property to the `Positioning` enum.
+```csharp	
+@using Microsoft.FluentUI.AspNetCore.Components.Migration
+
+<FluentTooltip Positioning="TooltipPosition.Top.ToPositioning()">My content</FluentTooltip>
+//                                              ^^^^^^^^^^^^^^^^
+```
+
+
+|v3 & v4|v5|
+|-----|-----|
+|`TooltipPosition.Top`    |`Positioning.Above`|
+|`TooltipPosition.Bottom` |`Positioning.Below`|
+|`TooltipPosition.Left`   |`Positioning.Before`|
+|`TooltipPosition.Right`  |`Positioning.After`|
+|`TooltipPosition.Start`  |`Positioning.AboveStart`|
+|`TooltipPosition.End`    |`Positioning.AboveEnd`|
+

--- a/examples/Demo/FluentUI.Demo.Client/Layout/DemoMainLayout.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Layout/DemoMainLayout.razor
@@ -93,3 +93,4 @@
 
 <!-- FluentUI Service Providers -->
 <FluentDialogProvider />
+<FluentTooltipProvider />

--- a/examples/Demo/FluentUI.Demo.Client/Layout/DemoMainLayout.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Layout/DemoMainLayout.razor
@@ -92,5 +92,4 @@
 </FluentLayoutItem>
 
 <!-- FluentUI Service Providers -->
-<FluentDialogProvider />
-<FluentTooltipProvider />
+<FluentProviders />

--- a/src/Core.Scripts/src/FluentUICustomEvents.ts
+++ b/src/Core.Scripts/src/FluentUICustomEvents.ts
@@ -12,24 +12,24 @@ export namespace Microsoft.FluentUI.Blazor.FluentUICustomEvents {
 
     blazor.registerCustomEventType('dialogbeforetoggle', {
       browserEventName: 'beforetoggle',
-      createEventArgs: event => {
+      createEventArgs: (event: any) => {
         return {
           id: event.target.id,
           type: event.type,
-          oldState: event.detail.oldState,
-          newState: event.detail.newState,
+          oldState: event.detail?.oldState ?? event.oldState,
+          newState: event.detail?.newState ?? event.newState,
         };
       }
     });
 
     blazor.registerCustomEventType('dialogtoggle', {
       browserEventName: 'toggle',
-      createEventArgs: event => {
+      createEventArgs: (event: any) => {
         return {
           id: event.target.id,
           type: event.type,
-          oldState: event.detail.oldState,
-          newState: event.detail.newState,
+          oldState: event.detail?.oldState ?? event.oldState,
+          newState: event.detail?.newState ?? event.newState,
         };
       }
     });

--- a/src/Core/Components/Base/FluentServiceBase.cs
+++ b/src/Core/Components/Base/FluentServiceBase.cs
@@ -23,7 +23,7 @@ public abstract class FluentServiceBase<TComponent> : IFluentServiceBase<TCompon
     /// <see cref="IFluentServiceBase{TComponent}.Items" />
     /// </summary>
     ConcurrentDictionary<string, TComponent> IFluentServiceBase<TComponent>.Items => _list;
-   
+
     /// <summary>
     /// <see cref="IFluentServiceBase{TComponent}.OnUpdatedAsync" />
     /// </summary>

--- a/src/Core/Components/Dialog/FluentDialogProvider.razor.cs
+++ b/src/Core/Components/Dialog/FluentDialogProvider.razor.cs
@@ -4,7 +4,6 @@
 
 using System.Globalization;
 using Microsoft.AspNetCore.Components;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.FluentUI.AspNetCore.Components.Utilities;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
@@ -12,8 +11,6 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// <summary />
 public partial class FluentDialogProvider : FluentComponentBase
 {
-    private IDialogService? _dialogService;
-
     /// <summary />
     public FluentDialogProvider()
     {
@@ -37,7 +34,7 @@ public partial class FluentDialogProvider : FluentComponentBase
     public IServiceProvider? ServiceProvider { get; set; }
 
     /// <summary />
-    protected virtual IDialogService? DialogService => _dialogService ??= ServiceProvider?.GetService<IDialogService>();
+    protected virtual IDialogService? DialogService => GetCachedServiceOrNull<IDialogService>();
 
     /// <summary />
     protected override void OnInitialized()

--- a/src/Core/Components/Tooltip/FluentTooltip.razor
+++ b/src/Core/Components/Tooltip/FluentTooltip.razor
@@ -8,6 +8,7 @@
                 anchor="@Anchor"
                 delay="@Delay"
                 positioning="@Positioning.ToAttributeValue()"
+                @ondialogtoggle="@OnToggleAsync"
                 @attributes="AdditionalAttributes">
     @ChildContent
 </fluent-tooltip>

--- a/src/Core/Components/Tooltip/FluentTooltip.razor
+++ b/src/Core/Components/Tooltip/FluentTooltip.razor
@@ -1,0 +1,13 @@
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components
+@using Microsoft.FluentUI.AspNetCore.Components.Extensions
+@inherits FluentComponentBase
+
+<fluent-tooltip id="@Id"
+                class="@ClassValue"
+                style="@StyleValue"
+                anchor="@Anchor"
+                delay="@Delay"
+                positioning="@Positioning.ToAttributeValue()"
+                @attributes="AdditionalAttributes">
+    @ChildContent
+</fluent-tooltip>

--- a/src/Core/Components/Tooltip/FluentTooltip.razor
+++ b/src/Core/Components/Tooltip/FluentTooltip.razor
@@ -2,13 +2,16 @@
 @using Microsoft.FluentUI.AspNetCore.Components.Extensions
 @inherits FluentComponentBase
 
-<fluent-tooltip id="@Id"
-                class="@ClassValue"
-                style="@StyleValue"
-                anchor="@Anchor"
-                delay="@Delay"
-                positioning="@Positioning.ToAttributeValue()"
-                @ondialogtoggle="@OnToggleAsync"
-                @attributes="AdditionalAttributes">
-    @ChildContent
-</fluent-tooltip>
+@if (DrawTooltipWithoutService)
+{
+    <fluent-tooltip id="@Id"
+                    class="@ClassValue"
+                    style="@StyleValue"
+                    anchor="@Anchor"
+                    delay="@Delay"
+                    positioning="@Positioning.ToAttributeValue()"
+                    @ondialogtoggle="@OnToggleAsync"
+                    @attributes="AdditionalAttributes">
+        @ChildContent
+    </fluent-tooltip>
+}

--- a/src/Core/Components/Tooltip/FluentTooltip.razor.cs
+++ b/src/Core/Components/Tooltip/FluentTooltip.razor.cs
@@ -83,6 +83,12 @@ public partial class FluentTooltip : FluentComponentBase
     [Parameter]
     public EventCallback<EventArgs> OnDismissed { get; set; }
 
+    /// <summary>
+    /// Callback for when the tooltip is opened or closed.
+    /// </summary>  
+    [Parameter]
+    public EventCallback<TooltipEventArgs> OnToggle { get; set; }
+
     /// <summary />
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -93,6 +99,27 @@ public partial class FluentTooltip : FluentComponentBase
 
             // Call a function from the JavaScript module
             await jsModule.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Tooltip.FluentTooltipInitialize", Id);
+        }
+    }
+
+    /// <summary />
+    internal async Task OnToggleAsync(DialogToggleEventArgs args)
+    {
+        if (string.CompareOrdinal(args.Id, Id) != 0 || string.IsNullOrEmpty(Id))
+        {
+            return;
+        }
+
+        var opened = string.CompareOrdinal(args.NewState, "open") == 0;
+
+        if (OnToggle.HasDelegate)
+        {
+            await OnToggle.InvokeAsync(new TooltipEventArgs(Id, opened));
+        }
+
+        if (OnDismissed.HasDelegate && !opened)
+        {
+            await OnDismissed.InvokeAsync(EventArgs.Empty);
         }
     }
 }

--- a/src/Core/Components/Tooltip/FluentTooltip.razor.cs
+++ b/src/Core/Components/Tooltip/FluentTooltip.razor.cs
@@ -39,7 +39,7 @@ public partial class FluentTooltip : FluentComponentBase
     public string Anchor { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets the delay (in milliseconds). 
+    /// Gets or sets number of milliseconds to delay the tooltip from showing/hiding on hover. Default is 250ms.
     /// </summary>
     [Parameter]
     public int? Delay { get; set; }

--- a/src/Core/Components/Tooltip/FluentTooltip.razor.cs
+++ b/src/Core/Components/Tooltip/FluentTooltip.razor.cs
@@ -29,6 +29,7 @@ public partial class FluentTooltip : FluentComponentBase
 
     /// <summary />
     protected string? StyleValue => DefaultStyleBuilder
+        .AddStyle("max-width", MaxWidth, when: () => !string.IsNullOrWhiteSpace(MaxWidth))
         .Build();
 
     /// <summary>
@@ -49,6 +50,12 @@ public partial class FluentTooltip : FluentComponentBase
     /// </summary>
     [Parameter]
     public Positioning? Positioning { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum width of tooltip panel. Default is 240px.
+    /// </summary>
+    [Parameter]
+    public string? MaxWidth { get; set; }
 
     /// <summary>
     /// Gets or sets the content to be rendered inside the component.

--- a/src/Core/Components/Tooltip/FluentTooltip.razor.cs
+++ b/src/Core/Components/Tooltip/FluentTooltip.razor.cs
@@ -9,7 +9,8 @@ using Microsoft.JSInterop;
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 /// <summary>
-/// 
+/// A FluentTooltip displays additional information about another component.
+/// The information is displayed above and near the target component.
 /// </summary>
 public partial class FluentTooltip : FluentComponentBase
 {

--- a/src/Core/Components/Tooltip/FluentTooltip.razor.cs
+++ b/src/Core/Components/Tooltip/FluentTooltip.razor.cs
@@ -15,9 +15,7 @@ public partial class FluentTooltip : FluentComponentBase
 {
     private const string JAVASCRIPT_FILE = FluentJSModule.JAVASCRIPT_ROOT + "Tooltip/FluentTooltip.razor.js";
 
-    /// <summary>
-    /// 
-    /// </summary>
+    /// <summary />    
     public FluentTooltip()
     {
         Id = Identifier.NewId();
@@ -34,9 +32,14 @@ public partial class FluentTooltip : FluentComponentBase
         .AddStyle("margin-block", SpacingVertical, when: () => !string.IsNullOrWhiteSpace(SpacingVertical))
         .Build();
 
-    /// <summary />
-    [Inject]
-    protected virtual ITooltipService? TooltipService { get; set; }
+    /// <summary>
+    /// Gets or sets the injected service provider.
+    /// </summary>
+    /// <remarks>
+    /// We cannot inject `ITooltipService` directly, as an exception will be thrown if the service is not injected.
+    /// https://github.com/dotnet/aspnetcore/issues/24193
+    /// </remarks>
+    private ITooltipService? TooltipService => GetCachedServiceOrNull<ITooltipService>();
 
     /// <summary>
     /// Use ITooltipService to create the tooltip, if this service was injected.

--- a/src/Core/Components/Tooltip/FluentTooltip.razor.cs
+++ b/src/Core/Components/Tooltip/FluentTooltip.razor.cs
@@ -30,6 +30,8 @@ public partial class FluentTooltip : FluentComponentBase
     /// <summary />
     protected string? StyleValue => DefaultStyleBuilder
         .AddStyle("max-width", MaxWidth, when: () => !string.IsNullOrWhiteSpace(MaxWidth))
+        .AddStyle("margin-inline", SpacingHorizontal, when: () => !string.IsNullOrWhiteSpace(SpacingHorizontal))
+        .AddStyle("margin-block", SpacingVertical, when: () => !string.IsNullOrWhiteSpace(SpacingVertical))
         .Build();
 
     /// <summary>
@@ -56,6 +58,18 @@ public partial class FluentTooltip : FluentComponentBase
     /// </summary>
     [Parameter]
     public string? MaxWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tooltip's horizontal spacing. Default is 4px;
+    /// </summary>
+    [Parameter]
+    public string? SpacingHorizontal { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tooltip's horizontal spacing. Default is 4px;
+    /// </summary>
+    [Parameter]
+    public string? SpacingVertical { get; set; }
 
     /// <summary>
     /// Gets or sets the content to be rendered inside the component.

--- a/src/Core/Components/Tooltip/FluentTooltip.razor.cs
+++ b/src/Core/Components/Tooltip/FluentTooltip.razor.cs
@@ -146,7 +146,9 @@ public partial class FluentTooltip : FluentComponentBase
     /// <summary />
     internal async Task OnToggleAsync(DialogToggleEventArgs args)
     {
-        if (string.CompareOrdinal(args.Id, Id) != 0 || string.IsNullOrEmpty(Id))
+        ArgumentNullException.ThrowIfNullOrEmpty(Id);
+
+        if (string.CompareOrdinal(args.Id, Id) != 0)
         {
             return;
         }

--- a/src/Core/Components/Tooltip/FluentTooltip.razor.cs
+++ b/src/Core/Components/Tooltip/FluentTooltip.razor.cs
@@ -1,0 +1,77 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.FluentUI.AspNetCore.Components.Utilities;
+using Microsoft.JSInterop;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// 
+/// </summary>
+public partial class FluentTooltip : FluentComponentBase
+{
+    private const string JAVASCRIPT_FILE = FluentJSModule.JAVASCRIPT_ROOT + "Tooltip/FluentTooltip.razor.js";
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public FluentTooltip()
+    {
+        Id = Identifier.NewId();
+    }
+
+    /// <summary />
+    protected string? ClassValue => DefaultClassBuilder
+        .Build();
+
+    /// <summary />
+    protected string? StyleValue => DefaultStyleBuilder
+        .Build();
+
+    /// <summary>
+    /// Gets or sets the component identifier associated with the tooltip (Required).
+    /// </summary>
+    [Parameter]
+    [EditorRequired]
+    public string Anchor { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the delay (in milliseconds). 
+    /// </summary>
+    [Parameter]
+    public int? Delay { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tooltip's position. See <see cref="Components.Positioning"/>.
+    /// </summary>
+    [Parameter]
+    public Positioning? Positioning { get; set; }
+
+    /// <summary>
+    /// Gets or sets the content to be rendered inside the component.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>
+    /// Callback for when the tooltip is dismissed.
+    /// </summary>  
+    [Parameter]
+    public EventCallback<EventArgs> OnDismissed { get; set; }
+
+    /// <summary />
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            // Import the JavaScript module
+            var jsModule = await JSModule.ImportJavaScriptModuleAsync(JAVASCRIPT_FILE);
+
+            // Call a function from the JavaScript module
+            await jsModule.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Tooltip.FluentTooltipInitialize", Id);
+        }
+    }
+}

--- a/src/Core/Components/Tooltip/FluentTooltip.razor.cs
+++ b/src/Core/Components/Tooltip/FluentTooltip.razor.cs
@@ -137,10 +137,8 @@ public partial class FluentTooltip : FluentComponentBase
 
         if (firstRender)
         {
-            // Import the JavaScript module
+            // FluentTooltipInitialize will be removed when the WebComponents Teams will be ready.
             var jsModule = await JSModule.ImportJavaScriptModuleAsync(JAVASCRIPT_FILE);
-
-            // Call a function from the JavaScript module
             await jsModule.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Tooltip.FluentTooltipInitialize", Id);
         }
     }

--- a/src/Core/Components/Tooltip/FluentTooltip.razor.ts
+++ b/src/Core/Components/Tooltip/FluentTooltip.razor.ts
@@ -8,9 +8,57 @@ export namespace Microsoft.FluentUI.Blazor.Tooltip {
    */
 
   export function FluentTooltipInitialize(id: string) {
+
     const element = document.getElementById(id) as any;
     if (element && element.anchorElement && typeof element.connectedCallback === "function") {
       element.connectedCallback();
     }
+
+    if (element) {
+      // Keep the original positioning value
+      element.originalPositionning = element.getAttribute("positioning");
+
+      element.addEventListener('toggle', (e: ToggleEvent) => {
+        // Rollback the positionArea if the tooltip is closing
+        if (e.newState != "open") {
+          element.setAttribute("positioning", element.originalPositionning);
+          return;
+        }
+
+        // Inverse the positionning if the tooltip is not in the viewport
+        if (!isElementInViewport(element)) {
+          const positionning = element.getAttribute("positioning");
+          if (positionMap[positionning]) {
+            element.setAttribute("positioning", positionMap[positionning]);
+          }
+        }
+      });
+    }
   }
+
+  const positionMap: { [key: string]: string } = {
+    "above-start": "below-end",
+    "above": "below",
+    "above-end": "below-start",
+    "below-start": "above-end",
+    "below": "above",
+    "below-end": "above-start",
+    "before-top": "after-bottom",
+    "before": "after",
+    "before-bottom": "after-top",
+    "after-top": "before-bottom",
+    "after": "before",
+    "after-bottom": "before-top",
+  };
+
+  function isElementInViewport(element: HTMLElement) {
+    const rect = element.getBoundingClientRect();
+    return (
+      rect.top >= 0 &&
+      rect.left >= 0 &&
+      rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+      rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+    );
+  }
+
 }

--- a/src/Core/Components/Tooltip/FluentTooltip.razor.ts
+++ b/src/Core/Components/Tooltip/FluentTooltip.razor.ts
@@ -1,0 +1,16 @@
+export namespace Microsoft.FluentUI.Blazor.Tooltip {
+
+  /**
+   * To update when the FluentUI Web Component team will fix this issue:
+   * 
+   * This method is called when the component is rendered.
+   * This bypasses the problem of creating the web component before the DOM is ready.
+   */
+
+  export function FluentTooltipInitialize(id: string) {
+    const element = document.getElementById(id) as any;
+    if (element && element.anchorElement && typeof element.connectedCallback === "function") {
+      element.connectedCallback();
+    }
+  }
+}

--- a/src/Core/Components/Tooltip/FluentTooltipProvider.razor
+++ b/src/Core/Components/Tooltip/FluentTooltipProvider.razor
@@ -1,0 +1,30 @@
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components
+@using System.Linq
+@inherits FluentComponentBase
+
+<div id="@Id" class="@ClassValue" style="@StyleValue" @attributes="AdditionalAttributes">
+    @if (TooltipService != null)
+    {
+        @foreach (var tooltip in TooltipService.Items.Values)
+        {
+            <FluentTooltip UseTooltipService="false"
+                           Id="@tooltip.Id"
+                           Class="@tooltip.ClassValue"
+                           Style="@tooltip.StyleValue"
+                           Margin="@tooltip.Margin"
+                           Padding="@tooltip.Padding"
+                           Anchor="@tooltip.Anchor"
+                           MaxWidth="@tooltip.MaxWidth"
+                           SpacingHorizontal="@tooltip.SpacingHorizontal"
+                           SpacingVertical="@tooltip.SpacingVertical"
+                           Delay="@tooltip.Delay"
+                           Positioning="@tooltip.Positioning"
+                           Data="@tooltip.Data"
+                           OnToggle="@tooltip.OnToggle"
+                           OnDismissed="@tooltip.OnDismissed"
+                           @attributes="@tooltip.AdditionalAttributes">
+                @tooltip.ChildContent
+            </FluentTooltip>
+        }
+    }
+</div>

--- a/src/Core/Components/Tooltip/FluentTooltipProvider.razor.cs
+++ b/src/Core/Components/Tooltip/FluentTooltipProvider.razor.cs
@@ -1,0 +1,50 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using System.Globalization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.FluentUI.AspNetCore.Components.Utilities;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary />
+public partial class FluentTooltipProvider : FluentComponentBase
+{
+    /// <summary />
+    public FluentTooltipProvider()
+    {
+        Id = Identifier.NewId();
+    }
+
+    /// <summary />
+    internal string? ClassValue => DefaultClassBuilder
+        .AddClass("fluent-tooltip-provider")
+        .Build();
+
+    /// <summary />
+    internal string? StyleValue => DefaultStyleBuilder
+        .AddStyle("z-index", ZIndex.Tooltip.ToString(CultureInfo.InvariantCulture))
+        .Build();
+
+    /// <summary>
+    /// Gets or sets the injected service provider.
+    /// </summary>
+    [Inject]
+    private ITooltipService? TooltipService { get; set; }
+
+    /// <summary />
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+
+        if (TooltipService is not null)
+        {
+            TooltipService.ProviderId = Id;
+            TooltipService.OnUpdatedAsync = async (item) =>
+            {
+                await InvokeAsync(StateHasChanged);
+            };
+        }
+    }
+}

--- a/src/Core/Components/Tooltip/FluentTooltipProvider.razor.cs
+++ b/src/Core/Components/Tooltip/FluentTooltipProvider.razor.cs
@@ -3,7 +3,6 @@
 // ------------------------------------------------------------------------
 
 using System.Globalization;
-using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components.Utilities;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
@@ -30,8 +29,11 @@ public partial class FluentTooltipProvider : FluentComponentBase
     /// <summary>
     /// Gets or sets the injected service provider.
     /// </summary>
-    [Inject]
-    private ITooltipService? TooltipService { get; set; }
+    /// <remarks>
+    /// We cannot inject `ITooltipService` directly, as an exception will be thrown if the service is not injected.
+    /// https://github.com/dotnet/aspnetcore/issues/24193
+    /// </remarks>
+    private ITooltipService? TooltipService => GetCachedServiceOrNull<ITooltipService>();
 
     /// <summary />
     protected override void OnInitialized()

--- a/src/Core/Components/Tooltip/Services/ITooltipService.cs
+++ b/src/Core/Components/Tooltip/Services/ITooltipService.cs
@@ -1,0 +1,13 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// Interface for DialogService
+/// </summary>
+public interface ITooltipService : IFluentServiceBase<FluentTooltip>
+{
+
+}

--- a/src/Core/Components/Tooltip/Services/LibraryTooltipOptions.cs
+++ b/src/Core/Components/Tooltip/Services/LibraryTooltipOptions.cs
@@ -1,0 +1,24 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// Options for the Fluent UI Blazor component library.
+/// </summary>
+public class LibraryTooltipOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LibraryTooltipOptions"/> class.
+    /// </summary>
+    internal LibraryTooltipOptions()
+    {
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the library should use the TooltipServiceProvider.
+    /// If set to true, add the FluentTooltipProvider component at end of the MainLayout.razor page.
+    /// </summary>
+    public bool UseServiceProvider { get; set; } = true;
+}

--- a/src/Core/Components/Tooltip/Services/TooltipService.cs
+++ b/src/Core/Components/Tooltip/Services/TooltipService.cs
@@ -1,0 +1,13 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// Service for managing tooltips.
+/// </summary>
+public class TooltipService : FluentServiceBase<FluentTooltip>, ITooltipService
+{
+
+}

--- a/src/Core/Components/Tooltip/TooltipEventArgs.cs
+++ b/src/Core/Components/Tooltip/TooltipEventArgs.cs
@@ -1,0 +1,28 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// Event arguments for the FluentTooltip component.
+/// </summary>
+public class TooltipEventArgs : EventArgs
+{
+    /// <summary />
+    internal TooltipEventArgs(string id, bool opened)
+    {
+        Id = id;
+        Opened = opened;
+    }
+
+    /// <summary>
+    /// Gets the component identifier associated with the tooltip.
+    /// </summary>
+    public string Id { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the tooltip is opened or closed.
+    /// </summary>
+    public bool Opened { get; }
+}

--- a/src/Core/Enums/Positioning.cs
+++ b/src/Core/Enums/Positioning.cs
@@ -89,5 +89,4 @@ public enum Positioning
     /// </summary>
     [Description("center-center")]
     CenterCenter,
-
 }

--- a/src/Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Core/Extensions/ServiceCollectionExtensions.cs
@@ -30,6 +30,7 @@ public static class ServiceCollectionExtensions
         // Add services
         services.Add<LibraryConfiguration>(provider => options ?? new(), serviceLifetime);
         services.Add<IDialogService, DialogService>(serviceLifetime);
+        services.Add<ITooltipService, TooltipService>(serviceLifetime);
         services.Add<IFluentLocalizer>(provider => options?.Localizer ?? FluentLocalizerInternal.Default, serviceLifetime);
 
         return services;

--- a/src/Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Core/Extensions/ServiceCollectionExtensions.cs
@@ -30,8 +30,12 @@ public static class ServiceCollectionExtensions
         // Add services
         services.Add<LibraryConfiguration>(provider => options ?? new(), serviceLifetime);
         services.Add<IDialogService, DialogService>(serviceLifetime);
-        services.Add<ITooltipService, TooltipService>(serviceLifetime);
         services.Add<IFluentLocalizer>(provider => options?.Localizer ?? FluentLocalizerInternal.Default, serviceLifetime);
+
+        if (configuration == null || configuration.UseTooltipServiceProvider)
+        {
+            services.Add<ITooltipService, TooltipService>(serviceLifetime);
+        }
 
         return services;
     }

--- a/src/Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Core/Extensions/ServiceCollectionExtensions.cs
@@ -32,7 +32,7 @@ public static class ServiceCollectionExtensions
         services.Add<IDialogService, DialogService>(serviceLifetime);
         services.Add<IFluentLocalizer>(provider => options?.Localizer ?? FluentLocalizerInternal.Default, serviceLifetime);
 
-        if (configuration == null || configuration.UseTooltipServiceProvider)
+        if (configuration == null || configuration.Tooltip.UseServiceProvider)
         {
             services.Add<ITooltipService, TooltipService>(serviceLifetime);
         }

--- a/src/Core/Infrastructure/FluentProviders.razor
+++ b/src/Core/Infrastructure/FluentProviders.razor
@@ -1,0 +1,7 @@
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components
+@inherits FluentComponentBase
+
+<div id="@Id" class="@ClassValue" style="@StyleValue" @attributes="AdditionalAttributes">
+    <FluentDialogProvider />
+    <FluentTooltipProvider />
+</div>

--- a/src/Core/Infrastructure/FluentProviders.razor.cs
+++ b/src/Core/Infrastructure/FluentProviders.razor.cs
@@ -1,0 +1,18 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary />
+public partial class FluentProviders : FluentComponentBase
+{
+    /// <summary />
+    internal string? ClassValue => DefaultClassBuilder
+        .AddClass("fluent-providers")
+        .Build();
+
+    /// <summary />
+    internal string? StyleValue => DefaultStyleBuilder
+        .Build();
+}

--- a/src/Core/Infrastructure/FluentProviders.razor.cs
+++ b/src/Core/Infrastructure/FluentProviders.razor.cs
@@ -14,5 +14,6 @@ public partial class FluentProviders : FluentComponentBase
 
     /// <summary />
     internal string? StyleValue => DefaultStyleBuilder
+        .AddStyle("display", "contents")
         .Build();
 }

--- a/src/Core/Infrastructure/LibraryConfiguration.cs
+++ b/src/Core/Infrastructure/LibraryConfiguration.cs
@@ -18,12 +18,6 @@ public class LibraryConfiguration
     public static readonly string? AssemblyVersion = typeof(LibraryConfiguration).Assembly.GetName().Version?.ToString();
 
     /// <summary>
-    /// Gets or sets a value indicating whether the library should use the TooltipServiceProvider.
-    /// If set to true, add the FluentTooltipProvider component at end of the MainLayout.razor page.
-    /// </summary>
-    public bool UseTooltipServiceProvider { get; set; } = true;
-
-    /// <summary>
     /// Gets or sets the service lifetime for the library services, when using Fluent UI in WebAssembly, it can make sense to use <see cref="ServiceLifetime.Singleton"/>.
     /// Default is <see cref="ServiceLifetime.Scoped"/>.
     /// <para>Only <see cref="ServiceLifetime.Scoped"/> and <see cref="ServiceLifetime.Singleton"/> are supported.</para>
@@ -36,9 +30,14 @@ public class LibraryConfiguration
     public IFluentLocalizer? Localizer { get; set; }
 
     /// <summary>
-    /// Gets or sets the default CSS class and styles for the library components.
+    /// Gets the default CSS class and styles for the library components.
     /// </summary>
     public DefaultStyles DefaultStyles { get; } = new DefaultStyles();
+
+    /// <summary>
+    /// Gets the options for the library tooltip.
+    /// </summary>
+    public LibraryTooltipOptions Tooltip { get; } = new LibraryTooltipOptions();
 
     /* TODO: Implement these properties
      

--- a/src/Core/Migration/TooltipPosition.cs
+++ b/src/Core/Migration/TooltipPosition.cs
@@ -1,0 +1,41 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// Describes the position at which a <see cref="FluentTooltip"/> is shown.
+/// </summary>
+public enum TooltipPosition
+{
+    /// <summary>
+    /// The tooltip is positioned above the anchor element.
+    /// </summary>
+    Top,
+
+    /// <summary>
+    /// The tooltip is positioned below the anchor element.
+    /// </summary>
+    Bottom,
+
+    /// <summary>
+    /// The tooltip is positioned to the left of the anchor element.
+    /// </summary>
+    Left,
+
+    /// <summary>
+    /// The tooltip is positioned to the right of the anchor element.
+    /// </summary>
+    Right,
+
+    /// <summary>
+    /// The tooltip is positioned at the start of the anchor element.
+    /// </summary>
+    Start,
+
+    /// <summary>
+    /// The tooltip is positioned at the end of the anchor element.
+    /// </summary>
+    End
+}

--- a/src/Core/Migration/TooltipPosition.cs
+++ b/src/Core/Migration/TooltipPosition.cs
@@ -12,30 +12,36 @@ public enum TooltipPosition
     /// <summary>
     /// The tooltip is positioned above the anchor element.
     /// </summary>
+    [Obsolete("This value is obsolete. Use the Positioning.Above value instead.")]
     Top,
 
     /// <summary>
     /// The tooltip is positioned below the anchor element.
     /// </summary>
+    [Obsolete("This value is obsolete. Use the Positioning.Below value instead.")]
     Bottom,
 
     /// <summary>
     /// The tooltip is positioned to the left of the anchor element.
     /// </summary>
+    [Obsolete("This value is obsolete. Use the Positioning.Before value instead.")]
     Left,
 
     /// <summary>
     /// The tooltip is positioned to the right of the anchor element.
     /// </summary>
+    [Obsolete("This value is obsolete. Use the Positioning.After value instead.")]
     Right,
 
     /// <summary>
     /// The tooltip is positioned at the start of the anchor element.
     /// </summary>
+    [Obsolete("This value is obsolete. Use the Positioning.AboveStart value instead.")]
     Start,
 
     /// <summary>
     /// The tooltip is positioned at the end of the anchor element.
     /// </summary>
-    End
+    [Obsolete("This value is obsolete. Use the Positioning.AboveEnd value instead.")]
+    End,
 }

--- a/src/Core/Migration/TooltipPositionExtension.cs
+++ b/src/Core/Migration/TooltipPositionExtension.cs
@@ -1,0 +1,30 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Migration;
+
+/// <summary />
+public static class TooltipPositionExtension
+{
+    /// <summary>
+    /// Converts an obsolete <see cref="TooltipPosition"/> enum value to a <see cref="Positioning"/>.
+    /// </summary>
+    /// <param name="position"></param>
+    /// <returns></returns>
+    public static Positioning? ToPositioning(this TooltipPosition position)
+    {
+#pragma warning disable CS0618 // Type or member is obsolete
+        return position switch
+        {
+            TooltipPosition.Top => Positioning.Above,
+            TooltipPosition.Bottom => Positioning.Below,
+            TooltipPosition.Left => Positioning.Before,
+            TooltipPosition.Right => Positioning.After,
+            TooltipPosition.Start => Positioning.AboveStart,
+            TooltipPosition.End => Positioning.AboveEnd,
+            _ => Positioning.Above
+        };
+#pragma warning restore CS0618 // Type or member is obsolete
+    }
+}

--- a/src/Core/Migration/TooltipPositionExtension.cs
+++ b/src/Core/Migration/TooltipPositionExtension.cs
@@ -12,7 +12,7 @@ public static class TooltipPositionExtension
     /// </summary>
     /// <param name="position"></param>
     /// <returns></returns>
-    public static Positioning? ToPositioning(this TooltipPosition position)
+    public static Positioning? ToPositioning(this TooltipPosition? position)
     {
 #pragma warning disable CS0618 // Type or member is obsolete
         return position switch

--- a/src/Core/Utilities/ZIndex.cs
+++ b/src/Core/Utilities/ZIndex.cs
@@ -18,4 +18,10 @@ public static class ZIndex
     /// ZIndex for the <see cref="FluentBadge" /> and <see cref="FluentCounterBadge"/> components.
     /// </summary>
     public static int Badge { get; set; } = 999;
+
+    /// <summary>
+    /// ZIndex for the <see cref="FluentTooltip" /> component.
+    /// </summary>
+    public static int Tooltip { get; set; } = 9999;
+
 }

--- a/tests/Core/Components/Tooltip/FluentTooltipTests.FluentTooltip_Default.verified.razor.html
+++ b/tests/Core/Components/Tooltip/FluentTooltipTests.FluentTooltip_Default.verified.razor.html
@@ -1,0 +1,7 @@
+
+<div>
+  <div id="xxx" class="fluent-tooltip-provider" style="z-index: 9999;">
+    <fluent-tooltip id="xxx" anchor="xxx" blazor:ondialogtoggle="1">My content</fluent-tooltip>
+  </div>
+  <fluent-button id="xxx" icon-only="" blazor:onclick="x"></fluent-button>
+</div>

--- a/tests/Core/Components/Tooltip/FluentTooltipTests.FluentTooltip_NoTooltipProvider.verified.razor.html
+++ b/tests/Core/Components/Tooltip/FluentTooltipTests.FluentTooltip_NoTooltipProvider.verified.razor.html
@@ -1,0 +1,5 @@
+
+<div>
+  <fluent-button id="xxx" icon-only="" blazor:onclick="x"></fluent-button>
+  <fluent-tooltip id="xxx" anchor="xxx" blazor:ondialogtoggle="1">My content</fluent-tooltip>
+</div>

--- a/tests/Core/Components/Tooltip/FluentTooltipTests.razor
+++ b/tests/Core/Components/Tooltip/FluentTooltipTests.razor
@@ -2,6 +2,7 @@
 @using Microsoft.FluentUI.AspNetCore.Components.Utilities
 @using Xunit;
 @using Microsoft.FluentUI.AspNetCore.Components.Tests.Samples;
+@using Microsoft.FluentUI.AspNetCore.Components.Migration;
 @inherits TestContext
 @code
 {
@@ -167,28 +168,30 @@
             // Arrange & Act
             var cut = Render(@<div>
                 <FluentTooltip Anchor="MyButton">My content</FluentTooltip>
-            </div>);
+            </div>
+    );
         });
 
         Assert.Equal("<FluentTooltipProvider /> needs to be added to the main layout of your application/site. (Parameter 'UseTooltipService')", ex.Message);
     }
 
     [Theory]
-    [InlineData("MyTooltip", "open", true, false)]
-    [InlineData("MyTooltip", "close", false, true)]
-    [InlineData("MyTooltip", "", false, true)]
-    [InlineData("unknownId", "open", false, false)]
-    [InlineData("unknownId", "close", false, false)]
-    public async Task FluentTooltip_OnToggle_OnDismissed(string id, string newState, bool expectedOpened, bool expectedDismissed)
+    [InlineData("MyTooltip", "open", true, false, "MyTooltip")]
+    [InlineData("MyTooltip", "close", false, true, "MyTooltip")]
+    [InlineData("MyTooltip", "", false, true, "MyTooltip")]
+    [InlineData("UnknownId", "open", false, false, "")]
+    [InlineData("UnknownId", "close", false, false, "")]
+    public async Task FluentTooltip_OnToggle_OnDismissed(string id, string newState, bool expectedOpened, bool expectedDismissed, string expectedEventId)
     {
         var opened = false;
+        var eventId = string.Empty;
         var dismissed = false;
 
         // Arrange
         var cut = Render(@<div>
             <FluentTooltipProvider />
             <FluentTooltip Id="MyTooltip" Anchor="MyButton" SpacingVertical="20px"
-                           OnToggle="@(e => opened = e.Opened)"
+                           OnToggle="@(e => { opened = e.Opened; eventId = e.Id; })"
                            OnDismissed="@(e => dismissed = true)">My content</FluentTooltip>
         </div>);
 
@@ -201,6 +204,26 @@
 
         // Assert
         Assert.Equal(expectedOpened, opened);
+        Assert.Equal(expectedEventId, eventId);
         Assert.Equal(expectedDismissed, dismissed);
     }
+
+#pragma warning disable CS0618 // Type or member is obsolete
+
+    [Theory]
+    [InlineData(TooltipPosition.Top, Positioning.Above)]
+    [InlineData(TooltipPosition.Bottom, Positioning.Below)]
+    [InlineData(TooltipPosition.Left, Positioning.Before)]
+    [InlineData(TooltipPosition.Right, Positioning.After)]
+    [InlineData(TooltipPosition.Start, Positioning.AboveStart)]
+    [InlineData(TooltipPosition.End, Positioning.AboveEnd)]
+    [InlineData(null, Positioning.Above)]
+    [InlineData((TooltipPosition)999, Positioning.Above)]
+    public void FluentTooltip_TooltipPositionToPositioning(TooltipPosition? position, Positioning? expectedPositioning)
+    {
+        // Assert
+        Assert.Equal(expectedPositioning, position.ToPositioning());
+    }
+
+#pragma warning restore CS0618 // Type or member is obsolete
 }

--- a/tests/Core/Components/Tooltip/FluentTooltipTests.razor
+++ b/tests/Core/Components/Tooltip/FluentTooltipTests.razor
@@ -1,0 +1,206 @@
+﻿@using Microsoft.FluentUI.AspNetCore.Components.Extensions
+@using Microsoft.FluentUI.AspNetCore.Components.Utilities
+@using Xunit;
+@using Microsoft.FluentUI.AspNetCore.Components.Tests.Samples;
+@inherits TestContext
+@code
+{
+    public FluentTooltipTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddFluentUIComponents();
+    }
+
+    [Fact]
+    public void FluentTooltip_Default()
+    {
+        // Arrange
+        var cut = Render(@<div>
+            <FluentTooltipProvider />
+            <FluentButton Id="MyButton" />
+            <FluentTooltip Anchor="MyButton">My content</FluentTooltip>
+        </div>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentTooltip_NoTooltipProvider()
+    {
+        // Arrange
+        var cut = Render(@<div>
+            <FluentButton Id="MyButton" />
+            <FluentTooltip Anchor="MyButton" UseTooltipService="false">My content</FluentTooltip>
+        </div>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentTooltip_Delay()
+    {
+        // Arrange
+        var cut = Render(@<div>
+            <FluentTooltipProvider />
+            <FluentTooltip Anchor="MyButton" Delay="500">My content</FluentTooltip>
+        </div>);
+
+        // Act
+        var att = cut.Find("fluent-tooltip").GetAttribute("delay");
+
+        // Assert
+        Assert.Equal("500", att);
+    }
+
+    [Theory]
+    [InlineData(Positioning.AboveEnd)]
+    [InlineData(Positioning.AboveStart)]
+    [InlineData(Positioning.Above)]
+    [InlineData(Positioning.BelowStart)]
+    [InlineData(Positioning.Below)]
+    [InlineData(Positioning.BelowEnd)]
+    [InlineData(Positioning.BeforeTop)]
+    [InlineData(Positioning.Before)]
+    [InlineData(Positioning.BeforeBottom)]
+    [InlineData(Positioning.AfterTop)]
+    [InlineData(Positioning.After)]
+    [InlineData(Positioning.AfterBottom)]
+    [InlineData(Positioning.CenterCenter)]
+    [InlineData(null)]
+    [InlineData((Positioning)999)]
+    public void FluentTooltip_Positioning(Positioning? positioning)
+    {
+        // Arrange
+        var cut = Render(@<div>
+            <FluentTooltipProvider />
+            <FluentTooltip Anchor="MyButton" Positioning="@positioning">My content</FluentTooltip>
+        </div>);
+
+        // Act
+        var att = cut.Find("fluent-tooltip").GetAttribute("positioning");
+
+        // Assert
+        Assert.Equal(positioning.ToAttributeValue(), att);
+    }
+
+    [Fact]
+    public void FluentTooltip_MaxWidth()
+    {
+        // Arrange
+        var cut = Render(@<div>
+            <FluentTooltipProvider />
+            <FluentTooltip Anchor="MyButton" MaxWidth="200px">My content</FluentTooltip>
+        </div>);
+
+        // Act
+        var att = cut.Find("fluent-tooltip").GetAttribute("style");
+
+        // Assert
+        Assert.Equal("max-width: 200px;", att);
+    }
+
+    [Fact]
+    public void FluentTooltip_SpacingHorizontal()
+    {
+        // Arrange
+        var cut = Render(@<div>
+            <FluentTooltipProvider />
+            <FluentTooltip Anchor="MyButton" SpacingHorizontal="20px">My content</FluentTooltip>
+        </div>);
+
+        // Act
+        var att = cut.Find("fluent-tooltip").GetAttribute("style");
+
+        // Assert
+        Assert.Equal("margin-inline: 20px;", att);
+    }
+
+    [Fact]
+    public void FluentTooltip_SpacingVertical()
+    {
+        // Arrange
+        var cut = Render(@<div>
+            <FluentTooltipProvider />
+            <FluentTooltip Anchor="MyButton" SpacingVertical="20px">My content</FluentTooltip>
+        </div>);
+
+        // Act
+        var att = cut.Find("fluent-tooltip").GetAttribute("style");
+
+        // Assert
+        Assert.Equal("margin-block: 20px;", att);
+    }
+
+    [Fact]
+    public void FluentTooltip_Id_Required()
+    {
+        Assert.Throws<ArgumentException>(() =>
+        {
+            // Arrange & Act
+            var cut = Render(@<div>
+                <FluentTooltipProvider />
+                <FluentTooltip Id="" Anchor="MyButton">My content</FluentTooltip>
+            </div>);
+        });
+    }
+
+    [Fact]
+    public void FluentTooltip_Anchor_Required()
+    {
+        Assert.Throws<ArgumentException>(() =>
+        {
+            // Arrange & Act
+            var cut = Render(@<div>
+                <FluentTooltipProvider />
+                <FluentTooltip Anchor="">My content</FluentTooltip>
+            </div>);
+        });
+    }
+
+    [Fact]
+    public void FluentTooltip_Provider_Required()
+    {
+        var ex = Assert.Throws<ArgumentNullException>(() =>
+        {
+            // Arrange & Act
+            var cut = Render(@<div>
+                <FluentTooltip Anchor="MyButton">My content</FluentTooltip>
+            </div>);
+        });
+
+        Assert.Equal("<FluentTooltipProvider /> needs to be added to the main layout of your application/site. (Parameter 'UseTooltipService')", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("MyTooltip", "open", true, false)]
+    [InlineData("MyTooltip", "close", false, true)]
+    [InlineData("MyTooltip", "", false, true)]
+    [InlineData("unknownId", "open", false, false)]
+    [InlineData("unknownId", "close", false, false)]
+    public async Task FluentTooltip_OnToggle_OnDismissed(string id, string newState, bool expectedOpened, bool expectedDismissed)
+    {
+        var opened = false;
+        var dismissed = false;
+
+        // Arrange
+        var cut = Render(@<div>
+            <FluentTooltipProvider />
+            <FluentTooltip Id="MyTooltip" Anchor="MyButton" SpacingVertical="20px"
+                           OnToggle="@(e => opened = e.Opened)"
+                           OnDismissed="@(e => dismissed = true)">My content</FluentTooltip>
+        </div>);
+
+        // Act
+        await cut.FindComponent<FluentTooltip>().Instance.OnToggleAsync(new DialogToggleEventArgs
+        {
+            Id = id,
+            NewState = newState,
+        });
+
+        // Assert
+        Assert.Equal(expectedOpened, opened);
+        Assert.Equal(expectedDismissed, dismissed);
+    }
+}


### PR DESCRIPTION
# [dev-v5] FluentTooltip

A `FluentTooltip` displays additional information about another component. The information is displayed above and near the target component.

**Tooltip** is not expected to handle interactive content. If this is necessary behavior, an expand/collapse button + popover should be used instead.

Hover or focus the buttons in the examples to see their tooltips.

## Default

```razor
<FluentStack HorizontalAlignment="HorizontalAlignment.Center">
    <FluentButton Id="MyButton" IconStart="@(new Icons.Regular.Size20.Globe())">Hover me</FluentButton>

    <FluentTooltip Anchor="MyButton">
        This is the description of the button
    </FluentTooltip>
</FluentStack>
```

## Customized
The tooltip can be customized with a custom template,
adapting the delay to `700 ms`, the position of the tooltip to `BelowStart` (including spacings to `20px` and `10px`)
and the style "Inverted".

Each time the tooltip is shown or hidden, a message is logged in the console. Click on the top/right button to open the **Console**.

```razor
<FluentStack HorizontalAlignment="HorizontalAlignment.Center">
    <FluentButton Id="MyCustomizedButton" IconStart="@(new Icons.Regular.Size20.Globe())">Hover me</FluentButton>

    <FluentTooltip Anchor="MyCustomizedButton"
                   OnToggle="@OnToggleAsync"
                   OnDismissed="@OnDismissAsync"
                   Delay="700"
                   Positioning="@Positioning.BelowStart"
                   MaxWidth="300px"
                   SpacingHorizontal="20px"
                   SpacingVertical="10px"
                   Style="background-color: var(--colorBrandBackground); color: var(--colorNeutralForegroundInverted)">
        <FluentStack>
            <FluentIcon Value="@(new Icons.Regular.Size20.Info().WithColor(Color.Lightweight))"
                        Width="32px"
                        Margin="@(Margin.Vertical2 + Margin.Right2)" />
            <div>
                Really long <b>tooltip</b> content goes here.
                Lorem ipsum dolor sit a met.
            </div>
        </FluentStack>
    </FluentTooltip>
</FluentStack>

@code
{
    void OnToggleAsync(TooltipEventArgs args)
    {
        Console.WriteLine($"Tooltip is open: {args.Opened}.");
    }

    void OnDismissAsync(EventArgs args)
    {
        Console.WriteLine($"Tooltip is dismissed.");
    }
}
```


https://github.com/user-attachments/assets/4190c4a8-dee2-4235-8a1b-8f08ee1c2b0a



## Using Tooltip Service Provider

We advise you to always use this service when working with tooltips so all definitions will be generated with global options
and will be written **at the end** of the HTML page to support different z-index levels.

In the `Program.cs`, inject the Tooltip service with global options.
You can also use the `Services.AddFluentUIComponents` method to register **all** required FluentUI services, including this one.

```csharp
builder.Services.AddScoped<ITooltipService, TooltipService>();
```

At the end of your MainLayout.razor page, include the provider:

```xml
<FluentTooltipProvider />
```

For the `<FluentTooltipProvider />` to work properly, it needs interactivity!
If you are using "per page" interactivity, make sure to add a `@rendermode` to either the provider itself or the component the provider is placed in.

In some use cases, you may want to render a tooltip without the provider. For example when the child content is dynamic.
This is possible setting the `UseTooltipService` parameter to `false` in the component.
You can also configure it globally in the `Program.cs` file:
```csharp
builder.Services.AddFluentUIComponents(options =>
{
    options.Tooltip.UseServiceProvider = false;
});
```

## Unit Tests
![{0EC45207-D9EA-4D05-89A7-D11AA7F1A3A5}](https://github.com/user-attachments/assets/797c9655-f5a3-4ec3-a4cc-f90b9b6fe039)
