### PR TITLE
[FluentAssertions] Remove the FluentAssertions lib

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,6 @@
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="4.11.7" />
     <!-- Test dependencies -->
     <PackageVersion Include="bunit" Version="1.38.5" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />

--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -10128,7 +10128,7 @@
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentTooltip.Delay">
             <summary>
-            Gets or sets the delay (in milliseconds). 
+            Gets or sets the delay (in milliseconds).
             Default is 300.
             </summary>
         </member>
@@ -10168,7 +10168,7 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentTooltip.OnDismissed">
             <summary>
             Callback for when the tooltip is dismissed.
-            </summary>  
+            </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentTooltip.DrawTooltip">
             <summary />

--- a/tests/Core/Anchor/FluentAnchorTests.cs
+++ b/tests/Core/Anchor/FluentAnchorTests.cs
@@ -1,5 +1,4 @@
 using Bunit;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -148,11 +147,10 @@ public partial class FluentAnchorTests : TestContext
         // Assert
         if (target == "invalid")
         {
-            action.Should().Throw<ArgumentException>();
+            Assert.Throws< ArgumentException>(action);
         }
         else
         {
-            action.Should().NotThrow();
             cut!.Verify(suffix: target);
         }
     }

--- a/tests/Core/Badge/FluentBadgeTests.cs
+++ b/tests/Core/Badge/FluentBadgeTests.cs
@@ -1,5 +1,5 @@
 using Bunit;
-using FluentAssertions;
+
 using Xunit;
 
 namespace Microsoft.FluentUI.AspNetCore.Components.Tests.Badge;
@@ -42,11 +42,10 @@ public partial class FluentBadgeTests : TestContext
         // Assert
         if (appearance == Appearance.Hypertext)
         {
-            action.Should().Throw<ArgumentException>();
+            Assert.Throws<ArgumentException>(action);
         }
         else
         {
-            action.Should().NotThrow();
             cut!.Verify(suffix: appearance.ToString());
         }
     }
@@ -69,7 +68,7 @@ public partial class FluentBadgeTests : TestContext
         };
 
         // Assert
-        action.Should().ThrowExactly<ArgumentException>();
+        Assert.Throws<ArgumentException>(action);
     }
 
     [Fact]

--- a/tests/Core/Breadcrumb/FluentBreadcrumbItemTests.cs
+++ b/tests/Core/Breadcrumb/FluentBreadcrumbItemTests.cs
@@ -1,5 +1,5 @@
 using Bunit;
-using FluentAssertions;
+
 using Xunit;
 
 namespace Microsoft.FluentUI.AspNetCore.Components.Tests.Breadcrumb;
@@ -133,11 +133,10 @@ public class FluentBreadcrumbItemTests : TestBase
         // Assert
         if (targetAttribute == "invalid")
         {
-            action.Should().Throw<ArgumentException>();
+            Assert.Throws<ArgumentException>(action);
         }
         else
         {
-            action.Should().NotThrow();
             cut!.Verify(suffix: targetAttribute);
         }
     }

--- a/tests/Core/Button/FluentButtonTests.cs
+++ b/tests/Core/Button/FluentButtonTests.cs
@@ -1,5 +1,5 @@
 using Bunit;
-using FluentAssertions;
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.FluentUI.AspNetCore.Components.Tests.Extensions;
 using Xunit;
@@ -165,7 +165,7 @@ public partial class FluentButtonTests : TestContext
         };
 
         // Assert
-        action.Should().Throw<ArgumentException>();
+        Assert.Throws<ArgumentException>(action);
     }
 
     [Theory]

--- a/tests/Core/DataGrid/DataGridSortByTests.razor
+++ b/tests/Core/DataGrid/DataGridSortByTests.razor
@@ -1,5 +1,4 @@
 ﻿@using Bunit
-@using FluentAssertions
 @using Xunit
 
 @inherits TestContext

