### PR TITLE
[dev-v5] Add ITooltipComponent and common properties

### DIFF
--- a/src/Core/Components/Base/FluentComponentBase.cs
+++ b/src/Core/Components/Base/FluentComponentBase.cs
@@ -125,4 +125,32 @@ public abstract class FluentComponentBase : ComponentBase, IAsyncDisposable, IFl
         _services.TryAdd(typeof(T), service);
         return service;
     }
+
+    /// <summary>
+    /// Gets or sets the injected service provider.
+    /// </summary>
+    /// <remarks>
+    /// We cannot inject `ITooltipService` directly, as an exception will be thrown if the service is not injected.
+    /// https://github.com/dotnet/aspnetcore/issues/24193
+    /// </remarks>
+    private ITooltipService? TooltipService => GetCachedServiceOrNull<ITooltipService>();
+    
+    /// <summary />
+    protected async Task RenderTooltipAsync(string? label)
+    {
+        if (TooltipService is null || string.IsNullOrEmpty(label))
+        {
+            return;
+        }
+
+        if (string.IsNullOrEmpty(Id))
+        {
+            Id = Identifier.NewId();
+        }
+
+        var tooltip = new FluentTooltip(anchor: Id, $"<text>{label}</text>");
+
+        TooltipService.Items.TryAdd(Id, tooltip);
+        await TooltipService.OnUpdatedAsync.Invoke(tooltip);
+    }
 }

--- a/src/Core/Components/Button/FluentButton.razor.cs
+++ b/src/Core/Components/Button/FluentButton.razor.cs
@@ -12,7 +12,7 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// The FluentButton component allows users to commit a change or trigger an action via a single click or tap and
 /// is often found inside forms, dialogs, drawers (panels) and/or pages.
 /// </summary>
-public partial class FluentButton : FluentComponentBase
+public partial class FluentButton : FluentComponentBase, ITooltipComponent
 {
     /// <summary />
     private bool LoadingOverlay => Loading && IconStart == null && IconEnd == null;
@@ -208,6 +208,16 @@ public partial class FluentButton : FluentComponentBase
     /// </summary>
     [Parameter]
     public EventCallback<MouseEventArgs> OnClick { get; set; }
+
+    /// <inheritdoc cref="ITooltipComponent.Tooltip" />
+    [Parameter]
+    public string? Tooltip { get; set; }
+
+    /// <summary />
+    protected override async Task OnInitializedAsync()
+    {
+        await base.RenderTooltipAsync(Tooltip);
+    }
 
     /// <summary />
     protected override void OnParametersSet()

--- a/src/Core/Components/Tooltip/FluentTooltip.razor.cs
+++ b/src/Core/Components/Tooltip/FluentTooltip.razor.cs
@@ -26,6 +26,16 @@ public partial class FluentTooltip : FluentComponentBase
     }
 
     /// <summary />
+    internal FluentTooltip(string anchor, string? label) : this()
+    {
+        Anchor = anchor;
+        ChildContent = builder =>
+        {
+            builder.AddMarkupContent(0, label);
+        };
+    }
+
+    /// <summary />
     internal string? ClassValue => DefaultClassBuilder
         .Build();
 

--- a/src/Core/Components/Tooltip/ITooltipComponent.cs
+++ b/src/Core/Components/Tooltip/ITooltipComponent.cs
@@ -1,0 +1,19 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// Interface for components that support a Tooltip parameter.
+/// </summary>
+internal interface ITooltipComponent
+{
+    /// <summary>
+    /// Gets or sets the tooltip text (supports HTML tags).
+    /// </summary>
+    /// <remarks>
+    /// This parameter cannot be updated after the component has been rendered.
+    /// </remarks>
+    string? Tooltip { get; set; }
+}


### PR DESCRIPTION
# [dev-v5] Add ITooltipComponent and common properties

In many components, it is often useful to use a tooltip to provide more information about an element.
Having a simpler way than creating a `FluentTooltip` will be interesting for the developer.
Several other libraries, for example, have components with a `Tooltip` parameter that you simply need to complete for the entire mechanism to be set up.

```xml
<FluentButton Tooltip="Example of tooltip">Default</FluentButton>
```

![{B83503F2-3C65-433F-83AD-77573D2592A7}](https://github.com/user-attachments/assets/413c4eda-3523-4c1a-a3f4-6a3f24ab61a4)

In the lib, we can use an interface `ITooltipComponent` on component which need this `Tooltip` parameter,
and to add this code to render the tooltip.
```csharp
    [Parameter]
    public string? Tooltip { get; set; }

    protected override async Task OnInitializedAsync()
    {
        await base.RenderTooltipAsync(Tooltip);
    }
```