### PR TITLE
[dev-v5] Add ChangeAfterKeyPress parameter (TextInput and TextArea)

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextArea/Examples/TextAreaChangeAfterKeyPress.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextArea/Examples/TextAreaChangeAfterKeyPress.razor
@@ -1,0 +1,28 @@
+﻿<FluentTextArea Placeholder="Write your message and press Enter"
+                Style="--colorCompoundBrandStroke: transparent;"
+                Spellcheck="false"
+                ReadOnly="Running"
+                @bind-Value="@ChatInput"
+                ChangeAfterKeyPress="@([KeyPress.For(KeyCode.Enter).AndCtrlKey(), KeyPress.For(KeyCode.Enter)])"
+                OnChangeAfterKeyPress="@StartChatDiscussion" />
+
+<div style="height: 10px;">
+    <FluentProgressBar Visible="@Running" Width="280px" />
+</div>
+
+Message sent: <b>@ChatInput</b>
+
+@code
+{
+    string ChatInput = string.Empty;
+    bool Running = false;
+
+    async Task StartChatDiscussion(FluentKeyPressEventArgs e)
+    {
+        Running = true;
+
+        await Task.Delay(3000); // Simulate a delay for processing
+
+        Running = false;
+    }
+}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextArea/FluentTextArea.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextArea/FluentTextArea.md
@@ -39,6 +39,22 @@ This can be achieved by setting the `Immediate` and the (optional) `ImmediateDel
 
 {{ TextAreaImmediate }}
 
+## ChangeAfterKeyPress
+
+In the example of a command area or search text area, you can use the `ChangeAfterKeyPress` parameter to trigger the `OnChange` event
+after a specific key or keys are pressed. E.g. `Enter`, `Escape`, `Tab`, `Ctrl+Enter`, etc.
+You can capture the content of the text area from the `Value` parameter.
+
+An `OnChangeAfterKeyPress` event is also triggered when the user presses these key combinations.
+This also gives you the key used to trigger the event (this can be useful when you allow multiple key combinations).
+
+```razor
+<FluentTextArea ChangeAfterKeyPress="@([KeyPress.For(KeyCode.Enter).AndCtrlKey(), KeyPress.For(KeyCode.Enter)])"
+                OnChangeAfterKeyPress="@(e => ...)" />
+```
+
+{{ TextAreaChangeAfterKeyPress }}
+
 ## States
 
 A text input can be in different states, such as `Disabled`, `ReadOnly`, and `Required`.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextInput/Examples/TextInputChangeAfterKeyPress.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextInput/Examples/TextInputChangeAfterKeyPress.razor
@@ -1,0 +1,31 @@
+﻿<FluentTextInput Placeholder="Search"
+                 Spellcheck="false"
+                 ReadOnly="Running"
+                 @bind-Value="@SearchText"
+                 ChangeAfterKeyPress="@([KeyPress.For(KeyCode.Enter)])"
+                 OnChangeAfterKeyPress="@StartSearch">
+    <StartTemplate>
+        <FluentIcon Value="@(new Icons.Regular.Size16.Search())" Color="Color.Primary" />
+    </StartTemplate>
+</FluentTextInput>
+
+<div style="height: 10px;">
+    <FluentProgressBar Visible="@Running" Width="180px" />
+</div>
+
+Search: <b>@SearchText</b>
+
+@code
+{
+    string SearchText = string.Empty;
+    bool Running = false;
+
+    async Task StartSearch(FluentKeyPressEventArgs e)
+    {
+        Running = true;
+
+        await Task.Delay(2000); // Simulate a delay for processing
+
+        Running = false;
+    }
+}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextInput/FluentTextInput.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextInput/FluentTextInput.md
@@ -37,6 +37,22 @@ This can be achieved by setting the `Immediate` and the optional `ImmediateDelay
 
 {{ TextInputImmediate }}
 
