### PR TITLE
[dev-v5] Fix the documentation to be responsive

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Accordion/Examples/AccordionMarkerAndBlock.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Accordion/Examples/AccordionMarkerAndBlock.razor
@@ -1,11 +1,11 @@
 ﻿<FluentStack Orientation="Orientation.Vertical">
     <FluentCheckbox @bind-Value="@markerAtEnd" Label="Marker at the end" Message="The marker can be placed either in front or at the end of the item header" />
     <FluentCheckbox @bind-Value="@block" Label="Use 'Block' parameter" Disabled="@(!markerAtEnd)" Message="When the marker is placed at the end, this makes the item header use the full available width." />
-    <div class="demopanel" style="width: 450px;">
 
-
-
-    <FluentAccordion ExpandMode="AccordionExpandMode.Single" MarkerPosition="@markerPosition" Block="@block">
+    <FluentAccordion ExpandMode="AccordionExpandMode.Single"
+                     MarkerPosition="@markerPosition"
+                     Style="@($"width: 350px; {CommonStyles.NeutralBorder1}")"
+                     Block="@block">
         <FluentAccordionItem Header="Accordion Header 1">
             Accordion Panel 1
         </FluentAccordionItem>
@@ -18,7 +18,7 @@
             Accordion Panel 3
         </FluentAccordionItem>
     </FluentAccordion>
-    </div>
+
 </FluentStack>
 
 @code {

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Avatar/Examples/FluentAvatarActive.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Avatar/Examples/FluentAvatarActive.razor
@@ -1,9 +1,8 @@
-﻿@using System.Linq;
-
-<FluentStack HorizontalGap="12px"
+﻿<FluentStack HorizontalGap="12px"
              Style="margin-bottom:15px;"
              VerticalAlignment="VerticalAlignment.Bottom"
-             Orientation="Orientation.Horizontal">
+             Orientation="Orientation.Horizontal"
+             Wrap="true">
 
     <FluentSelect Label="Active"
                   Items="@activeModes"
@@ -19,11 +18,7 @@
 
 @code
 {
-    List<bool?> activeModes = new List<bool?> {
-        null,
-        true,
-        false
-    };
+    List<bool?> activeModes = new List<bool?> { null, true, false };
     bool? active;
     AvatarActiveAppearance activeAppearance = AvatarActiveAppearance.Ring;
 }

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Avatar/Examples/FluentAvatarColorful.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Avatar/Examples/FluentAvatarColorful.razor
@@ -1,4 +1,4 @@
-﻿<FluentStack Orientation="Orientation.Horizontal" HorizontalGap="12px">
+﻿<FluentStack Orientation="Orientation.Horizontal" HorizontalGap="12px" Wrap="true">
 
     <FluentAvatar Color="AvatarColor.Colorful" name="Katri Athokas" />
     <FluentAvatar Color="AvatarColor.Colorful" name="Elvia Atkins" />

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Avatar/Examples/FluentAvatarExample.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Avatar/Examples/FluentAvatarExample.razor
@@ -1,9 +1,8 @@
-﻿@using System.Linq;
-
-<FluentStack HorizontalGap="12px"
+﻿<FluentStack HorizontalGap="12px"
              Style="margin-bottom:15px;"
              VerticalAlignment="VerticalAlignment.Bottom"
-             Orientation="Orientation.Horizontal">
+             Orientation="Orientation.Horizontal"
+             Wrap="true">
 
     <FluentSelect Label="Color"
                   Items="@(Enum.GetValues<AvatarColor>())"

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Avatar/Examples/FluentAvatarName.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Avatar/Examples/FluentAvatarName.razor
@@ -2,7 +2,8 @@
 <FluentStack HorizontalGap="12px"
              Style="margin-bottom:15px;"
              VerticalAlignment="VerticalAlignment.Bottom"
-             Orientation="Orientation.Horizontal">
+             Orientation="Orientation.Horizontal"
+             Wrap="true">
 
     <FluentTextInput Label="Name" @bind-Value="@name" />
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/AnchorButton/Examples/AnchorButtonAppearances.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/AnchorButton/Examples/AnchorButtonAppearances.razor
@@ -1,4 +1,4 @@
-﻿<FluentStack HorizontalGap="10">
+﻿<FluentStack HorizontalGap="10" Wrap="true">
     <FluentAnchorButton Href="#">
         Default
     </FluentAnchorButton>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/AnchorButton/Examples/AnchorButtonLongText.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/AnchorButton/Examples/AnchorButtonLongText.razor
@@ -4,7 +4,7 @@
     }
 </style>
 
