### PR TITLE
[dev-v5] Add DateTimeProvider and DateTimeExtensions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,7 +31,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.13.61" />
     <PackageVersion Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" />
     <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="5.8.1" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="3.11.0-beta1.24527.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="3.12.0-beta1.25155.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="$(RuntimeVersion9)" />

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Localization.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Localization.md
@@ -34,10 +34,10 @@ Here's a step-by-step guide:
                 return key switch
                 {
                     "SomeKey" => "Your Custom Translation",
-                    "AnotherKey" => String.Format("Another Custom Translation {0}",
+                    "AnotherKey" => String.Format("Another Custom Translation {0}"),
 
                     // Fallback to the Default/English if no translation is found
-                    _ => IFluentLocalizer.GetDefault(key, arguments)
+                    _ => IFluentLocalizer.GetDefault(key, arguments),
                 };
             }
         }

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Localization.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Localization.md
@@ -46,7 +46,9 @@ Here's a step-by-step guide:
 
    > **Note:**
    >
-   > The list of keys can be found in the `Core\Microsoft.FluentUI.AspNetCore.Components\Localization\LanguageResource.resx` file.
+   > The list of keys can be found in the `Core\Microsoft.FluentUI.AspNetCore.Components\Localization\LanguageResource.resx` file.  
+   > Or you can use a constant from the `Microsoft.FluentUI.AspNetCore.Components.Localization.LanguageResource` class.
+   > Example: `Localization.LanguageResource.MessageBox_ButtonOk`.
 
 2. **Register the Custom Localizer**
 

--- a/spelling.dic
+++ b/spelling.dic
@@ -15,7 +15,11 @@ datalist
 elementreference
 evenodd
 gzip
+heure
+heures
 javascript
+jours
+maintenant
 menuchecked
 menuclicked
 menuitem
@@ -26,6 +30,7 @@ menuitemradio
 menuitemradioobsolete
 menuitems
 microsoft
+mois
 myid
 noattribute
 nonfile
@@ -45,6 +50,7 @@ demopanel
 dialogtoggle
 rightclick
 rrggbb
+secondes
 sourcecode
 summarydata
 tabindex

--- a/src/Core/Components/Base/FluentInputBase.cs
+++ b/src/Core/Components/Base/FluentInputBase.cs
@@ -211,7 +211,7 @@ public abstract partial class FluentInputBase<TValue> : InputBase<TValue>, IFlue
     protected virtual string? GetAriaLabelWithRequired()
     {
         return (AriaLabel ?? Label ?? string.Empty) +
-               (Required == true ? $", {Localizer["FluentInputBase_Required"]}" : string.Empty);
+               (Required == true ? $", {Localizer[Localization.LanguageResource.FluentInputBase_Required]}" : string.Empty);
     }
 
     /// <summary>

--- a/src/Core/Components/Layout/FluentLayoutHamburger.razor.cs
+++ b/src/Core/Components/Layout/FluentLayoutHamburger.razor.cs
@@ -4,7 +4,6 @@
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
-using Microsoft.FluentUI.AspNetCore.Components.Localization;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
 

--- a/src/Core/Components/Layout/FluentLayoutHamburger.razor.cs
+++ b/src/Core/Components/Layout/FluentLayoutHamburger.razor.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.FluentUI.AspNetCore.Components.Localization;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
@@ -78,7 +79,7 @@ public partial class FluentLayoutHamburger
     /// <summary />
     protected override void OnInitialized()
     {
-        Title = Localizer["FluentLayoutHamburger_Title"];
+        Title = Localizer[Localization.LanguageResource.FluentLayoutHamburger_Title];
 
         var layout = Layout ?? LayoutContainer;
         layout?.AddHamburger(this);

--- a/src/Core/Extensions/DateTimeExtensions.cs
+++ b/src/Core/Extensions/DateTimeExtensions.cs
@@ -171,12 +171,12 @@ public static class DateTimeExtensions
 
         if (delay.Seconds > MAX_SECONDS_FOR_JUST_NOW)
         {
-            return string.Format(CultureInfo.InvariantCulture, localizer[LangResx.TimeAgo_SecondAgo], delay.Seconds);
+            return string.Format(CultureInfo.InvariantCulture, localizer[LangResx.TimeAgo_SecondsAgo], delay.Seconds);
         }
 
         if (delay.Seconds <= MAX_SECONDS_FOR_JUST_NOW)
         {
-            return string.Format(CultureInfo.InvariantCulture, localizer[LangResx.TimeAgo_SecondsAgo], delay.Seconds);
+            return string.Format(CultureInfo.InvariantCulture, localizer[LangResx.TimeAgo_SecondAgo], delay.Seconds);
         }
 
         throw new NotSupportedException("The DateTime object does not have a supported value.");

--- a/src/Core/Extensions/DateTimeExtensions.cs
+++ b/src/Core/Extensions/DateTimeExtensions.cs
@@ -174,12 +174,7 @@ public static class DateTimeExtensions
             return string.Format(CultureInfo.InvariantCulture, localizer[LangResx.TimeAgo_SecondsAgo], delay.Seconds);
         }
 
