### PR TITLE
[dev-v5] Fix Tooltip Parameters

### DIFF
--- a/src/Core/Components/Base/CachedServices.cs
+++ b/src/Core/Components/Base/CachedServices.cs
@@ -68,7 +68,6 @@ internal class CachedServices : IDisposable
 
         var tooltip = new FluentTooltip(anchor: component.Id, $"<text>{label}</text>");
 
-        Console.WriteLine($"Add Tooltip {component.Id}");
         TooltipService.Items.TryAdd(component.Id, tooltip);
         await TooltipService.OnUpdatedAsync.Invoke(tooltip);
     }
@@ -81,7 +80,6 @@ internal class CachedServices : IDisposable
             return;
         }
 
-        Console.WriteLine($"Remove Tooltip {component.Id}");
         var isRemoved = TooltipService.Items.TryRemove(component.Id, out var tooltip);
 
         if (isRemoved && tooltip is not null)

--- a/src/Core/Components/Base/CachedServices.cs
+++ b/src/Core/Components/Base/CachedServices.cs
@@ -56,7 +56,7 @@ internal class CachedServices : IDisposable
     /// <summary />
     public async Task RenderTooltipAsync(IFluentComponentBase component, string? label)
     {
-        if (TooltipService is null || string.IsNullOrEmpty(label))
+        if (TooltipService is null || string.IsNullOrEmpty(label) || component is FluentTooltip)
         {
             return;
         }
@@ -68,8 +68,26 @@ internal class CachedServices : IDisposable
 
         var tooltip = new FluentTooltip(anchor: component.Id, $"<text>{label}</text>");
 
+        Console.WriteLine($"Add Tooltip {component.Id}");
         TooltipService.Items.TryAdd(component.Id, tooltip);
         await TooltipService.OnUpdatedAsync.Invoke(tooltip);
+    }
+
+    /// <summary />
+    public async Task DisposeTooltipAsync(IFluentComponentBase component)
+    {
+        if (TooltipService is null || string.IsNullOrEmpty(component.Id) || component is FluentTooltip)
+        {
+            return;
+        }
+
+        Console.WriteLine($"Remove Tooltip {component.Id}");
+        var isRemoved = TooltipService.Items.TryRemove(component.Id, out var tooltip);
+
+        if (isRemoved && tooltip is not null)
+        {
+            await TooltipService.OnUpdatedAsync.Invoke(tooltip);
+        }
     }
 
     /// <summary />

--- a/src/Core/Components/Base/FluentComponentBase.cs
+++ b/src/Core/Components/Base/FluentComponentBase.cs
@@ -84,6 +84,7 @@ public abstract class FluentComponentBase : ComponentBase, IAsyncDisposable, IFl
     [ExcludeFromCodeCoverage]
     public virtual async ValueTask DisposeAsync()
     {
+        _cachedServices?.DisposeTooltipAsync(this);
         _cachedServices?.Dispose();
         await JSModule.DisposeAsync();
     }
@@ -96,6 +97,7 @@ public abstract class FluentComponentBase : ComponentBase, IAsyncDisposable, IFl
     [ExcludeFromCodeCoverage]
     protected virtual async ValueTask DisposeAsync(IJSObjectReference? jsModule)
     {
+        _cachedServices?.DisposeTooltipAsync(this);
         _cachedServices?.Dispose();
         await JSModule.DisposeAsync(jsModule);
     }
@@ -113,5 +115,5 @@ public abstract class FluentComponentBase : ComponentBase, IAsyncDisposable, IFl
     /// </summary>
     /// <param name="label"></param>
     /// <returns></returns>
-    protected Task RenderTooltipAsync(string? label) => (_cachedServices ??= new CachedServices(ServiceProvider)).RenderTooltipAsync(this, label);
+    protected Task RenderTooltipAsync(string? label) => (_cachedServices ??= new CachedServices(ServiceProvider)).RenderTooltipAsync(this, label);    
 }

--- a/src/Core/Components/Base/FluentComponentBase.cs
+++ b/src/Core/Components/Base/FluentComponentBase.cs
@@ -115,5 +115,5 @@ public abstract class FluentComponentBase : ComponentBase, IAsyncDisposable, IFl
     /// </summary>
     /// <param name="label"></param>
     /// <returns></returns>
-    protected Task RenderTooltipAsync(string? label) => (_cachedServices ??= new CachedServices(ServiceProvider)).RenderTooltipAsync(this, label);    
+    protected Task RenderTooltipAsync(string? label) => (_cachedServices ??= new CachedServices(ServiceProvider)).RenderTooltipAsync(this, label);
 }

--- a/src/Core/Components/Base/FluentInputBase.cs
+++ b/src/Core/Components/Base/FluentInputBase.cs
@@ -222,6 +222,7 @@ public abstract partial class FluentInputBase<TValue> : InputBase<TValue>, IFlue
     [ExcludeFromCodeCoverage]
     public virtual async ValueTask DisposeAsync()
     {
+        _cachedServices?.DisposeTooltipAsync(this);
         _cachedServices?.Dispose();
         await JSModule.DisposeAsync();
     }
@@ -234,6 +235,7 @@ public abstract partial class FluentInputBase<TValue> : InputBase<TValue>, IFlue
     [ExcludeFromCodeCoverage]
     protected virtual async ValueTask DisposeAsync(IJSObjectReference? jsModule)
     {
+        _cachedServices?.DisposeTooltipAsync(this);
         _cachedServices?.Dispose();
         await JSModule.DisposeAsync(jsModule);
     }

