### PR TITLE
[dev-v5] Add `FluentField.IncludeInputSlot` parameter

### DIFF
--- a/src/Core/Components/Field/FluentField.razor
+++ b/src/Core/Components/Field/FluentField.razor
@@ -28,7 +28,7 @@
 
     @if (ChildContent is not null)
     {
-        @if (Parameters.HasInputComponent)
+        @if (Parameters.HasInputComponent || !IncludeInputSlot)
         {
             @ChildContent
         }

--- a/src/Core/Components/Field/FluentField.razor.cs
+++ b/src/Core/Components/Field/FluentField.razor.cs
@@ -74,7 +74,14 @@ public partial class FluentField : FluentComponentBase, IFluentField
     public bool? Disabled { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the <see cref="ChildContent" /> should be rendered in an extra `div slot="input"`.
+    /// </summary>
+    [Parameter]
+    public bool IncludeInputSlot { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets the child content of the field.
+    /// ⚠️ If the <see cref="InputComponent"/> is not set, you must set the `id="@Id"` and `slot="@FluentSlot.FieldInput"` parameters in YOUR input component.
     /// </summary>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }

--- a/tests/Core/Components/Field/FluentFieldTests.razor
+++ b/tests/Core/Components/Field/FluentFieldTests.razor
@@ -201,4 +201,21 @@
 
 
     }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void FluentField_IncludeInputSlot(bool withInputSlot)
+    {
+        // Arrange & Act
+        var cut = Render(@<FluentField Id="MyField" IncludeInputSlot="@withInputSlot">Field content</FluentField>);
+
+        // Act
+        var hasContent = cut.Markup.Contains(">Field content<");
+        var hasSlot = cut.Markup.Contains("<div slot=\"input\" id=\"MyField-input\">Field content</div>");
+
+        // Assert
+        Assert.True(hasContent);
+        Assert.Equal(withInputSlot, hasSlot);
+    }
 }


### PR DESCRIPTION
# [dev-v5] Add `FluentField.IncludeInputSlot` parameter

Add the `IncludeInputSlot` parameter to NOT insert a `<div slot="input" id="...">` automatically,
If the `InputComponent` is not set, you must set the `id="@Id"` and `slot="@FluentSlot.FieldInput"` parameters in YOUR input component; And next switch the  `IncludeInputSlot=false`.


```csharp
/// <summary>
/// Gets or sets a value indicating whether the <see cref="ChildContent" /> should be rendered in an extra `div slot="input"`.
/// </summary>
[Parameter]
public bool IncludeInputSlot { get; set; } = true;

/// <summary>
/// Gets or sets the child content of the field.
/// ⚠️ If the <see cref="InputComponent"/> is not set, you must set the `id="@Id"` and `slot="@FluentSlot.FieldInput"` parameters in YOUR input component.
/// </summary>
[Parameter]
public RenderFragment? ChildContent { get; set; }
```

## Unit Tests

Added