### PR TITLE
Fix combobox GetOptionValue

### DIFF
--- a/src/Core/Components/List/FluentCombobox.razor
+++ b/src/Core/Components/List/FluentCombobox.razor
@@ -14,7 +14,7 @@
                      style="@StyleValue"
                      autocomplete="@Autocomplete.ToAttributeValue()"
                      open=@Open
-                     current-value=@Value
+                     current-value=@GetComboboxContent()
                      placeholder=@Placeholder
                      position=@Position.ToAttributeValue()
                      disabled=@Disabled

--- a/src/Core/Components/List/FluentCombobox.razor.cs
+++ b/src/Core/Components/List/FluentCombobox.razor.cs
@@ -163,6 +163,18 @@ public partial class FluentCombobox<TOption> : ListComponentBase<TOption>, IAsyn
         }
     }
 
+    private string? GetComboboxContent()
+    {
+        if (SelectedOption != null)
+        {
+            return OptionText.Invoke(SelectedOption) ?? OptionValue.Invoke(SelectedOption) ?? SelectedOption.ToString();
+        }
+        else
+        {
+            return null;
+        }
+    }
+
     public new async ValueTask DisposeAsync()
     {
         try

--- a/src/Core/Components/List/FluentCombobox.razor.cs
+++ b/src/Core/Components/List/FluentCombobox.razor.cs
@@ -163,18 +163,6 @@ public partial class FluentCombobox<TOption> : ListComponentBase<TOption>, IAsyn
         }
     }
 
-    protected override string? GetOptionValue(TOption? item)
-    {
-        if (item != null)
-        {
-            return OptionText.Invoke(item) ?? OptionValue.Invoke(item) ?? item.ToString();
-        }
-        else
-        {
-            return null;
-        }
-    }
-
     public new async ValueTask DisposeAsync()
     {
         try

--- a/tests/Core/List/FluentComboboxTests.FluentCombobox_ClearSelection.verified.html
+++ b/tests/Core/List/FluentComboboxTests.FluentCombobox_ClearSelection.verified.html
@@ -1,5 +1,5 @@
 
 <style>#myComponent::part(listbox) {  z-index: 9995 }</style>
-<fluent-combobox id="xxx" current-value="" position="below" blazor:oncomboboxchange="1" blazor:oncontrolinput="2" blazor:elementreference="">
+<fluent-combobox id="xxx" position="below" blazor:oncomboboxchange="1" blazor:oncontrolinput="2" blazor:elementreference="">
   <fluent-option id="xxx" value="Contoso" blazor:onclick="3" aria-selected="false" blazor:elementreference="">Contoso</fluent-option>
 </fluent-combobox>


### PR DESCRIPTION
# Fix combobox GetOptionValue

The correct `GetOptionValue` is already included in the `ListComponentBase` class.

```csharp
// From ListComponentBase

protected virtual string? GetOptionValue(TOption? item)
{
    if (item != null)
    {
        return OptionValue?.Invoke(item) ?? OptionText?.Invoke(item) ?? item?.ToString();
    }
    else
    {
        return null;
    }
}
```

#3734