### PR TITLE
[General] Add missing try..catch in DisposeAsync

### DIFF
--- a/src/Core/Components/List/FluentCombobox.razor.cs
+++ b/src/Core/Components/List/FluentCombobox.razor.cs
@@ -177,11 +177,20 @@ public partial class FluentCombobox<TOption> : ListComponentBase<TOption>, IAsyn
 
     public new async ValueTask DisposeAsync()
     {
-        if (Module is not null && !string.IsNullOrEmpty(Id))
+        try
         {
-            await Module.InvokeVoidAsync("detachIndicatorClickHandler", Id);
-            await Module.DisposeAsync();
+            if (Module is not null && !string.IsNullOrEmpty(Id))
+            {
+                await Module.InvokeVoidAsync("detachIndicatorClickHandler", Id);
+                await Module.DisposeAsync();
+            }
+            await base.DisposeAsync();
         }
-        await base.DisposeAsync();
+        catch (Exception ex) when (ex is JSDisconnectedException ||
+                                   ex is OperationCanceledException)
+        {
+            // The JSRuntime side may routinely be gone already if the reason we're disposing is that
+            // the client disconnected. This is not an error.
+        }
     }
 }

--- a/src/Core/Components/Overlay/FluentOverlay.razor.cs
+++ b/src/Core/Components/Overlay/FluentOverlay.razor.cs
@@ -266,11 +266,21 @@ public partial class FluentOverlay : IAsyncDisposable
     /// <returns></returns>
     public async ValueTask DisposeAsync()
     {
-        await InvokeOverlayDisposeAsync();
-
-        if (_jsModule != null)
+        try
         {
-            await _jsModule.DisposeAsync();
+            await InvokeOverlayDisposeAsync();
+
+            if (_jsModule != null)
+            {
+                await _jsModule.DisposeAsync();
+            }
+
+        }
+        catch (Exception ex) when (ex is JSDisconnectedException ||
+                                   ex is OperationCanceledException)
+        {
+            // The JSRuntime side may routinely be gone already if the reason we're disposing is that
+            // the client disconnected. This is not an error.
         }
 
         GlobalState.OnChange -= UpdateNeutralColor;


### PR DESCRIPTION
Both `FluentCombobox` and `FluentOverflow` were missing try...catch blocks in their `DisposeAsync` methods.

Fix #3697 