### PR TITLE
[Menu] Account for screen width and height when positioning menu

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -6682,12 +6682,14 @@
             </summary>
             <returns></returns>
         </member>
-        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentMenu.OpenAsync(System.Int32,System.Int32)">
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentMenu.OpenAsync(System.Int32,System.Int32,System.Int32,System.Int32)">
             <summary>
-            Method called from JavaScript to get the current mouse ccordinates.
+            Method called from JavaScript to get the current mouse coordinates.
             </summary>
-            <param name="x"></param>
-            <param name="y"></param>
+            <param name="x">x-coordinate of point clicked on</param>
+            <param name="y">y-coordinate of point clicked on</param>
+            <param name="screenWidth">width of the screen</param>
+            <param name="screenHeight">height of the screen</param>
             <returns></returns>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentMenu.DrawMenuWithoutService">

--- a/examples/Demo/Shared/wwwroot/css/site.css
+++ b/examples/Demo/Shared/wwwroot/css/site.css
@@ -1,4 +1,4 @@
-@import '_content/Microsoft.FluentUI.AspNetCore.Components/css/reboot.css';
+@import '/_content/Microsoft.FluentUI.AspNetCore.Components/css/reboot.css';
 
 body {
     height: 100%;

--- a/src/Core/Components/Menu/FluentMenu.razor.js
+++ b/src/Core/Components/Menu/FluentMenu.razor.js
@@ -3,7 +3,7 @@ export function addEventLeftClick(id, dotNetHelper) {
     var item = document.getElementById(id);
     if (!!item) {
         item.addEventListener("click", function(e) {
-            dotNetHelper.invokeMethodAsync('OpenAsync', e.clientX, e.clientY);
+            dotNetHelper.invokeMethodAsync('OpenAsync', window.innerWidth, window.innerHeight, e.clientX, e.clientY);
         });
     }
 }
@@ -14,7 +14,7 @@ export function addEventRightClick(id, dotNetHelper) {
     if (!!item) {
         item.addEventListener('contextmenu', function (e) {
             e.preventDefault();
-            dotNetHelper.invokeMethodAsync('OpenAsync', e.clientX, e.clientY);
+            dotNetHelper.invokeMethodAsync('OpenAsync', window.innerWidth, window.innerHeight, e.clientX, e.clientY);
             return false;
         }, false);
     }


### PR DESCRIPTION
Position menu not just based on x and y but also take screen width and height into account.

**Before:**
![image](https://github.com/user-attachments/assets/92fb8e4f-25de-406b-b15d-c7c3f7c5868d)

**After:**
![image](https://github.com/user-attachments/assets/6d6fb51f-57e3-44ee-a41f-a1e6d46a2284)

Based on changes made in Aspire. Thanks @JamesNK!

Fix #3660 