### PR TITLE
[dev-v5] FluentGrid simplifications

### DIFF
--- a/src/Core/Components/Grid/FluentGrid.razor
+++ b/src/Core/Components/Grid/FluentGrid.razor
@@ -3,9 +3,7 @@
 @inherits FluentComponentBase
 
 <CascadingValue IsFixed Value="this">
-    <div class="@ClassValue" style="@StyleValue" @attributes="AdditionalAttributes">
-        <div id="@Id" class="fluent-grid" style="@($"justify-content: {Justify.ToAttributeValue()};")" spacing="@Spacing">
-            @ChildContent
-        </div>
+    <div id="@Id" class="@ClassValue" style="@StyleValue" @attributes="AdditionalAttributes" spacing="@Spacing">
+        @ChildContent
     </div>
 </CascadingValue>

--- a/src/Core/Components/Grid/FluentGrid.razor.cs
+++ b/src/Core/Components/Grid/FluentGrid.razor.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
+using Microsoft.FluentUI.AspNetCore.Components.Extensions;
 using Microsoft.FluentUI.AspNetCore.Components.Utilities;
 using Microsoft.JSInterop;
 
@@ -28,10 +29,12 @@ public partial class FluentGrid : FluentComponentBase
 
     /// <summary />
     protected string? ClassValue => DefaultClassBuilder
+        .AddClass("fluent-grid")
         .Build();
 
     /// <summary />
     protected string? StyleValue => DefaultStyleBuilder
+        .AddStyle("justify-content", Justify.ToAttributeValue())
         .Build();
 
     /// <summary />
@@ -42,7 +45,7 @@ public partial class FluentGrid : FluentComponentBase
     /// Only values from 0 to 10 are possible.
     /// </summary>
     [Parameter]
-    public int Spacing { get; set; } = 3;
+    public int Spacing { get; set; }
 
     /// <summary>
     /// Defines how the browser distributes space between and around content items.

--- a/tests/Core/Components/Grid/FluentGridTests.FluentGrid_Default.verified.razor.html
+++ b/tests/Core/Components/Grid/FluentGridTests.FluentGrid_Default.verified.razor.html
@@ -1,4 +1,1 @@
-
-<div>
-  <div id="xxx" class="fluent-grid" style="justify-content: flex-start;" spacing="3">My content</div>
-</div>
+<div id="xxx" class="fluent-grid" style="justify-content: flex-start;" spacing="0">My content</div>

--- a/tests/Core/Components/Grid/FluentGridTests.FluentGrid_Items_AllBreakpoints.verified.razor.html
+++ b/tests/Core/Components/Grid/FluentGridTests.FluentGrid_Items_AllBreakpoints.verified.razor.html
@@ -1,6 +1,3 @@
-
-<div>
-  <div id="xxx" class="fluent-grid" style="justify-content: flex-start;" spacing="3">
-    <div xs="1" sm="2" md="3" lg="4" xl="5" xxl="6">My cell</div>
-  </div>
+<div id="xxx" class="fluent-grid" style="justify-content: flex-start;" spacing="0">
+  <div xs="1" sm="2" md="3" lg="4" xl="5" xxl="6">My cell</div>
 </div>

--- a/tests/Core/Components/Grid/FluentGridTests.FluentGrid_Items_Default.verified.razor.html
+++ b/tests/Core/Components/Grid/FluentGridTests.FluentGrid_Items_Default.verified.razor.html
@@ -1,7 +1,4 @@
-
-<div>
-  <div id="xxx" class="fluent-grid" style="justify-content: flex-start;" spacing="3">
-    <div xs="6" md="6">Cell 1</div>
-    <div xs="6" md="6">Cell 2</div>
-  </div>
+<div id="xxx" class="fluent-grid" style="justify-content: flex-start;" spacing="0">
+  <div xs="6" md="6">Cell 1</div>
+  <div xs="6" md="6">Cell 2</div>
 </div>

--- a/tests/Core/Components/Grid/FluentGridTests.FluentGrid_Items_JustifyGap.verified.razor.html
+++ b/tests/Core/Components/Grid/FluentGridTests.FluentGrid_Items_JustifyGap.verified.razor.html
@@ -1,6 +1,3 @@
-
-<div>
-  <div id="xxx" class="fluent-grid" style="justify-content: flex-start;" spacing="3">
-    <div style="justify-content: center; display: flex; gap: 10px;" xs="1">My cell</div>
-  </div>
+<div id="xxx" class="fluent-grid" style="justify-content: flex-start;" spacing="0">
+  <div style="justify-content: center; display: flex; gap: 10px;" xs="1">My cell</div>
 </div>

--- a/tests/Core/Components/Grid/FluentGridTests.FluentGrid_Items_NoBreapoint.verified.razor.html
+++ b/tests/Core/Components/Grid/FluentGridTests.FluentGrid_Items_NoBreapoint.verified.razor.html
@@ -1,6 +1,3 @@
-
-<div>
-  <div id="xxx" class="fluent-grid" style="justify-content: flex-start;" spacing="3">
-    <div style="min-width: 200px;" xs="0">My cell</div>
-  </div>
+<div id="xxx" class="fluent-grid" style="justify-content: flex-start;" spacing="0">
+  <div style="min-width: 200px;" xs="0">My cell</div>
 </div>

--- a/tests/Core/Components/Grid/FluentGridTests.FluentGrid_SpacingJustify.verified.razor.html
+++ b/tests/Core/Components/Grid/FluentGridTests.FluentGrid_SpacingJustify.verified.razor.html
@@ -1,4 +1,1 @@
-
-<div>
-  <div id="xxx" class="fluent-grid" style="justify-content: center;" spacing="5">My content</div>
-</div>
+<div id="xxx" class="fluent-grid" style="justify-content: center;" spacing="5">My content</div>


### PR DESCRIPTION
# [dev-v5] FluentGrid simplifications

1. Remove the incorrect `div` container to apply the **styles** and the **class** to the `fluent-grid`.
2. Set default `Spacing=0`

## Unit Tests

Fixed