+## Search Text Input
+
+In the example of a search text area, you can use the `ChangeAfterKeyPress` parameter to trigger the `OnChange` event
+after a specific key or keys are pressed. E.g. `Enter`, `Tab`, `Ctrl+Enter`, etc.
+You can capture the content of the text area from the `Value` parameter.
+
+An `OnChangeAfterKeyPress` event is also triggered when the user presses these key combinations.
+This also gives you the key used to trigger the event (this can be useful when you allow multiple key combinations).
+
+```razor
+<FluentTextInput ChangeAfterKeyPress="@([KeyPress.For(KeyCode.Enter)])"
+                 OnChangeAfterKeyPress="@(e => ...)" />
+```
+
+{{ TextInputChangeAfterKeyPress }}
+
 ## States
 
 A text input can be in different states, such as `Disabled`, `ReadOnly`, and `Required`.

--- a/src/Core.Scripts/src/ExportedMethods.ts
+++ b/src/Core.Scripts/src/ExportedMethods.ts
@@ -1,5 +1,6 @@
 import { Microsoft as LoggerFile } from './Utilities/Logger';
 import { Microsoft as AttributesFile } from './Utilities/Attributes';
+import { Microsoft as KeyPressFile } from './Utilities/KeyPress';
 import { Microsoft as FluentDialogFile } from './Components/Dialog/FluentDialog';
 import { Microsoft as FluentTabsFile } from './Components/Tabs/FluentTabs';
 import { Microsoft as FluentMultiSplitterFile } from './Components/Splitter/FluentMultiSplitter';
