### PR TITLE
[Tooltip] Add AdditionalProperties when using TooltipService

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -3198,6 +3198,11 @@
             Gets or sets a value indicating whether the tooltip is visible.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.Components.Tooltip.TooltipOptions.AdditionalAttributes">
+            <summary>
+            Gets or sets a collection of additional attributes that will be applied to the created element.
+            </summary>
+        </member>
         <member name="T:Microsoft.FluentUI.AspNetCore.Components.Components.Tooltip.TooltipService">
             <inheritdoc cref="T:Microsoft.FluentUI.AspNetCore.Components.Components.Tooltip.ITooltipService"/>
         </member>

--- a/examples/Demo/Shared/Pages/Tooltip/Examples/TooltipDefault.razor
+++ b/examples/Demo/Shared/Pages/Tooltip/Examples/TooltipDefault.razor
@@ -2,7 +2,7 @@
 
 <FluentTooltip Anchor="myFirstButton" OnDismissed="OnDismiss">
     Hello World <br />
-    It is a <i>small</i> tootip.
+    It is a <i>small</i> tooltip.
 </FluentTooltip>
 
 @code {

--- a/src/Core/Components/Tooltip/FluentTooltip.razor
+++ b/src/Core/Components/Tooltip/FluentTooltip.razor
@@ -15,7 +15,7 @@
                     vertical-viewport-lock="@VerticalViewportLock"
                     role="tooltip"
                     @ontooltipdismiss="HandleDismissed"
-                    @attributes="AdditionalAttributes">
+                    @attributes="@AdditionalAttributes">
         @if (string.IsNullOrWhiteSpace(MaxWidth ?? GlobalOptions?.MaxWidth))
         {
             @ChildContent

--- a/src/Core/Components/Tooltip/FluentTooltip.razor.cs
+++ b/src/Core/Components/Tooltip/FluentTooltip.razor.cs
@@ -1,3 +1,7 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.FluentUI.AspNetCore.Components.Components.Tooltip;
@@ -69,7 +73,7 @@ public partial class FluentTooltip : FluentComponentBase, IDisposable
     public string Anchor { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets the delay (in milliseconds). 
+    /// Gets or sets the delay (in milliseconds).
     /// Default is 300.
     /// </summary>
     [Parameter]
@@ -116,7 +120,7 @@ public partial class FluentTooltip : FluentComponentBase, IDisposable
 
     /// <summary>
     /// Callback for when the tooltip is dismissed.
-    /// </summary>  
+    /// </summary>
     [Parameter]
     public EventCallback<EventArgs> OnDismissed { get; set; }
 
@@ -136,7 +140,7 @@ public partial class FluentTooltip : FluentComponentBase, IDisposable
     /// <summary />
     protected override void OnInitialized()
     {
-        HideTooltipOnCursorLeave = HideTooltipOnCursorLeave ?? LibraryConfiguration?.HideTooltipOnCursorLeave;
+        HideTooltipOnCursorLeave ??= LibraryConfiguration?.HideTooltipOnCursorLeave;
         _tooltipService = ServiceProvider?.GetService<ITooltipService>();
 
         if (TooltipService != null && UseTooltipService)
@@ -151,6 +155,7 @@ public partial class FluentTooltip : FluentComponentBase, IDisposable
                 Position = Position,
                 OnDismissed = OnDismissed,
                 Visible = Visible,
+                AdditionalAttributes = AdditionalAttributes,
             });
         }
     }

--- a/src/Core/Components/Tooltip/FluentTooltipProvider.razor
+++ b/src/Core/Components/Tooltip/FluentTooltipProvider.razor
@@ -12,7 +12,10 @@
                            Delay="@item.Delay"
                            Position="@item.Position"
                            OnDismissed="@item.OnDismissed"
-                           UseTooltipService="false">@item.ChildContent</FluentTooltip>
+                           UseTooltipService="false"
+                           AdditionalAttributes="@item.AdditionalAttributes">
+                @item.ChildContent
+            </FluentTooltip>
         }
     }
 </div>

--- a/src/Core/Components/Tooltip/Services/TooltipOptions.cs
+++ b/src/Core/Components/Tooltip/Services/TooltipOptions.cs
@@ -1,3 +1,7 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
 using Microsoft.AspNetCore.Components;
 
 namespace Microsoft.FluentUI.AspNetCore.Components.Components.Tooltip;
@@ -31,24 +35,25 @@ public class TooltipOptions
     /// Gets or sets the delay (in milliseconds). 
     /// Default is 300.
     /// </summary>
-    [Parameter]
     public int? Delay { get; set; } = TooltipGlobalOptions.DefaultDelay;
 
     /// <summary>
     /// Gets or sets the tooltip's position. See <see cref="TooltipPosition"/>.
     /// </summary>
-    [Parameter]
     public TooltipPosition? Position { get; set; }
 
     /// <summary>
     /// Callback for when the tooltip is dismissed.
     /// </summary>  
-    [Parameter]
     public EventCallback<EventArgs> OnDismissed { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the tooltip is visible.
     /// </summary>
-    [Parameter]
     public bool Visible { get; set; }
+
+    /// <summary>
+    /// Gets or sets a collection of additional attributes that will be applied to the created element.
+    /// </summary>
+    public virtual IReadOnlyDictionary<string, object>? AdditionalAttributes { get; set; }
 }

--- a/src/Core/Components/Tooltip/Services/TooltipService.cs
+++ b/src/Core/Components/Tooltip/Services/TooltipService.cs
@@ -1,3 +1,7 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
 namespace Microsoft.FluentUI.AspNetCore.Components.Components.Tooltip;
 
 /// <inheritdoc cref="ITooltipService"/>
@@ -44,7 +48,7 @@ public class TooltipService : ITooltipService, IDisposable
     }
 
     /// <summary />
-    private IList<TooltipOptions> TooltipList { get; } = new List<TooltipOptions>();
+    private List<TooltipOptions> TooltipList { get; } = [];
 
     /// <summary />
     private ReaderWriterLockSlim TooltipLock { get; } = new ReaderWriterLockSlim();


### PR DESCRIPTION
This PR adds the `AdditionalAttributes` property to the `TooltipOptions` class in the `Microsoft.FluentUI.AspNetCore.Components.Components.Tooltip` namespace. This property allows users to set a collection of additional attributes that will be applied to the created element even when using the TooltipService. 

Fix #3689 