-        if (delay.Seconds <= MAX_SECONDS_FOR_JUST_NOW)
-        {
-            return string.Format(CultureInfo.InvariantCulture, localizer[LangResx.TimeAgo_SecondAgo], delay.Seconds);
-        }
-
-        throw new NotSupportedException("The DateTime object does not have a supported value.");
+        return string.Format(CultureInfo.InvariantCulture, localizer[LangResx.TimeAgo_SecondAgo], delay.Seconds);
 
         string Pluralize(decimal count, string singular, string plural)
         {

--- a/src/Core/Extensions/DateTimeExtensions.cs
+++ b/src/Core/Extensions/DateTimeExtensions.cs
@@ -1,0 +1,387 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using System.Globalization;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Extensions;
+
+/// <summary>
+/// Extension methods for <see cref="DateTime"/>.
+/// </summary>
+public static class DateTimeExtensions
+{
+    /// <summary>
+    /// Returns a string in the ISO format yyyy-MM-dd.
+    /// </summary>
+    /// <param name="self"></param>
+    /// <returns></returns>
+    public static string ToIsoDateString(this DateTime? self)
+    {
+        if (self == null)
+        {
+            return string.Empty;
+        }
+
+        return $"{self.Value.Year:D4}-{self.Value.Month:D2}-{self.Value.Day:D2}";
+    }
+
+    /// <summary>
+    /// Returns the first day of the month.
+    /// </summary>
+    /// <param name="self"></param>
+    /// <param name="culture"></param>
+    /// <returns></returns>
+    public static DateTime StartOfMonth(this DateTime self, CultureInfo culture)
+    {
+        var month = culture.Calendar.GetMonth(self);
+        var year = culture.Calendar.GetYear(self);
+        return culture.Calendar.ToDateTime(year, month, 1, 0, 0, 0, 0);
+    }
+
+    /// <summary>
+    /// Returns the first day of the year
+    /// </summary>
+    /// <param name="self"></param>
+    /// <param name="culture"></param>
+    /// <returns></returns>
+    public static DateTime StartOfYear(this DateTime self, CultureInfo culture)
+    {
+        var year = culture.Calendar.GetYear(self);
+        return culture.Calendar.ToDateTime(year, 1, 1, 0, 0, 0, 0);
+    }
+
+    /// <summary>
+    /// Returns the last day of the year.
+    /// </summary>
+    /// <param name="self"></param>
+    /// <param name="culture"></param>
+    /// <returns></returns>
+    public static DateTime EndOfYear(this DateTime self, CultureInfo culture)
+    {
+        return self.StartOfYear(culture).AddYears(1, culture).AddDays(-1, culture);
+    }
+
+    /// <summary>
+    /// Returns the last day of the month.
+    /// </summary>
+    /// <param name="self"></param>
+    /// <param name="culture"></param>
+    /// <returns></returns>
+    public static DateTime EndOfMonth(this DateTime self, CultureInfo culture)
+    {
+        var month = culture.Calendar.GetMonth(self);
+        var year = culture.Calendar.GetYear(self);
+        var days = culture.Calendar.GetDaysInMonth(year, month);
+        return culture.Calendar.ToDateTime(year, month, days, 0, 0, 0, 0);
+    }
+    /// <summary>
+    /// Returns the first day of the week.
+    /// </summary>
+    /// <param name="self"></param>
+    /// <param name="firstDayOfWeek"></param>
+    /// <returns></returns>
+    public static DateTime StartOfWeek(this DateTime self, DayOfWeek firstDayOfWeek)
+    {
+        var diff = (7 + (self.DayOfWeek - firstDayOfWeek)) % 7;
+        if (self.Year == 1 && self.Month == 1 && (self.Day - diff) < 1)
+        {
+            return self.Date;
+        }
+
+        return self.AddDays(-1 * diff).Date;
+    }
+
+    /// <summary>
+    /// Returns the first day of the week.
+    /// </summary>
+    /// <param name="self"></param>
+    /// <param name="culture"></param>
+    /// <returns></returns>
+    public static DateTime StartOfWeek(this DateTime self, CultureInfo culture)
+    {
+        var minDate = culture.Calendar.MinSupportedDateTime;
+        var firstDayOfWeek = culture.DateTimeFormat.FirstDayOfWeek;
+
+        var diff = (7 + (self.DayOfWeek - firstDayOfWeek)) % 7;
+        if (self.Year == minDate.Year && self.Month == minDate.Month && (self.Day - diff) < 1)
+        {
+            return self.Date;
+        }
+
+        return self.AddDays(-1 * diff, culture).Date;
+    }
+
+    /// <summary>
+    /// Returns the first day of the week.
+    /// </summary>
+    /// <param name="self"></param>
+    /// <returns></returns>
+    public static DateTime StartOfWeek(this DateTime self)
+    {
+        return StartOfWeek(self, CultureInfo.CurrentUICulture);
+    }
+
+    /*
+    /// <summary>
+    /// Get a string showing how long ago a DateTime was, for example '4 minutes ago'.
+    /// </summary>
+    /// <param name="delay"></param>
+    /// <param name="resources"></param>
+    /// <returns></returns>
+    /// <remarks>Inspired from https://github.com/NickStrupat/TimeAgo.</remarks>
+    public static string ToTimeAgo(this TimeSpan delay, TimeAgoOptions? resources = null)
+    {
+        const int MAX_SECONDS_FOR_JUST_NOW = 10;
+
+        if (resources == null)
+        {
+            resources = new TimeAgoOptions();
+        }
+
+        if (delay.Days > 365)
+        {
+            var years = Math.Round(decimal.Divide(delay.Days, 365));
+            return string.Format(years == 1 ? resources.YearAgo : resources.YearsAgo, years);
+        }
+
+        if (delay.Days > 30)
+        {
+            var months = delay.Days / 30;
+            if (delay.Days % 31 != 0)
+            {
+                months += 1;
+            }
+
+            return string.Format(months == 1 ? resources.MonthAgo : resources.MonthsAgo, months);
+        }
+
+        if (delay.Days > 0)
+        {
+            return string.Format(delay.Days == 1 ? resources.DayAgo : resources.DaysAgo, delay.Days);
+        }
+
+        if (delay.Hours > 0)
+        {
+            return string.Format(delay.Hours == 1 ? resources.HourAgo : resources.HoursAgo, delay.Hours);
+        }
+
+        if (delay.Minutes > 0)
+        {
+            return string.Format(delay.Minutes == 1 ? resources.MinuteAgo : resources.MinutesAgo, delay.Minutes);
+        }
+
+        if (delay.Seconds > MAX_SECONDS_FOR_JUST_NOW)
+        {
+            return string.Format(resources.SecondsAgo, delay.Seconds);
+        }
+
+        if (delay.Seconds <= MAX_SECONDS_FOR_JUST_NOW)
+        {
+            return string.Format(resources.SecondAgo, delay.Seconds);
+        }
+
+        throw new NotSupportedException("The DateTime object does not have a supported value.");
+    }
+    */
+
+    /// <summary>
+    /// Converts the DateOnly to an equivalent DateTime.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static DateTime ToDateTime(this DateOnly value)
+    {
+        return value.ToDateTime(TimeOnly.MinValue);
+    }
+
+    /// <summary>
+    /// Converts the TimeOnly to an equivalent DateTime.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static DateTime ToDateTime(this TimeOnly value)
+    {
+        return new DateTime(value.Ticks);
+    }
+
+    /// <summary>
+    /// Converts the nullable DateOnly to an equivalent DateTime.
+    /// Returns <see cref="DateOnly.MinValue"/> if the <paramref name="value"/> is null.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static DateTime ToDateTime(this DateOnly? value)
+    {
+        return value == null ? DateTime.MinValue : value.Value.ToDateTime(TimeOnly.MinValue);
+    }
+
+    /// <summary>
+    /// Converts the nullable TimeOnly to an equivalent DateTime.
+    /// Returns <see cref="DateTime.MinValue"/> if the <paramref name="value"/> is null.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static DateTime ToDateTime(this TimeOnly? value)
+    {
+        return value == null ? DateTime.MinValue : value.Value.ToDateTime();
+    }
+
+    /// <summary>
+    /// Converts the nullable DateOnly to an equivalent DateTime.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static DateTime? ToDateTimeNullable(this DateOnly? value)
+    {
+        return value == null ? (DateTime?)null : value.Value.ToDateTime(TimeOnly.MinValue);
+    }
+
+    /// <summary>
+    /// Converts the nullable TimeOnly to an equivalent DateTime.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static DateTime? ToDateTimeNullable(this TimeOnly? value)
+    {
+        return value == null ? (DateTime?)null : value.Value.ToDateTime();
+    }
+
+    /// <summary>
+    /// Converts the nullable DateTime to an equivalent DateTime.
+    /// Returns <see cref="DateOnly.MinValue"/> if the <paramref name="value"/> is null.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static DateTime ToDateTime(this DateTime? value)
+    {
+        return value == null ? DateTime.MinValue : value.Value;
+    }
+
+    /// <summary>
+    /// Converts the nullable DateTime to an equivalent DateOnly, removing the time part.
+    /// Returns <see cref="DateOnly.MinValue"/> if the <paramref name="value"/> is null.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static DateOnly ToDateOnly(this DateTime? value)
+    {
+        return value == null ? DateOnly.MinValue : DateOnly.FromDateTime(value.Value);
+    }
+
+    /// <summary>
+    /// Converts the nullable DateTime to an equivalent TimeOnly, removing the time part.
+    /// Returns <see cref="TimeOnly.MinValue"/> if the <paramref name="value"/> is null.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static TimeOnly ToTimeOnly(this DateTime? value)
+    {
+        return value == null ? TimeOnly.MinValue : TimeOnly.FromDateTime(value.Value);
+    }
+
+    /// <summary>
+    /// Converts the nullable DateTime to an equivalent DateOnly?, removing the time part.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static DateOnly? ToDateOnlyNullable(this DateTime? value)
+    {
+        return value == null ? (DateOnly?)null : DateOnly.FromDateTime(value.Value);
+    }
+
+    /// <summary>
+    /// Converts the nullable DateTime to an equivalent TimeOnly?, removing the time part.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static TimeOnly? ToTimeOnlyNullable(this DateTime? value)
+    {
+        return value == null ? (TimeOnly?)null : TimeOnly.FromDateTime(value.Value);
+    }
+
+    /// <summary>
+    /// Returns the year
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="culture"></param>
+    /// <returns></returns>
+    public static int GetYear(this DateTime value, CultureInfo culture)
+    {
+        return culture.Calendar.GetYear(value);
+    }
+
+    /// <summary>
+    /// Returns the month
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="culture"></param>
+    /// <returns></returns>
+    public static int GetMonth(this DateTime value, CultureInfo culture)
+    {
+        return culture.Calendar.GetMonth(value);
+    }
+
+    /// <summary>
+    /// Returns the day
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="culture"></param>
+    /// <returns></returns>
+    public static int GetDay(this DateTime value, CultureInfo culture)
+    {
+        return culture.Calendar.GetDayOfMonth(value);
+    }
+
+    /// <summary>
+    /// Returns the DateTime resulting from adding the given number of
+    /// days to the specified DateTime.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="days"></param>
+    /// <param name="culture"></param>
+    /// <returns></returns>
+    public static DateTime AddDays(this DateTime value, int days, CultureInfo culture)
+    {
+        return culture.Calendar.AddDays(value, days);
+    }
+
+    /// <summary>
+    /// Returns the DateTime resulting from adding the given number of
+    /// months to the specified DateTime.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="months"></param>
+    /// <param name="culture"></param>
+    /// <returns></returns>
+    public static DateTime AddMonths(this DateTime value, int months, CultureInfo culture)
+    {
+        return culture.Calendar.AddMonths(value, months);
+    }
+
+    /// <summary>
+    /// Returns the DateTime resulting from adding the given number of
+    /// years to the specified DateTime.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="years"></param>
+    /// <param name="culture"></param>
+    /// <returns></returns>
+    public static DateTime AddYears(this DateTime value, int years, CultureInfo culture)
+    {
+        return culture.Calendar.AddYears(value, years);
+    }
+
+    /// <summary>
+    /// Returns the name of the month
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="culture"></param>
+    /// <returns></returns>
+    public static string GetMonthName(this DateTime value, CultureInfo culture)
+    {
+        var month = culture.Calendar.GetMonth(value);
+
+        return culture.DateTimeFormat.MonthNames[month - 1];
+    }
+}

--- a/src/Core/Extensions/DateTimeExtensions.cs
+++ b/src/Core/Extensions/DateTimeExtensions.cs
@@ -3,6 +3,7 @@
 // ------------------------------------------------------------------------
 
 using System.Globalization;
+using LangResx = Microsoft.FluentUI.AspNetCore.Components.Localization.LanguageResource;
 
 namespace Microsoft.FluentUI.AspNetCore.Components.Extensions;
 
@@ -122,27 +123,24 @@ public static class DateTimeExtensions
         return StartOfWeek(self, CultureInfo.CurrentUICulture);
     }
 
