### PR TITLE
[dev-v5] Add FluentCompoundButton

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,35 +1,35 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <RuntimeVersion9>9.0.0</RuntimeVersion9>
-    <AspNetCoreVersion9>9.0.0</AspNetCoreVersion9>
-    <EfCoreVersion9>9.0.0</EfCoreVersion9>
+    <RuntimeVersion9>9.0.3</RuntimeVersion9>
+    <AspNetCoreVersion9>9.0.3</AspNetCoreVersion9>
+    <EfCoreVersion9>9.0.3</EfCoreVersion9>
   </PropertyGroup>
   <!-- Independent from TargetFrameWorks-->
   <ItemGroup>
     <!-- For Sample Apps -->
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.9.3" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" version="4.10.4" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="4.6.0" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" version="4.11.7" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="4.11.7" />
     <PackageVersion Include="LoxSmoke.DocXml" Version="3.8.0" />
     <!-- Test dependencies -->
-    <PackageVersion Include="bunit" Version="1.33.3" />
+    <PackageVersion Include="bunit" Version="1.38.5" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.0" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-    <PackageVersion Include="Microsoft.Playwright" Version="1.48.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="Microsoft.Playwright" Version="1.51.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.3" />
     <!-- Shared dependencies -->
     <PackageVersion Include="Markdig.Signed" Version="0.34.0" />
     <PackageVersion Include="Meziantou.Analyzer" Version="2.0.162" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0-1.final" />
-    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.13.61" />
     <PackageVersion Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" />
-    <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="5.7.3" />
+    <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="5.8.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="3.11.0-beta1.24527.2" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/AnchorButton/FluentAnchorButton.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/AnchorButton/FluentAnchorButton.md
@@ -20,3 +20,7 @@ route: /AchorButton
 
 ## Long text
 {{ AnchorButtonLongText }}
