### PR TITLE
Swallow the JSDisconnectedException when trying to call the 'dispose' Javascript method.

### DIFF
--- a/src/Core/Components/InputFile/FluentInputFile.razor.cs
+++ b/src/Core/Components/InputFile/FluentInputFile.razor.cs
@@ -429,7 +429,15 @@ public partial class FluentInputFile : FluentComponentBase, IAsyncDisposable
     {
         if (_containerInstance != null)
         {
-            await _containerInstance.InvokeVoidAsync("dispose");
+            try
+            {
+                await _containerInstance.InvokeVoidAsync("dispose");
+            }
+            catch (JSDisconnectedException)
+            {
+                // Swallow. See: https://stackoverflow.com/questions/72488563/blazor-server-side-application-throwing-system-invalidoperationexception-javas
+            }
+
             await _containerInstance.DisposeAsync();
         }
 


### PR DESCRIPTION


# Pull Request

## 📖 Description

The following error occurs when refreshing a page that has a `FluentInputFile` control:

![image](https://github.com/user-attachments/assets/dfa08890-190d-49b2-960b-8051696206ea)

We can't really do much about it other than swallow the error. See here: [https://stackoverflow.com/questions/72488563/blazor-server-side-application-throwing-system-invalidoperationexception-javas](https://stackoverflow.com/questions/72488563/blazor-server-side-application-throwing-system-invalidoperationexception-javas)

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component
