### PR TITLE
[DOCS] - Clarify FluentSelect SelectedOptionsChanged not triggered with manual options (#3670 and #1207)

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -6131,6 +6131,13 @@
             Gets or sets the maximum number of options that should be visible in the listbox scroll area.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentListbox`1.SelectedOptionsChanged">
+            <summary>
+            Called whenever the selection changed.
+            ⚠️ Only available when Multiple = true.
+            ⚠️ When using manual options, the internal data structure cannot be updated reliably, because of this, the SelectedOptionsChanged event will not be triggered.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentListbox`1.BorderStyle">
             <summary />
         </member>
@@ -6269,6 +6276,13 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentSelect`1.Appearance">
             <summary>
             Gets or sets the visual appearance. See <seealso cref="T:Microsoft.FluentUI.AspNetCore.Components.Appearance"/>
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentSelect`1.SelectedOptionsChanged">
+            <summary>
+            Called whenever the selection changed.
+            ⚠️ Only available when Multiple = true.
+            ⚠️ When using manual options, the internal data structure cannot be updated reliably, because of this, the SelectedOptionsChanged event will not be triggered.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.InternalListContext`1.Options">

--- a/src/Core/Components/List/FluentListbox.razor.cs
+++ b/src/Core/Components/List/FluentListbox.razor.cs
@@ -12,6 +12,14 @@ public partial class FluentListbox<TOption> : ListComponentBase<TOption> where T
     [Parameter]
     public int Size { get; set; }
 
+    /// <summary>
+    /// Called whenever the selection changed.
+    /// ⚠️ Only available when Multiple = true.
+    /// ⚠️ When using manual options, the internal data structure cannot be updated reliably, because of this, the SelectedOptionsChanged event will not be triggered.
+    /// </summary>
+    [Parameter]
+    public override EventCallback<IEnumerable<TOption>?> SelectedOptionsChanged { get; set; }
+
     /// <summary />
     protected virtual StyleBuilder BorderStyle => new StyleBuilder()
         .AddStyle("width", Width, when: !string.IsNullOrEmpty(Width))

--- a/src/Core/Components/List/FluentSelect.razor.cs
+++ b/src/Core/Components/List/FluentSelect.razor.cs
@@ -50,6 +50,14 @@ public partial class FluentSelect<TOption> : ListComponentBase<TOption> where TO
     [Parameter]
     public Appearance? Appearance { get; set; }
 
+    /// <summary>
+    /// Called whenever the selection changed.
+    /// ⚠️ Only available when Multiple = true.
+    /// ⚠️ When using manual options, the internal data structure cannot be updated reliably, because of this, the SelectedOptionsChanged event will not be triggered.
+    /// </summary>
+    [Parameter]
+    public override EventCallback<IEnumerable<TOption>?> SelectedOptionsChanged { get; set; }
+
     private string? GetAriaLabelWithRequired()
     {
 #pragma warning disable CS0618 // Type or member is obsolete


### PR DESCRIPTION
## Clarify FluentSelect SelectedOptionsChanged not triggered with manual options (#3670 and #1207)

## 📖 Description

This PR improves the documentation of the `FluentSelect` component by adding a clarification about the `SelectedOptionsChanged` event.

When using manual options, FluentSelect's internal data structure cannot be reliably updated. Because of that, the `SelectedOptionsChanged` callback will not be triggered.  
This is a known limitation, and we do not foresee changes to this behavior in the short term.

### 🎫 Issues

Fixes #3670 and #1207

## 📑 Test Plan

- Validated that the updated note appears correctly in the FluentSelect documentation page.
- Confirmed that no visual or structural issues were introduced.

Updated documentation:

![Preview](https://github.com/user-attachments/assets/b4aba401-5f5f-4f37-b36a-af53a9942de8)

Let me know if you’d like me to include any additional details.

Thanks!