-    /*
     /// <summary>
     /// Get a string showing how long ago a DateTime was, for example '4 minutes ago'.
     /// </summary>
     /// <param name="delay"></param>
-    /// <param name="resources"></param>
+    /// <param name="localizer"></param>
     /// <returns></returns>
     /// <remarks>Inspired from https://github.com/NickStrupat/TimeAgo.</remarks>
-    public static string ToTimeAgo(this TimeSpan delay, TimeAgoOptions? resources = null)
+    public static string ToTimeAgo(this TimeSpan delay, IFluentLocalizer? localizer = null)
     {
         const int MAX_SECONDS_FOR_JUST_NOW = 10;
 
-        if (resources == null)
-        {
-            resources = new TimeAgoOptions();
-        }
+        // Use the default localizer if none is provided
+        localizer = localizer ?? FluentLocalizerInternal.Default;
 
         if (delay.Days > 365)
         {
             var years = Math.Round(decimal.Divide(delay.Days, 365));
-            return string.Format(years == 1 ? resources.YearAgo : resources.YearsAgo, years);
+            return Pluralize(years, LangResx.TimeAgo_YearAgo, LangResx.TimeAgo_YearsAgo);
         }
 
         if (delay.Days > 30)
@@ -153,37 +151,41 @@ public static class DateTimeExtensions
                 months += 1;
             }
 
-            return string.Format(months == 1 ? resources.MonthAgo : resources.MonthsAgo, months);
+            return Pluralize(months, LangResx.TimeAgo_MonthAgo, LangResx.TimeAgo_MonthsAgo);
         }
 
         if (delay.Days > 0)
         {
-            return string.Format(delay.Days == 1 ? resources.DayAgo : resources.DaysAgo, delay.Days);
+            return Pluralize(delay.Days, LangResx.TimeAgo_DayAgo, LangResx.TimeAgo_DaysAgo);
         }
 
         if (delay.Hours > 0)
         {
-            return string.Format(delay.Hours == 1 ? resources.HourAgo : resources.HoursAgo, delay.Hours);
+            return Pluralize(delay.Hours, LangResx.TimeAgo_HourAgo, LangResx.TimeAgo_HoursAgo);
         }
 
         if (delay.Minutes > 0)
         {
-            return string.Format(delay.Minutes == 1 ? resources.MinuteAgo : resources.MinutesAgo, delay.Minutes);
+            return Pluralize(delay.Minutes, LangResx.TimeAgo_MinuteAgo, LangResx.TimeAgo_MinutesAgo);
         }
 
         if (delay.Seconds > MAX_SECONDS_FOR_JUST_NOW)
         {
-            return string.Format(resources.SecondsAgo, delay.Seconds);
+            return string.Format(CultureInfo.InvariantCulture, localizer[LangResx.TimeAgo_SecondAgo], delay.Seconds);
         }
 
         if (delay.Seconds <= MAX_SECONDS_FOR_JUST_NOW)
         {
-            return string.Format(resources.SecondAgo, delay.Seconds);
+            return string.Format(CultureInfo.InvariantCulture, localizer[LangResx.TimeAgo_SecondsAgo], delay.Seconds);
         }
 
         throw new NotSupportedException("The DateTime object does not have a supported value.");
+
+        string Pluralize(decimal count, string singular, string plural)
+        {
+            return string.Format(CultureInfo.InvariantCulture, count == 1 ? localizer[singular] : localizer[plural], count);
+        }
     }
-    */
 
     /// <summary>
     /// Converts the DateOnly to an equivalent DateTime.

--- a/src/Core/Localization/LanguageResource.resx
+++ b/src/Core/Localization/LanguageResource.resx
@@ -165,4 +165,40 @@
   <data name="Field_WarningMessage" xml:space="preserve">
     <value>Please, check this value</value>
   </data>
+  <data name="TimeAgo_DayAgo" xml:space="preserve">
+    <value>{0} day ago</value>
+  </data>
+  <data name="TimeAgo_DaysAgo" xml:space="preserve">
+    <value>{0} days ago</value>
+  </data>
+  <data name="TimeAgo_HourAgo" xml:space="preserve">
+    <value>{0} hour ago</value>
+  </data>
+  <data name="TimeAgo_HoursAgo" xml:space="preserve">
+    <value>{0} hours ago</value>
+  </data>
+  <data name="TimeAgo_MinuteAgo" xml:space="preserve">
+    <value>{0} minute ago</value>
+  </data>
+  <data name="TimeAgo_MinutesAgo" xml:space="preserve">
+    <value>{0} minutes ago</value>
+  </data>
+  <data name="TimeAgo_MonthAgo" xml:space="preserve">
+    <value>{0} month ago</value>
+  </data>
+  <data name="TimeAgo_MonthsAgo" xml:space="preserve">
+    <value>{0} months ago</value>
+  </data>
+  <data name="TimeAgo_SecondAgo" xml:space="preserve">
+    <value>Just now</value>
+  </data>
+  <data name="TimeAgo_SecondsAgo" xml:space="preserve">
+    <value>{0} seconds ago</value>
+  </data>
+  <data name="TimeAgo_YearAgo" xml:space="preserve">
+    <value>{0} year ago</value>
+  </data>
+  <data name="TimeAgo_YearsAgo" xml:space="preserve">
+    <value>{0} years ago</value>
+  </data>
 </root>