-<FluentStack HorizontalGap="10">
+<FluentStack HorizontalGap="10" Wrap="true">
     <FluentAnchorButton href="#">
         Short text
     </FluentAnchorButton>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/AnchorButton/Examples/AnchorButtonShapes.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/AnchorButton/Examples/AnchorButtonShapes.razor
@@ -1,4 +1,4 @@
-﻿<FluentStack HorizontalGap="10">
+﻿<FluentStack HorizontalGap="10" Wrap="true">
     <FluentAnchorButton Href="#" Shape="ButtonShape.Rounded">Rounded</FluentAnchorButton>
     <FluentAnchorButton Href="#" Shape="ButtonShape.Circular">Circular</FluentAnchorButton>
     <FluentAnchorButton Href="#" Shape="ButtonShape.Square">Square</FluentAnchorButton>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/AnchorButton/Examples/AnchorButtonSizes.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/AnchorButton/Examples/AnchorButtonSizes.razor
@@ -1,5 +1,5 @@
 ﻿<FluentStack Orientation="Orientation.Vertical" VerticalGap="15">
-    <FluentStack HorizontalGap="10">
+    <FluentStack HorizontalGap="10" Wrap="true">
         <FluentAnchorButton href="#" Size="ButtonSize.Small">Small</FluentAnchorButton>
         <FluentAnchorButton href="#" Size="ButtonSize.Small" IconStart="@(new Icons.Regular.Size16.Globe())">
             Small with globe icon
@@ -12,7 +12,7 @@
         </FluentAnchorButton>
     </FluentStack>
 
-    <FluentStack HorizontalGap="10">
+    <FluentStack HorizontalGap="10" Wrap="true">
         <FluentAnchorButton href="#" Size="ButtonSize.Medium">Medium</FluentAnchorButton>
         <FluentAnchorButton href="#" Size="ButtonSize.Medium" IconStart="@(new Icons.Regular.Size20.Globe())">
             Medium with globe icon
@@ -25,7 +25,7 @@
         </FluentAnchorButton>
     </FluentStack>
 
-    <FluentStack HorizontalGap="10">
+    <FluentStack HorizontalGap="10" Wrap="true">
         <FluentAnchorButton href="#" Size="ButtonSize.Large">Large</FluentAnchorButton>
         <FluentAnchorButton href="#" Size="ButtonSize.Large" IconStart="@(new Icons.Regular.Size24.Globe())">
             Large with globe icon

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/Button/Examples/ButtonDisabled.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/Button/Examples/ButtonDisabled.razor
@@ -1,4 +1,4 @@
-﻿<FluentStack HorizontalGap="10">
+﻿<FluentStack HorizontalGap="10" Wrap="true">
     <FluentButton>Enabled state</FluentButton>
     <FluentButton Disabled="true">Disabled state</FluentButton>
     <FluentButton DisabledFocusable="true">Disabled focusable state</FluentButton>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/Button/Examples/ButtonLongText.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/Button/Examples/ButtonLongText.razor
@@ -1,12 +1,6 @@
-﻿<style>
-    .max-width {
-        width: 280px;
-    }
-</style>
-
-<FluentStack HorizontalGap="10">
+﻿<FluentStack HorizontalGap="10" Wrap="true">
     <FluentButton Label="Short text"></FluentButton>
-    <FluentButton Class="max-width">
+    <FluentButton Style="max-width: 280px;">
         <ChildContent>
             Long text wraps after it hits the max width of the component
         </ChildContent>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/Button/Examples/ButtonSizes.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/Button/Examples/ButtonSizes.razor
@@ -1,5 +1,5 @@
 ﻿<FluentStack Orientation="Orientation.Vertical" VerticalGap="15">
-    <FluentStack HorizontalGap="10">
+    <FluentStack HorizontalGap="10" Wrap="true">
         <FluentButton Size="ButtonSize.Small">Small</FluentButton>
         <FluentButton Size="ButtonSize.Small" IconStart="@(new Icons.Regular.Size16.Globe())">
             Small with globe icon
@@ -11,7 +11,7 @@
         </FluentButton>
     </FluentStack>
 