@@ -17,10 +18,11 @@ export namespace Microsoft.FluentUI.Blazor.ExportedMethods {
     (window as any).Microsoft.FluentUI = (window as any).Microsoft.FluentUI || {};
     (window as any).Microsoft.FluentUI.Blazor = (window as any).Microsoft.FluentUI.Blazor || {};
 
-    // Utilities methods (Logger)
+    // Utilities methods
     (window as any).Microsoft.FluentUI.Blazor.Utilities = (window as any).Microsoft.FluentUI.Blazor.Utilities || {};
     (window as any).Microsoft.FluentUI.Blazor.Utilities.Logger = LoggerFile.FluentUI.Blazor.Utilities.Logger;
     (window as any).Microsoft.FluentUI.Blazor.Utilities.Attributes = AttributesFile.FluentUI.Blazor.Utilities.Attributes;
+    (window as any).Microsoft.FluentUI.Blazor.Utilities.KeyPress = KeyPressFile.FluentUI.Blazor.Utilities.KeyPress;
 
     // Components methods
     (window as any).Microsoft.FluentUI.Blazor.Components = (window as any).Microsoft.FluentUI.Blazor.Components || {};

--- a/src/Core.Scripts/src/Utilities/KeyPress.ts
+++ b/src/Core.Scripts/src/Utilities/KeyPress.ts
@@ -8,23 +8,23 @@ export namespace Microsoft.FluentUI.Blazor.Utilities.KeyPress {
       return;
     }
 
-    element.addEventListener("keyup", (event: KeyboardEvent) => {
-      const ev = event as any;
-      const keyCode: number = ev.which || ev.keyCode || ev.charCode;
+    // PreventDefault
+    element.addEventListener("keydown", (event: KeyboardEvent) => {
 
-      const matchedKeyPress = keyPress.find(kp =>
-        keyCode === kp.key &&
-        event.altKey == kp.altKey &&
-        event.ctrlKey == kp.ctrlKey &&
-        event.metaKey == kp.metaKey &&
-        event.shiftKey == kp.shiftKey
-      );
+      const matchedKeyPress = getMatchedKeyPress(event, keyPress);
+
+      if (matchedKeyPress && matchedKeyPress.preventDefault === true) {
+        event.preventDefault();
+      }
+
+    });
+
+    // ChangeAfterKeyPress
+    element.addEventListener("keyup", (event: KeyboardEvent) => {
+
+      const matchedKeyPress = getMatchedKeyPress(event, keyPress);
 
       if (matchedKeyPress) {
-
-        if (matchedKeyPress.preventDefault === true) {
-          event.preventDefault();
-        }
 
         let value = "";
         switch (true) {
@@ -43,6 +43,19 @@ export namespace Microsoft.FluentUI.Blazor.Utilities.KeyPress {
         dotnet.invokeMethodAsync("ChangeAfterKeyPressHandlerAsync", value, matchedKeyPress);
       }
     });
+  }
+
+  function getMatchedKeyPress(event: KeyboardEvent, keyPress: IKeyPress[]): IKeyPress | undefined {
+    const ev = event as any;
+    const keyCode: number = ev.which || ev.keyCode || ev.charCode;
+
+    return keyPress.find(kp =>
+      keyCode === kp.key &&
+      event.altKey == kp.altKey &&
+      event.ctrlKey == kp.ctrlKey &&
+      event.metaKey == kp.metaKey &&
+      event.shiftKey == kp.shiftKey
+    );
   }
 
   interface IKeyPress {

--- a/src/Core.Scripts/src/Utilities/KeyPress.ts
+++ b/src/Core.Scripts/src/Utilities/KeyPress.ts
@@ -1,0 +1,59 @@
+import { DotNet } from "../d-ts/Microsoft.JSInterop";
+import * as FluentUIComponents from '@fluentui/web-components'
+
+export namespace Microsoft.FluentUI.Blazor.Utilities.KeyPress {
+
+  export function addKeyPressEventListener(element: HTMLElement, dotnet: DotNet.DotNetObject, keyPress: IKeyPress[]): void {
+    if (element == null || element == undefined) {
+      return;
+    }
+
+    element.addEventListener("keyup", (event: KeyboardEvent) => {
+      const ev = event as any;
+      const keyCode: number = ev.which || ev.keyCode || ev.charCode;
+
+      const matchedKeyPress = keyPress.find(kp =>
+        keyCode === kp.key &&
+        event.altKey == kp.altKey &&
+        event.ctrlKey == kp.ctrlKey &&
+        event.metaKey == kp.metaKey &&
+        event.shiftKey == kp.shiftKey
+      );
+
+      if (matchedKeyPress) {
+
+        if (matchedKeyPress.preventDefault === true) {
+          event.preventDefault();
+        }
+
+        let value = "";
+        switch (true) {
+          case element instanceof HTMLInputElement:
+          case element instanceof HTMLTextAreaElement:
+          case element instanceof FluentUIComponents.TextInput:
+          case element instanceof FluentUIComponents.TextArea:
+            value = element.value;
+            break;
+
+          default:
+            value = "";
+            break;
+        }
+
+        dotnet.invokeMethodAsync("ChangeAfterKeyPressHandlerAsync", value, matchedKeyPress);
+      }
+    });
+  }
+
+  interface IKeyPress {
+    key: number;
+    ctrlKey: boolean;
+    shiftKey: boolean;
+    altKey: boolean;
+    metaKey: boolean;
+    preventDefault: boolean;
+  }
+
+}
+
+

--- a/src/Core/Components/Base/IFluentComponentChangeAfterKeyPress.cs
+++ b/src/Core/Components/Base/IFluentComponentChangeAfterKeyPress.cs
@@ -1,0 +1,93 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/*  
+ *  -----------------------------------------------------------------------------------------------------------------------------------
+ *  Example of usage (the component class must implemented `IFluentComponentElementBase` and `IFluentComponentChangeAfterKeyPress` :
+ *  -----------------------------------------------------------------------------------------------------------------------------------
+ *  
+ *  /// <inheritdoc cref="IFluentComponentChangeAfterKeyPress.ChangeAfterKeyPress" />
+ *  [Parameter]
+ *  public KeyPress[]? ChangeAfterKeyPress { get; set; }
+ *
+ *  /// <inheritdoc cref="IFluentComponentChangeAfterKeyPress.OnChangeAfterKeyPress" />
+ *  [Parameter]
+ *  public EventCallback<FluentKeyPressEventArgs> OnChangeAfterKeyPress { get; set; }
+ *
+ *  /// <inheritdoc cref="IFluentComponentChangeAfterKeyPress.ChangeAfterKeyPressHandlerAsync(string, KeyPress)" />
+ *  [JSInvokable]
+ *  public async Task ChangeAfterKeyPressHandlerAsync(string value, KeyPress key)
+ *  {
+ *      await ChangeHandlerAsync(new ChangeEventArgs() { Value = value });
+ *
+ *      if (OnChangeAfterKeyPress.HasDelegate)
+ *      {
+ *          await OnChangeAfterKeyPress.InvokeAsync(new FluentKeyPressEventArgs() { KeyPress = key});
+ *      }
+ *  }
+ * 
+ *  ------------------------------------------
+ *  And in the `OnAfterRenderAsync` method:
+ *  ------------------------------------------
+ *  
+ *  protected override async Task OnAfterRenderAsync(bool firstRender)
+ *  {
+ *      if (firstRender)
+ *      {
+ *          // Initialize the change after key press event
+ *          await IFluentComponentChangeAfterKeyPress.InitializeRuntimeAsync(this, JSRuntime, Element);
+ *      }
+ *  }
+ *  
+ */
+
+/// <summary>
+/// 
+/// </summary>
+public interface IFluentComponentChangeAfterKeyPress
+{
+    /// <summary>
+    /// Gets or sets the key press events that will trigger a change.
+    /// This property must have a `[Parameter]` attribute to be used in the component.
+    /// </summary>
+    KeyPress[]? ChangeAfterKeyPress { get; set; }
+
+    /// <summary>
+    /// Gets or sets the callback to be invoked when the value changes after a <see cref="ChangeAfterKeyPress"/> key press.
+    /// This property must have a `[Parameter]` attribute to be used in the component.
+    /// </summary>
+    EventCallback<FluentKeyPressEventArgs> OnChangeAfterKeyPress { get; set; }
+
+    /// <summary>
+    /// Handles the change in value after a key press event.
+    /// This method is called by the JavaScript function and must have a `[JSInvokable]` attribute.
+    /// </summary>
+    Task ChangeAfterKeyPressHandlerAsync(string value, KeyPress key);
+  
+    /// <summary>
+    /// Initializes a key press event listener for the specified component, enabling the execution of actions after
+    /// specific key presses.
+    /// </summary>
+    /// <remarks>This method sets up a JavaScript event listener for key press events on the specified DOM element</remarks>
+    /// <param name="component">The component implementing <see cref="IFluentComponentChangeAfterKeyPress"/> that defines the key press behavior.</param>
+    /// <param name="jsRuntime">The <see cref="IJSRuntime"/> instance used to invoke JavaScript interop calls.</param>
+    /// <param name="element">The <see cref="ElementReference"/> representing the DOM element to which the key press event listener will be attached.</param>
+    /// <returns></returns>
+    internal static async Task InitializeRuntimeAsync(IFluentComponentChangeAfterKeyPress component, IJSRuntime jsRuntime, ElementReference element)
+    {
+        if (component.ChangeAfterKeyPress != null && component.ChangeAfterKeyPress.Length > 0)
+        {
+            await jsRuntime.InvokeVoidAsync(
+                "Microsoft.FluentUI.Blazor.Utilities.KeyPress.addKeyPressEventListener",
+                element,
+                DotNetObjectReference.Create(component),
+                component.ChangeAfterKeyPress);
+        }
+    }
+}

--- a/src/Core/Components/KeyCode/FluentKeyPressEventArgs.cs
+++ b/src/Core/Components/KeyCode/FluentKeyPressEventArgs.cs
@@ -13,4 +13,9 @@ public class FluentKeyPressEventArgs : EventArgs
     /// Gets the key press event data associated with the current operation.
     /// </summary>
     public required KeyPress KeyPress { get; init; }
+
+    /// <summary>
+    /// Gets the value associated with this instance.
+    /// </summary>
+    public required string Value { get; init; }
 }

--- a/src/Core/Components/KeyCode/FluentKeyPressEventArgs.cs
+++ b/src/Core/Components/KeyCode/FluentKeyPressEventArgs.cs
@@ -1,0 +1,16 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// Provides data for a KeyPress event.
+/// </summary>
+public class FluentKeyPressEventArgs : EventArgs
+{
+    /// <summary>
+    /// Gets the key press event data associated with the current operation.
+    /// </summary>
+    public required KeyPress KeyPress { get; init; }
+}

--- a/src/Core/Components/KeyCode/KeyPress.cs
+++ b/src/Core/Components/KeyCode/KeyPress.cs
@@ -57,7 +57,7 @@ public record KeyPress
 
     /// <summary>
     /// Gets or sets a boolean value that indicates if the JS client event should be cancelled.
-    /// Default is true.
+    /// Default is true, this means that the key will not be propagated and added to the component value.
     /// </summary>
     public bool PreventDefault { get; init; } = true;
 

--- a/src/Core/Components/KeyCode/KeyPress.cs
+++ b/src/Core/Components/KeyCode/KeyPress.cs
@@ -1,0 +1,113 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// Represents a key press event, including the key pressed and associated modifier keys.
+/// </summary>
+/// <remarks>The <see cref="KeyPress"/> record provides a way to encapsulate information about a key press event,
+/// including the key itself, modifier keys (e.g., Ctrl, Alt, Shift, Meta), and whether the event should be prevented
+/// from propagating further in the client-side environment.
+/// </remarks>
+public record KeyPress
+{
+    /// <summary>
+    /// Creates a new <see cref="KeyPress"/> instance for the specified key.
+    /// </summary>
+    /// <param name="key">The key to associate with the <see cref="KeyPress"/> instance.</param>
+    /// <returns>A <see cref="KeyPress"/> instance with the specified key.</returns>
+    public static KeyPress For(KeyCode key)
+    {
+        return new KeyPress
+        {
+            Key = key,
+        };
+    }
+
+    /// <summary>
+    /// Gets the <see cref="KeyCode"/> equivalent value.
+    /// </summary>
+    public KeyCode Key { get; init; }
+
+    /// <summary>
+    /// Gets a boolean value that indicates if the Control key was pressed.
+    /// Default is false.
+    /// </summary>
+    public bool CtrlKey { get; init; }
+
+    /// <summary>
+    /// Gets a boolean value that indicates if the Shift key was pressed.
+    /// Default is false.
+    /// </summary>
+    public bool ShiftKey { get; init; }
+
+    /// <summary>
+    /// Gets a boolean value that indicates if the Alt key was pressed.
+    /// Default is false.
+    /// </summary>
+    public bool AltKey { get; init; }
+
+    /// <summary>
+    /// Gets a boolean value that indicates if the Meta key was pressed.
+    /// Default is false.
+    /// </summary>
+    public bool MetaKey { get; init; }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates if the JS client event should be cancelled.
+    /// Default is true.
+    /// </summary>
+    public bool PreventDefault { get; init; } = true;
+
+    /// <summary>
+    /// Returns a new <see cref="KeyPress"/> instance with the <see cref="CtrlKey"/> property set to the specified value.
+    /// </summary>
+    /// <param name="pressed">A value indicating whether the Ctrl key is pressed. The default is <see langword="true"/>.</param>
+    /// <returns>A new <see cref="KeyPress"/> instance with the updated <see cref="CtrlKey"/> property.</returns>
+    public KeyPress AndCtrlKey(bool pressed = true)
+    {
+        return this with { CtrlKey = pressed };
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="KeyPress"/> instance with the <see cref="AltKey"/> property set to the specified value.
+    /// </summary>
+    /// <param name="pressed">A value indicating whether the Alt key is pressed. The default is <see langword="true"/>.</param>
+    /// <returns>A new <see cref="KeyPress"/> instance with the updated <see cref="AltKey"/> property.</returns>
+    public KeyPress AndAltKey(bool pressed = true)
+    {
+        return this with { AltKey = pressed };
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="KeyPress"/> instance with the <see cref="ShiftKey"/> property set to the specified value.
+    /// </summary>
+    /// <param name="pressed">A value indicating whether the Shift key is pressed. The default is <see langword="true"/>.</param>
+    /// <returns>A new <see cref="KeyPress"/> instance with the updated <see cref="ShiftKey"/> property.</returns>
+    public KeyPress AndShiftKey(bool pressed = true)
+    {
+        return this with { ShiftKey = pressed };
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="KeyPress"/> instance with the <see cref="MetaKey"/> property set to the specified value.
+    /// </summary>
+    /// <param name="pressed">A value indicating whether the Meta key is pressed. The default is <see langword="true"/>.</param>
+    /// <returns>A new <see cref="KeyPress"/> instance with the updated <see cref="MetaKey"/> property.</returns>
+    public KeyPress AndMetaKey(bool pressed = true)
+    {
+        return this with { MetaKey = pressed };
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="KeyPress"/> instance with the <see cref="PreventDefault"/> property set to the specified value.
+    /// </summary>
+    /// <param name="prevent">A value indicating whether the PreventDefault value is set. The default is <see langword="false"/>.</param>
+    /// <returns>A new <see cref="KeyPress"/> instance with the updated <see cref="PreventDefault"/> property.</returns>
+    public KeyPress WithPreventDefault(bool prevent = false)
+    {
+        return this with { PreventDefault = prevent };
+    }
+}

--- a/src/Core/Components/TextArea/FluentTextArea.razor.cs
+++ b/src/Core/Components/TextArea/FluentTextArea.razor.cs
@@ -109,11 +109,18 @@ public partial class FluentTextArea : FluentInputImmediateBase<string?>, IFluent
     [JSInvokable]
     public async Task ChangeAfterKeyPressHandlerAsync(string value, KeyPress key)
     {
-        await ChangeHandlerAsync(new ChangeEventArgs() { Value = value });
+        await ChangeHandlerAsync(new ChangeEventArgs()
+        {
+            Value = value,
+        });
 
         if (OnChangeAfterKeyPress.HasDelegate)
         {
-            await OnChangeAfterKeyPress.InvokeAsync(new FluentKeyPressEventArgs() { KeyPress = key });
+            await OnChangeAfterKeyPress.InvokeAsync(new FluentKeyPressEventArgs()
+            {
+                Value = value,
+                KeyPress = key,
+            });
         }
     }
 

--- a/src/Core/Components/TextArea/FluentTextArea.razor.cs
+++ b/src/Core/Components/TextArea/FluentTextArea.razor.cs
@@ -12,7 +12,7 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// <summary>
 /// A textarea component that allows users to enter and edit a single line of text.
 /// </summary>
-public partial class FluentTextArea : FluentInputImmediateBase<string?>, IFluentComponentElementBase, ITooltipComponent
+public partial class FluentTextArea : FluentInputImmediateBase<string?>, IFluentComponentElementBase, ITooltipComponent, IFluentComponentChangeAfterKeyPress
 {
 
     /// <summary>
@@ -97,6 +97,26 @@ public partial class FluentTextArea : FluentInputImmediateBase<string?>, IFluent
     [Parameter]
     public string? Tooltip { get; set; }
 
+    /// <inheritdoc cref="IFluentComponentChangeAfterKeyPress.ChangeAfterKeyPress" />
+    [Parameter]
+    public KeyPress[]? ChangeAfterKeyPress { get; set; }
+
+    /// <inheritdoc cref="IFluentComponentChangeAfterKeyPress.OnChangeAfterKeyPress" />
+    [Parameter]
+    public EventCallback<FluentKeyPressEventArgs> OnChangeAfterKeyPress { get; set; }
+
+    /// <inheritdoc cref="IFluentComponentChangeAfterKeyPress.ChangeAfterKeyPressHandlerAsync(string, KeyPress)" />
+    [JSInvokable]
+    public async Task ChangeAfterKeyPressHandlerAsync(string value, KeyPress key)
+    {
+        await ChangeHandlerAsync(new ChangeEventArgs() { Value = value });
+
+        if (OnChangeAfterKeyPress.HasDelegate)
+        {
+            await OnChangeAfterKeyPress.InvokeAsync(new FluentKeyPressEventArgs() { KeyPress = key });
+        }
+    }
+
     /// <summary />
     protected override async Task OnInitializedAsync()
     {
@@ -109,6 +129,9 @@ public partial class FluentTextArea : FluentInputImmediateBase<string?>, IFluent
         if (firstRender)
         {
             await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Utilities.Attributes.observeAttributeChange", Element, "value");
+
+            // Initialize the change after key press event
+            await IFluentComponentChangeAfterKeyPress.InitializeRuntimeAsync(this, JSRuntime, Element);
         }
     }
 

--- a/src/Core/Components/TextInput/FluentTextInput.razor.cs
+++ b/src/Core/Components/TextInput/FluentTextInput.razor.cs
@@ -135,11 +135,18 @@ public partial class FluentTextInput : FluentInputImmediateBase<string?>, IFluen
     [JSInvokable]
     public async Task ChangeAfterKeyPressHandlerAsync(string value, KeyPress key)
     {
-        await ChangeHandlerAsync(new ChangeEventArgs() { Value = value });
+        await ChangeHandlerAsync(new ChangeEventArgs()
+        {
+            Value = value,
+        });
 
         if (OnChangeAfterKeyPress.HasDelegate)
         {
-            await OnChangeAfterKeyPress.InvokeAsync(new FluentKeyPressEventArgs() { KeyPress = key});
+            await OnChangeAfterKeyPress.InvokeAsync(new FluentKeyPressEventArgs()
+            {
+                Value = value,
+                KeyPress = key,
+            });
         }
     }
 

--- a/src/Core/Components/TextInput/FluentTextInput.razor.cs
+++ b/src/Core/Components/TextInput/FluentTextInput.razor.cs
@@ -12,7 +12,7 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// <summary>
 /// A text input component that allows users to enter and edit a single line of text.
 /// </summary>
-public partial class FluentTextInput : FluentInputImmediateBase<string?>, IFluentComponentElementBase, ITooltipComponent
+public partial class FluentTextInput : FluentInputImmediateBase<string?>, IFluentComponentElementBase, ITooltipComponent, IFluentComponentChangeAfterKeyPress
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="FluentTextInput"/> class.
@@ -123,6 +123,26 @@ public partial class FluentTextInput : FluentInputImmediateBase<string?>, IFluen
     [Parameter]
     public string? Tooltip { get; set; }
 
+    /// <inheritdoc cref="IFluentComponentChangeAfterKeyPress.ChangeAfterKeyPress" />
+    [Parameter]
+    public KeyPress[]? ChangeAfterKeyPress { get; set; }
+
+    /// <inheritdoc cref="IFluentComponentChangeAfterKeyPress.OnChangeAfterKeyPress" />
+    [Parameter]
+    public EventCallback<FluentKeyPressEventArgs> OnChangeAfterKeyPress { get; set; }
+
+    /// <inheritdoc cref="IFluentComponentChangeAfterKeyPress.ChangeAfterKeyPressHandlerAsync(string, KeyPress)" />
+    [JSInvokable]
+    public async Task ChangeAfterKeyPressHandlerAsync(string value, KeyPress key)
+    {
+        await ChangeHandlerAsync(new ChangeEventArgs() { Value = value });
+
+        if (OnChangeAfterKeyPress.HasDelegate)
+        {
+            await OnChangeAfterKeyPress.InvokeAsync(new FluentKeyPressEventArgs() { KeyPress = key});
+        }
+    }
+
     /// <summary />
     protected override async Task OnInitializedAsync()
     {
@@ -135,6 +155,9 @@ public partial class FluentTextInput : FluentInputImmediateBase<string?>, IFluen
         if (firstRender)
         {
             await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Utilities.Attributes.observeAttributeChange", Element, "value");
+
+            // Initialize the change after key press event
+            await IFluentComponentChangeAfterKeyPress.InitializeRuntimeAsync(this, JSRuntime, Element);
         }
     }
 

--- a/tests/Core/Components/TextArea/FluentTextAreaTests.razor
+++ b/tests/Core/Components/TextArea/FluentTextAreaTests.razor
@@ -18,12 +18,12 @@
     {
         // Arrange && Act
         var cut = Render(@<FluentTextArea Appearance="@TextAreaAppearance.Outline"
-                 Autofocus="true"
-                 AriaLabel="My aria label"
-                 Label="My Label"
-                 Name="MyName"
-                 Placeholder="My help"
-                 Value="My Value" />
+                Autofocus="true"
+                AriaLabel="My aria label"
+                Label="My Label"
+                Name="MyName"
+                Placeholder="My help"
+                Value="My Value" />
         );
 
         // Assert
@@ -96,8 +96,8 @@
         // Arrange && Act
         var cut = Render(
             @<FluentTextArea>
-                <LabelTemplate><div style="font-weight: bold;">My label</div></LabelTemplate>
-            </FluentTextArea>
+    <LabelTemplate><div style="font-weight: bold;">My label</div></LabelTemplate>
+</FluentTextArea>
         );
 
         // Assert
@@ -168,5 +168,25 @@
         var value = AspNetCore.Components.Migration.FluentInputAppearanceExtensions.ToTextAreaAppearance(appearance);
 
         Assert.Equal(expected, value);
+    }
+
+    [Fact]
+    public async Task FluentTextArea_ChangeAfterKeyPress()
+    {
+        var value = string.Empty;
+        var lastEventArgs = new FluentKeyPressEventArgs() { KeyPress = new KeyPress(), Value = "" };
+
+        // Arrange && Act
+        var cut = Render(@<FluentTextArea @bind-Value="@value"
+                ChangeAfterKeyPress="@([KeyPress.For(KeyCode.Enter)])"
+                OnChangeAfterKeyPress="@(e => lastEventArgs = e)" />
+        );
+
+        // Act
+        await cut.FindComponent<FluentTextArea>().Instance.ChangeAfterKeyPressHandlerAsync("MyValue", KeyPress.For(KeyCode.Enter));
+
+        // Assert
+        Assert.Equal(KeyCode.Enter, lastEventArgs.KeyPress.Key);
+        Assert.Equal("MyValue", lastEventArgs.Value);
     }
 }

--- a/tests/Core/Components/TextInput/FluentTextInputTests.razor
+++ b/tests/Core/Components/TextInput/FluentTextInputTests.razor
@@ -181,4 +181,24 @@
 
         Assert.Equal(expected, value);
     }
+
+    [Fact]
+    public async Task FluentInputText_ChangeAfterKeyPress()
+    {
+        var value = string.Empty;
+        var lastEventArgs = new FluentKeyPressEventArgs() { KeyPress = new KeyPress(), Value = "" };
+
+        // Arrange && Act
+        var cut = Render(@<FluentTextInput @bind-Value="@value"
+                ChangeAfterKeyPress="@([KeyPress.For(KeyCode.Enter)])"
+                OnChangeAfterKeyPress="@(e => lastEventArgs = e)" />
+        );
+
+        // Act
+        await cut.FindComponent<FluentTextInput>().Instance.ChangeAfterKeyPressHandlerAsync("MyValue", KeyPress.For(KeyCode.Enter));
+
+        // Assert
+        Assert.Equal(KeyCode.Enter, lastEventArgs.KeyPress.Key);
+        Assert.Equal("MyValue", lastEventArgs.Value);
+    }
 }


### PR DESCRIPTION
# [dev-v5] Add ChangeAfterKeyPress parameter (TextInput and TextArea)

In the example of a command area or search text area, you can use the `ChangeAfterKeyPress` parameter to trigger the `OnChange` event
after a specific key or keys are pressed. E.g. `Enter`, `Escape`, `Tab`, `Ctrl+Enter`, etc.
You can capture the content of the text area from the `Value` parameter.

An `OnChangeAfterKeyPress` event is also triggered when the user presses these key combinations.
This also gives you the key used to trigger the event (this can be useful when you allow multiple key combinations).

```razor
<FluentTextArea  @bind-Value="@ChatInput"
                ChangeAfterKeyPress="@([KeyPress.For(KeyCode.Enter).AndCtrlKey(), KeyPress.For(KeyCode.Enter)])"
                OnChangeAfterKeyPress="@StartChatDiscussion" />

@code
{
    string ChatInput = string.Empty;

    async Task StartChatDiscussion(FluentKeyPressEventArgs e)
    {
        // ...
    }
}
```

## Unit Tests

TODO