### PR TITLE
[InputFile] [a11y] Fix missing focus indicator in FluentInputFile (#3693)

### DIFF
--- a/src/Core/Components/InputFile/FluentInputFile.razor.css
+++ b/src/Core/Components/InputFile/FluentInputFile.razor.css
@@ -17,6 +17,11 @@
         justify-self: center;
     }
 
+    .fluent-inputfile-container:has(input[type='file']:focus-visible) {
+        outline: calc(var(--focus-stroke-width) * 1px) solid var(--focus-stroke-outer);
+        outline-offset: calc(var(--focus-stroke-width) * -1px);
+    }
+
     .fluent-inputfile-container ::deep input[type='file'] {
         width: 100%;
         height: 100%;


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR fixes the missing focus indicator in `FluentInputFile`.

Before:
![before](https://github.com/user-attachments/assets/aa84ba9a-fd02-4ae7-8667-96c107a0f46f)

After:
![after](https://github.com/user-attachments/assets/ecc56bbd-edbd-479a-84ad-a801b965e9ca)

### 🎫 Issues

Fixes #3693

## 👩‍💻 Reviewer Notes

This issue is being caused by the input field having `opacity` set to `0`. This results in the UI not showing any focus borders. This PR fixes this by giving the parent container the corresponding outline.

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [ ] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

