### PR TITLE
[Tabs] 

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,8 +12,8 @@
     <SolutionDir>$(MSBuildThisFileDirectory)</SolutionDir>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
 
-    <VersionFile>4.11.8</VersionFile>
-    <VersionPrefix>4.11.8</VersionPrefix>
+    <VersionFile>4.11.9</VersionFile>
+    <VersionPrefix>4.11.9</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <AssemblyVersion>$(VersionFile)</AssemblyVersion>
     <FileVersion>$(VersionFile)</FileVersion>

--- a/eng/pipelines/version.yml
+++ b/eng/pipelines/version.yml
@@ -2,5 +2,5 @@ variables:
   # File and Package version
   # dev  branch: 1.2.4-Preview-23282-1'    (PackageSuffix is always ignored in Dev branch)
   # main branch: 1.2.4-RC.1'               (PackageSuffix is ignored, if empty, in Main branch)
-  FileVersion: '4.11.8'   # Set the next final version here.
+  FileVersion: '4.11.9'   # Set the next final version here.
   PackageSuffix: ''

--- a/src/Core/Components/Overflow/OverflowItem.cs
+++ b/src/Core/Components/Overflow/OverflowItem.cs
@@ -1,3 +1,7 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 /// <summary />

--- a/src/Core/Components/Tabs/FluentTabs.razor.cs
+++ b/src/Core/Components/Tabs/FluentTabs.razor.cs
@@ -137,6 +137,7 @@ public partial class FluentTabs : FluentComponentBase
     /// </summary>
     public IEnumerable<FluentTab> TabsOverflow => _tabs.Where(i => i.Overflow == true);
 
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(OverflowItem))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(TabChangeEventArgs))]
 
     public FluentTabs()


### PR DESCRIPTION
Fix issue #3591 by placing the `DynamicDependency` attribute on `FluentTabs`. Earlier it was tried to solve this by pacing the `DynamicDependency` on `FluentOverflow`. That was insufficient and did not fix the issue.

![image](https://github.com/user-attachments/assets/9132f5f1-21ff-4f86-828a-90bdcd781075)

As part of this PR the version number has also been adjusted to in preparation of the next version
