### PR TITLE
[dev-v5] Update the default class value from `my-3` to `my-3-o`

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Field/FluentField.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Field/FluentField.md
@@ -34,7 +34,7 @@ This label can be fully customized (bold, italic, icons, ...) using `LabelTempla
 
 {{ FieldLabelExample }}
 
-> By default, the `my-3` class is added to all `FluentField`
+> By default, the `my-3-o`, an overridable "my-3" class, is added to all `FluentField`
 > that contain at least one `Label` or `Message`,
 > to add `12px` before (top) and after (bottom) the field.
 > This will automatically make all your form fields **24px** apart,

--- a/src/Core/Components/Field/FluentField.razor.css
+++ b/src/Core/Components/Field/FluentField.razor.css
@@ -1,3 +1,8 @@
+.my-3-o {
+  margin-bottom: var(--spacingVerticalM);
+  margin-top: var(--spacingVerticalM);
+}
+
 fluent-field[label-position='before'] > fluent-label[slot='label'] {
   margin-top: 8px;
   align-self: flex-start;

--- a/src/Core/Infrastructure/DefaultStyles.cs
+++ b/src/Core/Infrastructure/DefaultStyles.cs
@@ -18,9 +18,9 @@ public class DefaultStyles
 
     /// <summary>
     /// Gets or sets the default CSS class for the FluentField component, used with all the input components.
-    /// The default value is "mt-6". Spacing between text fields and other components is 24 pixels.
+    /// The default value is "my-3-o", an overridable "my-3" class. Spacing between text fields and other components is 24 pixels.
     /// </summary>
-    public string? FluentFieldClass { get; set; } = "my-3";
+    public string? FluentFieldClass { get; set; } = "my-3-o";
 
     /// <summary>
     /// Gets or sets the gap between vertically stacked components.

--- a/src/Core/Infrastructure/DefaultStyles.cs
+++ b/src/Core/Infrastructure/DefaultStyles.cs
@@ -18,7 +18,7 @@ public class DefaultStyles
 
     /// <summary>
     /// Gets or sets the default CSS class for the FluentField component, used with all the input components.
-    /// The default value is "my-3-o", an overridable "my-3" class. Spacing between text fields and other components is 24 pixels.
+    /// The default value is "my-3-o", an overridable "my-3" class. Spacing between text fields and other components is 12 pixels.
     /// </summary>
     public string? FluentFieldClass { get; set; } = "my-3-o";
 

--- a/tests/Core/Components/Checkbox/FluentCheckboxTests.FluentCheckbox_LabelTemplate.verified.razor.html
+++ b/tests/Core/Components/Checkbox/FluentCheckboxTests.FluentCheckbox_LabelTemplate.verified.razor.html
@@ -1,5 +1,5 @@
 
-<fluent-field id="xxx" label-position="after" class="my-3">
+<fluent-field id="xxx" label-position="after" class="my-3-o">
   <label id="xxx" slot="label" for="xxx">Title
   </label>
   <fluent-checkbox checked="false" indeterminate="false" id="xxx" blazor:onfocusout="1" blazor:onchange="2" slot="input" blazor:elementreference="xxx"></fluent-checkbox>

--- a/tests/Core/Components/Field/FluentFieldTests.FluentField_Default.verified.razor.html
+++ b/tests/Core/Components/Field/FluentFieldTests.FluentField_Default.verified.razor.html
@@ -1,5 +1,5 @@
 
-<fluent-field label-position="above" class="my-3">
+<fluent-field label-position="above" class="my-3-o">
   <label slot="label" for="xxx">My label
   </label>
   <div slot="input" id="xxx">Field content</div>

--- a/tests/Core/Components/Field/FluentFieldTests.FluentField_DefaultTemplate.verified.razor.html
+++ b/tests/Core/Components/Field/FluentFieldTests.FluentField_DefaultTemplate.verified.razor.html
@@ -1,5 +1,5 @@
 
-<fluent-field label-position="above" class="my-3">
+<fluent-field label-position="above" class="my-3-o">
   <label slot="label" for="xxx">
     My
     <b>label</b>

--- a/tests/Core/Components/Field/FluentFieldTests.FluentField_MessageIcon.verified.razor.html
+++ b/tests/Core/Components/Field/FluentFieldTests.FluentField_MessageIcon.verified.razor.html
@@ -1,5 +1,5 @@
 
-<fluent-field label-position="above" class="my-3">
+<fluent-field label-position="above" class="my-3-o">
   <div slot="input" id="xxx">Field content</div>
   <fluent-text as="span" size="200" slot="message">
     <svg style="margin: 0px 4px 0px 0px; width: 12px;" focusable="false" viewBox="0 0 24 24" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">

--- a/tests/Core/Components/Field/FluentFieldTests.FluentField_MessageState-99.verified.razor.html
+++ b/tests/Core/Components/Field/FluentFieldTests.FluentField_MessageState-99.verified.razor.html
@@ -1,5 +1,5 @@
 
-<fluent-field label-position="above" class="my-3">
+<fluent-field label-position="above" class="my-3-o">
   <div slot="input" id="xxx">Field content</div>
   <fluent-text as="span" size="200" slot="message"></fluent-text>
 </fluent-field>

--- a/tests/Core/Components/Field/FluentFieldTests.FluentField_MessageState-error.verified.razor.html
+++ b/tests/Core/Components/Field/FluentFieldTests.FluentField_MessageState-error.verified.razor.html
@@ -1,5 +1,5 @@
 
-<fluent-field label-position="above" class="my-3">
+<fluent-field label-position="above" class="my-3-o">
   <div slot="input" id="xxx">Field content</div>
   <fluent-text as="span" size="200" slot="message">
     <svg style="margin: 0px 4px 0px 0px; width: 12px; fill: var(--error);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">

--- a/tests/Core/Components/Field/FluentFieldTests.FluentField_MessageState-success.verified.razor.html
+++ b/tests/Core/Components/Field/FluentFieldTests.FluentField_MessageState-success.verified.razor.html
@@ -1,5 +1,5 @@
 
-<fluent-field label-position="above" class="my-3">
+<fluent-field label-position="above" class="my-3-o">
   <div slot="input" id="xxx">Field content</div>
   <fluent-text as="span" size="200" slot="message">
     <svg style="margin: 0px 4px 0px 0px; width: 12px; fill: var(--success);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">

--- a/tests/Core/Components/Field/FluentFieldTests.FluentField_MessageState-warning.verified.razor.html
+++ b/tests/Core/Components/Field/FluentFieldTests.FluentField_MessageState-warning.verified.razor.html
@@ -1,5 +1,5 @@
 
-<fluent-field label-position="above" class="my-3">
+<fluent-field label-position="above" class="my-3-o">
   <div slot="input" id="xxx">Field content</div>
   <fluent-text as="span" size="200" slot="message">
     <svg style="margin: 0px 4px 0px 0px; width: 12px; fill: var(--warning);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">

--- a/tests/Core/Components/Field/FluentFieldTests.FluentField_Size-99.verified.razor.html
+++ b/tests/Core/Components/Field/FluentFieldTests.FluentField_Size-99.verified.razor.html
@@ -1,5 +1,5 @@
 
-<fluent-field label-position="above" class="my-3" size="">
+<fluent-field label-position="above" class="my-3-o" size="">
   <label slot="label" for="xxx">My label
   </label>
   <div slot="input" id="xxx">Field content</div>

--- a/tests/Core/Components/Field/FluentFieldTests.FluentField_Size-[empty].verified.razor.html
+++ b/tests/Core/Components/Field/FluentFieldTests.FluentField_Size-[empty].verified.razor.html
@@ -1,5 +1,5 @@
 
-<fluent-field label-position="above" class="my-3">
+<fluent-field label-position="above" class="my-3-o">
   <label slot="label" for="xxx">My label
   </label>
   <div slot="input" id="xxx">Field content</div>

--- a/tests/Core/Components/Field/FluentFieldTests.FluentField_Size-large.verified.razor.html
+++ b/tests/Core/Components/Field/FluentFieldTests.FluentField_Size-large.verified.razor.html
@@ -1,5 +1,5 @@
 
-<fluent-field label-position="above" class="my-3" size="large">
+<fluent-field label-position="above" class="my-3-o" size="large">
   <label slot="label" for="xxx">My label
   </label>
   <div slot="input" id="xxx">Field content</div>

--- a/tests/Core/Components/Field/FluentFieldTests.FluentField_Size-medium.verified.razor.html
+++ b/tests/Core/Components/Field/FluentFieldTests.FluentField_Size-medium.verified.razor.html
@@ -1,5 +1,5 @@
 
-<fluent-field label-position="above" class="my-3" size="medium">
+<fluent-field label-position="above" class="my-3-o" size="medium">
   <label slot="label" for="xxx">My label
   </label>
   <div slot="input" id="xxx">Field content</div>

--- a/tests/Core/Components/Field/FluentFieldTests.FluentField_Size-small.verified.razor.html
+++ b/tests/Core/Components/Field/FluentFieldTests.FluentField_Size-small.verified.razor.html
@@ -1,5 +1,5 @@
 
-<fluent-field label-position="above" class="my-3" size="small">
+<fluent-field label-position="above" class="my-3-o" size="small">
   <label slot="label" for="xxx">My label
   </label>
   <div slot="input" id="xxx">Field content</div>

--- a/tests/Core/Components/List/FluentComboboxTests.FluentCombobox_Label.verified.razor.html
+++ b/tests/Core/Components/List/FluentComboboxTests.FluentCombobox_Label.verified.razor.html
@@ -1,5 +1,5 @@
 
-<fluent-field id="xxx" label-position="above" class="my-3">
+<fluent-field id="xxx" label-position="above" class="my-3-o">
   <label id="xxx" slot="label" for="xxx" required="">List of digits
     <span class="asterisk" aria-hidden="true"></span>
   </label>

--- a/tests/Core/Components/List/FluentSelectTests.FluentSelect_Label.verified.razor.html
+++ b/tests/Core/Components/List/FluentSelectTests.FluentSelect_Label.verified.razor.html
@@ -1,5 +1,5 @@
 
-<fluent-field id="xxx" label-position="above" class="my-3">
+<fluent-field id="xxx" label-position="above" class="my-3-o">
   <label id="xxx" slot="label" for="xxx" required="">
     List of digits
     <span class="asterisk" aria-hidden="true"></span>

--- a/tests/Core/Components/Switch/FluentSwitchTests.FluentCheckbox_LabelTemplate.verified.razor.html
+++ b/tests/Core/Components/Switch/FluentSwitchTests.FluentCheckbox_LabelTemplate.verified.razor.html
@@ -1,5 +1,5 @@
 
-<fluent-field id="xxx" label-position="after" class="my-3">
+<fluent-field id="xxx" label-position="after" class="my-3-o">
   <label id="xxx" slot="label" for="xxx">
     Label with <b>bold</b> text
   </label>

--- a/tests/Core/Components/TextArea/FluentTextAreaTests.FluentTextArea_Default.verified.razor.html
+++ b/tests/Core/Components/TextArea/FluentTextAreaTests.FluentTextArea_Default.verified.razor.html
@@ -1,4 +1,4 @@
-<fluent-field id="xxx" label-position="above" class="my-3">
+<fluent-field id="xxx" label-position="above" class="my-3-o">
     <label id="xxx" slot="label" for="xxx">
         My Label
     </label>

--- a/tests/Core/Components/TextArea/FluentTextAreaTests.FluentTextArea_LabelTemplate.verified.razor.html
+++ b/tests/Core/Components/TextArea/FluentTextAreaTests.FluentTextArea_LabelTemplate.verified.razor.html
@@ -1,5 +1,5 @@
 
-<fluent-field id="xxx" label-position="above" class="my-3">
+<fluent-field id="xxx" label-position="above" class="my-3-o">
   <label id="xxx" slot="label" for="xxx">
     <div style="font-weight: bold;">My label</div>
   </label>

--- a/tests/Core/Components/TextInput/FluentTextInputTests.FluentInputText_Default.verified.razor.html
+++ b/tests/Core/Components/TextInput/FluentTextInputTests.FluentInputText_Default.verified.razor.html
@@ -1,5 +1,5 @@
 
-<fluent-field id="xxx" label-position="above" class="my-3">
+<fluent-field id="xxx" label-position="above" class="my-3-o">
   <label id="xxx" slot="label" for="xxx">
     My Label
   </label>

--- a/tests/Core/Components/TextInput/FluentTextInputTests.FluentInputText_LabelTemplate.verified.razor.html
+++ b/tests/Core/Components/TextInput/FluentTextInputTests.FluentInputText_LabelTemplate.verified.razor.html
@@ -1,5 +1,5 @@
 
-<fluent-field id="xxx" label-position="above" class="my-3">
+<fluent-field id="xxx" label-position="above" class="my-3-o">
   <label id="xxx" slot="label" for="xxx">
     <div style="font-weight: bold;">My label</div>
   </label>


### PR DESCRIPTION
# [dev-v5] Update the default class value from `my-3` to `my-3-o`

To allow the default margins of the **FluentField** component to be redefined, 
the `my-3-o` class has been defined (identical to `my-3` but without the `important`).

## Unit Tests

Updated: `my-3` -> `my-3-o`