### PR TITLE
[dev-v5] Upgrade the FluentTabs to use fluent-tablist

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsCustomized.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsCustomized.razor
@@ -1,4 +1,4 @@
-﻿<FluentTabs @bind-ActiveTab="@ActiveTab" Height="100px" Width="400px" Style="border: 1px solid var(colorNeutralStroke1);">
+﻿<FluentTabs @bind-ActiveTab="@ActiveTab" Height="100px" Width="400px" Style="border: 1px dashed var(--colorNeutralStroke1);">
     <FluentTab>
         <HeaderTemplate>
             Chat
@@ -21,7 +21,7 @@
 </FluentTabs>
 
 <p>
-    ActiveTab: <b>@(ActiveTab?.Header)</b>
+    ActiveTab: <b>@(ActiveTab?.HeaderTemplate)</b>
 </p>
 
 @code

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsDefault.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsDefault.razor
@@ -1,13 +1,13 @@
-﻿<FluentTabs ActiveTabId="tab3" @bind-ActiveTab="@ActiveTab" @bind-ActiveTab:after="@OnTabChanged">
-    <FluentTab Id="tab1" Header="Chat" IconStart="@(new Icons.Regular.Size16.Chat())">
+﻿<FluentTabs ActiveTabId="@ActiveTabId" @bind-ActiveTab="@ActiveTab" @bind-ActiveTab:after="@OnTabChanged">
+    <FluentTab Id="default-tab1" Header="Chat" IconStart="@(new Icons.Regular.Size16.Chat())">
         Here's some information about the chat.
     </FluentTab>
 
-    <FluentTab Id="tab2" Header="Files" Disabled="true" IconStart="@(new Icons.Regular.Size16.Folder())">
+    <FluentTab Id="default-tab2" Header="Files" Disabled="true" IconStart="@(new Icons.Regular.Size16.Folder())">
         Here's the list of all files.
     </FluentTab>
 
-    <FluentTab Id="tab3" Header="Recap" IconStart="@(new Icons.Regular.Size16.List())" IconColor="@Color.Primary">
+    <FluentTab Id="default-tab3" Header="Recap" IconStart="@(new Icons.Regular.Size16.List())" IconColor="@Color.Primary">
         Here's some information about the recap.
     </FluentTab>
 </FluentTabs>
