### PR TITLE
[a11y] Fix certain controls not adapting text spacing (#3692)

### DIFF
--- a/src/Core.Assets/src/index.ts
+++ b/src/Core.Assets/src/index.ts
@@ -66,7 +66,8 @@ fluent-text-field.invalid::part(root),
 }
 
 fluent-button::part(control),
-fluent-text-area::part(control)
+fluent-text-area::part(control),
+fluent-text-field::part(control)
 {
     letter-spacing: inherit;
 }

--- a/src/Core.Assets/src/index.ts
+++ b/src/Core.Assets/src/index.ts
@@ -65,6 +65,10 @@ fluent-text-field.invalid::part(root),
     outline: calc(var(--stroke-width) * 1px)  solid var(--error);
 }
 
+fluent-button::part(control)
+{
+    letter-spacing: inherit;
+}
 `;
 
 styleSheet.replaceSync(styles);

--- a/src/Core.Assets/src/index.ts
+++ b/src/Core.Assets/src/index.ts
@@ -65,7 +65,8 @@ fluent-text-field.invalid::part(root),
     outline: calc(var(--stroke-width) * 1px)  solid var(--error);
 }
 
-fluent-button::part(control)
+fluent-button::part(control),
+fluent-text-area::part(control)
 {
     letter-spacing: inherit;
 }

--- a/src/Core.Assets/src/index.ts
+++ b/src/Core.Assets/src/index.ts
@@ -69,7 +69,8 @@ fluent-button::part(control),
 fluent-text-area::part(control),
 fluent-text-field::part(control),
 fluent-search::part(control),
-fluent-combobox::part(selected-value)
+fluent-combobox::part(selected-value),
+fluent-number-field::part(control)
 {
     letter-spacing: inherit;
 }

--- a/src/Core.Assets/src/index.ts
+++ b/src/Core.Assets/src/index.ts
@@ -68,7 +68,8 @@ fluent-text-field.invalid::part(root),
 fluent-button::part(control),
 fluent-text-area::part(control),
 fluent-text-field::part(control),
-fluent-search::part(control)
+fluent-search::part(control),
+fluent-combobox::part(selected-value)
 {
     letter-spacing: inherit;
 }

--- a/src/Core.Assets/src/index.ts
+++ b/src/Core.Assets/src/index.ts
@@ -67,7 +67,8 @@ fluent-text-field.invalid::part(root),
 
 fluent-button::part(control),
 fluent-text-area::part(control),
-fluent-text-field::part(control)
+fluent-text-field::part(control),
+fluent-search::part(control)
 {
     letter-spacing: inherit;
 }

--- a/src/Core/wwwroot/css/reboot.css
+++ b/src/Core/wwwroot/css/reboot.css
@@ -458,7 +458,3 @@ progress {
 [hidden] {
     display: none !important;
 }
-
-fluent-button::part(control) {
-    letter-spacing: inherit;
-}

--- a/src/Core/wwwroot/css/reboot.css
+++ b/src/Core/wwwroot/css/reboot.css
@@ -458,3 +458,7 @@ progress {
 [hidden] {
     display: none !important;
 }
+
+fluent-button::part(control) {
+    letter-spacing: inherit;
+}


### PR DESCRIPTION
# Pull Request

## 📖 Description

`FluentButton` hasn't been adopting text spacing correctly. This PR fixes this.

Before:
![before](https://github.com/user-attachments/assets/f0d26110-30bf-460b-a918-f7abd668e642)

After:
![after](https://github.com/user-attachments/assets/027d1d0a-ca79-4793-9cd1-d9d456eebb9c)

### 🎫 Issues

Fixes #3692 




## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [ ] I have modified an existing component
- [ ] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component
