### PR TITLE
[dev-v5] Fix a Combobox in a DialogBox

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/FluentDialog.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/FluentDialog.md
@@ -54,12 +54,22 @@ all parameters defined when calling `ShowDialogAsync`, as well as the `CloseAsyn
 Using `CloseAsync` you can pass a return object to the parent component.
 It is then retrieved in the `DialogResult` like in the example below.
 
-```xml
+```razor
 @inherits FluentDialogInstance
 
 <FluentDialogBody>
     Content dialog
 </FluentDialogBody>
+
+@code
+{
+    protected override Task OnActionClickedAsync(bool primary)
+    {
+        return primary
+        ? DialogInstance.CloseAsync()
+        : DialogInstance.CancelAsync();
+    }
+}
 ```
 
 > **Note:**  

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/List/Combobox/DebugPages/DebugCombobox.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/List/Combobox/DebugPages/DebugCombobox.razor
@@ -1,0 +1,28 @@
+﻿@page "/List/Combobox/Debug"
+@inject IDialogService DialogService
+
+@* Combobox in a Dialog *@
+<FluentStack Margin="@Margin.All3"
+             Padding="@Padding.All3"
+             Style="@CommonStyles.NeutralBorder1"
+             Orientation="Orientation.Vertical"
+             Width="90%">
+    <FluentButton OnClick="@OpenDialogAsync">Open</FluentButton>
+    <div>
+        Selected: @SelectedNumber
+    </div>
+</FluentStack>
+
+@code {
+    int SelectedNumber = 0;
+
+    async Task OpenDialogAsync()
+    {
+        var result = await DialogService.ShowDrawerAsync<DebugComboboxDialog>(options =>
+        {
+            options.Modal = true;
+        });
+
+        SelectedNumber = result.GetValue<int>();
+    }
+}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/List/Combobox/DebugPages/DebugComboboxDialog.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/List/Combobox/DebugPages/DebugComboboxDialog.razor
@@ -1,0 +1,22 @@
+﻿@inherits FluentDialogInstance
+
+<FluentDialogBody>
+    <FluentCombobox Label="Number" Items="@Numbers" @bind-Value="@SelectedNumber" />
+
+    <div>
+        Selected: @SelectedNumber
+    </div>
+</FluentDialogBody>
+
+@code
+{
+    int[] Numbers = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+    int SelectedNumber = 1;
+
+    protected override Task OnActionClickedAsync(bool primary)
+    {
+        return primary
+        ? DialogInstance.CloseAsync(SelectedNumber)
+        : DialogInstance.CancelAsync();
+    }
+}

--- a/src/Core/Components/Dialog/FluentDialog.razor.cs
+++ b/src/Core/Components/Dialog/FluentDialog.razor.cs
@@ -99,6 +99,11 @@ public partial class FluentDialog : FluentComponentBase
     /// <summary />
     internal async Task OnToggleAsync(DialogToggleEventArgs args)
     {
+        if (string.CompareOrdinal(args.Id, Instance?.Id) != 0)
+        {
+            return;
+        }
+
         // Raise the event received from the Web Component
         var dialogEventArgs = await RaiseOnStateChangeAsync(args);
 

--- a/tests/Core/Components/Dialog/FluentDialogTests.razor
+++ b/tests/Core/Components/Dialog/FluentDialogTests.razor
@@ -92,6 +92,8 @@
         // Act
         var dialogTask = DialogService.ShowDialogAsync<Templates.DialogRender>(options =>
                {
+                   options.Id = "my-id";
+
                    options.OnStateChange = (args) =>
                    {
                        dialogEventArgs = args;


### PR DESCRIPTION
# [dev-v5] Fix a Combobox in a DialogBox

When a **ComboBox** is used in a **DialogBox**, the HTML toggle event of the **ComboBox** is detected by the **DialogBox**. And the **DialogBox** is closed.

A new test `if (string.CompareOrdinal(args.Id, Instance?.Id) != 0)` can check if the correct toggle is detected.

Before
![Before](https://github.com/user-attachments/assets/9889075a-da39-4598-adaa-d40f00b22dab)

After
![After](https://github.com/user-attachments/assets/ca58f73b-7008-4e7e-9778-3c8ef42fcf3a)

## Extra

Add a `DebugPages/DebugCombobox.razor` page to validate tricky features (page not included in the documentation)

## Unit Tests

Updated to specify the correct ID