@@ -18,6 +18,7 @@
 
 @code
 {
+    string? ActiveTabId = "default-tab3";
     FluentTab? ActiveTab;
 
     void OnTabChanged()

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsDeferred.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsDeferred.razor
@@ -1,13 +1,13 @@
-﻿<FluentTabs @bind-ActiveTabId="@ActiveTabId" Height="100px" Width="300px">
-    <FluentTab Id="tab1" Header="Chat">
+﻿<FluentTabs @bind-ActiveTabId="@ActiveTabId" Height="100px" Width="400px">
+    <FluentTab Header="Chat">
         Here's some information about the chat.
     </FluentTab>
 
-    <FluentTab Id="tab2" Header="Files" DeferredLoading="true">
+    <FluentTab Header="Files" DeferredLoading="true">
         @GetContentTab2
     </FluentTab>
 
-    <FluentTab Id="tab3" Header="Recap">
+    <FluentTab Header="Recap">
         Here's some information about the recap.
     </FluentTab>
 </FluentTabs>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsDeferred.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsDeferred.razor
@@ -1,4 +1,4 @@
-﻿<FluentTabs @bind-ActiveTabId="@ActiveTabId" Height="100px" Width="400px">
+﻿<FluentTabs @bind-ActiveTab="@ActiveTab" Height="100px" Width="400px">
     <FluentTab Header="Chat">
         Here's some information about the chat.
     </FluentTab>
@@ -13,17 +13,17 @@
 </FluentTabs>
 
 <p>
-    ActiveTab: <b>@ActiveTabId</b>
+    ActiveTab: <b>@ActiveTab?.Header</b>
 </p>
 
 @code
 {
-    string? ActiveTabId;
+    FluentTab? ActiveTab;
 
     RenderFragment? GetContentTab2 => builder =>
     {
         // To simulate a long running process
-        Thread.Sleep(3000);
+        Thread.Sleep(2000);
 
         // Add <span>Here's the list of all files.</span>
         builder.OpenElement(0, "span");

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsVisual.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsVisual.razor
@@ -1,0 +1,38 @@
+﻿<FluentSelect Label="Appearance"
+              Items="@(Enum.GetValues<TabsAppearance>())"
+              @bind-Value="@Appearance" />
+
+<FluentSelect Label="Orientation"
+              Items="@(Enum.GetValues<Orientation>())"
+              @bind-Value="@Orientation" />
+
+<FluentSelect Label="Size"
+              Items="@(Enum.GetValues<TabsSize>())"
+              @bind-Value="@Size" />
+
+<FluentSelect Label="Disabled"
+              Items="@([true, false])"
+              @bind-Value="@Disabled" />
+
+<FluentTabs Disabled="@Disabled" Appearance="@Appearance" Orientation="@Orientation" Size="@Size"
+            Style="border: 1px dashed var(--colorNeutralStroke1);">
+    <FluentTab Header="Chat" IconStart="@(new Icons.Regular.Size16.Chat())">
+        Here's some information about the chat.
+    </FluentTab>
+
+    <FluentTab Header="Files" Disabled="true" IconStart="@(new Icons.Regular.Size16.Folder())">
+        Here's the list of all files.
+    </FluentTab>
+
+    <FluentTab Header="Recap" IconStart="@(new Icons.Regular.Size16.List())" IconColor="@Color.Primary">
+        Here's some information about the recap.
+    </FluentTab>
+</FluentTabs>
+
+@code
+{
+    TabsAppearance Appearance;
+    Orientation Orientation;
+    TabsSize Size;
+    bool Disabled;
+}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/FluentTabs.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/FluentTabs.md
@@ -38,7 +38,7 @@ By default, a progress indicator is shown while the content is being loaded.
 You can customize the progress indicator by using the `LoadingTemplate` parameter.
 
 In the following example, the `Deferred` parameter is set to `true` for Tab two.
-This tab will be loaded after 3 seconds of processing (to simulate a long running process).
+This tab will be loaded after 2 seconds of processing (to simulate a long running process).
 
 {{ TabsDeferred }}
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/FluentTabs.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/FluentTabs.md
@@ -13,6 +13,9 @@ and require less scrolling.
 For navigation beyond closely related categories, use a [FluentLink](/link) instead.
 To initiate an action, use a [FluentButton](/button) instead.
 
+> **note**: For the moment, there are no 'scrolling' functions when the number of tabs is too large
+> in relation to the size of the container or screen.
+
 ## Default
 
 To know which tab is selected, you can bind the `ActiveTabId` or `ActiveTab` parameter to a variable.
@@ -21,6 +24,12 @@ Setting the `ActiveTabId` parameter to an initial value will set the selected ta
 A tab can be disabled by setting the `Disabled` parameter to `true`.
 
 {{ TabsDefault }}
+
+## Appearance
+
+Multiple parameters are available to customize the appearance of the tabs.
+
+{{ TabsVisual }}
 
 ## Customized
 

--- a/spelling.dic
+++ b/spelling.dic
@@ -1,3 +1,8 @@
+# ***************************
+# List of misspelled words
+# Please, sort the list alphabetically
+# ***************************
+
 ansi
 appsettings
 blazor
@@ -5,33 +10,35 @@ brotli
 combobox
 cref
 csproj
+currentcolor
 datalist
 elementreference
 evenodd
 gzip
 javascript
+menuchecked
+menuclicked
+menuitem
+menuitem
+menuitemcheckbox
+menuitemcheckboxobsolete
+menuitemradio
+menuitemradioobsolete
+menuitems
 microsoft
+myid
 noattribute
 nonfile
-rrggbb
-tabindex
-textarea
-sourcecode
-summarydata
-currentcolor
-menuitem
-menuitems
-rightclick
-menuitemcheckbox
-menuitem
-menuitemradio
-menuitemcheckboxobsolete
-menuitemradioobsolete
+ondialogbeforetoggle
+ondialogtoggle
+ondropdownchange
 onmenuitemchange
 ontabchange
-ondropdownchange
-ondialogtoggle
-ondialogbeforetoggle
-myid
-menuclicked
-menuchecked
+rightclick
+rrggbb
+sourcecode
+summarydata
+tabindex
+tablist
+tabpanel
+textarea

--- a/src/Core.Scripts/package-lock.json
+++ b/src/Core.Scripts/package-lock.json
@@ -8,7 +8,7 @@
       "name": "microsoft.fluentui.aspnetcore.components.assets",
       "license": "ISC",
       "dependencies": {
-        "@fluentui/web-components": "3.0.0-beta.87"
+        "@fluentui/web-components": "3.0.0-beta.89"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^7.6.0",
@@ -486,10 +486,9 @@
       }
     },
     "node_modules/@fluentui/web-components": {
-      "version": "3.0.0-beta.87",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@fluentui/web-components/-/web-components-3.0.0-beta.87.tgz",
-      "integrity": "sha1-JdDTgFSExn2yA8kSi8pZKsMNvg8=",
-      "license": "MIT",
+      "version": "3.0.0-beta.89",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@fluentui/web-components/-/web-components-3.0.0-beta.89.tgz",
+      "integrity": "sha1-KF8b8aZxs89FVR1VJ6XpI/CHKno=",
       "dependencies": {
         "@fluentui/tokens": "1.0.0-alpha.21",
         "@microsoft/fast-web-utilities": "^6.0.0",

--- a/src/Core.Scripts/package.json
+++ b/src/Core.Scripts/package.json
@@ -25,6 +25,6 @@
     "typescript": "^5.4.4"
   },
   "dependencies": {
-    "@fluentui/web-components": "3.0.0-beta.87"
+    "@fluentui/web-components": "3.0.0-beta.89"
   }
 }

--- a/src/Core.Scripts/src/Components/Tabs/FluentTabs.ts
+++ b/src/Core.Scripts/src/Components/Tabs/FluentTabs.ts
@@ -1,0 +1,35 @@
+export namespace Microsoft.FluentUI.Blazor.Components.Tabs {
+
+  /**
+   * Initiates the list of tabs when a tab is added or removed
+   * @param id The id of the fluent-tablist container to refresh
+   */
+  export function ObserveTabsChanged(id: string): void {
+    const tabsContainer = document.getElementById(id) as HTMLElement | null;
+    const tabsList = tabsContainer?.querySelector('fluent-tablist') as HTMLElement | null;
+
+    if (!tabsContainer || !tabsList) {
+      return;
+    }
+
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (mutation.type === 'childList') {
+          const addedNodes = Array.from(mutation.addedNodes).filter(
+            (node) => node instanceof HTMLElement && node.classList.contains('fluent-tab-panel')
+          );
+          const removedNodes = Array.from(mutation.removedNodes).filter(
+            (node) => node instanceof HTMLElement && node.classList.contains('fluent-tab-panel')
+          );
+
+          if (addedNodes.length > 0 || removedNodes.length > 0) {
+            // Call the tabsChanged method on the fluent-tablist element
+            (tabsList as any).tabsChanged();
+          }
+        }
+      });
+    });
+
+    observer.observe(tabsContainer, { childList: true });
+  }
+}