--- a/src/Core/Localization/ReadMe.md
+++ b/src/Core/Localization/ReadMe.md
@@ -1,0 +1,38 @@
+# Localization
+
+Localization allows the text in some components to be translated.
+
+## Explanation
+
+**Fluent UI Blazor** itself provides English language strings for texts found in.
+To customize translations in **Fluent UI Blazor**, the developer can register a
+custom `IFluentLocalizer` implementation as a service, and register this custom localizer
+in the `Program.cs` file, during the service registration.
+
+```csharp
+builder.Services.AddFluentUIComponents(config => config.Localizer = new CustomFluentLocalizer());
+```
+
+## How to add a new resource string?
+
+In this library, to add a new resource string, follow these steps:
+
+1. Open the file **LanguageResource.resx** and add a new entry with the name `<prefix>_<item>`.
+   Where `<prefix>` is the name of the component, and `<item>` is the name of the string.
+   Example:
+     - `MessageBox_ButtonYes` for the Yes button label, of the MessageBox component.
+     - `FluentLayoutHamburger_Title` for the title of the Layout Hamburger component.
+
+2. The `FluentComponentBase` class provides a `Localizer` property that can be used to access the
+   resource strings. The `Localizer` property is an instance of `IFluentLocalizer`, which
+   is registered in the service collection.
+   You can use the `Localizer` property to access the resource strings in your component.
+   The `Localization.LanguageResource` class contains the list of all resource string constants to use.
+
+   Example:
+   ```csharp
+   protected override void OnInitialized()
+   {
+       Title = Localizer[Localization.LanguageResource.FluentLayoutHamburger_Title];
+   }
+   ```

--- a/src/Core/Localization/ReadMe.md
+++ b/src/Core/Localization/ReadMe.md
@@ -4,7 +4,7 @@ Localization allows the text in some components to be translated.
 
 ## Explanation
 
-**Fluent UI Blazor** itself provides English language strings for texts found in.
+**Fluent UI Blazor** itself provides English language strings for texts found in  its components.
 To customize translations in **Fluent UI Blazor**, the developer can register a
 custom `IFluentLocalizer` implementation as a service, and register this custom localizer
 in the `Program.cs` file, during the service registration.

--- a/src/Core/Microsoft.FluentUI.AspNetCore.Components.csproj
+++ b/src/Core/Microsoft.FluentUI.AspNetCore.Components.csproj
@@ -110,7 +110,7 @@
     </PackageReference>
 
     <EmbeddedResource Update="Localization\LanguageResource.resx">
-      <Public>true</Public>
+      <Public>false</Public>
       <OmitGetResourceString>true</OmitGetResourceString>
       <AsConstants>true</AsConstants>
       <NoWarn>CS1591</NoWarn>

--- a/src/Core/Microsoft.FluentUI.AspNetCore.Components.csproj
+++ b/src/Core/Microsoft.FluentUI.AspNetCore.Components.csproj
@@ -110,7 +110,7 @@
     </PackageReference>
 
     <EmbeddedResource Update="Localization\LanguageResource.resx">
-      <Public>false</Public>
+      <Public>true</Public>
       <OmitGetResourceString>true</OmitGetResourceString>
       <AsConstants>true</AsConstants>
       <NoWarn>CS1591</NoWarn>

--- a/src/Core/Utilities/DateTime/DateTimeProvider.cs
+++ b/src/Core/Utilities/DateTime/DateTimeProvider.cs
@@ -1,0 +1,51 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// Returns the current date and time on this computer, expressed as the local time.
+/// </summary>
+public static class DateTimeProvider
+{
+    /// <summary>
+    /// Gets a <see cref="DateTime" /> object that is set to the current date and time 
+    /// on this computer, expressed as the local time.
+    /// </summary>
+    public static DateTime Now => DateTimeProviderContext.Current == null
+                                ? GetSystemDate()
+                                : DateTimeProviderContext.Current.NextValue();
+
+    /// <summary>
+    /// Gets a <see cref="DateTime" /> object that is set to the current date and time
+    /// on this computer, expressed as the Coordinated Universal Time (UTC).
+    /// </summary>
+    public static DateTime UtcNow => Now.ToUniversalTime();
+
+    /// <summary>
+    /// Gets a <see cref="DateTime" /> object that is set to today's date, with the time component set to 00:00:00.
+    /// </summary>
+    public static DateTime Today => Now.Date;
+
+    /// <summary>
+    /// Indicates whether a context is required to be active.
+    /// </summary>
+    public static bool RequiredActiveContext { get; set; }
+
+    /// <summary>
+    /// Returns the current date and time on this computer.
+    /// </summary>
+    /// <param name="requiredContext">Indicates whether a context is required to be active (used by internal unit tests).</param>
+    /// <returns>The current date and time on this computer.</returns>
+    /// <exception cref="InvalidOperationException">If <see cref="RequiredActiveContext"/> is true and no context is active.</exception>
+    internal static DateTime GetSystemDate(bool requiredContext = true)
+    {
+        if (RequiredActiveContext && requiredContext)
+        {
+            throw new InvalidOperationException("DateTimeProvider requires a context to be set (e.g. `using var context = new DateTimeProviderContext(new DateTime(2025, 1, 18));`");
+        }
+
+        return DateTime.Now;
+    }
+}

