### PR TITLE
[Templates] Fix overwriting standard Blazor Hybrid template

### DIFF
--- a/src/Templates/templates/maui-blazor-solution/.template.config/template.json
+++ b/src/Templates/templates/maui-blazor-solution/.template.config/template.json
@@ -3,7 +3,7 @@
   "author": "Microsoft",
   "classifications": [ "MAUI", "Android", "iOS", "macOS", "Mac Catalyst", "Windows", "Tizen", "Blazor", "Blazor Hybrid", "Mobile", "Fluent" ],
   "identity": "Microsoft.Maui.Fluent.BlazorSolution.CSharp.9.0",
-  "groupIdentity": "Microsoft.Maui.BlazorSolution",
+  "groupIdentity": "Microsoft.Maui.Fluent.BlazorSolution",
   "precedence": "9004",
   "name": "Fluent .NET MAUI Blazor Hybrid and Web App",
   "description": "A multi-project app for creating a .NET MAUI Fluent Blazor Hybrid application with a Blazor Web project with a shared user interface, using the Fluent UI Blazor components.",


### PR DESCRIPTION
Fix #3667by changing the `groupIdentity` in the `template.json` file from `Microsoft.Maui.BlazorSolution` to `Microsoft.Maui.Fluent.BlazorSolution`.