### PR TITLE
[dev-v5] FluentTabs

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsCustomized.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsCustomized.razor
@@ -21,7 +21,7 @@
 </FluentTabs>
 
 <p>
-    ActiveTab: @(ActiveTab?.Header)
+    ActiveTab: <b>@(ActiveTab?.Header)</b>
 </p>
 
 @code

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsCustomized.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsCustomized.razor
@@ -27,5 +27,5 @@
 @code
 {
     FluentTab? ActiveTab;
-    int NumberOfFiles = Random.Shared.Next(20);
+    int NumberOfFiles = Random.Shared.Next(1, 20);
 }

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsCustomized.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsCustomized.razor
@@ -1,0 +1,31 @@
+﻿<FluentTabs @bind-ActiveTab="@ActiveTab" Height="100px" Width="400px" Style="border: 1px solid var(colorNeutralStroke1);">
+    <FluentTab>
+        <HeaderTemplate>
+            Chat
+        </HeaderTemplate>
+        <ChildContent>
+            Here's some information about the chat.
+        </ChildContent>            
+    </FluentTab>
+
+    <FluentTab>
+        <HeaderTemplate>
+            <FluentCounterBadge Count="@((ushort)NumberOfFiles)" OverflowCount="9">
+                Files
+            </FluentCounterBadge>
+        </HeaderTemplate>
+        <ChildContent>
+            Here's the list of all files.
+        </ChildContent>                    
+    </FluentTab>
+</FluentTabs>
+
+<p>
+    ActiveTab: @(ActiveTab?.Header)
+</p>
+
+@code
+{
+    FluentTab? ActiveTab;
+    int NumberOfFiles = Random.Shared.Next(20);
+}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsDefault.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsDefault.razor
@@ -1,13 +1,13 @@
-﻿<FluentTabs ActiveTabId="tab2" @bind-ActiveTab="@ActiveTab" @bind-ActiveTab:after="@OnTabChanged">
-    <FluentTab Id="tab1" Header="Chat">
+﻿<FluentTabs ActiveTabId="tab3" @bind-ActiveTab="@ActiveTab" @bind-ActiveTab:after="@OnTabChanged">
+    <FluentTab Id="tab1" Header="Chat" IconStart="@(new Icons.Regular.Size16.Chat())">
         Here's some information about the chat.
     </FluentTab>
 
-    <FluentTab Id="tab2" Header="Files" Disabled="true">
+    <FluentTab Id="tab2" Header="Files" Disabled="true" IconStart="@(new Icons.Regular.Size16.Folder())">
         Here's the list of all files.
     </FluentTab>
 
-    <FluentTab Id="tab3" Header="Recap">
+    <FluentTab Id="tab3" Header="Recap" IconStart="@(new Icons.Regular.Size16.List())" IconColor="@Color.Primary">
         Here's some information about the recap.
     </FluentTab>
 </FluentTabs>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsDefault.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsDefault.razor
@@ -13,7 +13,7 @@
 </FluentTabs>
 
 <p>
-    ActiveTab: @(ActiveTab?.Header)
+    ActiveTab: <b>@(ActiveTab?.Header)</b>
 </p>
 
 @code

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsDefault.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsDefault.razor
@@ -1,0 +1,32 @@
+﻿<FluentTabs ActiveTabId="tab2" @bind-ActiveTab="@ActiveTab" @bind-ActiveTab:after="@OnTabChanged" Height="300px" Width="400px" Style="border: 1px solid red;">
+    <FluentTab Id="tab1" Header="Tab 1">
+        Example of content 1
+    </FluentTab>
+
+    <FluentTab Id="tab2" Header="Tab 2" Disabled>
+        Example of content 2
+    </FluentTab>
+
+    <FluentTab Id="tab3">
+        <HeaderTemplate>
+            Tab <b>3</b>
+        </HeaderTemplate>
+        <ChildContent>
+            Example of content 3
+        </ChildContent>
+    </FluentTab>
+</FluentTabs>
+
+<p>
+    ActiveTab: @(ActiveTab?.Header)
+</p>
+
+@code
+{
+    FluentTab? ActiveTab;
+
+    void OnTabChanged()
+    {
+        Console.WriteLine($"Tab changed to '{ActiveTab?.Header}'."); 
+    }
+}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsDefault.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsDefault.razor
@@ -1,19 +1,14 @@
-﻿<FluentTabs ActiveTabId="tab2" @bind-ActiveTab="@ActiveTab" @bind-ActiveTab:after="@OnTabChanged" Height="300px" Width="400px" Style="border: 1px solid red;">
-    <FluentTab Id="tab1" Header="Tab 1">
-        Example of content 1
+﻿<FluentTabs ActiveTabId="tab2" @bind-ActiveTab="@ActiveTab" @bind-ActiveTab:after="@OnTabChanged">
+    <FluentTab Id="tab1" Header="Chat">
+        Here's some information about the chat.
     </FluentTab>
 
-    <FluentTab Id="tab2" Header="Tab 2" Disabled>
-        Example of content 2
+    <FluentTab Id="tab2" Header="Files" Disabled="true">
+        Here's the list of all files.
     </FluentTab>
 
-    <FluentTab Id="tab3">
-        <HeaderTemplate>
-            Tab <b>3</b>
-        </HeaderTemplate>
-        <ChildContent>
-            Example of content 3
-        </ChildContent>
+    <FluentTab Id="tab3" Header="Recap">
+        Here's some information about the recap.
     </FluentTab>
 </FluentTabs>
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsDeferred.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsDeferred.razor
@@ -1,0 +1,33 @@
+﻿<FluentTabs @bind-ActiveTabId="@ActiveTabId" Height="100px" Width="300px">
+    <FluentTab Id="tab1" Header="Chat">
+        Here's some information about the chat.
+    </FluentTab>
+
+    <FluentTab Id="tab2" Header="Files" DeferredLoading="true">
+        @GetContentTab2
+    </FluentTab>
+
+    <FluentTab Id="tab3" Header="Recap">
+        Here's some information about the recap.
+    </FluentTab>
+
+</FluentTabs>
+
+<p>
+    ActiveTab: @ActiveTabId
+</p>
+
+@code
+{
+    string? ActiveTabId;
+
+    RenderFragment? GetContentTab2 => builder =>
+    {
+        // To simulate a long running process
+        Thread.Sleep(3000);
+
+        builder.OpenElement(0, "span");
+        builder.AddContent(1, "Here's the list of all files.");
+        builder.CloseElement();
+    };
+}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsDeferred.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsDeferred.razor
@@ -10,7 +10,6 @@
     <FluentTab Id="tab3" Header="Recap">
         Here's some information about the recap.
     </FluentTab>