--- a/tests/Core/DataGrid/FluentDataGridTests.razor
+++ b/tests/Core/DataGrid/FluentDataGridTests.razor
@@ -1,5 +1,4 @@
-﻿@using FluentAssertions
-@using Xunit
+﻿@using Xunit
 @inherits TestContext
 
 @code {
@@ -43,14 +42,14 @@
             </FluentDataGrid>);
 
         // Assert
-        cut.Find("#loading-content").Should().NotBeNull();
+        Assert.NotNull(cut.Find("#loading-content"));
         Assert.Throws<ElementNotFoundException>(() => cut.Find("#empty-content"));
 
         cut.SetParametersAndRender(parameters => parameters
             .Add(p => p.Loading, false));
 
         Assert.Throws<ElementNotFoundException>(() => cut.Find("#loading-content"));
-        cut.Find("#empty-content").Should().NotBeNull();
+        Assert.NotNull(cut.Find("#empty-content"));
     }
 
     [Fact]
@@ -76,17 +75,17 @@
 
         // Assert
         var dataGrid = cut.Instance;
-        cut.Find("#loading-content").Should().NotBeNull();
+        Assert.NotNull(cut.Find("#loading-content"));
 
         // should stay loading even after data refresh
         await cut.InvokeAsync(() => dataGrid.RefreshDataAsync());
-        cut.Find("#loading-content").Should().NotBeNull();
+        Assert.NotNull(cut.Find("#loading-content"));
 
         // now not loading but still with 0 items, should render empty content
         cut.SetParametersAndRender(parameters => parameters
             .Add(p => p.Loading, false));
 
-        cut.Find("#empty-content").Should().NotBeNull();
+        Assert.NotNull(cut.Find("#empty-content"));
     }
 
     [Fact]
@@ -117,7 +116,7 @@
         var dataGrid = cut.Instance;
 
         // Data is still loading, so loading content should be displayed
-        cut.Find("#loading-content").Should().NotBeNull();
+        Assert.NotNull(cut.Find("#loading-content"));
 
         tcs.SetResult();
 
@@ -136,7 +135,7 @@
         tcs = new TaskCompletionSource();
         cut.SetParametersAndRender(parameters => parameters
             .Add(p => p.Loading, null));
-        cut.Find("#loading-content").Should().NotBeNull();
+        Assert.NotNull(cut.Find("#loading-content"));
 
         tcs.SetResult();
 

--- a/tests/Core/DataGrid/GridSortTests.cs
+++ b/tests/Core/DataGrid/GridSortTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+
 using Xunit;
 
 namespace Microsoft.FluentUI.AspNetCore.Components.Tests.DataGrid;
@@ -22,9 +22,7 @@ public class GridSortTests : TestBase
         var sort = GridSort<GridRow>.ByAscending(x => x.Number);
         var ordered = sort.Apply(_gridData.AsQueryable(), ascending);
 
-        ordered.Select(x => x.Number)
-            .SequenceEqual(expected)
-            .Should().BeTrue();
+        Assert.True(ordered.Select(x => x.Number).SequenceEqual(expected));
     }
 
     [Theory]
@@ -38,9 +36,7 @@ public class GridSortTests : TestBase
 
         var ordered = sort.Apply(_gridData.AsQueryable(), ascending);
 
-        ordered.Select(x => x.Number)
-            .SequenceEqual(expected)
-            .Should().BeTrue();
+        Assert.True(ordered.Select(x => x.Number).SequenceEqual(expected));
     }
 
     [Theory]
@@ -54,9 +50,7 @@ public class GridSortTests : TestBase
 
         var ordered = sort.Apply(_gridData.AsQueryable(), ascending);
 
-        ordered.Select(x => x.Number)
-            .SequenceEqual(expected)
-            .Should().BeTrue();
+        Assert.True(ordered.Select(x => x.Number).SequenceEqual(expected));
     }
 
     [Theory]