-    <FluentStack HorizontalGap="10">
+    <FluentStack HorizontalGap="10" Wrap="true">
         <FluentButton Size="ButtonSize.Medium">Medium</FluentButton>
         <FluentButton Size="ButtonSize.Medium" IconStart="@(new Icons.Regular.Size20.Globe())">
             Medium with globe icon
@@ -23,7 +23,7 @@
         </FluentButton>
     </FluentStack>
 
-    <FluentStack HorizontalGap="10">
+    <FluentStack HorizontalGap="10" Wrap="true">
         <FluentButton Size="ButtonSize.Large">Large</FluentButton>
         <FluentButton Size="ButtonSize.Large" IconStart="@(new Icons.Regular.Size24.Globe())">
             Large with globe icon

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/CompoundButton/Examples/CompoundButtonAppearances.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/CompoundButton/Examples/CompoundButtonAppearances.razor
@@ -1,4 +1,4 @@
-﻿<FluentStack HorizontalGap="10">
+﻿<FluentStack HorizontalGap="10" Wrap="true">
     <FluentCompoundButton Label="Default">
         <Description>Description content</Description>
     </FluentCompoundButton>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/CompoundButton/Examples/CompoundButtonDisabled.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/CompoundButton/Examples/CompoundButtonDisabled.razor
@@ -1,4 +1,4 @@
-﻿<FluentStack HorizontalGap="10">
+﻿<FluentStack HorizontalGap="10" Wrap="true">
     <FluentCompoundButton>
         <ChildContent>Enabled state</ChildContent>
         <Description>Description content</Description>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/CompoundButton/Examples/CompoundButtonLongText.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/CompoundButton/Examples/CompoundButtonLongText.razor
@@ -4,7 +4,7 @@
     }
 </style>
 
-<FluentStack HorizontalGap="10">
+<FluentStack HorizontalGap="10" Wrap="true">
     <FluentCompoundButton Label="Short text">
         <Description>Description content</Description>
     </FluentCompoundButton>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/CompoundButton/Examples/CompoundButtonShapes.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/CompoundButton/Examples/CompoundButtonShapes.razor
@@ -1,4 +1,4 @@
-﻿<FluentStack HorizontalGap="10">
+﻿<FluentStack HorizontalGap="10" Wrap="true">
     <FluentCompoundButton Label="Rounded" Shape="ButtonShape.Rounded">
         <Description>Description content</Description>
     </FluentCompoundButton>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/CompoundButton/Examples/CompoundButtonSizes.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/CompoundButton/Examples/CompoundButtonSizes.razor
@@ -1,5 +1,5 @@
 ﻿<FluentStack Orientation="Orientation.Vertical" VerticalGap="15">
-    <FluentStack HorizontalGap="10">
+    <FluentStack HorizontalGap="10" Wrap="true">
         <FluentCompoundButton Size="ButtonSize.Small">
             <ChildContent>Small</ChildContent>
             <Description>Description content</Description>
@@ -15,7 +15,7 @@
         </FluentCompoundButton>
     </FluentStack>
 
-    <FluentStack HorizontalGap="10">
+    <FluentStack HorizontalGap="10" Wrap="true">
         <FluentCompoundButton Size="ButtonSize.Medium">
             <ChildContent>Medium</ChildContent>
             <Description>Description content</Description>
@@ -31,7 +31,7 @@
         </FluentCompoundButton>
     </FluentStack>
 
-    <FluentStack HorizontalGap="10">
+    <FluentStack HorizontalGap="10" Wrap="true">
         <FluentCompoundButton Size="ButtonSize.Large">
             <ChildContent>Large</ChildContent>
             <Description>Description content</Description>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/MenuButton/Examples/MenuButtonDisabled.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/MenuButton/Examples/MenuButtonDisabled.razor
@@ -1,4 +1,4 @@
-﻿<FluentStack HorizontalGap="10">
+﻿<FluentStack HorizontalGap="10" Wrap="true">
     <FluentMenuButton>Enabled state</FluentMenuButton>
     <FluentMenuButton Disabled="true">Disabled state</FluentMenuButton>
     <FluentMenuButton DisabledFocusable="true">Disabled focusable state</FluentMenuButton>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/MenuButton/Examples/MenuButtonLongText.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/MenuButton/Examples/MenuButtonLongText.razor