-
 </FluentTabs>
 
 <p>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsDeferred.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsDeferred.razor
@@ -13,7 +13,7 @@
 </FluentTabs>
 
 <p>
-    ActiveTab: @ActiveTabId
+    ActiveTab: <b>@ActiveTabId</b>
 </p>
 
 @code
@@ -25,6 +25,7 @@
         // To simulate a long running process
         Thread.Sleep(3000);
 
+        // Add <span>Here's the list of all files.</span>
         builder.OpenElement(0, "span");
         builder.AddContent(1, "Here's the list of all files.");
         builder.CloseElement();

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/FluentTabs.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/FluentTabs.md
@@ -30,8 +30,8 @@ The header of each tab can be customized using the `HeaderTemplate` parameter.
 
 ## Deferred
 
-In some situations, the content of a tab may be expensive to load.
-In these cases, you can use the `Deferred` parameter to load the content only when the tab is selected.
+In some situations, loading and rendering the content of a tab may take a lot of time.
+In these cases, you can use the `Deferred` parameter to load the content after a tab has been selected.
 This can improve performance and reduce the initial load time of your application.
 
 By default, a progress indicator is shown while the content is being loaded.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/FluentTabs.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/FluentTabs.md
@@ -1,0 +1,10 @@
+---
+title: Tabs
+route: /Tabs
+---
+
+# Tabs
+
+## Default
+
+{{ TabsDefault }}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/FluentTabs.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/FluentTabs.md
@@ -41,3 +41,15 @@ In the following example, the `Deferred` parameter is set to `true` for Tab two.
 This tab will be loaded after 3 seconds of processing (to simulate a long running process).
 
 {{ TabsDeferred }}
+
+## API FluentTabs
+
+{{ API Type=FluentTabs }}
+
+## API FluentTab
+
+{{ API Type=FluentTab }}
+
+## Migrating to v5
+
+TODO

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/FluentTabs.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/FluentTabs.md
@@ -5,6 +5,34 @@ route: /Tabs
 
 # Tabs
 
+A **FluentTabs** allows people to switch between categories of related information without going to different pages.
+They’re are ideal for dividing content-heavy pages into distinct but related categories that are easier to process
+and require less scrolling.
+**FluentTabs** can also be used for navigation between a small set of closely related, frequently accessed pages.
+
+For navigation beyond closely related categories, use a [FluentLink](/link) instead.
+To initiate an action, use a [FluentButton](/button) instead.
+
 ## Default
 
 {{ TabsDefault }}
+
+## Customized
+
+The header of each tab can be customized using the `HeaderTemplate` parameter.
+
+{{ TabsCustomized }}
+
+## Deferred
+
+In some situations, the content of a tab may be expensive to load.
+In these cases, you can use the `Deferred` parameter to load the content only when the tab is selected.
+This can improve performance and reduce the initial load time of your application.
+
+By default, a progress indicator is shown while the content is being loaded.
+You can customize the progress indicator by using the `LoadingTemplate` parameter.
+
+In the following example, the `Deferred` parameter is set to `true` for Tab two.
+This tab will be loaded after 3 seconds of processing (to simulate a long running process).
+
+{{ TabsDeferred }}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/FluentTabs.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/FluentTabs.md
@@ -15,6 +15,11 @@ To initiate an action, use a [FluentButton](/button) instead.
 
 ## Default
 
+To know which tab is selected, you can bind the `ActiveTabId` or `ActiveTab` parameter to a variable.
+Setting the `ActiveTabId` parameter to an initial value will set the selected tab when the component is first rendered.
+
+A tab can be disabled by setting the `Disabled` parameter to `true`.
+
 {{ TabsDefault }}
 
 ## Customized

--- a/src/Core.Scripts/src/FluentUICustomEvents.ts
+++ b/src/Core.Scripts/src/FluentUICustomEvents.ts
@@ -35,6 +35,19 @@ export namespace Microsoft.FluentUI.Blazor.FluentUICustomEvents {
     });
   }
 
+  export function Tabs(blazor: Blazor) {
+
+    // Event when a tab is selected
+    blazor.registerCustomEventType('tabchange', {
+      browserEventName: 'change',
+      createEventArgs: (event: any) => {
+        return {
+          id: event.target.id,
+          activeid: event.detail?.id,
+        };
+      }
+    });
+  }
 
   // [^^^ Add your other custom events before this line ^^^]
 