--- a/src/Core/Utilities/DateTime/DateTimeProviderContext.cs
+++ b/src/Core/Utilities/DateTime/DateTimeProviderContext.cs
@@ -1,0 +1,93 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using System.Collections.Immutable;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// Represents the context for the <see cref="DateTimeProvider" />.
+/// This context returns the specified date and time while it is in scope.
+/// </summary>
+public record DateTimeProviderContext : IDisposable
+{
+    private static readonly AsyncLocal<ImmutableStack<DateTimeProviderContext>> s_asyncScopeStack = new();
+    private readonly AsyncLocal<uint> _asyncCurrentIndex = new();
+
+    /// <summary>
+    /// Gets the current <see cref="DateTimeProviderContext" />.
+    /// </summary>
+    internal static DateTimeProviderContext? Current => s_asyncScopeStack.Value?.IsEmpty == false ? s_asyncScopeStack.Value.Peek() : null;
+
+    /// <summary>
+    /// Create a new context for the <see cref="DateTimeProvider" /> using a sequence of date and time.
+    /// </summary>
+    /// <param name="sequence">Sequence of date and time to return while in scope.</param>
+    public DateTimeProviderContext(Func<uint, DateTime> sequence)
+    {
+        s_asyncScopeStack.Value = (s_asyncScopeStack.Value ?? ImmutableStack<DateTimeProviderContext>.Empty).Push(this);
+        Sequence = sequence;
+    }
+
+    /// <summary>
+    /// Create a new context for the <see cref="DateTimeProvider" /> using the specified date and time.
+    /// </summary>
+    /// <param name="value">Specifies the date and time to return while in scope.</param>
+    public DateTimeProviderContext(DateTime value) : this(_ => value) { }
+
+    /// <summary>
+    /// Create a new context for the <see cref="DateTimeProvider" /> using a list of date and time.
+    /// Each call to <see cref="DateTimeProvider.Now" /> will return the next date and time in the list,
+    /// until the last date and time is reached.
+    /// If more calls are made after the last date and time, an <see cref="InvalidOperationException" /> is thrown.
+    /// </summary>
+    /// <param name="values"></param>
+    /// <exception cref="InvalidOperationException"></exception>
+    public DateTimeProviderContext(DateTime[] values)
+        : this(i => i < values.Length
+                  ? values[i]
+                  : throw new InvalidOperationException("This is the last call in the sequence. No more dates are available."))
+    { }
+
+    /// <summary>
+    /// Gets the date and time to return while in scope.
+    /// </summary>
+    internal Func<uint, DateTime> Sequence { get; }
+
+    /// <summary>
+    /// Returns the next number between 0 and 99999999.
+    /// </summary>
+    /// <returns></returns>
+    internal DateTime NextValue()
+    {
+        var currentIndex = _asyncCurrentIndex.Value;
+        var value = Sequence.Invoke(currentIndex);
+
+        _asyncCurrentIndex.Value = currentIndex >= uint.MaxValue ? 0 : currentIndex + 1;
+
+        return value;
+    }
+
+    /// <summary>
+    /// Force the next value to used with the NextValue method.
+    /// Only for testing purposes.
+    /// </summary>
+    /// <param name="value"></param>
+    internal void ForceNextValue(uint value)
+    {
+        _asyncCurrentIndex.Value = value;
+    }
+
+    /// <summary>
+    /// Disposes the <see cref="DateTimeProviderContext" />
+    /// and return to the previous context.
+    /// </summary>
+    public void Dispose()
+    {
+        if (s_asyncScopeStack.Value?.IsEmpty == false)
+        {
+            s_asyncScopeStack.Value = s_asyncScopeStack.Value.Pop();
+        }
+    }
+}

