### PR TITLE
[AutoComplete] - Introduce Position parameter.

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -5909,7 +5909,7 @@
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.Position">
             <summary>
-            Gets or sets the vertical default position of the options popup.
+            Gets or sets the position of the options popup.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.Value">
@@ -6103,6 +6103,12 @@
         </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.RaiseValueTextChangedAsync(System.String)">
             <summary />
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.GetVerticalPosition">
+            <summary>
+            Gets the position of the popup.
+            </summary>
+            <returns></returns>
         </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.MustBeClosed">
             <summary />

--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -5907,6 +5907,11 @@
             Gets or sets the callback that is invoked when the text field value changes.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.Position">
+            <summary>
+            Gets or sets the vertical default position of the options popup.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAutocomplete`1.Value">
             <summary>
             Gets or sets the value of the input. This should be used with two-way binding.

--- a/src/Core/Components/List/FluentAutocomplete.razor
+++ b/src/Core/Components/List/FluentAutocomplete.razor
@@ -117,7 +117,7 @@
             <FluentAnchoredRegion Anchor="@Id"
                                   HorizontalDefaultPosition="HorizontalPosition.Right"
                                   HorizontalInset="true"
-                                  VerticalDefaultPosition="@VerticalPosition.Unset"
+                                  VerticalDefaultPosition="Position"
                                   Style="margin-top: 10px; border-radius: calc(var(--control-corner-radius) * 2px); background-color: var(--neutral-layer-floating);"
                                   Shadow="ElevationShadow.Flyout">
                 @if (HeaderContent != null)
@@ -160,7 +160,7 @@
             <FluentAnchoredRegion Anchor="@Id"
                                   HorizontalDefaultPosition="HorizontalPosition.Right"
                                   HorizontalInset="true"
-                                  VerticalDefaultPosition="@VerticalPosition.Unset"
+                                  VerticalDefaultPosition="Position"
                                   Style="margin-top: 10px; border-radius: calc(var(--control-corner-radius) * 2px); background-color: var(--neutral-layer-floating); padding: 10px;"
                                   Shadow="ElevationShadow.Flyout">
                 @MaximumSelectedOptionsMessage

--- a/src/Core/Components/List/FluentAutocomplete.razor
+++ b/src/Core/Components/List/FluentAutocomplete.razor
@@ -117,7 +117,7 @@
             <FluentAnchoredRegion Anchor="@Id"
                                   HorizontalDefaultPosition="HorizontalPosition.Right"
                                   HorizontalInset="true"
-                                  VerticalDefaultPosition="Position"
+                                  VerticalDefaultPosition="GetVerticalPosition()"
                                   Style="margin-top: 10px; border-radius: calc(var(--control-corner-radius) * 2px); background-color: var(--neutral-layer-floating);"
                                   Shadow="ElevationShadow.Flyout">
                 @if (HeaderContent != null)
@@ -160,7 +160,7 @@
             <FluentAnchoredRegion Anchor="@Id"
                                   HorizontalDefaultPosition="HorizontalPosition.Right"
                                   HorizontalInset="true"
-                                  VerticalDefaultPosition="Position"
+                                  VerticalDefaultPosition="GetVerticalPosition()"
                                   Style="margin-top: 10px; border-radius: calc(var(--control-corner-radius) * 2px); background-color: var(--neutral-layer-floating); padding: 10px;"
                                   Shadow="ElevationShadow.Flyout">
                 @MaximumSelectedOptionsMessage

--- a/src/Core/Components/List/FluentAutocomplete.razor.cs
+++ b/src/Core/Components/List/FluentAutocomplete.razor.cs
@@ -57,10 +57,10 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
     public EventCallback<string> ValueTextChanged { get; set; }
 
     /// <summary>
-    /// Gets or sets the vertical default position of the options popup.
+    /// Gets or sets the position of the options popup.
     /// </summary>
     [Parameter]
-    public VerticalPosition Position { get; set; } = VerticalPosition.Unset;
+    public SelectPosition? Position { get; set; }
 
     /// <summary>
     /// Gets or sets the value of the input. This should be used with two-way binding.
@@ -656,6 +656,18 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
         }
 
     }
+
+    /// <summary>
+    /// Gets the position of the popup.
+    /// </summary>
+    /// <returns></returns>
+    private VerticalPosition? GetVerticalPosition()
+            => Position switch
+            {
+                SelectPosition.Above => VerticalPosition.Top,
+                SelectPosition.Below => VerticalPosition.Bottom,
+                _ => VerticalPosition.Unset,
+            };
 
     /// <summary />
     private bool MustBeClosed()

--- a/src/Core/Components/List/FluentAutocomplete.razor.cs
+++ b/src/Core/Components/List/FluentAutocomplete.razor.cs
@@ -57,6 +57,12 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
     public EventCallback<string> ValueTextChanged { get; set; }
 
     /// <summary>
+    /// Gets or sets the vertical default position of the options popup.
+    /// </summary>
+    [Parameter]
+    public VerticalPosition Position { get; set; } = VerticalPosition.Unset;
+
+    /// <summary>
     /// Gets or sets the value of the input. This should be used with two-way binding.
     /// For the FluentAutocomplete component, use the <see cref="ValueText"/> property instead.
     /// </summary>


### PR DESCRIPTION
## [FEAT] - Introduce Position parameter with default value in FluentAutocomplete component.

This PR introduces a new Position parameter to the FluentAutocomplete component. The new parameter allows developers to control the positioning of the autocomplete dropdown.

```
  /// <summary>
  /// Gets or sets the vertical default position of the options popup.
  /// </summary>
  [Parameter]
  public VerticalPosition Position { get; set; } = VerticalPosition.Unset;
```

The AutocompletePosition enum includes two options:

**The VerticalPosition enum includes the following options:**
   - Top: Displays the dropdown above the input.
   - Bottom (default): Displays the dropdown below the input.
   - Center: Aligns the dropdown centrally.
   - Unset: No positioning specified (default fallback behavior).

**Why this change?**
With this enhancement, developers can now dynamically control the dropdown position based on layout constraints or UI preferences.

**Backward Compatibility**
Default behavior remains unchanged (Unset), ensuring existing applications continue to work as expected.

**Testing**
- Verified all VerticalPosition enum options in multiple layout scenarios.
- Ensured visual consistency and fallback behaviors are preserved.

Looking forward to feedback from the team.

Best regards,
Pedro Constantino