+
+## API FluentAnchorButton
+
+{{ API Type=FluentAnchorButton }}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/CompoundButton/Examples/CompoundButtonAppearances.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/CompoundButton/Examples/CompoundButtonAppearances.razor
@@ -1,0 +1,17 @@
+﻿<FluentStack HorizontalGap="10">
+    <FluentCompoundButton Label="Default">
+        <Description>Description content</Description>
+    </FluentCompoundButton>
+    <FluentCompoundButton Label="Primary" Appearance="ButtonAppearance.Primary">
+        <Description>Description content</Description>
+    </FluentCompoundButton>
+    <FluentCompoundButton Label="Outline" Appearance="ButtonAppearance.Outline">
+        <Description>Description content</Description>
+    </FluentCompoundButton>
+    <FluentCompoundButton Label="Subtle" Appearance="ButtonAppearance.Subtle">
+        <Description>Description content</Description>
+    </FluentCompoundButton>
+    <FluentCompoundButton Label="Transparent" Appearance="ButtonAppearance.Transparent">
+        <Description>Description content</Description>
+    </FluentCompoundButton>
+</FluentStack>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/CompoundButton/Examples/CompoundButtonDefault.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/CompoundButton/Examples/CompoundButtonDefault.razor
@@ -1,0 +1,34 @@
+﻿<p>
+    You can use <code>Content</code> and/or <code>ChildContent</code> to specify the main text on the button.
+</p>
+<p>
+    When you supply both, both will be rendered.
+</p>
+
+<FluentStack HorizontalGap="10">
+    <div>
+        <strong>ChildContent</strong>
+        <br />
+        <FluentCompoundButton>
+            <ChildContent>Child content</ChildContent>
+            <Description>Description content</Description>
+        </FluentCompoundButton>
+    </div>
+
+    <div>
+        <strong>Label</strong>
+        <br />
+        <FluentCompoundButton Label="Label">
+            <Description>Description content</Description>
+        </FluentCompoundButton>
+    </div>
+
+    <div>
+        <strong>Both</strong>
+        <br />
+        <FluentCompoundButton Label="Both">
+            <ChildContent>Both</ChildContent>
+            <Description>Description content</Description>
+        </FluentCompoundButton>
+    </div>
+</FluentStack>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/CompoundButton/Examples/CompoundButtonDisabled.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/CompoundButton/Examples/CompoundButtonDisabled.razor
@@ -1,0 +1,26 @@
+﻿<FluentStack HorizontalGap="10">
+    <FluentCompoundButton>
+        <ChildContent>Enabled state</ChildContent>
+        <Description>Description content</Description>
+    </FluentCompoundButton>
+    <FluentCompoundButton Disabled="true">
+        <ChildContent>Disabled state</ChildContent>
+        <Description>Description content</Description>
+    </FluentCompoundButton>
+    <FluentCompoundButton DisabledFocusable="true">
+        <ChildContent>Disabled focusable state</ChildContent>
+        <Description>Description content</Description>
+    </FluentCompoundButton>
+    <FluentCompoundButton Appearance="ButtonAppearance.Primary">
+        <ChildContent>Enabled state</ChildContent>
+        <Description>Description content</Description>
+    </FluentCompoundButton>
+    <FluentCompoundButton Appearance="ButtonAppearance.Primary" Disabled="true">
+        <ChildContent>Disabled state</ChildContent>
+        <Description>Description content</Description>
+    </FluentCompoundButton>
+    <FluentCompoundButton Appearance="ButtonAppearance.Primary" DisabledFocusable="true">
+        <ChildContent>Disabled focusable state</ChildContent>
+        <Description>Description content</Description>
+    </FluentCompoundButton>
+</FluentStack>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/CompoundButton/Examples/CompoundButtonLongText.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/CompoundButton/Examples/CompoundButtonLongText.razor
@@ -1,0 +1,17 @@
+﻿<style>
+    .max-width {
+        width: 280px;
+    }
+</style>
+
+<FluentStack HorizontalGap="10">
+    <FluentCompoundButton Label="Short text">
+        <Description>Description content</Description>
+    </FluentCompoundButton>
+    <FluentCompoundButton Class="max-width">
+        <ChildContent>
+            Long text wraps after it hits the max width of the component
+        </ChildContent>
+        <Description>Description content</Description>
+    </FluentCompoundButton>
+</FluentStack>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/CompoundButton/Examples/CompoundButtonShapes.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/CompoundButton/Examples/CompoundButtonShapes.razor
@@ -1,0 +1,11 @@
+﻿<FluentStack HorizontalGap="10">
+    <FluentCompoundButton Label="Rounded" Shape="ButtonShape.Rounded">
+        <Description>Description content</Description>
+    </FluentCompoundButton>
+    <FluentCompoundButton Label="Circular" Shape="ButtonShape.Circular">
+        <Description>Description content</Description>
+    </FluentCompoundButton>
+    <FluentCompoundButton Label="Square" Shape="ButtonShape.Square">
+        <Description>Description content</Description>
+    </FluentCompoundButton>
+</FluentStack>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/CompoundButton/Examples/CompoundButtonSizes.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/CompoundButton/Examples/CompoundButtonSizes.razor
@@ -1,0 +1,49 @@
+﻿<FluentStack Orientation="Orientation.Vertical" VerticalGap="15">
+    <FluentStack HorizontalGap="10">
+        <FluentCompoundButton Size="ButtonSize.Small">
+            <ChildContent>Small</ChildContent>
+            <Description>Description content</Description>
+        </FluentCompoundButton>
+        <FluentCompoundButton Size="ButtonSize.Small" IconStart="@(new Icons.Regular.Size16.Globe())">
+            <ChildContent>Small with calendar icon</ChildContent>
+            <Description>Description content</Description>
+        </FluentCompoundButton>
+        <FluentCompoundButton Size="ButtonSize.Small"
+                              IconOnly="true"
+                              Title="Small icon only button">
+            <FluentIcon Value="@(new Icons.Regular.Size16.Globe())" />
+        </FluentCompoundButton>
+    </FluentStack>
+
+    <FluentStack HorizontalGap="10">
+        <FluentCompoundButton Size="ButtonSize.Medium">
+            <ChildContent>Medium</ChildContent>
+            <Description>Description content</Description>
+        </FluentCompoundButton>
+        <FluentCompoundButton Size="ButtonSize.Medium" IconStart="@(new Icons.Regular.Size20.Globe())">
+            <ChildContent>Medium with calendar icon</ChildContent>
+            <Description>Description content</Description>
+        </FluentCompoundButton>
+        <FluentCompoundButton Size="ButtonSize.Medium"
+                              IconOnly="true"
+                              Title="Medium icon only button">
+            <FluentIcon Value="@(new Icons.Regular.Size20.Globe())" />
+        </FluentCompoundButton>
+    </FluentStack>
+
+    <FluentStack HorizontalGap="10">
+        <FluentCompoundButton Size="ButtonSize.Large">
+            <ChildContent>Large</ChildContent>
+            <Description>Description content</Description>
+        </FluentCompoundButton>
+        <FluentCompoundButton Size="ButtonSize.Large" IconStart="@(new Icons.Regular.Size24.Globe())">
+            <ChildContent>Large with calendar icon</ChildContent>
+            <Description>Description content</Description>
+        </FluentCompoundButton>
+        <FluentCompoundButton Size="ButtonSize.Large"
+                              IconOnly="true"
+                              Title="Large icon only button">
+            <FluentIcon Value="@(new Icons.Regular.Size24.Globe())" />
+        </FluentCompoundButton>
+    </FluentStack>
+</FluentStack>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/CompoundButton/FluentCompoundButton.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/CompoundButton/FluentCompoundButton.md
@@ -1,0 +1,29 @@
+---
+title: CompoundButton
+route: /CompoundButton 
+---
+
+# CompoundButton
+
+## Default
+
+{{ CompoundButtonDefault }}
+
+## Appearances
+{{ CompoundButtonAppearances }}
+
+## Shapes
+{{ CompoundButtonShapes }}
+
+## Sizes
+{{ CompoundButtonSizes }}
+
+## Disabled
+{{ CompoundButtonDisabled }}
+
+## Long text
+{{ CompoundButtonLongText }}
+
+## API FluentCompoundButton
+
+{{ API Type=FluentCompoundButton }}