--- a/src/Core.Scripts/src/Startup.ts
+++ b/src/Core.Scripts/src/Startup.ts
@@ -50,6 +50,7 @@ export namespace Microsoft.FluentUI.Blazor.Startup {
 
     // Register all custom events
     FluentUICustomEvents.DialogToggle(blazor);
+    FluentUICustomEvents.Tabs(blazor);
     // [^^^ Add your other custom events before this line ^^^]
 
     // Finishing

--- a/src/Core/Components/Tabs/FluentTab.razor
+++ b/src/Core/Components/Tabs/FluentTab.razor
@@ -1,0 +1,15 @@
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components
+@inherits FluentComponentBase
+
+<fluent-tab id="@Id"
+            class="@ClassValue"
+            style="@StyleValue"
+            disabled="@Disabled">
+    <AddTag Name="span" TagWhen="@(() => HeaderTemplate is not null)">
+        @Header
+        @HeaderTemplate
+    </AddTag>
+</fluent-tab>
+<fluent-tab-panel>
+    @ChildContent
+</fluent-tab-panel>

--- a/src/Core/Components/Tabs/FluentTab.razor
+++ b/src/Core/Components/Tabs/FluentTab.razor
@@ -11,5 +11,19 @@
     </AddTag>
 </fluent-tab>
 <fluent-tab-panel>
-    @ChildContent
+    @if (Owner?.ActiveTabId == Id || !DeferredLoading)
+    {
+        @ChildContent
+    }
+    else
+    {
+        if (LoadingTemplate is null)
+        {
+            <FluentProgressBar />
+        }
+        else
+        {
+            @LoadingTemplate
+        }
+    }
 </fluent-tab-panel>

--- a/src/Core/Components/Tabs/FluentTab.razor
+++ b/src/Core/Components/Tabs/FluentTab.razor
@@ -8,17 +8,17 @@
                 style="@StyleValue"
                 disabled="@Disabled"
                 @attributes="@AdditionalAttributes">
-        <AddTag Name="span" TagWhen="@(() => HeaderTemplate is not null)">
+        <AddTag Name="span" TagWhen="@(() => HeaderTemplate is not null || IconStart is not null)">
+            @if (IconStart is not null)
+            {
+                <FluentIcon Value="@IconStart" Color="@IconColor" />
+            }
             @Header
             @HeaderTemplate
         </AddTag>
     </fluent-tab>
     <fluent-tab-panel id="@(Id + "-panel")">
-        @if (Owner?.ActiveTabId == Id || !DeferredLoading)
-        {
-            @ChildContent
-        }
-        else
+        @if (DeferredLoading && Owner?.ActiveTabId != Id)
         {
             if (LoadingTemplate is null)
             {
@@ -28,6 +28,10 @@
             {
                 @LoadingTemplate
             }
+        }
+        else
+        {
+            @ChildContent
         }
     </fluent-tab-panel>
 }

--- a/src/Core/Components/Tabs/FluentTab.razor
+++ b/src/Core/Components/Tabs/FluentTab.razor
@@ -1,29 +1,33 @@
 ﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 @inherits FluentComponentBase
 
-<fluent-tab id="@Id"
-            class="@ClassValue"
-            style="@StyleValue"
-            disabled="@Disabled">
-    <AddTag Name="span" TagWhen="@(() => HeaderTemplate is not null)">
-        @Header
-        @HeaderTemplate
-    </AddTag>
-</fluent-tab>
-<fluent-tab-panel>
-    @if (Owner?.ActiveTabId == Id || !DeferredLoading)
-    {
-        @ChildContent
-    }
-    else
-    {
-        if (LoadingTemplate is null)
+@if (Visible)
+{
+    <fluent-tab id="@Id"
+                class="@ClassValue"
+                style="@StyleValue"
+                disabled="@Disabled"
+                @attributes="@AdditionalAttributes">
+        <AddTag Name="span" TagWhen="@(() => HeaderTemplate is not null)">
+            @Header
+            @HeaderTemplate
+        </AddTag>
+    </fluent-tab>
+    <fluent-tab-panel>
+        @if (Owner?.ActiveTabId == Id || !DeferredLoading)
         {
-            <FluentProgressBar />
+            @ChildContent
         }
         else
         {
-            @LoadingTemplate
+            if (LoadingTemplate is null)
+            {
+                <FluentProgressBar />
+            }
+            else
+            {
+                @LoadingTemplate
+            }
         }
-    }
-</fluent-tab-panel>
+    </fluent-tab-panel>
+}

--- a/src/Core/Components/Tabs/FluentTab.razor
+++ b/src/Core/Components/Tabs/FluentTab.razor
@@ -13,7 +13,7 @@
             @HeaderTemplate
         </AddTag>
     </fluent-tab>
-    <fluent-tab-panel>
+    <fluent-tab-panel id="@(Id + "-panel")">
         @if (Owner?.ActiveTabId == Id || !DeferredLoading)
         {
             @ChildContent

--- a/src/Core/Components/Tabs/FluentTab.razor.cs
+++ b/src/Core/Components/Tabs/FluentTab.razor.cs
@@ -8,6 +8,7 @@ using Microsoft.FluentUI.AspNetCore.Components.Utilities;
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 /// <summary>
+/// A FluentTabs allows people to switch between categories of related information without going to different pages
 /// </summary>
 public partial class FluentTab : FluentComponentBase
 {
@@ -48,7 +49,20 @@ public partial class FluentTab : FluentComponentBase
     public RenderFragment? HeaderTemplate { get; set; }
 
     /// <summary>
+    /// Gets or sets the icon to be displayed at the start of the tab.
+    /// </summary>
+    [Parameter]
+    public Icon? IconStart { get; set; }
+
+    /// <summary>
+    /// Gets or sets the icon color.
+    /// </summary>
+    [Parameter]
+    public Color? IconColor { get; set; }
+
+    /// <summary>
     /// Gets or sets whether the tab content is rendered only when the tab is selected.
+    /// To reduce the HTML page size, the tab content is cleared when the tab is unselected.
     /// </summary>
     [Parameter]
     public bool DeferredLoading { get; set; } = false;

--- a/src/Core/Components/Tabs/FluentTab.razor.cs
+++ b/src/Core/Components/Tabs/FluentTab.razor.cs
@@ -1,0 +1,64 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.FluentUI.AspNetCore.Components.Utilities;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// </summary>
+public partial class FluentTab : FluentComponentBase
+{
+    /// <summary />
+    public FluentTab()
+    {
+        Id = Identifier.NewId();
+    }
+
+    /// <summary />
+    protected string? ClassValue => DefaultClassBuilder
+        .Build();
+
+    /// <summary />
+    protected string? StyleValue => DefaultStyleBuilder
+        .Build();
+
+    /// <summary />
+    [CascadingParameter]
+    private FluentTabs? Owner { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the tab is disabled.
+    /// </summary>
+    [Parameter]
+    public bool Disabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets the label of the tab.
+    /// </summary>
+    [Parameter]
+    public string? Header { get; set; }
+
+    /// <summary>
+    /// Gets or sets the header content of the tab.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? HeaderTemplate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the content to be rendered inside the component.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    /// <summary />
+    protected override async Task OnInitializedAsync()
+    {
+        if (Owner is not null)
+        {
+            await Owner.AddTabAsync(this);
+        }
+    }
+}

--- a/src/Core/Components/Tabs/FluentTab.razor.cs
+++ b/src/Core/Components/Tabs/FluentTab.razor.cs
@@ -65,6 +65,12 @@ public partial class FluentTab : FluentComponentBase
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
 
+    /// <summary>
+    /// Gets or sets whether the tab is displayed. Default is true.
+    /// </summary>
+    [Parameter]
+    public bool Visible { get; set; } = true;
+
     /// <summary />
     protected override async Task OnInitializedAsync()
     {

--- a/src/Core/Components/Tabs/FluentTab.razor.cs
+++ b/src/Core/Components/Tabs/FluentTab.razor.cs
@@ -48,6 +48,18 @@ public partial class FluentTab : FluentComponentBase
     public RenderFragment? HeaderTemplate { get; set; }
 
     /// <summary>
+    /// Gets or sets whether the tab content is rendered only when the tab is selected.
+    /// </summary>
+    [Parameter]
+    public bool DeferredLoading { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets the customized loading content message when using deferred loading.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? LoadingTemplate { get; set; }
+
+    /// <summary>
     /// Gets or sets the content to be rendered inside the component.
     /// </summary>
     [Parameter]

--- a/src/Core/Components/Tabs/FluentTab.razor.css
+++ b/src/Core/Components/Tabs/FluentTab.razor.css
@@ -1,0 +1,4 @@
+fluent-tab > span {
+    display: flex;
+    column-gap: 2px;
+}

--- a/src/Core/Components/Tabs/FluentTabs.razor
+++ b/src/Core/Components/Tabs/FluentTabs.razor
@@ -6,12 +6,13 @@
     <fluent-tabs id="@Id"
                  class="@ClassValue"
                  style="@StyleValue"
-                 appearance="@Appearance.ToAttributeValue()"
+                 appearance="@Appearance.ToAttributeValue(isNull: TabsAppearance.Default, returnEmptyAsNull: true)"
                  disabled="@Disabled"
-                 size="@Size.ToAttributeValue()"
+                 size="@Size.ToAttributeValue(isNull: TabsSize.Medium, returnEmptyAsNull: true)"
                  orientation="@Orientation.ToAttributeValue()"
                  activeid="@(ActiveTabId ?? ActiveTab?.Id)"
-                 ontabchange="@TabChangeHandlerAsync">
+                 ontabchange="@TabChangeHandlerAsync"
+                 @attributes="@AdditionalAttributes">
         @ChildContent
     </fluent-tabs>
 </CascadingValue>

--- a/src/Core/Components/Tabs/FluentTabs.razor
+++ b/src/Core/Components/Tabs/FluentTabs.razor
@@ -1,0 +1,17 @@
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components
+@using Microsoft.FluentUI.AspNetCore.Components.Extensions
+@inherits FluentComponentBase
+
+<CascadingValue Value="this">
+    <fluent-tabs id="@Id"
+                 class="@ClassValue"
+                 style="@StyleValue"
+                 appearance="@Appearance.ToAttributeValue()"
+                 disabled="@Disabled"
+                 size="@Size.ToAttributeValue()"
+                 orientation="@Orientation.ToAttributeValue()"
+                 activeid="@(ActiveTabId ?? ActiveTab?.Id)"
+                 ontabchange="@TabChangeHandlerAsync">
+        @ChildContent
+    </fluent-tabs>
+</CascadingValue>

--- a/src/Core/Components/Tabs/FluentTabs.razor
+++ b/src/Core/Components/Tabs/FluentTabs.razor
@@ -2,7 +2,7 @@
 @using Microsoft.FluentUI.AspNetCore.Components.Extensions
 @inherits FluentComponentBase
 
-<CascadingValue Value="this">
+<CascadingValue Value="this" IsFixed="true">
     <fluent-tabs id="@Id"
                  class="@ClassValue"
                  style="@StyleValue"

--- a/src/Core/Components/Tabs/FluentTabs.razor.cs
+++ b/src/Core/Components/Tabs/FluentTabs.razor.cs
@@ -1,0 +1,156 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using System.Collections.Concurrent;
+using Microsoft.AspNetCore.Components;
+using Microsoft.FluentUI.AspNetCore.Components.Utilities;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// </summary>
+public partial class FluentTabs: FluentComponentBase
+{
+    private ConcurrentDictionary<string, FluentTab> Tabs { get; } = new(StringComparer.Ordinal);
+
+    /// <summary />
+    public FluentTabs()
+    {
+        Id = Identifier.NewId();
+    }
+
+    /// <summary />
+    protected string? ClassValue => DefaultClassBuilder
+        .Build();
+
+    /// <summary />
+    protected string? StyleValue => DefaultStyleBuilder
+        .AddStyle("width", Width, when: !string.IsNullOrEmpty(Width))
+        .AddStyle("height", Height, when: !string.IsNullOrEmpty(Height))
+        .Build();
+
+    /// <summary>
+    /// Gets or sets the appearance affects each of the contained tabs.
+    /// </summary>
+    [Parameter]
+    public TabsAppearance? Appearance { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the tabs are disabled.
+    /// </summary>
+    [Parameter]
+    public bool Disabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets the size of the tabs. The default is medium.
+    /// </summary>
+    [Parameter]
+    public TabsSize? Size { get; set; }
+
+    /// <summary>
+    /// Gets or sets the orientation of the tabs. The default is horizontal.
+    /// </summary>
+    [Parameter]
+    public Orientation? Orientation { get; set; }
+
+    /// <summary>
+    /// Gets or sets the height of the tabs.
+    /// </summary>
+    [Parameter]
+    public string? Height { get; set; }
+
+    /// <summary>
+    /// Gets or sets the wudth of the tabs.
+    /// </summary>
+    [Parameter]
+    public string? Width { get; set; }
+
+    /// <summary>
+    /// Gets the the active selected tab id.
+    /// </summary>
+    [Parameter]
+    public string? ActiveTabId { get; set; }
+
+    /// <summary>
+    /// Represents a callback for when the active tab id changes. It can handle a nullable FluentTab parameter.
+    /// </summary>
+    [Parameter]
+    public EventCallback<string?> ActiveTabIdChanged { get; set; }
+
+    /// <summary>
+    /// Gets the the active selected tab.
+    /// </summary>
+    [Parameter]
+    public FluentTab? ActiveTab { get; set; }
+
+    /// <summary>
+    /// Represents a callback for when the active tab changes. It can handle a nullable FluentTab parameter.
+    /// </summary>
+    [Parameter]
+    public EventCallback<FluentTab?> ActiveTabChanged { get; set; }
+
+    /// <summary>
+    /// Gets or sets the content to be rendered inside the component.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    /// <summary />
+    internal async Task AddTabAsync(FluentTab tab)
+    {
+        if (tab is not null && !string.IsNullOrEmpty(tab.Id))
+        {
+            Tabs.TryAdd(tab.Id, tab);
+
+            // Set the default ActiveTab
+            if (!string.IsNullOrEmpty(ActiveTabId) && string.Equals(ActiveTabId, tab.Id, StringComparison.Ordinal))
+            {
+                ActiveTab = tab;
+
+                if (ActiveTabChanged.HasDelegate)
+                {
+                    await ActiveTabChanged.InvokeAsync(ActiveTab);
+                }
+            }
+
+            // Set the default ActiveTabId
+            else if (ActiveTabId is null  && ActiveTab == tab)
+            {
+                ActiveTabId = tab.Id;
+
+                if (ActiveTabIdChanged.HasDelegate)
+                {
+                    await ActiveTabIdChanged.InvokeAsync(ActiveTabId);
+                }
+            }
+        }
+    }
+
+    /// <summary />
+    private async Task TabChangeHandlerAsync(TabChangeEventArgs args)
+    {        
+        // Only for the current FluentTabs
+        if (!string.Equals(args.Id, Id, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        // Search for the tab
+        if (Tabs.TryGetValue(args.ActiveId ?? "", out var tab))
+        {
+            ActiveTabId = args.ActiveId;
+            ActiveTab = tab;
+
+            if (ActiveTabIdChanged.HasDelegate)
+            {
+                await ActiveTabIdChanged.InvokeAsync(ActiveTabId);
+            }
+
+            if (ActiveTabChanged.HasDelegate)
+            {
+                await ActiveTabChanged.InvokeAsync(ActiveTab);
+            }
+        }
+    }
+}

--- a/src/Core/Components/Tabs/FluentTabs.razor.cs
+++ b/src/Core/Components/Tabs/FluentTabs.razor.cs
@@ -9,6 +9,7 @@ using Microsoft.FluentUI.AspNetCore.Components.Utilities;
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 /// <summary>
+/// Each tab typically contains a text header and often includes an icon.
 /// </summary>
 public partial class FluentTabs: FluentComponentBase
 {
@@ -115,7 +116,7 @@ public partial class FluentTabs: FluentComponentBase
             }
 
             // Set the default ActiveTabId
-            else if (ActiveTabId is null  && ActiveTab == tab)
+            else if (ActiveTabId is null  && string.Equals(ActiveTab?.Id, tab.Id, StringComparison.Ordinal))
             {
                 ActiveTabId = tab.Id;
 

--- a/src/Core/Components/Tabs/FluentTabs.razor.cs
+++ b/src/Core/Components/Tabs/FluentTabs.razor.cs
@@ -128,8 +128,8 @@ public partial class FluentTabs: FluentComponentBase
     }
 
     /// <summary />
-    private async Task TabChangeHandlerAsync(TabChangeEventArgs args)
-    {        
+    internal async Task TabChangeHandlerAsync(TabChangeEventArgs args)
+    {
         // Only for the current FluentTabs
         if (!string.Equals(args.Id, Id, StringComparison.Ordinal))
         {

--- a/src/Core/Enums/TabsAppearance.cs
+++ b/src/Core/Enums/TabsAppearance.cs
@@ -1,0 +1,25 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using System.ComponentModel;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// The visual appearance of the <see cref="FluentTabs" />.
+/// </summary>
+public enum TabsAppearance
+{
+    /// <summary>
+    /// No background and border styling. This is the default value.
+    /// </summary>
+    [Description("transparent")]
+    Transparent,
+
+    /// <summary>
+    /// Minimizes emphasis to blend into the background until hovered or focused.
+    /// </summary>
+    [Description("subtle")]
+    Default,
+}

--- a/src/Core/Enums/TabsSize.cs
+++ b/src/Core/Enums/TabsSize.cs
@@ -1,0 +1,31 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using System.ComponentModel;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// The size of Tabs.
+/// </summary>
+public enum TabsSize
+{
+    /// <summary>
+    /// Medium tabs. This is the default size.
+    /// </summary>
+    [Description("medium")]
+    Medium,
+
+    /// <summary>
+    /// Small tabs.
+    /// </summary>
+    [Description("small")]
+    Small,
+
+    /// <summary>
+    /// Large tabs.
+    /// </summary>
+    [Description("large")]
+    Large,
+}

--- a/src/Core/Events/EventHandlers.cs
+++ b/src/Core/Events/EventHandlers.cs
@@ -29,6 +29,7 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// </summary>
 [EventHandler("ondialogbeforetoggle", typeof(DialogToggleEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
 [EventHandler("ondialogtoggle", typeof(DialogToggleEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
+[EventHandler("ontabchange", typeof(TabChangeEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
 public static class EventHandlers
 {
 }

--- a/src/Core/Events/TabChangeEventArgs.cs
+++ b/src/Core/Events/TabChangeEventArgs.cs
@@ -1,0 +1,21 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// Event arguments for the FluentTabs ActiveId changed event.
+/// </summary>
+internal class TabChangeEventArgs : EventArgs
+{
+    /// <summary>
+    /// Gets or sets the ID of the dialog.
+    /// </summary>
+    public string? Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets new active tab ID.
+    /// </summary>
+    public string? ActiveId { get; set; }
+}

--- a/tests/Core/Components.Tests.csproj
+++ b/tests/Core/Components.Tests.csproj
@@ -72,8 +72,4 @@
       <DependentUpon>FluentLocalizer.resx</DependentUpon>
     </Compile>
   </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Components\Tabs\" />
-  </ItemGroup>
 </Project>

--- a/tests/Core/Components.Tests.csproj
+++ b/tests/Core/Components.Tests.csproj
@@ -72,4 +72,8 @@
       <DependentUpon>FluentLocalizer.resx</DependentUpon>
     </Compile>
   </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Components\Tabs\" />
+  </ItemGroup>
 </Project>

--- a/tests/Core/Components/Tabs/FluentTabsTests.FluentTabs_Default.verified.razor.html
+++ b/tests/Core/Components/Tabs/FluentTabsTests.FluentTabs_Default.verified.razor.html
@@ -2,12 +2,12 @@
 <fluent-tabs id="xxx" blazor:ontabchange="1">
   <fluent-tab id="xxx">Chat
   </fluent-tab>
-  <fluent-tab-panel>
+  <fluent-tab-panel id="xxx">
     Here's some information about the chat.
   </fluent-tab-panel>
   <fluent-tab id="xxx">Files
   </fluent-tab>
-  <fluent-tab-panel>
+  <fluent-tab-panel id="xxx">
     Here's the list of all files.
   </fluent-tab-panel>
 </fluent-tabs>

--- a/tests/Core/Components/Tabs/FluentTabsTests.FluentTabs_Default.verified.razor.html
+++ b/tests/Core/Components/Tabs/FluentTabsTests.FluentTabs_Default.verified.razor.html
@@ -1,0 +1,13 @@
+
+<fluent-tabs id="xxx" blazor:ontabchange="1">
+  <fluent-tab id="xxx">Chat
+  </fluent-tab>
+  <fluent-tab-panel>
+    Here's some information about the chat.
+  </fluent-tab-panel>
+  <fluent-tab id="xxx">Files
+  </fluent-tab>
+  <fluent-tab-panel>
+    Here's the list of all files.
+  </fluent-tab-panel>
+</fluent-tabs>

--- a/tests/Core/Components/Tabs/FluentTabsTests.FluentTabs_DeferredLoading-After.verified.razor.html
+++ b/tests/Core/Components/Tabs/FluentTabsTests.FluentTabs_DeferredLoading-After.verified.razor.html
@@ -1,0 +1,12 @@
+
+<fluent-tabs id="xxx" activeid="Tab2" blazor:ontabchange="1">
+  <fluent-tab id="xxx">Tab 1
+  </fluent-tab>
+  <fluent-tab-panel id="xxx">Content 1</fluent-tab-panel>
+  <fluent-tab id="xxx">Tab 2
+  </fluent-tab>
+  <fluent-tab-panel id="xxx">Content 2</fluent-tab-panel>
+  <fluent-tab id="xxx">Tab 3
+  </fluent-tab>
+  <fluent-tab-panel id="xxx">Loading...</fluent-tab-panel>
+</fluent-tabs>

--- a/tests/Core/Components/Tabs/FluentTabsTests.FluentTabs_DeferredLoading-Before.verified.razor.html
+++ b/tests/Core/Components/Tabs/FluentTabsTests.FluentTabs_DeferredLoading-Before.verified.razor.html
@@ -1,0 +1,17 @@
+
+<fluent-tabs id="xxx" activeid="Tab1" blazor:ontabchange="1">
+  <fluent-tab id="xxx">
+    Tab 1
+  </fluent-tab>
+  <fluent-tab-panel id="xxx">Content 1</fluent-tab-panel>
+  <fluent-tab id="xxx">
+    Tab 2
+  </fluent-tab>
+  <fluent-tab-panel id="xxx">
+    <fluent-progress-bar></fluent-progress-bar>
+  </fluent-tab-panel>
+  <fluent-tab id="xxx">
+    Tab 3
+  </fluent-tab>
+  <fluent-tab-panel id="xxx">Loading...</fluent-tab-panel>
+</fluent-tabs>

--- a/tests/Core/Components/Tabs/FluentTabsTests.FluentTabs_HeaderTemplate.verified.razor.html
+++ b/tests/Core/Components/Tabs/FluentTabsTests.FluentTabs_HeaderTemplate.verified.razor.html
@@ -1,8 +1,12 @@
 
 <fluent-tabs id="xxx" blazor:ontabchange="1">
-  <fluent-tab id="xxx">Chat
+  <fluent-tab id="xxx">
+    <span>
+      Tab
+      <b>Name</b>
+    </span>
   </fluent-tab>
   <fluent-tab-panel id="xxx">
-    Here's some information about the chat.
+    Tab Content
   </fluent-tab-panel>
 </fluent-tabs>

--- a/tests/Core/Components/Tabs/FluentTabsTests.FluentTabs_Icon.verified.razor.html
+++ b/tests/Core/Components/Tabs/FluentTabsTests.FluentTabs_Icon.verified.razor.html
@@ -1,0 +1,23 @@
+
+<fluent-tabs id="xxx" blazor:ontabchange="1">
+  <fluent-tab id="xxx">
+    <span>
+      <svg style="width: 24px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 24 24" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
+        <path d="M12 2a10 10 0 1 1 0 20 10 10 0 0 1 0-20Zm0 8.25a1 1 0 0 0-1 .88v5.74a1 1 0 0 0 2 0v-5.62l-.01-.12a1 1 0 0 0-1-.88Zm0-3.75A1.25 1.25 0 1 0 12 9a1.25 1.25 0 0 0 0-2.5Z"></path>
+      </svg>Chat
+    </span>
+  </fluent-tab>
+  <fluent-tab-panel id="xxx">
+    Here's some information about the chat.
+  </fluent-tab-panel>
+  <fluent-tab id="xxx">
+    <span>
+      <svg style="width: 24px; fill: var(--success);" focusable="false" viewBox="0 0 24 24" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
+        <path d="M12 2a10 10 0 1 1 0 20 10 10 0 0 1 0-20Zm0 8.25a1 1 0 0 0-1 .88v5.74a1 1 0 0 0 2 0v-5.62l-.01-.12a1 1 0 0 0-1-.88Zm0-3.75A1.25 1.25 0 1 0 12 9a1.25 1.25 0 0 0 0-2.5Z"></path>
+      </svg>Files
+    </span>
+  </fluent-tab>
+  <fluent-tab-panel id="xxx">
+    Here's the list of all files.
+  </fluent-tab-panel>
+</fluent-tabs>

--- a/tests/Core/Components/Tabs/FluentTabsTests.FluentTabs_Visible.verified.razor.html
+++ b/tests/Core/Components/Tabs/FluentTabsTests.FluentTabs_Visible.verified.razor.html
@@ -1,0 +1,8 @@
+
+<fluent-tabs id="xxx" blazor:ontabchange="1">
+  <fluent-tab id="xxx">Chat
+  </fluent-tab>
+  <fluent-tab-panel>
+    Here's some information about the chat.
+  </fluent-tab-panel>
+</fluent-tabs>

--- a/tests/Core/Components/Tabs/FluentTabsTests.razor
+++ b/tests/Core/Components/Tabs/FluentTabsTests.razor
@@ -1,0 +1,143 @@
+﻿@using Xunit;
+@inherits TestContext
+
+@code
+{
+    public FluentTabsTests()
+    {
+        Services.AddFluentUIComponents();
+    }
+
+    [Fact]
+    public void FluentTabs_Default()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentTabs>
+            <FluentTab Id="tab1" Header="Chat">
+                Here's some information about the chat.
+            </FluentTab>
+
+            <FluentTab Id="tab2" Header="Files">
+                Here's the list of all files.
+            </FluentTab>
+        </FluentTabs>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Theory]
+    [InlineData("MyTabsId", "tab1", "tab1")]            // Normal case
+    [InlineData("INVALID_TABS_ID", "tab1", "tab2")]     // Main TabsID is unknown => no change (stay on tab2)
+    [InlineData("MyTabsId", "INVALID_TAB", "tab2")]     // Try to go to an unknow Tab => no change (stay on tab2)
+    public async Task FluentTabs_ActiveTabId(string eventTabsId, string eventActiveId, string? expectedActiveId)
+    {
+        string? activeTabId = "tab2";
+
+        // Arrange
+        var cut = Render(@<FluentTabs Id="MyTabsId" @bind-ActiveTabId="@activeTabId">
+            <FluentTab Id="tab1" Header="Chat">
+                Here's some information about the chat.
+            </FluentTab>
+
+            <FluentTab Id="tab2" Header="Files">
+                Here's the list of all files.
+            </FluentTab>
+        </FluentTabs>);
+
+        // Act
+        await cut.FindComponent<FluentTabs>().Instance.TabChangeHandlerAsync(new()
+        {
+            Id = eventTabsId,
+            ActiveId = eventActiveId,
+        });
+
+        // Assert
+        Assert.Equal(expectedActiveId, activeTabId);
+    }
+
+    [Theory]
+    [InlineData("MyTabsId", "tab2", "tab2")]          // Normal case
+    [InlineData("INVALID_TABS_ID", "tab2", null)]     // Main TabsID is unknown => no change (stay on tab1)
+    [InlineData("MyTabsId", "INVALID_TAB", null)]     // Try to go to an unknow Tab => no change (stay on tab1)
+    public async Task FluentTabs_ActiveTab(string eventTabsId, string eventActiveId, string? expectedActiveId)
+    {
+        FluentTab? activeTab = null;
+
+        // Arrange
+        var cut = Render(@<FluentTabs Id="MyTabsId" @bind-ActiveTab="@activeTab">
+            <FluentTab Id="tab1" Header="Chat">
+                Here's some information about the chat.
+            </FluentTab>
+
+            <FluentTab Id="tab2" Header="Files">
+                Here's the list of all files.
+            </FluentTab>
+        </FluentTabs>);
+
+        // Act
+        await cut.FindComponent<FluentTabs>().Instance.TabChangeHandlerAsync(new()
+        {
+            Id = eventTabsId,
+            ActiveId = eventActiveId,
+        });
+
+        // Assert
+        Assert.Equal(expectedActiveId, activeTab?.Id);
+    }
+
+    [Fact]
+    public void FluentTabs_Visible()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentTabs>
+            <FluentTab Id="tab1" Header="Chat" Visible="true">
+                Here's some information about the chat.
+            </FluentTab>
+
+            <FluentTab Id="tab2" Header="Files" Visible="false">
+                Here's the list of all files.
+            </FluentTab>
+        </FluentTabs>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Theory]
+    [InlineData(TabsAppearance.Default, null)]
+    [InlineData(TabsAppearance.Transparent, "transparent")]
+    [InlineData(null, null)]
+    [InlineData((TabsAppearance)999, null)]
+    public void FluentTabs_Appearance(TabsAppearance? appearance, string? expectedAttribute)
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentTabs Appearance="@appearance">
+            <FluentTab Header="MyTab"></FluentTab>
+        </FluentTabs>);
+
+        var attribute = cut.Find("fluent-tabs").GetAttribute("appearance");
+
+        // Assert
+        Assert.Equal(expectedAttribute, attribute);
+    }
+
+    [Theory]
+    [InlineData(TabsSize.Small, "small")]
+    [InlineData(TabsSize.Medium, null)]
+    [InlineData(TabsSize.Large, "large")]
+    [InlineData(null, null)]
+    [InlineData((TabsSize)999, null)]
+    public void FluentTabs_Size(TabsSize? size, string? expectedAttribute)
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentTabs Size="@size">
+            <FluentTab Header="MyTab"></FluentTab>
+        </FluentTabs>);
+
+        var attribute = cut.Find("fluent-tabs").GetAttribute("size");
+
+        // Assert
+        Assert.Equal(expectedAttribute, attribute);
+    }
+}

--- a/tests/Core/Components/Tabs/FluentTabsTests.razor
+++ b/tests/Core/Components/Tabs/FluentTabsTests.razor
@@ -140,4 +140,81 @@
         // Assert
         Assert.Equal(expectedAttribute, attribute);
     }
+
+    [Fact]
+    public void FluentTabs_WidthHeight()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentTabs Width="100px" Height="200px"></FluentTabs>);
+
+        // Assert
+        Assert.Equal("width: 100px; height: 200px;", cut.Find("fluent-tabs").GetAttribute("style"));
+    }
+
+    [Fact]
+    public void FluentTabs_HeaderTemplate()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentTabs>
+            <FluentTab>
+                <HeaderTemplate>Tab <b>Name</b></HeaderTemplate>
+                <ChildContent>
+                    Tab Content
+                </ChildContent>
+            </FluentTab>
+        </FluentTabs>);
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentTabs_Disabled()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentTabs>
+            <FluentTab Id="Tab1" Header="Tab 1" Disabled="false" />
+            <FluentTab Id="Tab2" Header="Tab 2" Disabled="true" />
+        </FluentTabs>);
+
+        var tab1Disabled = cut.Find("#Tab1").GetAttribute("disabled");
+        var tab2Disabled = cut.Find("#Tab2").GetAttribute("disabled");
+
+        // Assert
+        Assert.Null(tab1Disabled);
+        Assert.NotNull(tab2Disabled);
+    }
+
+    [Fact]
+    public void FluentTabs_DeferredLoading()
+    {
+        // Arrange
+        var cut = Render(@<FluentTabs ActiveTabId="Tab1">
+            <FluentTab Id="Tab1" Header="Tab 1" DeferredLoading="false">Content 1</FluentTab>
+            <FluentTab Id="Tab2" Header="Tab 2" DeferredLoading="true">Content 2</FluentTab>
+            <FluentTab Id="Tab3" Header="Tab 3" DeferredLoading="true"><LoadingTemplate>Loading...</LoadingTemplate></FluentTab>
+        </FluentTabs>
+    );
+
+        // Assert before Click
+        cut.Verify(suffix: "Before");
+
+        // Open Tab2 and re-render
+        cut.FindComponent<FluentTabs>().SetParametersAndRender(parameters => parameters.Add(p => p.ActiveTabId, "Tab2"));
+        var content2After = cut.Find("#Tab2-panel").InnerHtml;
+
+        // Assert
+        cut.Verify(suffix: "After");
+    }
+
+    private RenderFragment? GetDeferredContent => builder =>
+       {
+           // To simulate a long running process
+           Thread.Sleep(1000);
+
+           // Add <span>Here's the list of all files.</span>
+           builder.OpenElement(0, "span");
+           builder.AddContent(1, "Content 2");
+           builder.CloseElement();
+       };
 }

--- a/tests/Core/Components/Tabs/FluentTabsTests.razor
+++ b/tests/Core/Components/Tabs/FluentTabsTests.razor
@@ -26,6 +26,24 @@
         cut.Verify();
     }
 
+    [Fact]
+    public void FluentTabs_Icon()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentTabs>
+            <FluentTab Id="tab1" Header="Chat" IconStart="@Samples.Icons.Info" IconColor="@Color.Primary">
+                Here's some information about the chat.
+            </FluentTab>
+
+            <FluentTab Id="tab2" Header="Files" IconStart="@Samples.Icons.Info" IconColor="@Color.Success">
+                Here's the list of all files.
+            </FluentTab>
+        </FluentTabs>);
+
+        // Assert
+        cut.Verify();
+    }
+
     [Theory]
     [InlineData("MyTabsId", "tab1", "tab1")]            // Normal case
     [InlineData("INVALID_TABS_ID", "tab1", "tab2")]     // Main TabsID is unknown => no change (stay on tab2)
@@ -84,6 +102,29 @@
 
         // Assert
         Assert.Equal(expectedActiveId, activeTab?.Id);
+    }
+
+
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData(null, true)]
+    [InlineData("Tab2", false)]
+    [InlineData("Tab2", true)]
+    public void FluentTabs_LoadingOrder(string? initialActiveId, bool initialTab2)
+    {
+        RenderFragment Tab1 = @<FluentTab Id="Tab1" Header="Chat" />;
+        RenderFragment Tab2 = @<FluentTab Id="Tab2" Header="Files" />;
+
+        string? activeId = initialActiveId;
+        FluentTab? activeTab = initialTab2 ? Render(Tab2).FindComponent<FluentTab>().Instance : null;
+
+        // Arrange && Act
+        var cut = Render(@<FluentTabs @bind-ActiveTabId="@activeId" @bind-ActiveTab="@activeTab">
+            @Tab1
+            @Tab2
+        </FluentTabs>);
+
+        // Assert
     }
 
     [Fact]
@@ -190,10 +231,10 @@
     {
         // Arrange
         var cut = Render(@<FluentTabs ActiveTabId="Tab1">
-            <FluentTab Id="Tab1" Header="Tab 1" DeferredLoading="false">Content 1</FluentTab>
-            <FluentTab Id="Tab2" Header="Tab 2" DeferredLoading="true">Content 2</FluentTab>
-            <FluentTab Id="Tab3" Header="Tab 3" DeferredLoading="true"><LoadingTemplate>Loading...</LoadingTemplate></FluentTab>
-        </FluentTabs>
+    <FluentTab Id="Tab1" Header="Tab 1" DeferredLoading="false">Content 1</FluentTab>
+    <FluentTab Id="Tab2" Header="Tab 2" DeferredLoading="true">Content 2</FluentTab>
+    <FluentTab Id="Tab3" Header="Tab 3" DeferredLoading="true"><LoadingTemplate>Loading...</LoadingTemplate></FluentTab>
+</FluentTabs>
     );
 
         // Assert before Click


### PR DESCRIPTION
# [dev-v5] FluentTabs

A **FluentTabs** allows people to switch between categories of related information without going to different pages. They’re are ideal for dividing content-heavy pages into distinct but related categories that are easier to process and require less scrolling. **FluentTabs** can also be used for navigation between a small set of closely related, frequently accessed pages.

For navigation beyond closely related categories, use a _FluentLink_ instead. To initiate an action, use a _FluentButton_instead.

## Default
To know which tab is selected, you can bind the `ActiveTabId` or `ActiveTab` parameter to a variable. Setting the `ActiveTabId` parameter to an initial value will set the selected tab when the component is first rendered.

A tab can be disabled by setting the `Disabled` parameter to `true`.

```razor
<FluentTabs ActiveTabId="tab3" @bind-ActiveTab="@ActiveTab" @bind-ActiveTab:after="@OnTabChanged">
    <FluentTab Id="tab1" Header="Chat" IconStart="@(new Icons.Regular.Size16.Chat())">
        Here's some information about the chat.
    </FluentTab>

    <FluentTab Id="tab2" Header="Files" Disabled="true" IconStart="@(new Icons.Regular.Size16.Folder())">
        Here's the list of all files.
    </FluentTab>

    <FluentTab Id="tab3" Header="Recap" IconStart="@(new Icons.Regular.Size16.List())" IconColor="@Color.Primary">
        Here's some information about the recap.
    </FluentTab>
</FluentTabs>

<p>
    ActiveTab: <b>@(ActiveTab?.Header)</b>
</p>

@code
{
    FluentTab? ActiveTab;

    void OnTabChanged()
    {
        Console.WriteLine($"Tab changed to '{ActiveTab?.Header}'."); 
    }
}
```

![{7CAC2361-F11D-44A0-8D2D-15F4E324D0FF}](https://github.com/user-attachments/assets/5d8dc889-f835-44b5-a764-e8e8c15b4ab8)

## Unit Tests

![{D2A656CD-E941-4B38-8B9E-09264803D23C}](https://github.com/user-attachments/assets/a59f5933-ccf9-42e6-b305-a844ee09ada2)