@@ -4,7 +4,7 @@
     }
 </style>
 
-<FluentStack HorizontalGap="10">
+<FluentStack HorizontalGap="10" Wrap="true">
     <FluentMenuButton Label="Short text"></FluentMenuButton>
     <FluentMenuButton Class="max-width">
         <ChildContent>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/MenuButton/Examples/MenuButtonSizes.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/MenuButton/Examples/MenuButtonSizes.razor
@@ -1,5 +1,5 @@
 ﻿<FluentStack Orientation="Orientation.Vertical" VerticalGap="15">
-    <FluentStack HorizontalGap="10">
+    <FluentStack HorizontalGap="10" Wrap="true">
         <FluentMenuButton Size="ButtonSize.Small">Small</FluentMenuButton>
         <FluentMenuButton Size="ButtonSize.Small" IconStart="@(new Icons.Regular.Size16.Globe())">
             Small with globe icon
@@ -10,7 +10,7 @@
         </FluentMenuButton>
     </FluentStack>
 
-    <FluentStack HorizontalGap="10">
+    <FluentStack HorizontalGap="10" Wrap="true">
         <FluentMenuButton Size="ButtonSize.Medium">Medium</FluentMenuButton>
         <FluentMenuButton Size="ButtonSize.Medium" IconStart="@(new Icons.Regular.Size20.Globe())">
             Medium with globe icon
@@ -21,7 +21,7 @@
         </FluentMenuButton>
     </FluentStack>
 
-    <FluentStack HorizontalGap="10">
+    <FluentStack HorizontalGap="10" Wrap="true">
         <FluentMenuButton Size="ButtonSize.Large">Large</FluentMenuButton>
         <FluentMenuButton Size="ButtonSize.Large" IconStart="@(new Icons.Regular.Size24.Globe())">
             Large with globe icon

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/SplitButton/Examples/SplitButtonIcon.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/SplitButton/Examples/SplitButtonIcon.razor
@@ -1,24 +1,18 @@
 ﻿<FluentSplitButton IconStart="@(new Icons.Regular.Size20.Globe())"
                    Title="Open menu"
                    Label="Globe at start">
-    @RenderMenuItems()
+    <FluentMenuList>
+        <FluentMenuItem>Menu item 1</FluentMenuItem>
+        <FluentMenuItem>Menu item 2</FluentMenuItem>
+        <FluentMenuItem>Menu item 3</FluentMenuItem>
+        <FluentMenuItem>Menu item 4</FluentMenuItem>
+    </FluentMenuList>
 </FluentSplitButton>
 
 @* To be re-added when the web componnet gets fixed
 <FluentSplitButton IconToggle="@(new Icons.Regular.Size20.Globe())"
                    Title="Open menu"
                    Label="Replace chevron">
-    @RenderMenuItems()
+    ...
 </FluentSplitButton>
 *@
-
-@code
-{
-    RenderFragment RenderMenuItems() =>
-        @<FluentMenuList>
-        <FluentMenuItem>Menu item 1</FluentMenuItem>
-        <FluentMenuItem>Menu item 2</FluentMenuItem>
-        <FluentMenuItem>Menu item 3</FluentMenuItem>
-        <FluentMenuItem>Menu item 4</FluentMenuItem>
-    </FluentMenuList>;
-}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/SplitButton/Examples/SplitButtonShapes.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/SplitButton/Examples/SplitButtonShapes.razor
@@ -1,29 +1,28 @@
 ﻿<FluentSplitButton Shape="ButtonShape.Rounded"
                    Title="Open menu"
                    Label="Rounded">
-    @RenderMenuItems()
+    <FluentMenuList>
+        <FluentMenuItem>Menu item 1</FluentMenuItem>
+        <FluentMenuItem>Menu item 2</FluentMenuItem>
+        <FluentMenuItem>Menu item 3</FluentMenuItem>
+        <FluentMenuItem>Menu item 4</FluentMenuItem>
+    </FluentMenuList>
 </FluentSplitButton>
 
 <FluentSplitButton Shape="ButtonShape.Circular"
                    Title="Open menu"
                    Label="Circular">
-    @RenderMenuItems()
+    <FluentMenuList>
+        <FluentMenuItem>Menu item 1</FluentMenuItem>
+        <FluentMenuItem>Menu item 2</FluentMenuItem>
+    </FluentMenuList>
 </FluentSplitButton>
 
 <FluentSplitButton Shape="ButtonShape.Square"
                    Title="Open menu"
                    Label="Square">