--- a/examples/Demo/FluentUI.Demo.Client/FluentUI.Demo.Client.csproj
+++ b/examples/Demo/FluentUI.Demo.Client/FluentUI.Demo.Client.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>

--- a/examples/Demo/FluentUI.Demo.Client/_Imports.razor
+++ b/examples/Demo/FluentUI.Demo.Client/_Imports.razor
@@ -6,5 +6,6 @@
 @using static Microsoft.AspNetCore.Components.Web.RenderMode
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.FluentUI.AspNetCore.Components
+@using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons
 @using Microsoft.JSInterop
 @using FluentUI.Demo.Client

--- a/src/Core/Components/Button/FluentCompoundButton.razor
+++ b/src/Core/Components/Button/FluentCompoundButton.razor
@@ -1,0 +1,35 @@
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Rendering;
+@using Microsoft.FluentUI.AspNetCore.Components.Extensions
+@inherits FluentComponentBase
+
+<fluent-compound-button id="@Id"
+                        class="@ClassValue"
+                        style="@StyleValue"
+                        autofocus="@AutoFocus"
+                        appearance="@Appearance.ToAttributeValue()"
+                        shape="@Shape.ToAttributeValue()"
+                        size="@Size.ToAttributeValue()"
+                        name="@Name"
+                        aria-label="@Title"
+                        disabled="@Disabled"
+                        disabled-focusable="@DisabledFocusable"
+                        icon-only="@(IconOnly || (ChildContent is null && Label is null))"
+                        @onclick="@OnClickHandlerAsync"
+                        @onclick:stopPropagation="@StopPropagation"
+                        @attributes="@AdditionalAttributes">
+    @if (IconStart != null)
+    {
+        <FluentIcon Value="@IconStart" Slot="@((ChildContent is null && Label is null) ? null : "start")" />
+    }
+    @Label
+    @ChildContent
+    @if (!IconOnly)
+    {
+        <span slot="description">@Description</span>
+    }
+    @if (IconEnd != null)
+    {
+        <FluentIcon Value="@IconEnd" Slot="@((ChildContent is null && Label is null) ? null : "end")" />
+    }
+</fluent-compound-button>

--- a/src/Core/Components/Button/FluentCompoundButton.razor
+++ b/src/Core/Components/Button/FluentCompoundButton.razor
@@ -7,7 +7,7 @@
                         class="@ClassValue"
                         style="@StyleValue"
                         autofocus="@AutoFocus"
-                        appearance="@Appearance.ToAttributeValue()"
+                        appearance="@(Appearance == ButtonAppearance.Default ? null : Appearance.ToAttributeValue())"
                         shape="@Shape.ToAttributeValue()"
                         size="@Size.ToAttributeValue()"
                         name="@Name"