--- a/src/Core/Utilities/DateTime/ReadMe.md
+++ b/src/Core/Utilities/DateTime/ReadMe.md
@@ -1,0 +1,131 @@
+# DateTimeProvider
+
+## Introduction
+
+Today, a developer came to see me to ask how to test his code that contains a reference to `DateTime.Now`.
+This is because your application sometimes processes its data differently, depending on the current date.
+
+For example, how do you check the following code, which depends on the current quarter?
+
+```csharp
+int quarter = (DateTime.Today.Month - 1) / 3 + 1;
+if (quarter <= 2)
+    ...
+else 
+    ...
+```
+
+The main problem is that the date obviously changes every day. And the quarterly calculation will run
+unit tests today, but maybe not tomorrow.
+
+## Dependency injection
+
+A clean way to do this, if you're using **dependency injection** (IoC) in your project, 
+is to create an interface to inject wherever you want to get the system's current date, 
+and define it, as required, in the unit tests.
+
+```csharp
+public interface IDateTimeHelper
+{
+    DateTime GetDateTimeNow();
+}
+
+public class DateTimeHelper : IDateTimeHelper
+{
+    public DateTime GetDateTimeNow()
+    {
+        return DateTime.Now;
+    }
+}
+```
+
+This works fine, as long as you use dependency injection. 
+But some people don't like injecting such a simple class. 
+Plus, what if you have existing code and just want to rewrite it to replace the date and time?
+
+## Ambient Context Model
+
+To avoid injecting such a simple class and to simplify updating existing code, 
+We propose a solution that uses the **Ambient Context Model**.
+
+To do this, use a `DateTimeProvider` class that determines the current context of use: 
+`DateTime.Now` is replaced by `DateTimeProvider.Now` in your code.
+
+```csharp
+int trimester = (DateTimeProvider.Today.Month - 1) / 3 + 1;
+```
+
+This **provider** returns the system's current date. 
+However, by using it in a unit test, we can adapt the context to specify a predefined date.
+
+## Unit Test - Simulate a date
+
+```csharp
+var result = DateTimeProvider.Now;      // Returns DateTime.Now
+
+var fakeDate = new DateTime(2018, 5, 26);
+using (var context = new DateTimeProviderContext(fakeDate))
+{
+    var result = DateTimeProvider.Now;  // Returns 2018-05-26
+}
+```
+
+As you can see from the code above, the only thing we need to do to simulate the system's current date is to wrap 
+our method call in a using block. This creates a new instance of **DateTimeProviderContext** and specifies 
+the **desired date** as an argument to the constructor. That's it!
+
+## Unit Test - Sequential dates
+
+Some uses require dates that evolve with each call. For example, to simulate a kind of `StopWatch`.
+You can define a function (Lambda) that returns a different date for each call.
+
+For example, using the call index as the starting element :
+
+```csharp
+using var contextSequence = new DateTimeProviderContext(i => i switch
+{
+    0 => new DateTime(2018, 5, 26),
+    1 => new DateTime(2019, 5, 27),
+    _ => DateTime.MinValue,
+});
+```
+
+However, if you already know the list of dates to be returned for each call, you can define them in a list :
+
+```csharp
+using var contextSequence = new DateTimeProviderContext(
+[
+    new DateTime(2018, 5, 26),
+    new DateTime(2019, 5, 27)
+]);
+```
+
+If you make more than 2 calls, an `InvalidOperationException` exception will be thrown.
+This indicates that you have exhausted the defined return sequence and that there is no return value for the next call.
+
+## Unit Test - Requirement to use context
+
+Some uses (like Unit Tests) require that the date be defined in a context.
+You can define this requirement setting the `DateTimeProvider.RequiredActiveContext` property to `true`.
+
+## Bechmarks
+
+These benchmarks results check the performance of `DateTimeProvider` against `DateTime.Now`.
+- **SystemDateTime**: `DateTime.Now`
+- **DateTimeProvider**: `DateTimeProvider.Now`
+
+These results show that `DateTimeProvider` performs just as well as `DateTime.Now`.
+
+```
+BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.3321)
+11th Gen Intel Core i7-11850H 2.50GHz, 1 CPU, 16 logical and 8 physical cores```
+.NET SDK 9.0.200-preview.0.25057.12
+  [Host]     : .NET 9.0.2 (9.0.225.6610), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
+  DefaultJob : .NET 9.0.2 (9.0.225.6610), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
+
+
+| Method               | Mean     | Error    | StdDev   | Median   |
+|--------------------- |---------:|---------:|---------:|---------:|
+| SystemDateTime       | 69.06 ns | 1.774 ns | 5.174 ns | 68.09 ns |
+| DateTimeProvider     | 68.78 ns | 1.896 ns | 5.561 ns | 67.79 ns |
+```

--- a/tests/Core/Extensions/DateTimeExtensionsTests.cs
+++ b/tests/Core/Extensions/DateTimeExtensionsTests.cs
@@ -80,6 +80,32 @@ public class DateTimeExtensionsTests
     }
 
     [Fact]
+    public void DateTimeExtensions_StartOfWeek_Min()
+    {
+        var date = DateTime.MinValue; // January 1, 0001
+        var result = date.StartOfWeek(DayOfWeek.Wednesday);
+        Assert.Equal(new DateTime(1, 1, 1), result);
+    }
+
+    [Fact]
+    public void DateTimeExtensions_StartOfWeek_WithCulture_Min()
+    {
+        var date = DateTime.MinValue; // January 1, 0001
+        var culture = CultureInfo.InvariantCulture;
+        var result = date.StartOfWeek(culture);
+        Assert.Equal(new DateTime(1, 1, 1), result);
+    }
+
+    [Fact]
+    public void DateTimeExtensions_StartOfWeek_NoParameters_ReturnsFirstDayOfWeek()
+    {
+        var date = new DateTime(2025, 4, 19); // Saturday
+        var result = date.StartOfWeek();
+        var expected = date.StartOfWeek(CultureInfo.CurrentUICulture);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
     public void DateTimeExtensions_ToTimeAgo_ValidTimeSpan_ReturnsCorrectString()
     {
         var delay = TimeSpan.FromMinutes(5);
@@ -188,6 +214,90 @@ public class DateTimeExtensionsTests
         var culture = CultureInfo.InvariantCulture;
         var result = date.GetMonthName(culture);
         Assert.Equal("April", result);
+    }
+
+    [Fact]
+    public void DateTimeExtensions_ToDateTime_NullTimeOnly_ReturnsMinValue()
+    {
+        TimeOnly? timeOnly = null;
+        var result = timeOnly.ToDateTime();
+        Assert.Equal(DateTime.MinValue, result);
+    }
+
+    [Fact]
+    public void DateTimeExtensions_ToDateTime_NullableDateOnly_ReturnsCorrectDateTime()
+    {
+        // Test with null DateOnly  
+        DateOnly? nullDateOnly = null;
+        var result = nullDateOnly.ToDateTime();
+        Assert.Equal(DateTime.MinValue, result);
+
+        // Test with valid DateOnly  
+        DateOnly? validDateOnly = new DateOnly(2025, 4, 19);
+        result = validDateOnly.ToDateTime();
+        Assert.Equal(new DateTime(2025, 4, 19), result);
+    }
+
+    [Fact]
+    public void DateTimeExtensions_ToDateTimeNullable_ValidTimeOnly_ReturnsDateTime()
+    {
+        TimeOnly? timeOnly = new TimeOnly(14, 30);
+        var result = timeOnly.ToDateTimeNullable();
+        Assert.Equal(new DateTime(1, 1, 1, 14, 30, 0), result);
+    }
+
+    [Fact]
+    public void DateTimeExtensions_ToDateTimeNullable_NullTimeOnly_ReturnsNull()
+    {
+        TimeOnly? timeOnly = null;
+        var result = timeOnly.ToDateTimeNullable();
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void DateTimeExtensions_ToDateTime_NullableDateTime_ReturnsCorrectDateTime()
+    {
+        // Test with null DateTime
+        DateTime? nullDateTime = null;
+        var result = nullDateTime.ToDateTime();
+        Assert.Equal(DateTime.MinValue, result);
+
+        // Test with valid DateTime
+        DateTime? validDateTime = new DateTime(2025, 4, 19);
+        result = validDateTime.ToDateTime();
+        Assert.Equal(new DateTime(2025, 4, 19), result);
+    }
+
+    [Fact]
+    public void DateTimeExtensions_ToDateOnlyNullable_NullDateTime_ReturnsNull()
+    {
+        DateTime? dateTime = null;
+        var result = dateTime.ToDateOnlyNullable();
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void DateTimeExtensions_ToDateOnlyNullable_ValidDateTime_ReturnsDateOnly()
+    {
+        DateTime? dateTime = new DateTime(2025, 4, 19);
+        var result = dateTime.ToDateOnlyNullable();
+        Assert.Equal(new DateOnly(2025, 4, 19), result);
+    }
+
+    [Fact]
+    public void DateTimeExtensions_ToTimeOnlyNullable_NullDateTime_ReturnsNull()
+    {
+        DateTime? dateTime = null;
+        var result = dateTime.ToTimeOnlyNullable();
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void DateTimeExtensions_ToTimeOnlyNullable_ValidDateTime_ReturnsTimeOnly()
+    {
+        DateTime? dateTime = new DateTime(2025, 4, 19, 14, 30, 0);
+        var result = dateTime.ToTimeOnlyNullable();
+        Assert.Equal(new TimeOnly(14, 30), result);
     }
 }
 

--- a/tests/Core/Extensions/DateTimeExtensionsTests.cs
+++ b/tests/Core/Extensions/DateTimeExtensionsTests.cs
@@ -1,0 +1,193 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using System.Globalization;
+using Microsoft.FluentUI.AspNetCore.Components.Extensions;
+using Xunit;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Tests.Extensions;
+
+public class DateTimeExtensionsTests
+{
+    [Fact]
+    public void DateTimeExtensions_ToIsoDateString_NullDate_ReturnsEmptyString()
+    {
+        DateTime? date = null;
+        var result = date.ToIsoDateString();
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void DateTimeExtensions_ToIsoDateString_ValidDate_ReturnsIsoFormattedString()
+    {
+        DateTime? date = new DateTime(2025, 4, 19);
+        var result = date.ToIsoDateString();
+        Assert.Equal("2025-04-19", result);
+    }
+
+    [Fact]
+    public void DateTimeExtensions_StartOfMonth_ValidDate_ReturnsFirstDayOfMonth()
+    {
+        var date = new DateTime(2025, 4, 19);
+        var culture = CultureInfo.InvariantCulture;
+        var result = date.StartOfMonth(culture);
+        Assert.Equal(new DateTime(2025, 4, 1), result);
+    }
+
+    [Fact]
+    public void DateTimeExtensions_StartOfYear_ValidDate_ReturnsFirstDayOfYear()
+    {
+        var date = new DateTime(2025, 4, 19);
+        var culture = CultureInfo.InvariantCulture;
+        var result = date.StartOfYear(culture);
+        Assert.Equal(new DateTime(2025, 1, 1), result);
+    }
+
+    [Fact]
+    public void DateTimeExtensions_EndOfYear_ValidDate_ReturnsLastDayOfYear()
+    {
+        var date = new DateTime(2025, 4, 19);
+        var culture = CultureInfo.InvariantCulture;
+        var result = date.EndOfYear(culture);
+        Assert.Equal(new DateTime(2025, 12, 31), result);
+    }
+
+    [Fact]
+    public void DateTimeExtensions_EndOfMonth_ValidDate_ReturnsLastDayOfMonth()
+    {
+        var date = new DateTime(2025, 4, 19);
+        var culture = CultureInfo.InvariantCulture;
+        var result = date.EndOfMonth(culture);
+        Assert.Equal(new DateTime(2025, 4, 30), result);
+    }
+
+    [Fact]
+    public void DateTimeExtensions_StartOfWeek_ValidDate_ReturnsFirstDayOfWeek()
+    {
+        var date = new DateTime(2025, 4, 19); // Saturday
+        var result = date.StartOfWeek(DayOfWeek.Monday);
+        Assert.Equal(new DateTime(2025, 4, 14), result); // Monday
+    }
+
+    [Fact]
+    public void DateTimeExtensions_StartOfWeek_WithCulture_ReturnsFirstDayOfWeek()
+    {
+        var date = new DateTime(2025, 4, 19); // Saturday
+        var culture = CultureInfo.InvariantCulture;
+        var result = date.StartOfWeek(culture);
+        Assert.Equal(new DateTime(2025, 4, 13), result); // Sunday (default first day in InvariantCulture)
+    }
+
+    [Fact]
+    public void DateTimeExtensions_ToTimeAgo_ValidTimeSpan_ReturnsCorrectString()
+    {
+        var delay = TimeSpan.FromMinutes(5);
+        var result = delay.ToTimeAgo();
+        Assert.Contains("5 minutes ago", result);
+    }
+
+    [Fact]
+    public void DateTimeExtensions_ToDateTime_DateOnly_ReturnsDateTime()
+    {
+        var dateOnly = new DateOnly(2025, 4, 19);
+        var result = dateOnly.ToDateTime();
+        Assert.Equal(new DateTime(2025, 4, 19), result);
+    }
+
+    [Fact]
+    public void DateTimeExtensions_ToDateTime_TimeOnly_ReturnsDateTime()
+    {
+        var timeOnly = new TimeOnly(14, 30);
+        var result = timeOnly.ToDateTime();
+        Assert.Equal(new DateTime(1, 1, 1, 14, 30, 0), result);
+    }
+
+    [Fact]
+    public void DateTimeExtensions_ToDateTimeNullable_NullDateOnly_ReturnsNull()
+    {
+        DateOnly? dateOnly = null;
+        var result = dateOnly.ToDateTimeNullable();
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void DateTimeExtensions_ToDateOnly_NullDateTime_ReturnsMinValue()
+    {
+        DateTime? dateTime = null;
+        var result = dateTime.ToDateOnly();
+        Assert.Equal(DateOnly.MinValue, result);
+    }
+
+    [Fact]
+    public void DateTimeExtensions_ToTimeOnly_NullDateTime_ReturnsMinValue()
+    {
+        DateTime? dateTime = null;
+        var result = dateTime.ToTimeOnly();
+        Assert.Equal(TimeOnly.MinValue, result);
+    }
+
+    [Fact]
+    public void DateTimeExtensions_GetYear_ValidDate_ReturnsYear()
+    {
+        var date = new DateTime(2025, 4, 19);
+        var culture = CultureInfo.InvariantCulture;
+        var result = date.GetYear(culture);
+        Assert.Equal(2025, result);
+    }
+
+    [Fact]
+    public void DateTimeExtensions_GetMonth_ValidDate_ReturnsMonth()
+    {
+        var date = new DateTime(2025, 4, 19);
+        var culture = CultureInfo.InvariantCulture;
+        var result = date.GetMonth(culture);
+        Assert.Equal(4, result);
+    }
+
+    [Fact]
+    public void DateTimeExtensions_GetDay_ValidDate_ReturnsDay()
+    {
+        var date = new DateTime(2025, 4, 19);
+        var culture = CultureInfo.InvariantCulture;
+        var result = date.GetDay(culture);
+        Assert.Equal(19, result);
+    }
+
+    [Fact]
+    public void DateTimeExtensions_AddDays_ValidDate_AddsDays()
+    {
+        var date = new DateTime(2025, 4, 19);
+        var culture = CultureInfo.InvariantCulture;
+        var result = date.AddDays(5, culture);
+        Assert.Equal(new DateTime(2025, 4, 24), result);
+    }
+
+    [Fact]
+    public void DateTimeExtensions_AddMonths_ValidDate_AddsMonths()
+    {
+        var date = new DateTime(2025, 4, 19);
+        var culture = CultureInfo.InvariantCulture;
+        var result = date.AddMonths(2, culture);
+        Assert.Equal(new DateTime(2025, 6, 19), result);
+    }
+
+    [Fact]
+    public void DateTimeExtensions_AddYears_ValidDate_AddsYears()
+    {
+        var date = new DateTime(2025, 4, 19);
+        var culture = CultureInfo.InvariantCulture;
+        var result = date.AddYears(1, culture);
+        Assert.Equal(new DateTime(2026, 4, 19), result);
+    }
+
+    [Fact]
+    public void DateTimeExtensions_GetMonthName_ValidDate_ReturnsMonthName()
+    {
+        var date = new DateTime(2025, 4, 19);
+        var culture = CultureInfo.InvariantCulture;
+        var result = date.GetMonthName(culture);
+        Assert.Equal("April", result);
+    }
+}
+

--- a/tests/Core/Extensions/DateTimeExtensionsToTimeAgoTests.cs
+++ b/tests/Core/Extensions/DateTimeExtensionsToTimeAgoTests.cs
@@ -1,0 +1,95 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using Microsoft.FluentUI.AspNetCore.Components.Extensions;
+using Xunit;
+using LanguageResource = Microsoft.FluentUI.AspNetCore.Components.Localization.LanguageResource;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Tests.Extensions;
+
+public class ToTimeAgoTests
+{
+    [Theory]
+    [InlineData("000.00:00:02", "Just now")]
+    [InlineData("000.00:00:25", "25 seconds ago")]
+    [InlineData("000.00:01:00", "1 minute ago")]
+    [InlineData("000.00:05:00", "5 minutes ago")]
+    [InlineData("000.01:00:00", "1 hour ago")]
+    [InlineData("000.05:00:00", "5 hours ago")]
+    [InlineData("001.00:00:00", "1 day ago")]
+    [InlineData("005.00:00:00", "5 days ago")]
+    [InlineData("031.00:00:00", "1 month ago")]
+    [InlineData("035.00:00:00", "2 months ago")]
+    [InlineData("150.00:00:00", "6 months ago")]
+    [InlineData("370.00:00:00", "1 year ago")]
+    [InlineData("740.00:00:00", "2 years ago")]
+    [InlineData("900.00:00:00", "2 years ago")]
+    [InlineData("920.00:00:00", "3 years ago")]
+    public void ToTimeAgo_Default(string delayAsString, string expectedValue)
+    {
+        var delay = TimeSpan.ParseExact(delayAsString, @"ddd\.hh\:mm\:ss", null);
+
+        Assert.Equal(expectedValue, delay.ToTimeAgo());
+    }
+
+    [Theory]
+    [InlineData("000.00:00:02", "Maintenant")]
+    [InlineData("000.00:00:25", "Il y a 25 secondes")]
+    [InlineData("000.00:01:00", "Il y a une minute")]
+    [InlineData("000.00:05:00", "Il y a 5 minutes")]
+    [InlineData("000.01:00:00", "Il y a une heure")]
+    [InlineData("000.05:00:00", "Il y a 5 heures")]
+    [InlineData("001.00:00:00", "Il y a un jour")]
+    [InlineData("005.00:00:00", "Il y a 5 jours")]
+    [InlineData("031.00:00:00", "Il y a un mois")]
+    [InlineData("035.00:00:00", "Il y a 2 mois")]
+    [InlineData("150.00:00:00", "Il y a 6 mois")]
+    [InlineData("370.00:00:00", "Il y a 1 an")]
+    [InlineData("740.00:00:00", "Il y a 2 ans")]
+    [InlineData("900.00:00:00", "Il y a 2 ans")]
+    [InlineData("920.00:00:00", "Il y a 3 ans")]
+    public void ToTimeAgo_Customized(string delayAsString, string expectedValue)
+    {
+        var delay = TimeSpan.ParseExact(delayAsString, @"ddd\.hh\:mm\:ss", null);
+        Assert.Equal(expectedValue, delay.ToTimeAgo(new FrenchTimeAgoLocalizer()));
+    }
+
+    [Theory]
+    [InlineData("000.00:00:02", "Just now")]
+    public void ToTimeAgo_Ctor(string delayAsString, string expectedValue)
+    {
+        var delay = TimeSpan.ParseExact(delayAsString, @"ddd\.hh\:mm\:ss", null);
+
+        Assert.Equal(expectedValue, delay.ToTimeAgo(localizer: null));
+    }
+
+    private class FrenchTimeAgoLocalizer : IFluentLocalizer
+    {
+        public string this[string key, params object[] arguments]
+        {
+            get
+            {
+                // Provide custom translations based on the key
+                return key switch
+                {
+                    LanguageResource.TimeAgo_SecondAgo => "Maintenant",
+                    LanguageResource.TimeAgo_SecondsAgo => "Il y a {0} secondes",
+                    LanguageResource.TimeAgo_MinuteAgo => "Il y a une minute",
+                    LanguageResource.TimeAgo_MinutesAgo => "Il y a {0} minutes",
+                    LanguageResource.TimeAgo_HourAgo => "Il y a une heure",
+                    LanguageResource.TimeAgo_HoursAgo => "Il y a {0} heures",
+                    LanguageResource.TimeAgo_DayAgo => "Il y a un jour",
+                    LanguageResource.TimeAgo_DaysAgo => "Il y a {0} jours",
+                    LanguageResource.TimeAgo_MonthAgo => "Il y a un mois",
+                    LanguageResource.TimeAgo_MonthsAgo => "Il y a {0} mois",
+                    LanguageResource.TimeAgo_YearAgo => "Il y a {0} an",
+                    LanguageResource.TimeAgo_YearsAgo => "Il y a {0} ans",
+
+                    // Fallback to the Default/English if no translation is found
+                    _ => IFluentLocalizer.GetDefault(key, arguments),
+                };
+            }
+        }
+    }
+}

--- a/tests/Core/Utilities/DateTimeProviderTests.cs
+++ b/tests/Core/Utilities/DateTimeProviderTests.cs
@@ -151,6 +151,19 @@ public class DateTimeProviderTests
 
         Assert.Throws<InvalidOperationException>(() => DateTimeProvider.Today); // No more dates are available
     }
+    [Fact]
+    public void DateTimeProviderContext_RecordTypeTest()
+    {
+        // Arrange
+        var date = new DateTime(2020, 5, 26);
+
+        // Act
+        using var context = new DateTimeProviderContext(date);
+
+        // Assert
+        Assert.NotNull(context);
+        Assert.IsType<DateTimeProviderContext>(context);
+    }
 
     private class MyUserClass
     {

--- a/tests/Core/Utilities/DateTimeProviderTests.cs
+++ b/tests/Core/Utilities/DateTimeProviderTests.cs
@@ -1,0 +1,162 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Tests.Utilities;
+
+public class DateTimeProviderTests
+{
+    public DateTimeProviderTests(ITestOutputHelper testOutputHelper)
+    {
+        DateTimeProvider.RequiredActiveContext = true;
+    }
+
+    [Fact]
+    public void DateTimeProvider_WithContext()
+    {
+        using var context = new DateTimeProviderContext(new DateTime(2020, 5, 26));
+
+        var year = MyUserClass.GetCurrentYear();
+
+        Assert.Equal(2020, year);
+    }
+
+    [Fact]
+    public void DateTimeProvider_WithoutContext()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            var year = MyUserClass.GetCurrentYear();
+        });
+    }
+
+    [Fact]
+    public void DateTimeProvider_SystemDate_WithRequiredContext()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            var date = DateTimeProvider.GetSystemDate(requiredContext: true);
+        });
+    }
+
+    [Fact]
+    public void DateTimeProvider_SystemDate_WithoutRequiredContext()
+    {
+        var date = DateTimeProvider.GetSystemDate(requiredContext: false);
+
+        Assert.Equal(DateTime.Today.Year, date.Date.Year);
+    }
+
+    [Fact]
+    public void DateTimeProvider_DisposeEmptyContext()
+    {
+        using var context = new DateTimeProviderContext(new DateTime(2020, 5, 26));
+
+        context.Dispose();
+        context.Dispose();
+    }
+
+    [Fact]
+    public void DateTimeProvider_UtcNow()
+    {
+        var date = new DateTime(2020, 5, 26);
+        var currentOffset = Math.Abs(new DateTimeOffset(date).Offset.TotalHours);
+
+        using var context = new DateTimeProviderContext(date);
+        var contextOffset = Math.Abs((DateTimeProvider.UtcNow - DateTimeProvider.Now).TotalHours);
+
+        Assert.Equal(currentOffset, contextOffset);
+    }
+
+    [Fact]
+    public void DateTimeProvider_ResetCurrentIndex()
+    {
+        const uint maxValue = uint.MaxValue;
+
+        var currentIndex = 0u;
+        using var context = new DateTimeProviderContext(i =>
+        {
+            currentIndex = i;
+            return new DateTime(2020, 5, 26);
+        });
+
+        context.ForceNextValue(maxValue);
+
+        // First call => Max value
+        _ = DateTimeProvider.Today;
+        Assert.Equal(maxValue, currentIndex);
+
+        // Second call => Reset
+        _ = DateTimeProvider.Today;
+        Assert.Equal(0u, currentIndex);
+    }
+
+    [Fact]
+    public void DateTimeProvider_SimpleTest()
+    {
+        const int year = 2020;
+
+        // Context 1
+        using var context1 = new DateTimeProviderContext(new DateTime(year, 5, 26));
+        Assert.Equal(year, DateTimeProvider.Today.Year);
+
+        using (var context2 = new DateTimeProviderContext(new DateTime(year + 1, 5, 26)))
+        {
+            // Context 2
+            Assert.Equal(year + 1, DateTimeProvider.Today.Year);
+        }
+
+        // Context 1
+        Assert.Equal(year, DateTimeProvider.Today.Year);
+    }
+
+    [Fact]
+    public void DateTimeProvider_Sequence()
+    {
+        const int year = 2020;
+
+        // Context Sequence
+        using var contextSequence = new DateTimeProviderContext(i => i switch
+        {
+            0 => new DateTime(year + 10, 5, 26),
+            1 => new DateTime(year + 11, 5, 27),
+            _ => DateTime.MinValue,
+        });
+
+        Assert.Equal(year + 10, DateTimeProvider.Today.Year);    // Sequence 0
+        Assert.Equal(year + 11, DateTimeProvider.Today.Year);    // Sequence 1
+    }
+
+    [Fact]
+    public void DateTimeProvider_UsingListOfDates()
+    {
+        const int year = 2020;
+
+        // Context Sequence
+        using var contextSequence = new DateTimeProviderContext(
+        [
+            new DateTime(year + 10, 5, 26),
+            new DateTime(year + 11, 5, 27)
+        ]);
+
+        Assert.Equal(year + 10, DateTimeProvider.Today.Year);    // Sequence 0
+        Assert.Equal(year + 11, DateTimeProvider.Today.Year);    // Sequence 1
+
+        Assert.Throws<InvalidOperationException>(() => DateTimeProvider.Today); // No more dates are available
+    }
+
+    private class MyUserClass
+    {
+        public static int GetCurrentYear()
+        {
+            return DateTimeProvider.Today.Year;
+        }
+    }
+}


### PR DESCRIPTION
# [dev-v5] Add DateTimeProvider and DateTimeExtensions

1. Add a **DateTimeProvider** and **DateTimeProviderContext**
   See the **ReadMe.md** documentation in the **Utilities/DateTime** folder.

   > To simplify the possibility to unit test a current Date Time,
   > we propose a solution that uses the **Ambient Context Model**.
   >
   > To do this, use a `DateTimeProvider` class that determines the current date:
   > the default `DateTime.Now` is replaced by `DateTimeProvider.Now` in the code.
   >
   > Example:
   > ```csharp
   > int GetQuarter()
   > {
   >     return (DateTimeProvider.Today.Month - 1) / 3 + 1;
   > }
   > ```
   >
   > This **provider** returns the system's current date. However, by using it in a unit test, 
   > we can adapt the context to specify a predefined (fake / fixed) date.
   > 
   > ```csharp
   > var fakeDate = new DateTime(2018, 5, 26);
   > using (var context = new DateTimeProviderContext(fakeDate))
   > {
   >     var quarter = GetQuarter();  // 2
   > }

2. Add some `DateTimeExtensions` methods
3. Add a method `ToTimeAgo(TimeSpan)` to return an equivalent localizable string.

## Unit Tests

![image](https://github.com/user-attachments/assets/da3c3bad-09b9-49c5-9e09-131306cd92e7)
![image](https://github.com/user-attachments/assets/2d7d1923-6b2b-4b23-abed-3c9ef479cdaf)