--- a/src/Core/Components/Tooltip/FluentTooltip.razor.cs
+++ b/src/Core/Components/Tooltip/FluentTooltip.razor.cs
@@ -44,6 +44,7 @@ public partial class FluentTooltip : FluentComponentBase
         .AddStyle("max-width", MaxWidth, when: () => !string.IsNullOrWhiteSpace(MaxWidth))
         .AddStyle("margin-inline", SpacingHorizontal, when: () => !string.IsNullOrWhiteSpace(SpacingHorizontal))
         .AddStyle("margin-block", SpacingVertical, when: () => !string.IsNullOrWhiteSpace(SpacingVertical))
+        .AddStyle("position-anchor", $"--{Anchor}")
         .Build();
 
     /// <summary>

--- a/tests/Core/Components/Tooltip/FluentTooltipTests.FluentTooltip_Default.verified.razor.html
+++ b/tests/Core/Components/Tooltip/FluentTooltipTests.FluentTooltip_Default.verified.razor.html
@@ -1,7 +1,7 @@
 
 <div>
   <div id="xxx" class="fluent-tooltip-provider" style="z-index: 9999;">
-    <fluent-tooltip id="xxx" anchor="xxx" blazor:ondialogtoggle="1">My content</fluent-tooltip>
+    <fluent-tooltip style="position-anchor: --MyButton;" id="xxx" anchor="xxx" blazor:ondialogtoggle="1">My content</fluent-tooltip>
   </div>
   <fluent-button id="xxx" icon-only="" blazor:onclick="x"></fluent-button>
 </div>

--- a/tests/Core/Components/Tooltip/FluentTooltipTests.FluentTooltip_NoTooltipProvider.verified.razor.html
+++ b/tests/Core/Components/Tooltip/FluentTooltipTests.FluentTooltip_NoTooltipProvider.verified.razor.html
@@ -1,5 +1,5 @@
 
 <div>
   <fluent-button id="xxx" icon-only="" blazor:onclick="x"></fluent-button>
-  <fluent-tooltip id="xxx" anchor="xxx" blazor:ondialogtoggle="1">My content</fluent-tooltip>
+  <fluent-tooltip id="xxx" style="position-anchor: --MyButton;"  anchor="xxx" blazor:ondialogtoggle="1">My content</fluent-tooltip>
 </div>

--- a/tests/Core/Components/Tooltip/FluentTooltipTests.razor
+++ b/tests/Core/Components/Tooltip/FluentTooltipTests.razor
@@ -1,4 +1,5 @@
-﻿@using Microsoft.FluentUI.AspNetCore.Components.Extensions
+﻿@using AngleSharp.Css.Dom
+@using Microsoft.FluentUI.AspNetCore.Components.Extensions
 @using Microsoft.FluentUI.AspNetCore.Components.Utilities
 @using Xunit;
 @using Microsoft.FluentUI.AspNetCore.Components.Tests.Samples;
@@ -96,10 +97,10 @@
         </div>);
 
         // Act
-        var att = cut.Find("fluent-tooltip").GetAttribute("style");
+        var att = cut.Find("fluent-tooltip").GetStyle()["max-width"];
 
         // Assert
-        Assert.Equal("max-width: 200px;", att);
+        Assert.Equal("200px", att);
     }
 
     [Fact]
@@ -112,10 +113,10 @@
         </div>);
 
         // Act
-        var att = cut.Find("fluent-tooltip").GetAttribute("style");
+        var att = cut.Find("fluent-tooltip").GetStyle()["margin-inline"];
 
         // Assert
-        Assert.Equal("margin-inline: 20px;", att);
+        Assert.Equal("20px", att);
     }
 
     [Fact]
@@ -128,10 +129,10 @@
         </div>);
 
         // Act
-        var att = cut.Find("fluent-tooltip").GetAttribute("style");
+        var att = cut.Find("fluent-tooltip").GetStyle()["margin-block"];
 
         // Assert
-        Assert.Equal("margin-block: 20px;", att);
+        Assert.Equal("20px", att);
     }
 
     [Fact]
@@ -206,6 +207,34 @@
         Assert.Equal(expectedOpened, opened);
         Assert.Equal(expectedEventId, eventId);
         Assert.Equal(expectedDismissed, dismissed);
+    }
+
+    [Fact]
+    public void FluentTooltip_ParameterValue()
+    {
+        bool isVisible = true;
+
+        // Arrange
+        var cut = Render(@<FluentStack>
+            <FluentTooltipProvider />
+            @if (isVisible)
+            {
+                <FluentButton Id="MyButton" Tooltip="My Tooltip" Label="Button" />
+            }
+        </FluentStack>
+    );
+
+        // Pre-assert
+        var tooltips = Services.GetRequiredService<ITooltipService>().Items;
+        Assert.Single(tooltips);
+
+        // Act => Dispose and DisposeTooltipAsync methods will be called to remove the tooltip from the Provider.
+        isVisible = false;
+        cut.FindComponent<FluentStack>().Render();
+
+        // Assert
+        tooltips = Services.GetRequiredService<ITooltipService>().Items;
+        Assert.Empty(tooltips);
     }
 
 #pragma warning disable CS0618 // Type or member is obsolete


### PR DESCRIPTION
# [dev-v5] Fix Tooltip Parameters

When the Tooltip parameter is used with a component (ex. `Button.Tooltip`, a tooltip is added to the Provider. But when the component is destroyed, the tooltip remains in the Provider's item lists. This PR cleans up the tooltips linked to components during the Dispose process.

## Unit tests

100%