--- a/src/Core/Components/Button/FluentCompoundButton.razor.cs
+++ b/src/Core/Components/Button/FluentCompoundButton.razor.cs
@@ -1,0 +1,162 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// A FluentUI AnchorButton component.
+/// </summary>
+public partial class FluentCompoundButton : FluentComponentBase
+{
+    /// <summary />
+    protected string? ClassValue => DefaultClassBuilder
+        .Build();
+
+    /// <summary />
+    protected string? StyleValue => DefaultStyleBuilder
+        .AddStyle("background-color", BackgroundColor, when: () => !string.IsNullOrEmpty(BackgroundColor))
+        .AddStyle("color", Color, when: () => !string.IsNullOrEmpty(Color))
+        .Build();
+
+    /// <summary>
+    /// Gets or sets whether the button should be focused when the page is loaded.
+    /// </summary>
+    [Parameter]
+    public bool AutoFocus { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets the shape of the button.
+    /// The default value is `null`. Internally the component uses <see cref="ButtonShape.Rounded"/> as its default value.
+    /// </summary>
+    [Parameter]
+    public ButtonShape? Shape { get; set; }
+
+    /// <summary>
+    /// Gets or sets the size of the button.
+    /// The default value is `null`. Internally the component uses <see cref="ButtonSize.Medium"/> as its default value.
+    /// </summary>
+    [Parameter]
+    public ButtonSize? Size { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the element.
+    /// Allows access by name from the associated form.
+    /// </summary>
+    [Parameter]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the visual appearance.
+    /// The default value is `null`. Internally the component uses <see cref="ButtonAppearance.Outline"/> as its default value.
+    /// </summary>
+    [Parameter]
+    public ButtonAppearance? Appearance { get; set; }
+
+    /// <summary>
+    /// Gets or sets the background color of this button (overrides the <see cref="Appearance"/> property).
+    /// Set the value `rgba(0, 0, 0, 0)` to display a transparent button.
+    /// </summary>
+    [Parameter]
+    public string? BackgroundColor { get; set; }
+
+    /// <summary>
+    /// Gets or sets the color of the font (overrides the <see cref="Appearance"/> property).
+    /// </summary>
+    [Parameter]
+    public string? Color { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="Icon"/> displayed at the start of button content.
+    /// </summary>
+    [Parameter]
+    public Icon? IconStart { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="Icon"/> displayed at the end of button content.
+    /// </summary>
+    [Parameter]
+    public Icon? IconEnd { get; set; }
+
+    /// <summary>
+    /// Gets or sets the title of the button.
+    /// The text usually displayed in a `tooltip` popup when the mouse is over the button.
+    /// </summary>
+    [Parameter]
+    public string? Title { get; set; }
+
+    /// <summary>
+    /// Gets or sets the element's disabled state, ensuring it doesn't participate in form submission.
+    /// </summary>
+    [Parameter]
+    public bool Disabled { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets the value indicating the button is focusable.
+    /// </summary>
+    [Parameter]
+    public bool DisabledFocusable { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets a way to prevent further propagation of the current event in the capturing and bubbling phases.
+    /// </summary>
+    [Parameter]
+    public bool StopPropagation { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets if the button only shows an icon
+    /// Can be used when using <see cref="ChildContent"/> that renders as an icon
+    /// </summary>
+    [Parameter]
+    public bool IconOnly { get; set; }
+
+    /// <summary>
+    ///  Gets or sets the content to be rendered inside the button.
+    ///  This can be used as an alternative to specifying the content as a child component of the button.
+    ///  If both are specified, both will be rendered.
+    ///  </summary>
+    [Parameter]
+    public string? Label { get; set; }
+
+    /// <summary>
+    /// Gets or sets the content to be rendered inside description area of the button.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets the content to be rendered inside the button.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>
+    /// Command executed when the user clicks on the button.
+    /// </summary>
+    [Parameter]
+    public EventCallback<MouseEventArgs> OnClick { get; set; }
+
+    /// <summary />
+    protected async Task OnClickHandlerAsync(MouseEventArgs e)
+    {
+        if (!Disabled && OnClick.HasDelegate)
+        {
+            await OnClick.InvokeAsync(e);
+        }
+
+        await Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Disables the button.
+    /// </summary>
+    /// <param name="disabled">True to disable the button</param>
+    public void SetDisabled(bool disabled)
+    {
+        Disabled = disabled;
+        StateHasChanged();
+    }
+}

--- a/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_AdditionalAttribute.verified.razor.html
+++ b/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_AdditionalAttribute.verified.razor.html
@@ -1,0 +1,4 @@
+
+<fluent-compound-button blazor:onclick="x" additional-attribute-name="additional-attribute-value">Label
+  <span slot="description">Description content</span>
+</fluent-compound-button>

--- a/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_AdditionalAttributes.verified.razor.html
+++ b/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_AdditionalAttributes.verified.razor.html
@@ -1,0 +1,4 @@
+
+<fluent-compound-button blazor:onclick="x" additional-attribute1-name="additional-attribute1-value" additional-attribute2-name="additional-attribute2-value">Label
+  <span slot="description">Description content</span>
+</fluent-compound-button>

--- a/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_AutofocusAttribute.verified.razor.html
+++ b/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_AutofocusAttribute.verified.razor.html
@@ -1,0 +1,4 @@
+
+<fluent-compound-button autofocus="" blazor:onclick="x">
+  fluent-compound-button<span slot="description"></span>
+</fluent-compound-button>

--- a/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_BackgroundColor.verified.razor.html
+++ b/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_BackgroundColor.verified.razor.html
@@ -1,0 +1,4 @@
+
+<fluent-compound-button id="xxx" style="background-color: #ff0000;" blazor:onclick="x">Label
+  <span slot="description">Description content</span>
+</fluent-compound-button>

--- a/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_BackgroundColorColor.verified.razor.html
+++ b/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_BackgroundColorColor.verified.razor.html
@@ -1,0 +1,4 @@
+
+<fluent-compound-button id="xxx" style="background-color: #ff0000; color: #00ff00;" blazor:onclick="x">Label
+  <span slot="description">Description content</span>
+</fluent-compound-button>

--- a/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_ChildContentDescription.verified.razor.html
+++ b/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_ChildContentDescription.verified.razor.html
@@ -1,0 +1,4 @@
+
+<fluent-compound-button blazor:onclick="x">
+  Child content<span slot="description">Description content</span>
+</fluent-compound-button>

--- a/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_ChildContentLabelDescription.verified.razor.html
+++ b/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_ChildContentLabelDescription.verified.razor.html
@@ -1,0 +1,3 @@
+
+<fluent-compound-button blazor:onclick="x">Both     Both<span slot="description">Description content</span>
+</fluent-compound-button>

--- a/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_ClassAttribute.verified.razor.html
+++ b/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_ClassAttribute.verified.razor.html
@@ -1,0 +1,4 @@
+
+<fluent-compound-button class="additional-class" blazor:onclick="x">Label
+  <span slot="description">Description content</span>
+</fluent-compound-button>

--- a/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_Color.verified.razor.html
+++ b/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_Color.verified.razor.html
@@ -1,0 +1,4 @@
+
+<fluent-compound-button id="xxx" style="color: #00ff00;" blazor:onclick="x">Label
+  <span slot="description">Description content</span>
+</fluent-compound-button>

--- a/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_Default.verified.razor.html
+++ b/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_Default.verified.razor.html
@@ -1,0 +1,4 @@
+
+<fluent-compound-button blazor:onclick="x">Label
+  <span slot="description">Description content</span>
+</fluent-compound-button>

--- a/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_DisabledAttribute.verified.razor.html
+++ b/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_DisabledAttribute.verified.razor.html
@@ -1,0 +1,4 @@
+
+<fluent-compound-button disabled="" blazor:onclick="x">Label
+  <span slot="description">Description content</span>
+</fluent-compound-button>

--- a/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_DisabledFocusableAttribute.verified.razor.html
+++ b/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_DisabledFocusableAttribute.verified.razor.html
@@ -1,0 +1,4 @@
+
+<fluent-compound-button disabled-focusable="" blazor:onclick="x">Label
+  <span slot="description">Description content</span>
+</fluent-compound-button>

--- a/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_IconEnd.verified.razor.html
+++ b/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_IconEnd.verified.razor.html
@@ -1,0 +1,7 @@
+
+<fluent-compound-button blazor:onclick="x">Label
+  <span slot="description">Description content</span>
+  <svg slot="end" style="width: 24px;" focusable="false" viewBox="0 0 24 24" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
+    <path d="M12 2a10 10 0 1 1 0 20 10 10 0 0 1 0-20Zm0 8.25a1 1 0 0 0-1 .88v5.74a1 1 0 0 0 2 0v-5.62l-.01-.12a1 1 0 0 0-1-.88Zm0-3.75A1.25 1.25 0 1 0 12 9a1.25 1.25 0 0 0 0-2.5Z"></path>
+  </svg>
+</fluent-compound-button>

--- a/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_IconEndNoContent.verified.razor.html
+++ b/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_IconEndNoContent.verified.razor.html
@@ -1,0 +1,7 @@
+
+<fluent-compound-button icon-only="" blazor:onclick="x">
+  <span slot="description"></span>
+  <svg style="width: 24px;" focusable="false" viewBox="0 0 24 24" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
+    <path d="M12 2a10 10 0 1 1 0 20 10 10 0 0 1 0-20Zm0 8.25a1 1 0 0 0-1 .88v5.74a1 1 0 0 0 2 0v-5.62l-.01-.12a1 1 0 0 0-1-.88Zm0-3.75A1.25 1.25 0 1 0 12 9a1.25 1.25 0 0 0 0-2.5Z"></path>
+  </svg>
+</fluent-compound-button>

--- a/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_IconOnly.verified.razor.html
+++ b/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_IconOnly.verified.razor.html
@@ -1,0 +1,6 @@
+
+<fluent-compound-button icon-only="" blazor:onclick="x">
+  <svg viewBox="0 0 20 20">
+    <path fill="currentColor" d="M7.851 3.146a.5.5 0 0 1 0 .707L4.706 7H10c2.932 0 5.593 1.64 6.936 4.043a.5.5 0 1 1-.872.488C14.894 9.439 12.564 8 10 8H4.707l3.144 3.145a.5.5 0 0 1-.707.707L3.161 7.867a.5.5 0 0 1-.014-.721l3.997-4a.5.5 0 0 1 .707 0M8 15a2 2 0 1 1 4 0a2 2 0 0 1-4 0m2-1a1 1 0 1 0 0 2a1 1 0 0 0 0-2"></path>
+  </svg>
+</fluent-compound-button>

--- a/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_IconStart.verified.razor.html
+++ b/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_IconStart.verified.razor.html
@@ -1,0 +1,7 @@
+
+<fluent-compound-button blazor:onclick="x">
+  <svg slot="start" style="width: 24px;" focusable="false" viewBox="0 0 24 24" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
+    <path d="M12 2a10 10 0 1 1 0 20 10 10 0 0 1 0-20Zm0 8.25a1 1 0 0 0-1 .88v5.74a1 1 0 0 0 2 0v-5.62l-.01-.12a1 1 0 0 0-1-.88Zm0-3.75A1.25 1.25 0 1 0 12 9a1.25 1.25 0 0 0 0-2.5Z"></path>
+  </svg>Label
+  <span slot="description">Description content</span>
+</fluent-compound-button>

--- a/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_IconStartNoContent.verified.razor.html
+++ b/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_IconStartNoContent.verified.razor.html
@@ -1,0 +1,7 @@
+
+<fluent-compound-button icon-only="" blazor:onclick="x">
+  <svg style="width: 24px;" focusable="false" viewBox="0 0 24 24" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
+    <path d="M12 2a10 10 0 1 1 0 20 10 10 0 0 1 0-20Zm0 8.25a1 1 0 0 0-1 .88v5.74a1 1 0 0 0 2 0v-5.62l-.01-.12a1 1 0 0 0-1-.88Zm0-3.75A1.25 1.25 0 1 0 12 9a1.25 1.25 0 0 0 0-2.5Z"></path>
+  </svg>
+  <span slot="description"></span>
+</fluent-compound-button>

--- a/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_Label.verified.razor.html
+++ b/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_Label.verified.razor.html
@@ -1,0 +1,4 @@
+
+<fluent-compound-button blazor:onclick="x">Button Label
+  <span slot="description"></span>
+</fluent-compound-button>

--- a/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_LabelAndDescription.verified.razor.html
+++ b/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_LabelAndDescription.verified.razor.html
@@ -1,0 +1,4 @@
+
+<fluent-compound-button blazor:onclick="x">Button Label
+  <span slot="description">Description content</span>
+</fluent-compound-button>

--- a/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_NameAttribute.verified.razor.html
+++ b/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_NameAttribute.verified.razor.html
@@ -1,0 +1,4 @@
+
+<fluent-compound-button name="xxx" blazor:onclick="x">Label
+  <span slot="description">Description content</span>
+</fluent-compound-button>

--- a/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_StyleAttribute.verified.razor.html
+++ b/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_StyleAttribute.verified.razor.html
@@ -1,0 +1,4 @@
+
+<fluent-compound-button style="background-color: green;" blazor:onclick="x">Label
+  <span slot="description">Description content</span>
+</fluent-compound-button>

--- a/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_Title.verified.razor.html
+++ b/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.FluentCompoundButton_Title.verified.razor.html
@@ -1,0 +1,4 @@
+
+<fluent-compound-button aria-label="My Title" blazor:onclick="x">Label
+  <span slot="description">Description content</span>
+</fluent-compound-button>

--- a/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.razor
+++ b/tests/Core/Components/CompoundButton/FluentCompoundButtonTests.razor
@@ -1,0 +1,366 @@
+﻿@using Microsoft.FluentUI.AspNetCore.Components.Utilities
+@using Xunit;
+@using Microsoft.FluentUI.AspNetCore.Components.Tests.Samples;
+@inherits TestContext
+@code
+{
+    public FluentCompoundButtonTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddFluentUIComponents();
+    }
+
+    [Fact]
+    public void FluentCompoundButton_Default()
+    {
+        // Arrange
+        using var id = Identifier.SequentialContext();
+
+        // Act
+        var cut = Render(@<FluentCompoundButton Label="Label"><Description>Description content</Description></FluentCompoundButton>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentCompoundButton_AutofocusAttribute()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentCompoundButton AutoFocus="true">fluent-compound-button</FluentCompoundButton>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Theory]
+    [InlineData(ButtonShape.Rounded, "rounded")]
+    [InlineData(ButtonShape.Circular, "circular")]
+    [InlineData(ButtonShape.Square, "square")]
+    [InlineData(null, "")]
+    [InlineData((ButtonShape)99, "")]
+    public void FluentCompoundButton_ShapeAttribute(ButtonShape? shape, string expectedValue)
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentCompoundButton Shape="@shape" Label="Label"><Description>Description content</Description></FluentCompoundButton>);
+        // Assert
+        var attribute = cut.Find("fluent-compound-button").GetAttribute("shape") ?? string.Empty;
+        Assert.Equal(expectedValue, attribute);
+    }
+
+    [Theory]
+    [InlineData(ButtonSize.Large, "large")]
+    [InlineData(ButtonSize.Medium, "medium")]
+    [InlineData(ButtonSize.Small, "small")]
+    [InlineData(null, "")]
+    [InlineData((ButtonSize)99, "")]
+    public void FluentCompoundButton_SizeAttribute(ButtonSize? size, string expectedValue)
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentCompoundButton Size="@size" Label="Label"><Description>Description content</Description></FluentCompoundButton>);
+        // Assert
+        var attribute = cut.Find("fluent-compound-button").GetAttribute("size") ?? string.Empty;
+        Assert.Equal(expectedValue, attribute);
+    }
+
+    [Fact]
+    public void FluentCompoundButton_NameAttribute()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentCompoundButton Name="name-value" Label="Label"><Description>Description content</Description></FluentCompoundButton>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Theory]
+    [InlineData(ButtonAppearance.Default, "")]
+    [InlineData(ButtonAppearance.Primary, "primary")]
+    [InlineData(ButtonAppearance.Outline, "outline")]
+    [InlineData(ButtonAppearance.Transparent, "transparent")]
+    [InlineData(ButtonAppearance.Subtle, "subtle")]
+    [InlineData(null, "")]
+    [InlineData((ButtonAppearance)99, "")]
+    public void FluentCompoundButton_AppearanceAttribute(ButtonAppearance? appearance, string expectedValue)
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentCompoundButton Appearance="@appearance" Label="Label"><Description>Description content</Description></FluentCompoundButton>);
+
+        // Assert
+        var attribute = cut.Find("fluent-compound-button").GetAttribute("appearance") ?? string.Empty;
+        Assert.Equal(expectedValue, attribute);
+    }
+
+    [Fact]
+    public void FluentCompoundButton_BackgroundColor()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentCompoundButton Id="MyButton" BackgroundColor="#ff0000" Label="Label"><Description>Description content</Description></FluentCompoundButton>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentCompoundButton_Color()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentCompoundButton Id="MyButton" Color="#00ff00" Label="Label"><Description>Description content</Description></FluentCompoundButton>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentCompoundButton_BackgroundColorColor()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentCompoundButton Id="MyButton" BackgroundColor="#ff0000" Color="#00ff00" Label="Label"><Description>Description content</Description></FluentCompoundButton>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentCompoundButton_IconStart()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentCompoundButton IconStart="@Samples.Icons.Info" Label="Label"><Description>Description content</Description></FluentCompoundButton>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentCompoundButton_IconEnd()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentCompoundButton IconEnd="@Samples.Icons.Info" Label="Label"><Description>Description content</Description></FluentCompoundButton>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentCompoundButton_IconStartNoContent()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentCompoundButton IconStart="@Samples.Icons.Info" />);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentCompoundButton_IconEndNoContent()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentCompoundButton IconEnd="@Samples.Icons.Info" />);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentCompoundButton_Title()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentCompoundButton Title="My Title" Label="Label"><Description>Description content</Description></FluentCompoundButton>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentCompoundButton_DisabledAttribute()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentCompoundButton Disabled="true" Label="Label"><Description>Description content</Description></FluentCompoundButton>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentCompoundButton_DisabledFocusableAttribute()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentCompoundButton DisabledFocusable="true" Label="Label"><Description>Description content</Description></FluentCompoundButton>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentCompoundButton_OnClick_Disabled()
+    {
+        var clicked = false;
+
+        // Arrange
+        var cut = Render<FluentCompoundButton>(@<FluentCompoundButton OnClick="@(e => { clicked = true; })" Label="Label"><Description>Description content</Description></FluentCompoundButton>);
+
+        // Act - `InvokeAsync` to avoid "The current thread is not associated with the Dispatcher" error.
+        cut.InvokeAsync(() => cut.Instance.SetDisabled(true));
+        cut.Find("fluent-compound-button").Click();
+
+        // Assert
+        Assert.False(clicked);
+    }
+
+    [Fact]
+    public void FluentCompoundButton_StopPropagationFalse()
+    {
+        bool clickedondiv = false;
+        bool clicked = false;
+
+        // Arrange
+        // Not adding StopPropagation here explicitly because it is false by default
+        var cut = Render(@<div @onclick="@(e => {clickedondiv = true; })">
+            <FluentCompoundButton OnClick="@(e => { clicked = true; })" Label="Label">
+            <Description>Description content</Description>
+            </FluentCompoundButton>
+        </div>);
+
+        // Act
+        cut.Find("fluent-compound-button").Click();
+
+        // Assert
+        Assert.True(clickedondiv);
+        Assert.True(clicked);
+    }
+
+    [Fact]
+    public void FluentCompoundButton_StopPropagationTrue()
+    {
+        bool clickedondiv = false;
+        bool clicked = false;
+
+        // Arrange
+        var cut = Render(@<div @onclick="@(e => {clickedondiv = true; })">
+            <FluentCompoundButton StopPropagation="true" OnClick="@(e => { clicked = true; })"
+                Label="Label"><Description>Description content</Description></FluentCompoundButton>
+        </div>);
+
+        // Act
+        cut.Find("fluent-compound-button").Click();
+
+        // Assert
+        Assert.False(clickedondiv);
+        Assert.True(clicked);
+    }
+
+    [Fact]
+    public void FluentCompoundButton_IconOnly()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentCompoundButton IconOnly="true">
+            <svg viewBox="0 0 20 20">
+                <path fill="currentColor" d="M7.851 3.146a.5.5 0 0 1 0 .707L4.706 7H10c2.932 0 5.593 1.64 6.936 4.043a.5.5 0 1 1-.872.488C14.894 9.439 12.564 8 10 8H4.707l3.144 3.145a.5.5 0 0 1-.707.707L3.161 7.867a.5.5 0 0 1-.014-.721l3.997-4a.5.5 0 0 1 .707 0M8 15a2 2 0 1 1 4 0a2 2 0 0 1-4 0m2-1a1 1 0 1 0 0 2a1 1 0 0 0 0-2"></path>
+            </svg>
+        </FluentCompoundButton>);
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentCompoundButton_Label()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentCompoundButton Label="Button Label"></FluentCompoundButton>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentCompoundButton_ChildContentDescription()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentCompoundButton>
+            <ChildContent>Child content</ChildContent>
+            <Description>Description content</Description>
+        </FluentCompoundButton>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentCompoundButton_LabelAndDescription()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentCompoundButton Label="Button Label">
+            <Description>Description content</Description>
+        </FluentCompoundButton>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentCompoundButton_ChildContentLabelDescription()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentCompoundButton Label="Both">
+            <ChildContent>Both</ChildContent>
+            <Description>Description content</Description>
+        </FluentCompoundButton>);
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentCompoundButton_OnClick()
+    {
+        bool clicked = false;
+
+        // Arrange
+        var cut = Render(@<FluentCompoundButton OnClick="@(e => { clicked = true; })" Label="Label"><Description>Description content</Description></FluentCompoundButton>);
+
+        // Act
+        cut.Find("fluent-compound-button").Click();
+
+        // Assert
+        Assert.True(clicked);
+    }
+
+    [Fact]
+    public void FluentCompoundButton_ClassAttribute()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentCompoundButton Class="additional-class" Label="Label"><Description>Description content</Description></FluentCompoundButton>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentCompoundButton_StyleAttribute()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentCompoundButton Style="background-color: green;" Label="Label"><Description>Description content</Description></FluentCompoundButton>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentCompoundButton_AdditionalAttribute()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentCompoundButton additional-attribute-name="additional-attribute-value" Label="Label"><Description>Description content</Description></FluentCompoundButton>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentCompoundButton_AdditionalAttributes()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentCompoundButton additional-attribute1-name="additional-attribute1-value" additional-attribute2-name="additional-attribute2-value" Label="Label"><Description>Description content</Description></FluentCompoundButton>);
+
+        // Assert
+        cut.Verify();
+    }
+}


### PR DESCRIPTION
Ads the `FluentCompoundButton` component

A compound button renders a label and a description line in a button. 

The actual text for the button can be provided in 2 ways:
1) With the `Label` (string?) parameter.
2) With the `ChildContent` parameter.
We added this so you do not always have to supply a label in the form of a `<ChildContent>xyz</ChildContent>` form. When supplying both, both will be rendered.

The `Description` parameter is marked as `EditorRequired` because we assume you'd use a regular button if you do not want to use a description.

![image](https://github.com/user-attachments/assets/f9717450-d41e-4e35-87f1-594a495b3493)

Tests have been added:

![image](https://github.com/user-attachments/assets/881c1df5-57d7-47d6-a35b-ba252981648d)