-    @RenderMenuItems()
-</FluentSplitButton>
-
-@code
-{
-    RenderFragment RenderMenuItems() =>
-        @<FluentMenuList>
+    <FluentMenuList>
         <FluentMenuItem>Menu item 1</FluentMenuItem>
         <FluentMenuItem>Menu item 2</FluentMenuItem>
-        <FluentMenuItem>Menu item 3</FluentMenuItem>
-        <FluentMenuItem>Menu item 4</FluentMenuItem>
-    </FluentMenuList>;
-
-}
+    </FluentMenuList>
+</FluentSplitButton>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/SplitButton/Examples/SplitButtonSizes.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/SplitButton/Examples/SplitButtonSizes.razor
@@ -1,30 +1,29 @@
 ﻿<FluentSplitButton Size="ButtonSize.Small"
                    Title="Open menu"
                    Label="Small">
-    @RenderMenuItems()
+    <FluentMenuList>
+        <FluentMenuItem>Menu item 1</FluentMenuItem>
+        <FluentMenuItem>Menu item 2</FluentMenuItem>
+        <FluentMenuItem>Menu item 3</FluentMenuItem>
+        <FluentMenuItem>Menu item 4</FluentMenuItem>
+    </FluentMenuList>
 </FluentSplitButton>
 
 <FluentSplitButton Size="ButtonSize.Medium"
                    Title="Open menu"
                    Label="Medium">
-    @RenderMenuItems()
+    <FluentMenuList>
+        <FluentMenuItem>Menu item 1</FluentMenuItem>
+        <FluentMenuItem>Menu item 2</FluentMenuItem>
+    </FluentMenuList>
 </FluentSplitButton>
 
 
 <FluentSplitButton Size="ButtonSize.Large"
                    Title="Open menu"
                    Label="Large">
-    @RenderMenuItems()
-</FluentSplitButton>
-
-@code
-{
-    RenderFragment RenderMenuItems() =>
-        @<FluentMenuList>
+    <FluentMenuList>
         <FluentMenuItem>Menu item 1</FluentMenuItem>
         <FluentMenuItem>Menu item 2</FluentMenuItem>
-        <FluentMenuItem>Menu item 3</FluentMenuItem>
-        <FluentMenuItem>Menu item 4</FluentMenuItem>
-    </FluentMenuList>;
-
-}
+    </FluentMenuList>
+</FluentSplitButton>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/ToggleButton/Examples/ToggleButtonDisabled.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/ToggleButton/Examples/ToggleButtonDisabled.razor
@@ -1,4 +1,4 @@
-﻿<FluentStack HorizontalGap="10">
+﻿<FluentStack HorizontalGap="10" Wrap="true">
     <FluentToggleButton>Enabled state</FluentToggleButton>
     <FluentToggleButton Disabled="true">Disabled state</FluentToggleButton>
     <FluentToggleButton DisabledFocusable="true">Disabled focusable state</FluentToggleButton>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/ToggleButton/Examples/ToggleButtonLongText.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/ToggleButton/Examples/ToggleButtonLongText.razor
@@ -4,7 +4,7 @@
     }
 </style>
 
-<FluentStack HorizontalGap="10">
+<FluentStack HorizontalGap="10" Wrap="true">
     <FluentToggleButton Label="Short text"></FluentToggleButton>
     <FluentToggleButton Class="max-width">
         <ChildContent>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/ToggleButton/Examples/ToggleButtonSizes.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/ToggleButton/Examples/ToggleButtonSizes.razor
@@ -1,5 +1,5 @@
 ﻿<FluentStack Orientation="Orientation.Vertical" VerticalGap="15">
-    <FluentStack HorizontalGap="10">
+    <FluentStack HorizontalGap="10" Wrap="true">
         <FluentToggleButton Size="ButtonSize.Small">
             <ChildContent>Small</ChildContent>
         </FluentToggleButton>
@@ -13,7 +13,7 @@
         </FluentToggleButton>
     </FluentStack>
 
-    <FluentStack HorizontalGap="10">
+    <FluentStack HorizontalGap="10" Wrap="true">
         <FluentToggleButton Size="ButtonSize.Medium">
             <ChildContent>Medium</ChildContent>
         </FluentToggleButton>