@@ -70,9 +64,7 @@ public class GridSortTests : TestBase
 
         var ordered = sort.Apply(_gridData.AsQueryable(), ascending);
 
-        ordered.Select(x => x.Number)
-            .SequenceEqual(expected)
-            .Should().BeTrue();
+        Assert.True(ordered.Select(x => x.Number).SequenceEqual(expected));
     }
 
     [Theory]
@@ -86,9 +78,7 @@ public class GridSortTests : TestBase
 
         var ordered = sort.Apply(_gridData.AsQueryable(), ascending);
 
-        ordered.Select(x => x.Number)
-            .SequenceEqual(expected)
-            .Should().BeTrue();
+        Assert.True(ordered.Select(x => x.Number).SequenceEqual(expected));
     }
 
 #pragma warning restore CA1861 // Avoid constant arrays as arguments

--- a/tests/Core/FluentAssert.cs
+++ b/tests/Core/FluentAssert.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 using AngleSharp.Dom;
 using Bunit;
 using Bunit.Rendering;
-using FluentAssertions;
+
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.FluentUI.AspNetCore.Components.Tests;

--- a/tests/Core/List/FluentAutocompleteTests.razor
+++ b/tests/Core/List/FluentAutocompleteTests.razor
@@ -1,5 +1,4 @@
-﻿@using FluentAssertions
-@using Microsoft.FluentUI.AspNetCore.Components.Tests.Extensions
+﻿@using Microsoft.FluentUI.AspNetCore.Components.Tests.Extensions
 @using Xunit;
 @inherits TestContext
 @code
@@ -260,11 +259,11 @@
         var valueAttribute = textField.Attributes["value"];
         var currentValueAttribute = textField.Attributes["current-value"];
 
-        valueAttribute.Should().NotBeNull();
-        valueAttribute!.Value.Should().Be("Preselected value");
+        Assert.NotNull(valueAttribute);
+        Assert.Equal("Preselected value", valueAttribute!.Value);
 
-        currentValueAttribute.Should().NotBeNull();
-        currentValueAttribute!.Value.Should().Be("Preselected value");
+        Assert.NotNull(currentValueAttribute);
+        Assert.Equal("Preselected value", currentValueAttribute!.Value);
 
         cut.Verify();
     }
@@ -280,13 +279,13 @@
         parameters.Bind(p => p.ValueText, valueText, x => valueText = x);
     });
 
-        valueText.Should().NotBeNullOrEmpty();
+        Assert.False(string.IsNullOrEmpty(valueText));
 
         // Act
         cut.Find("svg").Click(); // Clear button
 
         // Assert
-        valueText.Should().BeNullOrEmpty();
+        Assert.True(string.IsNullOrEmpty(valueText));
 
         cut.Verify();
     }
@@ -305,7 +304,7 @@
         cut.Find("svg").Click(); // Clear button
 
         // Assert
-        cut.Find("fluent-anchored-region").Should().NotBeNull();
+        Assert.NotNull(cut.Find("fluent-anchored-region"));
         cut.Verify();
     }
 
@@ -324,7 +323,7 @@
         cut.Find("svg").Click(); // Clear button
 
         // Assert
-        cut.FindAll("fluent-anchored-region").Should().BeNullOrEmpty();
+        Assert.Empty(cut.FindAll("fluent-anchored-region"));
         cut.Verify();
     }
 

--- a/tests/Core/List/FluentListboxTests.razor
+++ b/tests/Core/List/FluentListboxTests.razor
@@ -1,5 +1,4 @@
-﻿@using FluentAssertions
-@using Microsoft.FluentUI.AspNetCore.Components.Tests.Extensions
+﻿@using Microsoft.FluentUI.AspNetCore.Components.Tests.Extensions
 @using Xunit;
 @inherits TestContext
 @code

