### PR TITLE
[DataGrid] Fix Width when `ResizableColumns` and `Sortable`

### DIFF
--- a/src/Core/Components/DataGrid/Columns/ColumnBase.razor
+++ b/src/Core/Components/DataGrid/Columns/ColumnBase.razor
@@ -92,7 +92,7 @@
 
             @if (Sortable.HasValue ? Sortable.Value : IsSortableByDefault())
             {
-                <FluentKeyCode Only="new [] { KeyCode.Ctrl, KeyCode.Enter}" OnKeyDown="HandleKeyDown" class="keycapture" StopPropagation="true" @oncontextmenu="@(() => Grid.RemoveSortByColumnAsync(this))">
+                <FluentKeyCode Only="new [] { KeyCode.Ctrl, KeyCode.Enter}" OnKeyDown="HandleKeyDown" class="keycapture" style="width: 100%;" StopPropagation="true" @oncontextmenu="@(() => Grid.RemoveSortByColumnAsync(this))">
                     <FluentButton Appearance="Appearance.Stealth" Class="col-sort-button" Style="@($"width: calc(100% - {wdelta});")" @onclick="@(() => Grid.SortByColumnAsync(this))" aria-label="@tooltip" title="@tooltip">
                             <div class="col-title-text" title="@tooltip">@Title</div>
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

If in a DataGrig: ResizableColumns="true" and Sortable="true" 

![image](https://github.com/user-attachments/assets/4d49f9d5-75ca-484a-9c82-b27f478ff5af)

The width is wrong.

### 🎫 Issues

I didn't find it

## 👩‍💻 Reviewer Notes

In DataGridTemplateColumns.razor change the grid to:

```
<div style="height: 500px; overflow-x:auto; display:flex;">
    <FluentDataGrid Items="@Data.People" RowSize="@DataGridRowSize.Medium" ResizableColumns="true">
        <TemplateColumn Title="Person" Sortable="true">
            <div class="flex items-center">
                <img class="flag" src="_content/FluentUI.Demo.Shared/flags/@(context.CountryCode.ToLower()).svg" alt="Flag of @(context.CountryCode)" />
                <nobr>
                    <strong>@context.LastName</strong>, @context.FirstName
                </nobr>
            </div>
        </TemplateColumn>
        <TemplateColumn Title="Bonus">
            <FluentButton Appearance="Appearance.Accent" @onclick="@(() => Bonus(context))">Regular</FluentButton>
            <FluentButton Appearance="Appearance.Accent" @onclick="@(() => DoubleBonus(context))">Double</FluentButton>
        </TemplateColumn>
    </FluentDataGrid>
</div>
```

And the error will occur.

## 📑 Test Plan

The datagrid above will be correct

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [] I have added tests for my changes.
- [X] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [X] I have modified an existing component
- [ ] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

No.