@@ -27,7 +27,7 @@
         </FluentToggleButton>
     </FluentStack>
 
-    <FluentStack HorizontalGap="10">
+    <FluentStack HorizontalGap="10" Wrap="true">
         <FluentToggleButton Size="ButtonSize.Large">
             <ChildContent>Large</ChildContent>
         </FluentToggleButton>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Divider/Examples/FluentDividerExamples.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Divider/Examples/FluentDividerExamples.razor
@@ -1,7 +1,8 @@
 ﻿<FluentStack HorizontalGap="12px"
              Style="margin-bottom:15px;"
              VerticalAlignment="VerticalAlignment.Bottom"
-             Orientation="Orientation.Horizontal">
+             Orientation="Orientation.Horizontal"
+             Wrap="true">
 
     <FluentTextInput Label="Content"
                      @bind-Value="@content" />

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Grid/FluentGrid.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Grid/FluentGrid.md
@@ -58,7 +58,7 @@ This allows for fine-grained control over when HTML is generated or not, for exa
 the grid item takes a lot of time or leads to a lot of data being transferred.
 
 
-<div class="grid-item-hidden">
+<div class="grid-item-hidden" style="overflow-x: auto;">
 
 |GridItemHidden|X Small<br/><sup>< 600px</sup>|Small<br/><sup>600px - 959px</sup>|Medium<br/><sup>960px - 1279px</sup>|Large<br/><sup>1280px - 1919px</sup>|X Large<br/><sup>1920px - 2559px</sup>|XX Large<br/><sup>≥ 2560px</sup>|
 |--------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/List/Select/Examples/SelectAppearance.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/List/Select/Examples/SelectAppearance.razor
@@ -1,5 +1,5 @@
 ﻿<b>Appearance</b>
-<FluentStack HorizontalGap="12px">
+<FluentStack HorizontalGap="12px" Wrap="true">
     <FluentSelect Label="Outline"
                   Appearance="@ListAppearance.Outline"
                   Items="@Colors"
@@ -23,7 +23,7 @@
 </FluentStack>
 
 <b>Size</b>
-<FluentStack HorizontalGap="12px">
+<FluentStack HorizontalGap="12px" Wrap="true">
     <FluentSelect Label="Small"
                   Size="@ListSize.Small"
                   Items="@Colors"

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Stack/Examples/StackCustomized.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Stack/Examples/StackCustomized.razor
@@ -1,7 +1,7 @@
 ﻿@namespace FluentUI.Demo.Shared
 
 <p>Alignment of the Stack content elements:</p>
-<FluentStack HorizontalGap="12px">
+<FluentStack HorizontalGap="12px" Wrap="true">
     <FluentSelect Label="Horizontal"
                   Items="@(Enum.GetValues<HorizontalAlignment>())"
                   @bind-Value="@Horizontal" />

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextArea/Examples/TextAreaAppearances.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextArea/Examples/TextAreaAppearances.razor
@@ -1,5 +1,5 @@
 ﻿<FluentStack Orientation="Orientation.Vertical">
