### PR TITLE
[dev-v5] Add FluentToggleButton

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/CompoundButton/FluentCompoundButton.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/CompoundButton/FluentCompoundButton.md
@@ -7,19 +7,19 @@ route: /CompoundButton
 
 You can use `LabelContent` and/or `ChildContent` to specify the main text on the button. When you supply both, both will be rendered.
 
-## Appearances
+## Appearance
 {{ CompoundButtonAppearances }}
 
-## Shapes
+## Shape
 {{ CompoundButtonShapes }}
 
-## Sizes
+## Size
 {{ CompoundButtonSizes }}
 
 ## Disabled
 {{ CompoundButtonDisabled }}
 
-## Long text
+## With long text
 {{ CompoundButtonLongText }}
 
 ## API FluentCompoundButton

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/ToggleButton/Examples/ToggleButtonDefault.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/ToggleButton/Examples/ToggleButtonDefault.razor
@@ -1,0 +1,14 @@
+﻿<FluentToggleButton OnClick="@ButtonClick">Default</FluentToggleButton>
+<FluentToggleButton OnClick="@ButtonClick" Appearance="ButtonAppearance.Primary">Primary</FluentToggleButton>
+<FluentToggleButton OnClick="@ButtonClick" Appearance="ButtonAppearance.Outline">Outline</FluentToggleButton>
+<FluentToggleButton OnClick="@ButtonClick" Appearance="ButtonAppearance.Subtle">Subtle</FluentToggleButton>
+<FluentToggleButton OnClick="@ButtonClick" Appearance="ButtonAppearance.Transparent">Transparent</FluentToggleButton>
+<FluentToggleButton OnClick="@ButtonClick" BackgroundColor="var(--highlight-bg)" Color="var(--presence-busy)">Colored</FluentToggleButton>
+
+@code
+{
+    void ButtonClick()
+    {
+        Console.WriteLine("Button clicked");
+    }
+}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/ToggleButton/Examples/ToggleButtonDisabled.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/ToggleButton/Examples/ToggleButtonDisabled.razor
@@ -1,0 +1,8 @@
+﻿<FluentStack HorizontalGap="10">
+    <FluentToggleButton>Enabled state</FluentToggleButton>
+    <FluentToggleButton Disabled="true">Disabled state</FluentToggleButton>
+    <FluentToggleButton DisabledFocusable="true">Disabled focusable state</FluentToggleButton>
+    <FluentToggleButton Appearance="ButtonAppearance.Primary">Enabled state</FluentToggleButton>
+    <FluentToggleButton Appearance="ButtonAppearance.Primary" Disabled="true">Disabled state</FluentToggleButton>
+    <FluentToggleButton Appearance="ButtonAppearance.Primary" DisabledFocusable="true">Disabled focusable state</FluentToggleButton>
+</FluentStack>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/ToggleButton/Examples/ToggleButtonIcon.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/ToggleButton/Examples/ToggleButtonIcon.razor
@@ -1,0 +1,25 @@
+﻿<FluentToggleButton IconStart="@(new Icons.Regular.Size20.Globe())"
+              Appearance="ButtonAppearance.Primary">
+    Button
+</FluentToggleButton>
+
+<FluentToggleButton IconEnd="@(new Icons.Regular.Size20.Globe())">
+    Button
+</FluentToggleButton>
+
+<FluentToggleButton IconStart="@(new Icons.Regular.Size20.Globe())" />
+
+<FluentToggleButton>
+    <FluentIcon Value="@(new Icons.Regular.Size20.Globe())" Color="Color.Error" Slot="start" />
+    Button
+</FluentToggleButton>
+
+
+<FluentToggleButton IconOnly="true">
+    <svg viewBox="0 0 20 20">
+        <path fill="currentColor" d="M7.851 3.146a.5.5 0 0 1 0 .707L4.706 7H10c2.932 0 5.593 1.64 6.936 4.043a.5.5 0 1 1-.872.488C14.894 9.439 12.564 8 10 8H4.707l3.144 3.145a.5.5 0 0 1-.707.707L3.161 7.867a.5.5 0 0 1-.014-.721l3.997-4a.5.5 0 0 1 .707 0M8 15a2 2 0 1 1 4 0a2 2 0 0 1-4 0m2-1a1 1 0 1 0 0 2a1 1 0 0 0 0-2"></path>
+    </svg>
+</FluentToggleButton>
+
+
+

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/ToggleButton/Examples/ToggleButtonLongText.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/ToggleButton/Examples/ToggleButtonLongText.razor
@@ -1,0 +1,14 @@
+﻿<style>
+    .max-width {
+        width: 280px;
+    }
+</style>
+
+<FluentStack HorizontalGap="10">
+    <FluentToggleButton Label="Short text"></FluentToggleButton>
+    <FluentToggleButton Class="max-width">
+        <ChildContent>
+            Long text wraps after it hits the max width of the component
+        </ChildContent>
+    </FluentToggleButton>
+</FluentStack>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/ToggleButton/Examples/ToggleButtonPressed.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/ToggleButton/Examples/ToggleButtonPressed.razor
@@ -1,0 +1,15 @@
+﻿<FluentToggleButton Pressed="true" OnClick="@ButtonClick">Default pressed</FluentToggleButton>
+<FluentToggleButton Pressed="true" OnClick="@ButtonClick" Appearance="ButtonAppearance.Primary">Primary pressed</FluentToggleButton>
+<FluentToggleButton Pressed="true" OnClick="@ButtonClick" Appearance="ButtonAppearance.Outline">Outline pressed</FluentToggleButton>
+<FluentToggleButton Pressed="true" OnClick="@ButtonClick" Appearance="ButtonAppearance.Subtle">Subtle pressed</FluentToggleButton>
+<FluentToggleButton Pressed="true" OnClick="@ButtonClick" Appearance="ButtonAppearance.Transparent">Transparent pressed</FluentToggleButton>
+<FluentToggleButton Pressed="true" OnClick="@ButtonClick" BackgroundColor="var(--highlight-bg)" Color="var(--presence-busy)">Colored pressed</FluentToggleButton>
+<FluentToggleButton Pressed="true" OnClick="@ButtonClick" Disabled="true">Disabled pressed</FluentToggleButton>
+
+@code
+{
+    void ButtonClick()
+    {
+        Console.WriteLine("Button clicked");
+    }
+}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/ToggleButton/Examples/ToggleButtonShapes.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/ToggleButton/Examples/ToggleButtonShapes.razor
@@ -1,0 +1,3 @@
+﻿<FluentToggleButton Shape="ButtonShape.Rounded">Rounded</FluentToggleButton>
+<FluentToggleButton Shape="ButtonShape.Circular">Circular</FluentToggleButton>
+<FluentToggleButton Shape="ButtonShape.Square">Square</FluentToggleButton>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/ToggleButton/Examples/ToggleButtonSizes.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/ToggleButton/Examples/ToggleButtonSizes.razor
@@ -1,0 +1,43 @@
+﻿<FluentStack Orientation="Orientation.Vertical" VerticalGap="15">
+    <FluentStack HorizontalGap="10">
+        <FluentToggleButton Size="ButtonSize.Small">
+            <ChildContent>Small</ChildContent>
+        </FluentToggleButton>
+        <FluentToggleButton Size="ButtonSize.Small" IconStart="@(new Icons.Regular.Size16.Globe())">
+            <ChildContent>Small with calendar icon</ChildContent>
+        </FluentToggleButton>
+        <FluentToggleButton Size="ButtonSize.Small"
+                              IconOnly="true"
+                              Title="Small icon only button">
+            <FluentIcon Value="@(new Icons.Regular.Size16.Globe())" />
+        </FluentToggleButton>
+    </FluentStack>
+
+    <FluentStack HorizontalGap="10">
+        <FluentToggleButton Size="ButtonSize.Medium">
+            <ChildContent>Medium</ChildContent>
+        </FluentToggleButton>
+        <FluentToggleButton Size="ButtonSize.Medium" IconStart="@(new Icons.Regular.Size20.Globe())">
+            <ChildContent>Medium with calendar icon</ChildContent>
+        </FluentToggleButton>
+        <FluentToggleButton Size="ButtonSize.Medium"
+                              IconOnly="true"
+                              Title="Medium icon only button">
+            <FluentIcon Value="@(new Icons.Regular.Size20.Globe())" />
+        </FluentToggleButton>
+    </FluentStack>
+
+    <FluentStack HorizontalGap="10">
+        <FluentToggleButton Size="ButtonSize.Large">
+            <ChildContent>Large</ChildContent>
+        </FluentToggleButton>
+        <FluentToggleButton Size="ButtonSize.Large" IconStart="@(new Icons.Regular.Size24.Globe())">
+            <ChildContent>Large with calendar icon</ChildContent>
+        </FluentToggleButton>
+        <FluentToggleButton Size="ButtonSize.Large"
+                              IconOnly="true"
+                              Title="Large icon only button">
+            <FluentIcon Value="@(new Icons.Regular.Size24.Globe())" />
+        </FluentToggleButton>
+    </FluentStack>
+</FluentStack>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/ToggleButton/FluentToggleButton.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/ToggleButton/FluentToggleButton.md
@@ -10,6 +10,8 @@ or tap and is often found inside forms, dialogs, drawers (panels) and/or pages.
 
 View the [Usage Guidance](https://fluent2.microsoft.design/components/web/react/button/behavior).
 
+> Although the `FluentToggleButton` inherits from `FluentButton`, it does not support the `Loading` state.
+
 ## Appearance
 
 Only use one **primary** button in a layout for the most important action.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/ToggleButton/FluentToggleButton.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/ToggleButton/FluentToggleButton.md
@@ -1,0 +1,63 @@
+---
+title: ToggleButton
+route: /ToggleButton
+---
+
+# ToggleButton
+
+The `ToggleButton` component allows users to commit a change or trigger a toggle action via a single click
+or tap and is often found inside forms, dialogs, drawers (panels) and/or pages.
+
+View the [Usage Guidance](https://fluent2.microsoft.design/components/web/react/button/behavior).
+
+## Appearance
+
+Only use one **primary** button in a layout for the most important action.
+If there are more than two buttons with equal priority, all buttons should have neutral backgrounds.
+
+When there are many available minor actions, use the **outline**, **subtle**, or **transparent** appearances
+on all buttons to avoid a busy layout.
+
+{{ ToggleButtonDefault }}
+
+## Pressed
+
+{{ ToggleButtonPressed }}
+
+## Icons
+
+You can add icons to a button to help identify the action it triggers.
+To do this, you can use an `IconStart` or `IconEnd` property to add an icon
+to the beginning or end of the button text. When using `IconStart` or `IconEnd`
+without supplying any content, the button will be displayed in a smaller form.
+
+By putting an icon in the content, it is possible to specify
+a `Color` for the icon.
+
+By setting the `IconOnly` parameter to true, you can use an icon as the button's content but still have it display in a smaller form. 
+
+{{ ToggleButtonIcon }}
+
+## Shape
+
+Toggle buttons can be square, rounded, or circular.
+
+{{ ToggleButtonShapes }}
+
+## Size
+
+{{ ToggleButtonSizes }}
+
+## Disabled
+
+{{ ToggleButtonDisabled }}
+
+## With long text
+
+{{ ToggleButtonLongText }}
+
+## API FluentButton
+
+{{ API Type=FluentToggleButton }}
+
+

--- a/src/Core/Components/Button/FluentButton.razor.cs
+++ b/src/Core/Components/Button/FluentButton.razor.cs
@@ -209,6 +209,11 @@ public partial class FluentButton : FluentComponentBase
     /// <summary />
     protected override void OnParametersSet()
     {
+        if (this is FluentToggleButton && Loading is true)
+        {
+            throw new ArgumentException("FluentToggleButton does not support Loading");
+        }
+
         string[] values = ["_self", "_blank", "_parent", "_top"];
 
         if (!string.IsNullOrEmpty(FormTarget) && !values.Contains(FormTarget, StringComparer.OrdinalIgnoreCase))

--- a/src/Core/Components/Button/FluentToggleButton.razor
+++ b/src/Core/Components/Button/FluentToggleButton.razor
@@ -17,9 +17,9 @@
                       size="@Size.ToAttributeValue()"
                       id="@Id"
                       value="@Value"
-                      icon-only="@(IconOnly || (ChildContent is null && Label is null))"
-                      disabled="@(Disabled || Loading)"
-                      disabled-focusable="@(DisabledFocusable || Loading)"
+                      icon-only="@(IconOnly || _emptyContent)"
+                      disabled="@(Disabled)"
+                      disabled-focusable="@(DisabledFocusable)"
                       name="@Name"
                       required="@Required"
                       aria-label="@Title"
@@ -32,12 +32,12 @@
                       @attributes="@AdditionalAttributes">
     @if (IconStart != null)
     {
-        <FluentIcon Value="@IconStart" Slot="@((ChildContent is null && Label is null) ? null : "start")" />
+        <FluentIcon Value="@IconStart" Slot="@((_emptyContent) ? null : "start")" />
     }
     @Label
     @ChildContent
     @if (IconEnd != null)
     {
-        <FluentIcon Value="@IconEnd" Slot="@((ChildContent is null && Label is null) ? null : "end")" />
+        <FluentIcon Value="@IconEnd" Slot="@((_emptyContent) ? null : "end")" />
     }
 </fluent-toggle-button>

--- a/src/Core/Components/Button/FluentToggleButton.razor
+++ b/src/Core/Components/Button/FluentToggleButton.razor
@@ -1,0 +1,43 @@
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Rendering;
+@using Microsoft.FluentUI.AspNetCore.Components.Extensions
+@inherits FluentButton
+
+<fluent-toggle-button class="@ClassValue"
+                      style="@StyleValue"
+                      autofocus="@AutoFocus"
+                      form="@FormId"
+                      formaction="@FormAction"
+                      formenctype="@FormEncType"
+                      formmethod="@FormMethod"
+                      formnovalidate="@FormNoValidate"
+                      formtarget="@FormTarget"
+                      type="@Type.ToAttributeValue()"
+                      shape="@Shape.ToAttributeValue()"
+                      size="@Size.ToAttributeValue()"
+                      id="@Id"
+                      value="@Value"
+                      icon-only="@(IconOnly || (ChildContent is null && Label is null))"
+                      disabled="@(Disabled || Loading)"
+                      disabled-focusable="@(DisabledFocusable || Loading)"
+                      name="@Name"
+                      required="@Required"
+                      aria-label="@Title"
+                      title="@Title"
+                      appearance="@(Appearance == ButtonAppearance.Default ? null : Appearance.ToAttributeValue())"
+                      mixed="@Mixed"
+                      pressed="@Pressed"
+                      @onclick="@OnClickHandlerAsync"
+                      @onclick:stopPropagation="@StopPropagation"
+                      @attributes="@AdditionalAttributes">
+    @if (IconStart != null)
+    {
+        <FluentIcon Value="@IconStart" Slot="@((ChildContent is null && Label is null) ? null : "start")" />
+    }
+    @Label
+    @ChildContent
+    @if (IconEnd != null)
+    {
+        <FluentIcon Value="@IconEnd" Slot="@((ChildContent is null && Label is null) ? null : "end")" />
+    }
+</fluent-toggle-button>

--- a/src/Core/Components/Button/FluentToggleButton.razor.cs
+++ b/src/Core/Components/Button/FluentToggleButton.razor.cs
@@ -1,0 +1,34 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// The FluentToggleButton component allows users to commit a change or trigger a toggle action via a single click or tap and
+/// is often found inside forms, dialogs, drawers (panels) and/or pages.
+/// </summary>
+public partial class FluentToggleButton : FluentButton
+{
+    /// <summary>
+    /// Gets or sets the mixed state of the component.
+    /// </summary>
+    [Parameter]
+    public bool Mixed { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets the pressed state of the button.
+    /// </summary>
+    [Parameter]
+    public bool Pressed { get; set; }
+
+    /// <summary />
+    protected new async Task OnClickHandlerAsync(MouseEventArgs e)
+    {
+        Pressed = !Pressed;
+        await base.OnClickHandlerAsync(e);
+    }
+}

--- a/src/Core/Components/Button/FluentToggleButton.razor.cs
+++ b/src/Core/Components/Button/FluentToggleButton.razor.cs
@@ -13,6 +13,8 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// </summary>
 public partial class FluentToggleButton : FluentButton
 {
+    private bool _emptyContent => ChildContent is null && Label is null;
+
     /// <summary>
     /// Gets or sets the mixed state of the component.
     /// </summary>

--- a/tests/Core/Components/Button/FluentToggleButtonTests.FluentToggleButton_Default.verified.razor.html
+++ b/tests/Core/Components/Button/FluentToggleButtonTests.FluentToggleButton_Default.verified.razor.html
@@ -1,0 +1,3 @@
+
+<fluent-toggle-button blazor:onclick="x">
+  fluent-toggle-button</fluent-toggle-button>

--- a/tests/Core/Components/Button/FluentToggleButtonTests.FluentToggleButton_IconEnd.verified.razor.html
+++ b/tests/Core/Components/Button/FluentToggleButtonTests.FluentToggleButton_IconEnd.verified.razor.html
@@ -1,0 +1,6 @@
+
+<fluent-toggle-button blazor:onclick="x">
+  My button<svg slot="end" style="width: 24px;" focusable="false" viewBox="0 0 24 24" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
+    <path d="M12 2a10 10 0 1 1 0 20 10 10 0 0 1 0-20Zm0 8.25a1 1 0 0 0-1 .88v5.74a1 1 0 0 0 2 0v-5.62l-.01-.12a1 1 0 0 0-1-.88Zm0-3.75A1.25 1.25 0 1 0 12 9a1.25 1.25 0 0 0 0-2.5Z"></path>
+  </svg>
+</fluent-toggle-button>

--- a/tests/Core/Components/Button/FluentToggleButtonTests.FluentToggleButton_IconEndNoContent.verified.razor.html
+++ b/tests/Core/Components/Button/FluentToggleButtonTests.FluentToggleButton_IconEndNoContent.verified.razor.html
@@ -1,0 +1,6 @@
+
+<fluent-toggle-button icon-only="" blazor:onclick="x">
+  <svg style="width: 24px;" focusable="false" viewBox="0 0 24 24" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
+    <path d="M12 2a10 10 0 1 1 0 20 10 10 0 0 1 0-20Zm0 8.25a1 1 0 0 0-1 .88v5.74a1 1 0 0 0 2 0v-5.62l-.01-.12a1 1 0 0 0-1-.88Zm0-3.75A1.25 1.25 0 1 0 12 9a1.25 1.25 0 0 0 0-2.5Z"></path>
+  </svg>
+</fluent-toggle-button>

--- a/tests/Core/Components/Button/FluentToggleButtonTests.FluentToggleButton_IconOnly.verified.razor.html
+++ b/tests/Core/Components/Button/FluentToggleButtonTests.FluentToggleButton_IconOnly.verified.razor.html
@@ -1,0 +1,6 @@
+
+<fluent-toggle-button icon-only="" blazor:onclick="x">
+  <svg viewBox="0 0 20 20">
+    <path fill="currentColor" d="M7.851 3.146a.5.5 0 0 1 0 .707L4.706 7H10c2.932 0 5.593 1.64 6.936 4.043a.5.5 0 1 1-.872.488C14.894 9.439 12.564 8 10 8H4.707l3.144 3.145a.5.5 0 0 1-.707.707L3.161 7.867a.5.5 0 0 1-.014-.721l3.997-4a.5.5 0 0 1 .707 0M8 15a2 2 0 1 1 4 0a2 2 0 0 1-4 0m2-1a1 1 0 1 0 0 2a1 1 0 0 0 0-2"></path>
+  </svg>
+</fluent-toggle-button>

--- a/tests/Core/Components/Button/FluentToggleButtonTests.FluentToggleButton_IconStart.verified.razor.html
+++ b/tests/Core/Components/Button/FluentToggleButtonTests.FluentToggleButton_IconStart.verified.razor.html
@@ -1,0 +1,6 @@
+
+<fluent-toggle-button blazor:onclick="x">
+  <svg slot="start" style="width: 24px;" focusable="false" viewBox="0 0 24 24" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
+    <path d="M12 2a10 10 0 1 1 0 20 10 10 0 0 1 0-20Zm0 8.25a1 1 0 0 0-1 .88v5.74a1 1 0 0 0 2 0v-5.62l-.01-.12a1 1 0 0 0-1-.88Zm0-3.75A1.25 1.25 0 1 0 12 9a1.25 1.25 0 0 0 0-2.5Z"></path>
+  </svg>
+  My button</fluent-toggle-button>

--- a/tests/Core/Components/Button/FluentToggleButtonTests.FluentToggleButton_IconStartNoContent.verified.razor.html
+++ b/tests/Core/Components/Button/FluentToggleButtonTests.FluentToggleButton_IconStartNoContent.verified.razor.html
@@ -1,0 +1,6 @@
+
+<fluent-toggle-button icon-only="" blazor:onclick="x">
+  <svg style="width: 24px;" focusable="false" viewBox="0 0 24 24" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
+    <path d="M12 2a10 10 0 1 1 0 20 10 10 0 0 1 0-20Zm0 8.25a1 1 0 0 0-1 .88v5.74a1 1 0 0 0 2 0v-5.62l-.01-.12a1 1 0 0 0-1-.88Zm0-3.75A1.25 1.25 0 1 0 12 9a1.25 1.25 0 0 0 0-2.5Z"></path>
+  </svg>
+</fluent-toggle-button>

--- a/tests/Core/Components/Button/FluentToggleButtonTests.FluentToggleButton_Mixed.verified.razor.html
+++ b/tests/Core/Components/Button/FluentToggleButtonTests.FluentToggleButton_Mixed.verified.razor.html
@@ -1,0 +1,3 @@
+
+<fluent-toggle-button mixed="" blazor:onclick="x">
+  fluent-toggle-button</fluent-toggle-button>

--- a/tests/Core/Components/Button/FluentToggleButtonTests.FluentToggleButton_Pressed.verified.razor.html
+++ b/tests/Core/Components/Button/FluentToggleButtonTests.FluentToggleButton_Pressed.verified.razor.html
@@ -1,0 +1,3 @@
+
+<fluent-toggle-button pressed="" blazor:onclick="x">
+  fluent-toggle-button</fluent-toggle-button>

--- a/tests/Core/Components/Button/FluentToggleButtonTests.FluentToggleButton_PressedAndMixed.verified.razor.html
+++ b/tests/Core/Components/Button/FluentToggleButtonTests.FluentToggleButton_PressedAndMixed.verified.razor.html
@@ -1,0 +1,3 @@
+
+<fluent-toggle-button mixed="" pressed="" blazor:onclick="x">
+  fluent-toggle-button</fluent-toggle-button>

--- a/tests/Core/Components/Button/FluentToggleButtonTests.FluentToggleButton_WithAppearanceAndPressedState.verified.razor.html
+++ b/tests/Core/Components/Button/FluentToggleButtonTests.FluentToggleButton_WithAppearanceAndPressedState.verified.razor.html
@@ -1,0 +1,3 @@
+
+<fluent-toggle-button appearance="primary" pressed="" blazor:onclick="x">
+  Primary toggle button</fluent-toggle-button>

--- a/tests/Core/Components/Button/FluentToggleButtonTests.FluentToggleButton_WithIconAndPressedState.verified.razor.html
+++ b/tests/Core/Components/Button/FluentToggleButtonTests.FluentToggleButton_WithIconAndPressedState.verified.razor.html
@@ -1,0 +1,6 @@
+
+<fluent-toggle-button pressed="" blazor:onclick="x">
+  <svg slot="start" style="width: 24px;" focusable="false" viewBox="0 0 24 24" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
+    <path d="M12 2a10 10 0 1 1 0 20 10 10 0 0 1 0-20Zm0 8.25a1 1 0 0 0-1 .88v5.74a1 1 0 0 0 2 0v-5.62l-.01-.12a1 1 0 0 0-1-.88Zm0-3.75A1.25 1.25 0 1 0 12 9a1.25 1.25 0 0 0 0-2.5Z"></path>
+  </svg>
+  Toggle with icon</fluent-toggle-button>

--- a/tests/Core/Components/Button/FluentToggleButtonTests.razor
+++ b/tests/Core/Components/Button/FluentToggleButtonTests.razor
@@ -1,0 +1,219 @@
+﻿@using Microsoft.FluentUI.AspNetCore.Components.Utilities
+@using Xunit;
+@using Microsoft.FluentUI.AspNetCore.Components.Tests.Samples;
+@inherits TestContext
+@code
+{
+    public FluentToggleButtonTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddFluentUIComponents();
+    }
+
+    [Fact]
+    public void FluentToggleButton_Default()
+    {
+        // Arrange & Act
+        var cut = Render(@<FluentToggleButton>fluent-toggle-button</FluentToggleButton>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentToggleButton_Pressed()
+    {
+        // Arrange & Act
+        var cut = Render(@<FluentToggleButton Pressed="true">fluent-toggle-button</FluentToggleButton>);
+
+        // Assert
+        cut.Verify();
+        var attribute = cut.Find("fluent-toggle-button").GetAttribute("pressed");
+        Assert.Equal("", attribute);
+    }
+
+    [Fact]
+    public void FluentToggleButton_Mixed()
+    {
+        // Arrange & Act
+        var cut = Render(@<FluentToggleButton Mixed="true">fluent-toggle-button</FluentToggleButton>);
+
+        // Assert
+        cut.Verify();
+        var attribute = cut.Find("fluent-toggle-button").GetAttribute("mixed");
+        Assert.Equal("", attribute);
+    }
+
+    [Fact]
+    public void FluentToggleButton_PressedAndMixed()
+    {
+        // Arrange & Act
+        var cut = Render(@<FluentToggleButton Pressed="true" Mixed="true">fluent-toggle-button</FluentToggleButton>);
+
+        // Assert
+        cut.Verify();
+        var pressedAttribute = cut.Find("fluent-toggle-button").GetAttribute("pressed");
+        var mixedAttribute = cut.Find("fluent-toggle-button").GetAttribute("mixed");
+        Assert.Equal("", pressedAttribute);
+        Assert.Equal("", mixedAttribute);
+    }
+
+    [Fact]
+    public void FluentToggleButton_TogglesPressedStateOnClick()
+    {
+        // Arrange
+        var cut = Render<FluentToggleButton>(@<FluentToggleButton>fluent-toggle-button</FluentToggleButton>);
+
+        // Initial state should be not pressed
+        Assert.False(cut.Instance.Pressed);
+
+        // Act - Click the button
+        cut.Find("fluent-toggle-button").Click();
+
+        // Assert - Should now be pressed
+        Assert.True(cut.Instance.Pressed);
+
+        // Act - Click the button again
+        cut.Find("fluent-toggle-button").Click();
+
+        // Assert - Should now be not pressed again
+        Assert.False(cut.Instance.Pressed);
+    }
+
+    [Fact]
+    public void FluentToggleButton_OnClickAndTogglePressedState()
+    {
+        bool clicked = false;
+
+        // Arrange
+        var cut = Render<FluentToggleButton>(@<FluentToggleButton OnClick="@(e => { clicked = true; })">fluent-toggle-button</FluentToggleButton>);
+
+        // Act
+        cut.Find("fluent-toggle-button").Click();
+
+        // Assert - Both the clicked flag and the Pressed state should be updated
+        Assert.True(clicked);
+        Assert.True(cut.Instance.Pressed);
+    }
+
+    [Fact]
+    public void FluentToggleButton_InitialPressedState()
+    {
+        // Arrange & Act
+        var cut = Render<FluentToggleButton>(@<FluentToggleButton Pressed="true">fluent-toggle-button</FluentToggleButton>);
+
+        // Assert - Initial state should match the parameter
+        Assert.True(cut.Instance.Pressed);
+
+        // Act - Click to toggle
+        cut.Find("fluent-toggle-button").Click();
+
+        // Assert - Should toggle to false
+        Assert.False(cut.Instance.Pressed);
+    }
+
+    [Fact]
+    public void FluentToggleButton_MixedWithPressedState()
+    {
+        // Arrange & Act
+        var cut = Render<FluentToggleButton>(@<FluentToggleButton Mixed="true" Pressed="true">fluent-toggle-button</FluentToggleButton>);
+
+        // Assert
+        Assert.True(cut.Instance.Mixed);
+        Assert.True(cut.Instance.Pressed);
+
+        // Act - Click should only affect the Pressed state, not Mixed
+        cut.Find("fluent-toggle-button").Click();
+
+        // Assert
+        Assert.True(cut.Instance.Mixed);
+        Assert.False(cut.Instance.Pressed);
+    }
+
+    [Fact]
+    public void FluentToggleButton_WithIconAndPressedState()
+    {
+        // Arrange & Act
+        var cut = Render<FluentToggleButton>(@<FluentToggleButton
+            IconStart="@Samples.Icons.Info"
+            Pressed="true">Toggle with icon</FluentToggleButton>);
+
+        // Assert
+        cut.Verify();
+        Assert.True(cut.Instance.Pressed);
+
+        // Verify the icon is present
+        var iconElement = cut.Find("svg");
+        Assert.NotNull(iconElement);
+    }
+
+    [Fact]
+    public void FluentToggleButton_WithAppearanceAndPressedState()
+    {
+        // Arrange & Act
+        var cut = Render<FluentToggleButton>(@<FluentToggleButton
+            Appearance="ButtonAppearance.Primary"
+            Pressed="true">Primary toggle button</FluentToggleButton>);
+
+        // Assert
+        cut.Verify();
+        Assert.True(cut.Instance.Pressed);
+
+        // Verify the appearance attribute
+        var appearance = cut.Find("fluent-toggle-button").GetAttribute("appearance") ?? string.Empty;
+        Assert.Equal("primary", appearance);
+    }
+
+    [Fact]
+    public void FluentToggleButton_IconStart()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentToggleButton IconStart="@Samples.Icons.Info">My button</FluentToggleButton>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentToggleButton_IconEnd()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentToggleButton IconEnd="@Samples.Icons.Info">My button</FluentToggleButton>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentToggleButton_IconStartNoContent()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentToggleButton IconStart="@Samples.Icons.Info" />);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentToggleButton_IconEndNoContent()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentToggleButton IconEnd="@Samples.Icons.Info" />);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentToggleButton_IconOnly()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentToggleButton IconOnly="true">
+            <svg viewBox="0 0 20 20">
+                <path fill="currentColor" d="M7.851 3.146a.5.5 0 0 1 0 .707L4.706 7H10c2.932 0 5.593 1.64 6.936 4.043a.5.5 0 1 1-.872.488C14.894 9.439 12.564 8 10 8H4.707l3.144 3.145a.5.5 0 0 1-.707.707L3.161 7.867a.5.5 0 0 1-.014-.721l3.997-4a.5.5 0 0 1 .707 0M8 15a2 2 0 1 1 4 0a2 2 0 0 1-4 0m2-1a1 1 0 1 0 0 2a1 1 0 0 0 0-2"></path>
+            </svg>
+        </FluentToggleButton>);
+        // Assert
+        cut.Verify();
+    }
+}


### PR DESCRIPTION
Ads the `FluentToggleButton` component

A toggle button is a two-state behavior that switches a state between on and off. A button’s rest state indicates “off” (`Pressed="false"`) while the selected state indicates “on” (`Pressed="true"`). The toggle state is in addition to the normal click behavior of a button.

![image](https://github.com/user-attachments/assets/502f1676-fc52-4f6b-b801-c57127655bcf)