--- a/tests/Core/List/FluentSelectTests.razor
+++ b/tests/Core/List/FluentSelectTests.razor
@@ -1,5 +1,4 @@
-﻿@using FluentAssertions
-@using Microsoft.FluentUI.AspNetCore.Components.Tests.Extensions
+﻿@using Microsoft.FluentUI.AspNetCore.Components.Tests.Extensions
 @using Xunit;
 @inherits TestContext
 @code

--- a/tests/Core/Microsoft.FluentUI.AspNetCore.Components.Tests.csproj
+++ b/tests/Core/Microsoft.FluentUI.AspNetCore.Components.Tests.csproj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="bunit" />
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/tests/Core/NumberField/FluentNumberFieldTests.cs
+++ b/tests/Core/NumberField/FluentNumberFieldTests.cs
@@ -1,5 +1,5 @@
 using Bunit;
-using FluentAssertions;
+
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -325,7 +325,7 @@ public class FluentNumberFieldTests : TestBase
         };
 
         // Assert
-        action.Should().Throw<ArgumentException>();
+        Assert.Throws<ArgumentException>(action);
     }
 
     [Theory]
@@ -348,7 +348,7 @@ public class FluentNumberFieldTests : TestBase
         };
 
         // Assert
-        action.Should().Throw<Exception>();
+        Assert.Throws<Exception>(action);
     }
 
     [Fact]
@@ -369,7 +369,7 @@ public class FluentNumberFieldTests : TestBase
         };
 
         // Assert
-        action.Should().Throw<ArgumentException>();
+        Assert.Throws<ArgumentException>(action);
     }
 
     [Fact]
@@ -390,7 +390,7 @@ public class FluentNumberFieldTests : TestBase
         };
 
         // Assert
-        action.Should().Throw<ArgumentException>();
+        Assert.Throws<ArgumentException>(action);
     }
 
     [Fact]
@@ -411,7 +411,7 @@ public class FluentNumberFieldTests : TestBase
         };
 
         // Assert
-        action.Should().Throw<ArgumentException>();
+        Assert.Throws<ArgumentException>(action);
     }
 
     [Fact]
@@ -431,7 +431,7 @@ public class FluentNumberFieldTests : TestBase
         };
 
         // Assert
-        action.Should().Throw<ArgumentException>();
+        Assert.Throws<ArgumentException>(action);
     }
 
     [Fact]
@@ -451,7 +451,7 @@ public class FluentNumberFieldTests : TestBase
         };
 
         // Assert
-        action.Should().Throw<ArgumentException>();
+        Assert.Throws<ArgumentException>(action);
     }
 
     [Fact]
@@ -471,7 +471,7 @@ public class FluentNumberFieldTests : TestBase
         };
 
         // Assert
-        action.Should().Throw<ArgumentException>();
+        Assert.Throws<ArgumentException>(action);
     }
 
     [Fact]
@@ -545,7 +545,7 @@ public class FluentNumberFieldTests : TestBase
         };
 
         // Assert
-        action.Should().Throw<ArgumentException>();
+        Assert.Throws<ArgumentException>(action);
     }
 
     [Fact]
@@ -566,7 +566,7 @@ public class FluentNumberFieldTests : TestBase
         };
 
         // Assert
-        action.Should().Throw<ArgumentException>();
+        Assert.Throws<ArgumentException>(action);
     }
 
     [Fact]

--- a/tests/Core/NumberField/FluentNumberFieldTests.cs
+++ b/tests/Core/NumberField/FluentNumberFieldTests.cs
@@ -348,7 +348,7 @@ public class FluentNumberFieldTests : TestBase
         };
 
         // Assert
-        Assert.Throws<Exception>(action);
+        Assert.Throws<FormatException>(action);
     }
 
     [Fact]


### PR DESCRIPTION
# [FluentAssertions] Remove the FluentAssertions lib

Remove the FluentAssertions lib and update the unit tests to use the default `Assert` keyword.

#3696