### PR TITLE
[DataGrid] Do not handle keypress if active element is text field

### DIFF
--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.js
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.js
@@ -64,7 +64,7 @@ export function init(gridElement, autoFocus) {
         }
 
         // check if start is a child of gridElement
-        if (start !== null && (gridElement.contains(start) || gridElement === start) && document.activeElement === start) {
+        if (start !== null && (gridElement.contains(start) || gridElement === start) && document.activeElement === start && document.activeElement.tagName.toLowerCase() !== 'fluent-text-field') {
             const idx = start.cellIndex;
 
             if (event.key === "ArrowUp") {


### PR DESCRIPTION
Fix #3742 by not handeling the arrow keys when the active element is a `FluentTextField`