### PR TITLE
Fix: Introduced warnings in the examples project 

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Spacer/Examples/SpacerDefault.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Spacer/Examples/SpacerDefault.razor
@@ -1,7 +1,7 @@
 ﻿<FluentStack Width="100%">
-    <FluentIcon Value="@(new Icons.Filled.Size48.Alert())" Color="@Color.Neutral" />
+    <FluentIcon Value="@(new Icons.Filled.Size48.Alert())" Color="@Color.Default" />
     <FluentSpacer />
-    <FluentIcon Value="@(new Icons.Filled.Size48.Alert())" Color="@Color.Accent" />
+    <FluentIcon Value="@(new Icons.Filled.Size48.Alert())" Color="@Color.Primary" />
     <FluentSpacer />
     <FluentIcon Value="@(new Icons.Filled.Size48.Alert())" Color="@Color.Warning" />
     <FluentSpacer />

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Spacer/Examples/SpacerHorizontalPixels.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Spacer/Examples/SpacerHorizontalPixels.razor
@@ -1,7 +1,7 @@
 ﻿<FluentStack Width="100%">
-    <FluentIcon Value="@(new Icons.Filled.Size48.Alert())" Color="@Color.Neutral" />
+    <FluentIcon Value="@(new Icons.Filled.Size48.Alert())" Color="@Color.Default" />
     <FluentSpacer Width="50px" />
-    <FluentIcon Value="@(new Icons.Filled.Size48.Alert())" />
+    <FluentIcon Value="@(new Icons.Filled.Size48.Alert())" Color="@Color.Primary"/>
     <FluentSpacer Width="50px" />
     <FluentIcon Value="@(new Icons.Filled.Size48.Alert())" Color="@Color.Warning" />
     <FluentSpacer Width="50px"/>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Spacer/Examples/SpacerVertical.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Spacer/Examples/SpacerVertical.razor
@@ -1,7 +1,7 @@
 ﻿<FluentStack Orientation="Orientation.Vertical" Height="400px">
-    <FluentIcon Value="@(new Icons.Filled.Size48.Alert())" Color="@Color.Neutral" />
+    <FluentIcon Value="@(new Icons.Filled.Size48.Alert())" Color="@Color.Default" />
     <FluentSpacer/>
-    <FluentIcon Value="@(new Icons.Filled.Size48.Alert())" Color="@Color.Accent" />
+    <FluentIcon Value="@(new Icons.Filled.Size48.Alert())" Color="@Color.Primary" />
     <FluentSpacer/>
     <FluentIcon Value="@(new Icons.Filled.Size48.Alert())" Color="@Color.Warning" />
     <FluentSpacer Orientation="Orientation.Vertical"/>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Spacer/Examples/SpacerVerticalPixels.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Spacer/Examples/SpacerVerticalPixels.razor
@@ -1,7 +1,7 @@
 ﻿<FluentStack Orientation="Orientation.Vertical" Height="400px">
-    <FluentIcon Value="@(new Icons.Filled.Size48.Alert())" Color="@Color.Neutral" />
+    <FluentIcon Value="@(new Icons.Filled.Size48.Alert())" Color="@Color.Default" />
     <FluentSpacer Orientation="Orientation.Vertical" Height="50px"/>
-    <FluentIcon Value="@(new Icons.Filled.Size48.Alert())" Color="@Color.Accent" />
+    <FluentIcon Value="@(new Icons.Filled.Size48.Alert())" Color="@Color.Primary" />
     <FluentSpacer Orientation="Orientation.Vertical" Height="50px"/>
     <FluentIcon Value="@(new Icons.Filled.Size48.Alert())" Color="@Color.Warning" />
     <FluentSpacer Orientation="Orientation.Vertical" Height="50px"/>


### PR DESCRIPTION
# Pull Request

## 📖 Description
Fixing warnings introduced in #3619 After building examples projects:

![image](https://github.com/user-attachments/assets/8778d1e5-7b7d-40ab-a9de-428bd271b162)


## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