-    <FluentStack HorizontalGap="12px" VerticalAlignment="VerticalAlignment.Bottom" Orientation="Orientation.Horizontal">
+    <FluentStack HorizontalGap="12px" VerticalAlignment="VerticalAlignment.Bottom" Orientation="Orientation.Horizontal" Wrap="true">
 
         <FluentSelect Label="Appearance"
                       Items="@(Enum.GetValues<TextAreaAppearance>())"

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextArea/Examples/TextAreaState.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextArea/Examples/TextAreaState.razor
@@ -1,4 +1,4 @@
-﻿<FluentStack HorizontalGap="20px">
+﻿<FluentStack HorizontalGap="20px" Wrap="true">
     <FluentTextArea Required="true" Label="Required" Placeholder="Required" @bind-Value="@Value" />
     <FluentTextArea Disabled="true" Label="Disabled" Placeholder="Disabled" @bind-Value="@Value" />
     <FluentTextArea ReadOnly="true" Label="ReadOnly" Placeholder="ReadOnly" @bind-Value="@Value" />

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Theme/Spacing/Examples/SpacingComputedBoxes.razor.cs
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Theme/Spacing/Examples/SpacingComputedBoxes.razor.cs
@@ -25,7 +25,7 @@ public partial class SpacingComputedBoxes
     {
         if (firstRender)
         {
-            JSModule = await JSRuntime.InvokeAsync<IJSObjectReference>("import", "./Documentation/Components/Spacing/Examples/SpacingComputedBoxes.razor.js");
+            JSModule = await JSRuntime.InvokeAsync<IJSObjectReference>("import", "./Documentation/Components/Theme/Spacing/Examples/SpacingComputedBoxes.razor.js");
         }
 
         if (JSModule != null)

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Theme/Spacing/Spacing.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Theme/Spacing/Spacing.md
@@ -1,6 +1,6 @@
 ---
 title: Theme / Spacing
-route: /theme/Spacing
+route: /theme/spacing
 ---
 
 # Spacing

--- a/examples/Demo/FluentUI.Demo.Client/Layout/DemoAsidePanel.razor.css
+++ b/examples/Demo/FluentUI.Demo.Client/Layout/DemoAsidePanel.razor.css
@@ -3,6 +3,7 @@
   border-left: var(--strokeWidthThin) solid var(--colorNeutralStroke1);
   padding: 0px 0px 24px 8px;
   min-height: 40vh;
+  background-color: var(--colorNeutralBackground1);
 }
 
   .demo-aside ::deep a {

--- a/examples/Demo/FluentUI.Demo.Client/Layout/DemoMainLayout.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Layout/DemoMainLayout.razor
@@ -99,11 +99,12 @@
 
             Version: @AppVersion.Version
 
-            <FluentLink Href="https://dotnet.microsoft.com/learn/aspnet/what-is-aspnet-core">
-                Powered by @AppVersion.FrameworkDescription
-            </FluentLink>
-
             <FluentSpacer />
+            <a href="https://dotnet.microsoft.com/learn/aspnet/what-is-aspnet-core" target="_blank">
+                Powered by @AppVersion.FrameworkDescription
+            </a>
+            <FluentSpacer />
+
             &copy; Microsoft @AppVersion.CurrentYear. All rights reserved.
         </FluentStack>
     </FluentLayoutItem>

--- a/examples/Tools/FluentUI.Demo.DocViewer/Components/MarkdownViewer.razor.css
+++ b/examples/Tools/FluentUI.Demo.DocViewer/Components/MarkdownViewer.razor.css
@@ -55,6 +55,7 @@
     font-weight: 500;
     background-color: var(--colorNeutralBackground5);
     padding: 0px 4px;
+    overflow-wrap: anywhere
   }
 
   .doc-viewer ::deep pre {

--- a/src/Core/Components/Layout/FluentLayoutItem.razor.cs
+++ b/src/Core/Components/Layout/FluentLayoutItem.razor.cs
@@ -126,7 +126,7 @@ public partial class FluentLayoutItem
                 asideArea.AddExtraStyles("margin-right", "0");
             }
 
-            contentArea?.AddExtraStyles("padding-right", string.IsNullOrEmpty(asideArea.Width) || !asideArea.Sticky ? "0" : asideArea.Width + " !important");
+            contentArea?.AddExtraStyles("padding-right", string.IsNullOrEmpty(asideArea.Width) || !asideArea.Sticky ? "0" : asideArea.Width);
         }
 
         // Grid Area

--- a/src/Core/Components/Layout/FluentLayoutItem.razor.css
+++ b/src/Core/Components/Layout/FluentLayoutItem.razor.css
@@ -76,6 +76,11 @@
     padding-right: unset !important;
   }
 
+  .fluent-layout-item[area="footer"],
+  .fluent-layout-item[area="footer-outside"] {
+    line-height: var(--lineHeightBase100);
+  }
+
   .fluent-layout-item *[hide-on-desktop] {
     display: unset;
   }


### PR DESCRIPTION
[dev-v5] Fix the documentation to be responsive

1. Add `Wrap="true"` in all `FluentStack` (Horizontal)
2. Simplification of Button "menu" samples.
3. Remove incorrect **FluentLayoutItem.Sticky** style

## Before
![Before](https://github.com/user-attachments/assets/1fc79cc5-0ed9-4bf2-87d0-ca7e6325c22a)

## After
![After](https://github.com/user-attachments/assets/4eba98da-0e9b-4368-a2ab-639810f57e3f)

## Unit Tests

No changes