--- a/src/Core.Scripts/src/ExportedMethods.ts
+++ b/src/Core.Scripts/src/ExportedMethods.ts
@@ -1,6 +1,7 @@
 import { Microsoft as LoggerFile } from './Utilities/Logger';
 import { Microsoft as AttributesFile } from './Utilities/Attributes';
 import { Microsoft as FluentDialogFile } from './Components/Dialog/FluentDialog';
+import { Microsoft as FluentTabsFile } from './Components/Tabs/FluentTabs';
 
 export namespace Microsoft.FluentUI.Blazor.ExportedMethods {
 
@@ -19,9 +20,10 @@ export namespace Microsoft.FluentUI.Blazor.ExportedMethods {
     (window as any).Microsoft.FluentUI.Blazor.Utilities.Logger = LoggerFile.FluentUI.Blazor.Utilities.Logger;
     (window as any).Microsoft.FluentUI.Blazor.Utilities.Attributes = AttributesFile.FluentUI.Blazor.Utilities.Attributes;
 
-    // Dialog methods
+    // Components methods
     (window as any).Microsoft.FluentUI.Blazor.Components = (window as any).Microsoft.FluentUI.Blazor.Components || {};
     (window as any).Microsoft.FluentUI.Blazor.Components.Dialog = FluentDialogFile.FluentUI.Blazor.Components.Dialog;
+    (window as any).Microsoft.FluentUI.Blazor.Components.Tabs = FluentTabsFile.FluentUI.Blazor.Components.Tabs;
 
     // [^^^ Add your other exported methods before this line ^^^]
   }

--- a/src/Core.Scripts/src/FluentUIWebComponents.ts
+++ b/src/Core.Scripts/src/FluentUIWebComponents.ts
@@ -55,6 +55,7 @@ export namespace Microsoft.FluentUI.Blazor.FluentUIWebComponents {
     FluentUIComponents.TextInputDefinition.define(registry);
     FluentUIComponents.ToggleButtonDefinition.define(registry);
     FluentUIComponents.TooltipDefinition.define(registry);
+    FluentUIComponents.TreeItemDefinition.define(registry);
   }
 
   /**

--- a/src/Core/Components/Tabs/FluentTab.razor
+++ b/src/Core/Components/Tabs/FluentTab.razor
@@ -7,6 +7,7 @@
                 class="@ClassValue"
                 style="@StyleValue"
                 disabled="@Disabled"
+                aria-controls="@TabPanelId"
                 @attributes="@AdditionalAttributes">
         <AddTag Name="span" TagWhen="@(() => HeaderTemplate is not null || IconStart is not null)">
             @if (IconStart is not null)
@@ -17,21 +18,4 @@
             @HeaderTemplate
         </AddTag>
     </fluent-tab>
-    <fluent-tab-panel id="@(Id + "-panel")">
-        @if (DeferredLoading && Owner?.ActiveTabId != Id)
-        {
-            if (LoadingTemplate is null)
-            {
-                <FluentProgressBar />
-            }
-            else
-            {
-                @LoadingTemplate
-            }
-        }
-        else
-        {
-            @ChildContent
-        }
-    </fluent-tab-panel>
 }

--- a/src/Core/Components/Tabs/FluentTab.razor.cs
+++ b/src/Core/Components/Tabs/FluentTab.razor.cs
@@ -103,22 +103,6 @@ public partial class FluentTab : FluentComponentBase, ITooltipComponent
         }
     }
 
-    /// <summary>
-    /// Refreshes the tab content.
-    /// </summary>
-    /// <returns></returns>
-    public Task RefreshAsync()
-    {
-        RefreshKey++;
-        return Task.CompletedTask;
-    }
-
-    /// <summary />
-    internal int RefreshKey { get; set; } = -Random.Shared.Next();
-
     /// <summary />
     internal string TabPanelId => $"{Id}-panel";
-
-    /// <summary />
-    internal bool IsInactiveActive => !string.Equals(Owner?.ActiveTabId, Id, StringComparison.Ordinal);
 }

--- a/src/Core/Components/Tabs/FluentTab.razor.cs
+++ b/src/Core/Components/Tabs/FluentTab.razor.cs
@@ -30,6 +30,9 @@ public partial class FluentTab : FluentComponentBase, ITooltipComponent
     [CascadingParameter]
     private FluentTabs? Owner { get; set; }
 
+    /// <summary />
+    internal int Index { get; set; }
+
     /// <summary>
     /// Gets or sets whether the tab is disabled.
     /// </summary>
@@ -96,7 +99,26 @@ public partial class FluentTab : FluentComponentBase, ITooltipComponent
 
         if (Owner is not null)
         {
-            await Owner.AddTabAsync(this);
+            Index = await Owner.AddTabAsync(this);
         }
     }
+
+    /// <summary>
+    /// Refreshes the tab content.
+    /// </summary>
+    /// <returns></returns>
+    public Task RefreshAsync()
+    {
+        RefreshKey++;
+        return Task.CompletedTask;
+    }
+
+    /// <summary />
+    internal int RefreshKey { get; set; } = -Random.Shared.Next();
+
+    /// <summary />
+    internal string TabPanelId => $"{Id}-panel";
+
+    /// <summary />
+    internal bool IsInactiveActive => !string.Equals(Owner?.ActiveTabId, Id, StringComparison.Ordinal);
 }

--- a/src/Core/Components/Tabs/FluentTab.razor.css
+++ b/src/Core/Components/Tabs/FluentTab.razor.css
@@ -1,3 +1,7 @@
+fluent-tab {
+  white-space: nowrap;
+}
+
 fluent-tab > span {
     display: flex;
     column-gap: 2px;

--- a/src/Core/Components/Tabs/FluentTabs.razor
+++ b/src/Core/Components/Tabs/FluentTabs.razor
@@ -21,7 +21,7 @@
         {
             if (tab.Visible)
             {
-                <div id="@tab.TabPanelId" index="@tab.Index" role="tabpanel" hidden="@tab.IsInactiveActive" class="fluent-tab-panel">
+                <div id="@tab.TabPanelId" index="@tab.Index" class="fluent-tab-panel">
                     @if (tab.DeferredLoading && ActiveTabId != tab.Id)
                     {
                         if (tab.LoadingTemplate is null)

--- a/src/Core/Components/Tabs/FluentTabs.razor
+++ b/src/Core/Components/Tabs/FluentTabs.razor
@@ -3,16 +3,42 @@
 @inherits FluentComponentBase
 
 <CascadingValue Value="this" IsFixed="true">
-    <fluent-tabs id="@Id"
-                 class="@ClassValue"
-                 style="@StyleValue"
-                 appearance="@Appearance.ToAttributeValue(isNull: TabsAppearance.Default, returnEmptyAsNull: true)"
-                 disabled="@Disabled"
-                 size="@Size.ToAttributeValue(isNull: TabsSize.Medium, returnEmptyAsNull: true)"
-                 orientation="@Orientation.ToAttributeValue()"
-                 activeid="@(ActiveTabId ?? ActiveTab?.Id)"
-                 ontabchange="@TabChangeHandlerAsync"
-                 @attributes="@AdditionalAttributes">
-        @ChildContent
-    </fluent-tabs>
+    <div id="@Id" class="@ClassValue" style="@StyleValue" @attributes="@AdditionalAttributes">
+
+        @* List of tab headers *@
+        <fluent-tablist id="@TabListId"
+                        appearance="@Appearance.ToAttributeValue(isNull: TabsAppearance.Default, returnEmptyAsNull: true)"
+                        disabled="@Disabled"
+                        size="@Size.ToAttributeValue(isNull: TabsSize.Medium, returnEmptyAsNull: true)"
+                        orientation="@Orientation.ToAttributeValue()"
+                        activeid="@(ActiveTabId ?? ActiveTab?.Id)"
+                        ontabchange="@TabChangeHandlerAsync">
+            @ChildContent
+        </fluent-tablist>
+
+        @* List of tab contents (need to be added outside of the fluent-tablist *@
+        @foreach (var tab in Tabs.Values.OrderBy(i => i.Index))
+        {
+            if (tab.Visible)
+            {
+                <div id="@tab.TabPanelId" index="@tab.Index" role="tabpanel" hidden="@tab.IsInactiveActive" class="fluent-tab-panel">
+                    @if (tab.DeferredLoading && ActiveTabId != tab.Id)
+                    {
+                        if (tab.LoadingTemplate is null)
+                        {
+                            <FluentProgressBar />
+                        }
+                        else
+                        {
+                            @tab.LoadingTemplate
+                        }
+                    }
+                    else
+                    {
+                        @tab.ChildContent
+                    }
+                </div>
+            }
+        }
+    </div>
 </CascadingValue>

--- a/src/Core/Components/Tabs/FluentTabs.razor
+++ b/src/Core/Components/Tabs/FluentTabs.razor
@@ -7,7 +7,7 @@
 
         @* List of tab headers *@
         <fluent-tablist id="@TabListId"
-                        appearance="@Appearance.ToAttributeValue(isNull: TabsAppearance.Default, returnEmptyAsNull: true)"
+                        appearance="@Appearance.ToAttributeValue(isNull: TabsAppearance.Transparent, returnEmptyAsNull: true)"
                         disabled="@Disabled"
                         size="@Size.ToAttributeValue(isNull: TabsSize.Medium, returnEmptyAsNull: true)"
                         orientation="@Orientation.ToAttributeValue()"

--- a/src/Core/Components/Tabs/FluentTabs.razor.cs
+++ b/src/Core/Components/Tabs/FluentTabs.razor.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components.Utilities;
+using Microsoft.JSInterop;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
@@ -66,7 +67,7 @@ public partial class FluentTabs: FluentComponentBase
     public string? Height { get; set; }
 
     /// <summary>
-    /// Gets or sets the wudth of the tabs.
+    /// Gets or sets the width of the tabs.
     /// </summary>
     [Parameter]
     public string? Width { get; set; }
@@ -100,6 +101,15 @@ public partial class FluentTabs: FluentComponentBase
     /// </summary>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
+
+    /// <summary />
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Components.Tabs.ObserveTabsChanged", Id);
+        }
+    }
 
     /// <summary />
     internal async Task<int> AddTabAsync(FluentTab tab)
@@ -160,9 +170,6 @@ public partial class FluentTabs: FluentComponentBase
             {
                 await ActiveTabChanged.InvokeAsync(ActiveTab);
             }
-
-            // Refresh the active tab content
-            await ActiveTab.RefreshAsync();
         }
     }
 

--- a/src/Core/Components/Tabs/FluentTabs.razor.cs
+++ b/src/Core/Components/Tabs/FluentTabs.razor.cs
@@ -112,7 +112,7 @@ public partial class FluentTabs: FluentComponentBase
     }
 
     /// <summary />
-    internal async Task<int> AddTabAsync(FluentTab tab)
+    internal async Task<int> AddTabAsync(FluentTab? tab)
     {
         if (tab is not null && !string.IsNullOrEmpty(tab.Id))
         {
@@ -140,7 +140,7 @@ public partial class FluentTabs: FluentComponentBase
                 }
             }
 
-            StateHasChanged();
+            await InvokeAsync(StateHasChanged);
 
             return Tabs.Count;
         }

--- a/src/Core/Components/Tabs/FluentTabs.razor.cs
+++ b/src/Core/Components/Tabs/FluentTabs.razor.cs
@@ -26,6 +26,7 @@ public partial class FluentTabs: FluentComponentBase
 
     /// <summary />
     protected string? ClassValue => DefaultClassBuilder
+        .AddClass("fluent-tabs")
         .Build();
 
     /// <summary />
@@ -101,7 +102,7 @@ public partial class FluentTabs: FluentComponentBase
     public RenderFragment? ChildContent { get; set; }
 
     /// <summary />
-    internal async Task AddTabAsync(FluentTab tab)
+    internal async Task<int> AddTabAsync(FluentTab tab)
     {
         if (tab is not null && !string.IsNullOrEmpty(tab.Id))
         {
@@ -128,14 +129,18 @@ public partial class FluentTabs: FluentComponentBase
                     await ActiveTabIdChanged.InvokeAsync(ActiveTabId);
                 }
             }
+
+            return Tabs.Count;
         }
+
+        return 0;
     }
 
     /// <summary />
     internal async Task TabChangeHandlerAsync(TabChangeEventArgs args)
     {
         // Only for the current FluentTabs
-        if (!string.Equals(args.Id, Id, StringComparison.Ordinal))
+        if (!string.Equals(args.Id, TabListId, StringComparison.Ordinal))
         {
             return;
         }
@@ -155,6 +160,12 @@ public partial class FluentTabs: FluentComponentBase
             {
                 await ActiveTabChanged.InvokeAsync(ActiveTab);
             }
+
+            // Refresh the active tab content
+            await ActiveTab.RefreshAsync();
         }
     }
+
+    /// <summary />
+    internal string TabListId => $"{Id}-tablist";
 }

--- a/src/Core/Components/Tabs/FluentTabs.razor.cs
+++ b/src/Core/Components/Tabs/FluentTabs.razor.cs
@@ -140,6 +140,8 @@ public partial class FluentTabs: FluentComponentBase
                 }
             }
 
+            StateHasChanged();
+
             return Tabs.Count;
         }
 

--- a/src/Core/Components/Tabs/FluentTabs.razor.css
+++ b/src/Core/Components/Tabs/FluentTabs.razor.css
@@ -2,6 +2,12 @@
   width: 100%;
 }
 
+  .fluent-tabs:has(fluent-tablist[orientation="vertical"]) {
+    display: flex;
+    flex-direction: row;
+  }
+
 .fluent-tab-panel {
   padding: var(--spacingVerticalS) var(--spacingHorizontalS);
+  width: 100%;
 }

--- a/src/Core/Components/Tabs/FluentTabs.razor.css
+++ b/src/Core/Components/Tabs/FluentTabs.razor.css
@@ -1,0 +1,7 @@
+.fluent-tabs {
+  width: 100%;
+}
+
+.fluent-tab-panel {
+  padding: var(--spacingVerticalS) var(--spacingHorizontalS);
+}

--- a/src/Core/Enums/TabsAppearance.cs
+++ b/src/Core/Enums/TabsAppearance.cs
@@ -21,5 +21,5 @@ public enum TabsAppearance
     /// Minimizes emphasis to blend into the background until hovered or focused.
     /// </summary>
     [Description("subtle")]
-    Default,
+    Subtle,
 }

--- a/tests/Core/Components/Tabs/FluentTabsTests.FluentTabs_Default.verified.razor.html
+++ b/tests/Core/Components/Tabs/FluentTabsTests.FluentTabs_Default.verified.razor.html
@@ -1,13 +1,17 @@
 
-<fluent-tabs id="xxx" blazor:ontabchange="1">
-  <fluent-tab id="xxx">Chat
-  </fluent-tab>
-  <fluent-tab-panel id="xxx">
+<div id="xxx" class="fluent-tabs">
+  <fluent-tablist id="xxx" blazor:ontabchange="1">
+    <fluent-tab id="xxx" aria-controls="tab1-panel">
+      Chat
+    </fluent-tab>
+    <fluent-tab id="xxx" aria-controls="tab2-panel">
+      Files
+    </fluent-tab>
+  </fluent-tablist>
+  <div id="xxx" index="1" class="fluent-tab-panel">
     Here's some information about the chat.
-  </fluent-tab-panel>
-  <fluent-tab id="xxx">Files
-  </fluent-tab>
-  <fluent-tab-panel id="xxx">
+  </div>
+  <div id="xxx" index="2" class="fluent-tab-panel">
     Here's the list of all files.
-  </fluent-tab-panel>
-</fluent-tabs>
+  </div>
+</div>

--- a/tests/Core/Components/Tabs/FluentTabsTests.FluentTabs_DeferredLoading-After.verified.razor.html
+++ b/tests/Core/Components/Tabs/FluentTabsTests.FluentTabs_DeferredLoading-After.verified.razor.html
@@ -1,12 +1,17 @@
 
-<fluent-tabs id="xxx" activeid="Tab2" blazor:ontabchange="1">
-  <fluent-tab id="xxx">Tab 1
-  </fluent-tab>
-  <fluent-tab-panel id="xxx">Content 1</fluent-tab-panel>
-  <fluent-tab id="xxx">Tab 2
-  </fluent-tab>
-  <fluent-tab-panel id="xxx">Content 2</fluent-tab-panel>
-  <fluent-tab id="xxx">Tab 3
-  </fluent-tab>
-  <fluent-tab-panel id="xxx">Loading...</fluent-tab-panel>
-</fluent-tabs>
+<div id="xxx" class="fluent-tabs">
+  <fluent-tablist id="xxx" activeid="Tab2" blazor:ontabchange="1">
+    <fluent-tab id="xxx" aria-controls="Tab1-panel">
+      Tab 1
+    </fluent-tab>
+    <fluent-tab id="xxx" aria-controls="Tab2-panel">
+      Tab 2
+    </fluent-tab>
+    <fluent-tab id="xxx" aria-controls="Tab3-panel">
+      Tab 3
+    </fluent-tab>
+  </fluent-tablist>
+  <div id="xxx" index="1" class="fluent-tab-panel">Content 1</div>
+  <div id="xxx" index="2" class="fluent-tab-panel">Content 2</div>
+  <div id="xxx" index="3" class="fluent-tab-panel">Loading...</div>
+</div>

--- a/tests/Core/Components/Tabs/FluentTabsTests.FluentTabs_DeferredLoading-Before.verified.razor.html
+++ b/tests/Core/Components/Tabs/FluentTabsTests.FluentTabs_DeferredLoading-Before.verified.razor.html
@@ -1,17 +1,19 @@
 
-<fluent-tabs id="xxx" activeid="Tab1" blazor:ontabchange="1">
-  <fluent-tab id="xxx">
-    Tab 1
-  </fluent-tab>
-  <fluent-tab-panel id="xxx">Content 1</fluent-tab-panel>
-  <fluent-tab id="xxx">
-    Tab 2
-  </fluent-tab>
-  <fluent-tab-panel id="xxx">
+<div id="xxx" class="fluent-tabs">
+  <fluent-tablist id="xxx" activeid="Tab1" blazor:ontabchange="1">
+    <fluent-tab id="xxx" aria-controls="Tab1-panel">
+      Tab 1
+    </fluent-tab>
+    <fluent-tab id="xxx" aria-controls="Tab2-panel">
+      Tab 2
+    </fluent-tab>
+    <fluent-tab id="xxx" aria-controls="Tab3-panel">
+      Tab 3
+    </fluent-tab>
+  </fluent-tablist>
+  <div id="xxx" index="1" class="fluent-tab-panel">Content 1</div>
+  <div id="xxx" index="2" class="fluent-tab-panel">
     <fluent-progress-bar></fluent-progress-bar>
-  </fluent-tab-panel>
-  <fluent-tab id="xxx">
-    Tab 3
-  </fluent-tab>
-  <fluent-tab-panel id="xxx">Loading...</fluent-tab-panel>
-</fluent-tabs>
+  </div>
+  <div id="xxx" index="3" class="fluent-tab-panel">Loading...</div>
+</div>

--- a/tests/Core/Components/Tabs/FluentTabsTests.FluentTabs_HeaderTemplate.verified.razor.html
+++ b/tests/Core/Components/Tabs/FluentTabsTests.FluentTabs_HeaderTemplate.verified.razor.html
@@ -1,12 +1,14 @@
 
-<fluent-tabs id="xxx" blazor:ontabchange="1">
-  <fluent-tab id="xxx">
-    <span>
-      Tab
-      <b>Name</b>
-    </span>
-  </fluent-tab>
-  <fluent-tab-panel id="xxx">
+<div id="xxx" class="fluent-tabs">
+  <fluent-tablist id="xxx" blazor:ontabchange="1">
+    <fluent-tab id="xxx" aria-controls="MyTab-panel">
+      <span>
+        Tab
+        <b>Name</b>
+      </span>
+    </fluent-tab>
+  </fluent-tablist>
+  <div id="xxx" index="1" class="fluent-tab-panel">
     Tab Content
-  </fluent-tab-panel>
-</fluent-tabs>
+  </div>
+</div>

--- a/tests/Core/Components/Tabs/FluentTabsTests.FluentTabs_Icon.verified.razor.html
+++ b/tests/Core/Components/Tabs/FluentTabsTests.FluentTabs_Icon.verified.razor.html
@@ -1,23 +1,25 @@
 
-<fluent-tabs id="xxx" blazor:ontabchange="1">
-  <fluent-tab id="xxx">
-    <span>
-      <svg style="width: 24px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 24 24" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
-        <path d="M12 2a10 10 0 1 1 0 20 10 10 0 0 1 0-20Zm0 8.25a1 1 0 0 0-1 .88v5.74a1 1 0 0 0 2 0v-5.62l-.01-.12a1 1 0 0 0-1-.88Zm0-3.75A1.25 1.25 0 1 0 12 9a1.25 1.25 0 0 0 0-2.5Z"></path>
-      </svg>Chat
-    </span>
-  </fluent-tab>
-  <fluent-tab-panel id="xxx">
+<div id="xxx" class="fluent-tabs">
+  <fluent-tablist id="xxx" blazor:ontabchange="1">
+    <fluent-tab id="xxx" aria-controls="tab1-panel">
+      <span>
+        <svg style="width: 24px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 24 24" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
+          <path d="M12 2a10 10 0 1 1 0 20 10 10 0 0 1 0-20Zm0 8.25a1 1 0 0 0-1 .88v5.74a1 1 0 0 0 2 0v-5.62l-.01-.12a1 1 0 0 0-1-.88Zm0-3.75A1.25 1.25 0 1 0 12 9a1.25 1.25 0 0 0 0-2.5Z"></path>
+        </svg>Chat
+      </span>
+    </fluent-tab>
+    <fluent-tab id="xxx" aria-controls="tab2-panel">
+      <span>
+        <svg style="width: 24px; fill: var(--success);" focusable="false" viewBox="0 0 24 24" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
+          <path d="M12 2a10 10 0 1 1 0 20 10 10 0 0 1 0-20Zm0 8.25a1 1 0 0 0-1 .88v5.74a1 1 0 0 0 2 0v-5.62l-.01-.12a1 1 0 0 0-1-.88Zm0-3.75A1.25 1.25 0 1 0 12 9a1.25 1.25 0 0 0 0-2.5Z"></path>
+        </svg>Files
+      </span>
+    </fluent-tab>
+  </fluent-tablist>
+  <div id="xxx" index="1" class="fluent-tab-panel">
     Here's some information about the chat.
-  </fluent-tab-panel>
-  <fluent-tab id="xxx">
-    <span>
-      <svg style="width: 24px; fill: var(--success);" focusable="false" viewBox="0 0 24 24" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
-        <path d="M12 2a10 10 0 1 1 0 20 10 10 0 0 1 0-20Zm0 8.25a1 1 0 0 0-1 .88v5.74a1 1 0 0 0 2 0v-5.62l-.01-.12a1 1 0 0 0-1-.88Zm0-3.75A1.25 1.25 0 1 0 12 9a1.25 1.25 0 0 0 0-2.5Z"></path>
-      </svg>Files
-    </span>
-  </fluent-tab>
-  <fluent-tab-panel id="xxx">
+  </div>
+  <div id="xxx" index="2" class="fluent-tab-panel">
     Here's the list of all files.
-  </fluent-tab-panel>
-</fluent-tabs>
+  </div>
+</div>

--- a/tests/Core/Components/Tabs/FluentTabsTests.FluentTabs_Visible.verified.razor.html
+++ b/tests/Core/Components/Tabs/FluentTabsTests.FluentTabs_Visible.verified.razor.html
@@ -1,8 +1,11 @@
 
-<fluent-tabs id="xxx" blazor:ontabchange="1">
-  <fluent-tab id="xxx">Chat
-  </fluent-tab>
-  <fluent-tab-panel id="xxx">
+<div id="xxx" class="fluent-tabs">
+  <fluent-tablist id="xxx" blazor:ontabchange="1">
+    <fluent-tab id="xxx" aria-controls="tab1-panel">
+      Chat
+    </fluent-tab>
+  </fluent-tablist>
+  <div id="xxx" index="1" class="fluent-tab-panel">
     Here's some information about the chat.
-  </fluent-tab-panel>
-</fluent-tabs>
+  </div>
+</div>

--- a/tests/Core/Components/Tabs/FluentTabsTests.razor
+++ b/tests/Core/Components/Tabs/FluentTabsTests.razor
@@ -259,4 +259,21 @@
            builder.AddContent(1, "Content 2");
            builder.CloseElement();
        };
+
+    [Fact]
+    public async Task FluentTabs_AddTabAsync_InvalidTab()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentTabs>
+            <FluentTab Id="tab1" Header="Chat" />
+            <FluentTab Id="tab2" Header="Files" />
+        </FluentTabs>
+    );
+
+        // Act
+        var index = await cut.FindComponent<FluentTabs>().Instance.AddTabAsync(null);
+
+        // Assert
+        Assert.Equal(0, index);
+    }
 }

--- a/tests/Core/Components/Tabs/FluentTabsTests.razor
+++ b/tests/Core/Components/Tabs/FluentTabsTests.razor
@@ -5,6 +5,7 @@
 {
     public FluentTabsTests()
     {
+        JSInterop.Mode = JSRuntimeMode.Loose;
         Services.AddFluentUIComponents();
     }
 
@@ -66,7 +67,7 @@
         // Act
         await cut.FindComponent<FluentTabs>().Instance.TabChangeHandlerAsync(new()
         {
-            Id = eventTabsId,
+            Id = eventTabsId + "-tablist",
             ActiveId = eventActiveId,
         });
 
@@ -96,7 +97,7 @@
         // Act
         await cut.FindComponent<FluentTabs>().Instance.TabChangeHandlerAsync(new()
         {
-            Id = eventTabsId,
+            Id = eventTabsId + "-tablist",
             ActiveId = eventActiveId,
         });
 
@@ -146,8 +147,8 @@
     }
 
     [Theory]
-    [InlineData(TabsAppearance.Default, null)]
-    [InlineData(TabsAppearance.Transparent, "transparent")]
+    [InlineData(TabsAppearance.Subtle, "subtle")]
+    [InlineData(TabsAppearance.Transparent, null)]
     [InlineData(null, null)]
     [InlineData((TabsAppearance)999, null)]
     public void FluentTabs_Appearance(TabsAppearance? appearance, string? expectedAttribute)
@@ -157,7 +158,7 @@
             <FluentTab Header="MyTab"></FluentTab>
         </FluentTabs>);
 
-        var attribute = cut.Find("fluent-tabs").GetAttribute("appearance");
+        var attribute = cut.Find("fluent-tablist").GetAttribute("appearance");
 
         // Assert
         Assert.Equal(expectedAttribute, attribute);
@@ -176,7 +177,7 @@
             <FluentTab Header="MyTab"></FluentTab>
         </FluentTabs>);
 
-        var attribute = cut.Find("fluent-tabs").GetAttribute("size");
+        var attribute = cut.Find("fluent-tablist").GetAttribute("size");
 
         // Assert
         Assert.Equal(expectedAttribute, attribute);
@@ -189,7 +190,7 @@
         var cut = Render(@<FluentTabs Width="100px" Height="200px"></FluentTabs>);
 
         // Assert
-        Assert.Equal("width: 100px; height: 200px;", cut.Find("fluent-tabs").GetAttribute("style"));
+        Assert.Equal("width: 100px; height: 200px;", cut.Find(".fluent-tabs").GetAttribute("style"));
     }
 
     [Fact]
@@ -197,7 +198,7 @@
     {
         // Arrange && Act
         var cut = Render(@<FluentTabs>
-            <FluentTab>
+            <FluentTab Id="MyTab">
                 <HeaderTemplate>Tab <b>Name</b></HeaderTemplate>
                 <ChildContent>
                     Tab Content


### PR DESCRIPTION
# [dev-v5] Upgrade the `FluentTabs` to use `fluent-tablist`

The WebComponents team deprecate `tabs` in favor of `tablist`
https://github.com/microsoft/fluentui/pull/34206

1. No change in existing Blazor parameters
2. Update the Unit Tests to be 100%
3. Add a new Appearance example

https://github.com/user-attachments/assets/1810487f-2654-455b-a844-04572f6f1763

## Unit Tests

![{69F9F8DB-7D56-4112-A310-84FF295354C3}](https://github.com/user-attachments/assets/06deccfd-6204-4112-9476-873ed9c1469f)
