### PR TITLE
[DataGrid] Do not use 'display: flex' on table header cells

### DIFF
--- a/src/Core/Components/DataGrid/Columns/ColumnBase.razor
+++ b/src/Core/Components/DataGrid/Columns/ColumnBase.razor
@@ -17,7 +17,7 @@
         {
             string? tooltip = Tooltip ? (HeaderTooltip ?? Title) : null;
 
-            <FluentKeyCode Only="new[] { KeyCode.Ctrl, KeyCode.Enter }" OnKeyDown="HandleKeyDown" class="keycapture" style="width: 100%;"  StopPropagation="true" @oncontextmenu="@(() => Grid.RemoveSortByColumnAsync(this))">
+            <FluentKeyCode Only="new[] { KeyCode.Ctrl, KeyCode.Enter }" OnKeyDown="HandleKeyDown" class="keycapture" style="width: 100%;" StopPropagation="true" @oncontextmenu="@(() => Grid.RemoveSortByColumnAsync(this))">
 
                 @if (AnyColumnActionEnabled)
                 {
@@ -96,74 +96,76 @@
             {
                 wdelta = "56px";
             }
-
-            @if (Align == Align.Start || Align == Align.Center)
-            {
-                @if (Grid.ResizeType is not null)
+            <div style="display: flex;">
+                @if (Align == Align.Start || Align == Align.Center)
                 {
-                    @OptionsButton()
-                }
-                else
-                {
-                    @if (ColumnOptions is not null)
+                    @if (Grid.ResizeType is not null)
                     {
-                        @FilterButton()
+                        @OptionsButton()
+                    }
+                    else
+                    {
+                        @if (ColumnOptions is not null)
+                        {
+                            @FilterButton()
+                        }
                     }
                 }
-            }
 
-            @if (Sortable.HasValue ? Sortable.Value : IsSortableByDefault())
-            {
-                <FluentKeyCode Only="new [] { KeyCode.Ctrl, KeyCode.Enter}" OnKeyDown="HandleKeyDown" class="keycapture" style="width: 100%;" StopPropagation="true" @oncontextmenu="@(() => Grid.RemoveSortByColumnAsync(this))">
-                    <FluentButton Appearance="Appearance.Stealth" Class="col-sort-button" Style="@($"width: calc(100% - {wdelta});")" @onclick="@(() => Grid.SortByColumnAsync(this))" aria-label="@tooltip" title="@tooltip">
+                @if (Sortable.HasValue ? Sortable.Value : IsSortableByDefault())
+                {
+                    <FluentKeyCode Only="new[] { KeyCode.Ctrl, KeyCode.Enter }" OnKeyDown="HandleKeyDown" class="keycapture" style="width: 100%;" StopPropagation="true" @oncontextmenu="@(() => Grid.RemoveSortByColumnAsync(this))">
+                        <FluentButton Appearance="Appearance.Stealth" Class="col-sort-button" Style="@($"width: calc(100% - {wdelta});")" @onclick="@(() => Grid.SortByColumnAsync(this))" aria-label="@tooltip" title="@tooltip">
                             <div class="col-title-text" title="@tooltip">@Title</div>
 
-                        @if (Grid.SortByAscending.HasValue && IsActiveSortColumn)
-                        {
-                            if (Grid.SortByAscending == true)
+                            @if (Grid.SortByAscending.HasValue && IsActiveSortColumn)
                             {
-                                <FluentIcon Value="@(new CoreIcons.Regular.Size20.ArrowSortUp())" Slot="end" Style="opacity: 0.5;" />
+                                if (Grid.SortByAscending == true)
+                                {
+                                    <FluentIcon Value="@(new CoreIcons.Regular.Size20.ArrowSortUp())" Slot="end" Style="opacity: 0.5;" />
+                                }
+                                else
+                                {
+                                    <FluentIcon Value="@(new CoreIcons.Regular.Size20.ArrowSortDown())" Slot="end" Style="opacity: 0.5;" />
+                                }
                             }
-                            else
+                            @if (ColumnOptions is not null && Filtered.GetValueOrDefault() && Grid.ResizeType is not null)
                             {
-                                <FluentIcon Value="@(new CoreIcons.Regular.Size20.ArrowSortDown())" Slot="end" Style="opacity: 0.5;" />
+                                <FluentIcon Value="@(new CoreIcons.Regular.Size20.Filter())" Slot="end" Style="opacity: 0.5;" />
                             }
-                        }
-                        @if (ColumnOptions is not null && Filtered.GetValueOrDefault() && Grid.ResizeType is not null)
-                        {
-                            <FluentIcon Value="@(new CoreIcons.Regular.Size20.Filter())" Slot="end" Style="opacity: 0.5;" />
-                        }
                         </FluentButton>
-                </FluentKeyCode>
-            }
-            else
-            {
-                <div class="col-title" style="@($"width: calc(100% - {wdelta});")">
-                    <div class="col-title-text" title="@tooltip" >@Title
-                        @if (ColumnOptions is not null && Filtered.GetValueOrDefault() && Grid.ResizeType.HasValue )
-                        {
-                            <span style="padding: 0 5px;">
-                            <FluentIcon Value="@(new CoreIcons.Regular.Size20.Filter())" Slot="end" Style="opacity: 0.5;" />
-                            </span>
-                        }
-                    </div>
-                </div>
-            }
-
-            @if (Align == Align.End)
-            {
-                @if (Grid.ResizeType is not null)
-                {
-                   @OptionsButton()
+                    </FluentKeyCode>
                 }
                 else
                 {
-                    @if (ColumnOptions is not null)
+                    <div class="col-title" style="@($"width: calc(100% - {wdelta});")">
+                        <div class="col-title-text" title="@tooltip">
+                            @Title
+                            @if (ColumnOptions is not null && Filtered.GetValueOrDefault() && Grid.ResizeType.HasValue)
+                            {
+                                <span style="padding: 0 5px;">
+                                    <FluentIcon Value="@(new CoreIcons.Regular.Size20.Filter())" Slot="end" Style="opacity: 0.5;" />
+                                </span>
+                            }
+                        </div>
+                    </div>
+                }
+
+                @if (Align == Align.End)
+                {
+                    @if (Grid.ResizeType is not null)
                     {
-                        @FilterButton()
+                        @OptionsButton()
+                    }
+                    else
+                    {
+                        @if (ColumnOptions is not null)
+                        {
+                            @FilterButton()
+                        }
                     }
                 }
-            }
+            </div>
 
         }
     }
@@ -181,23 +183,23 @@
     {
         return
             @<FluentButton Appearance="Appearance.Stealth" class="col-options-button" @onclick="@(() => Grid.ShowColumnOptionsAsync(this))" aria-label="Filter this column">
-                <FluentIcon Value="@(new CoreIcons.Regular.Size20.ChevronDown())" Color="Color.Neutral" Width="20px" Style="opacity: 0.5;" />
-            </FluentButton>;
+            <FluentIcon Value="@(new CoreIcons.Regular.Size20.ChevronDown())" Color="Color.Neutral" Width="20px" Style="opacity: 0.5;" />
+        </FluentButton>;
     }
 
     private RenderFragment FilterButton()
     {
         return
             @<FluentButton Appearance="Appearance.Stealth" class="col-options-button" @onclick="@(() => Grid.ShowColumnOptionsAsync(this))" aria-label="Filter this column">
-                @if (Filtered.GetValueOrDefault())
-            {
+        @if (Filtered.GetValueOrDefault())
+        {
                 <FluentIcon Value="@(new CoreIcons.Regular.Size20.FilterDismiss())" />
-            }
-            else
-            {
+        }
+        else
+        {
                 <FluentIcon Value="@(new CoreIcons.Regular.Size20.Filter())" />
-            }
+        }
 
-            </FluentButton>;
+        </FluentButton>;
     }
 }

--- a/src/Core/Components/DataGrid/FluentDataGridCell.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGridCell.razor.cs
@@ -79,7 +79,6 @@ public partial class FluentDataGridCell<TGridItem> : FluentComponentBase
         .AddStyle("height", $"{(int)Grid.RowSize}px", () => !Grid.EffectiveLoadingValue && !Grid.Virtualize && !Grid.MultiLine && (Grid.Items is not null || Grid.ItemsProvider is not null))
         .AddStyle("height", "100%", Grid.MultiLine)
         .AddStyle("min-height", "44px", Owner.RowType != DataGridRowType.Default)
-        .AddStyle("display", "flex", ShouldHaveDisplayFlex())
         .AddStyle("z-index", ZIndex.DataGridHeaderPopup.ToString(), CellType == DataGridCellType.ColumnHeader && Grid._columns.Count > 0)
         .AddStyle(Owner.Style)
         .Build();
@@ -126,25 +125,4 @@ public partial class FluentDataGridCell<TGridItem> : FluentComponentBase
 
     public void Dispose() => Owner.Unregister(this);
 
-    private bool ShouldHaveDisplayFlex()
-    {
-
-        var isHeaderCell = CellType == DataGridCellType.ColumnHeader;
-
-        if (!isHeaderCell)
-        {
-            return false;
-        }
-
-        var isButtonWithMenu = Grid.HeaderCellAsButtonWithMenu;
-        var isResizable = Grid.ResizableColumns;
-        var isNotResizableWithOptions = !Grid.ResizableColumns && Column?.ColumnOptions is not null;
-        var isSelectColumn = Column?.GetType() == typeof(SelectColumn<TGridItem>);
-        //var isColumnNull = Column is null;
-        var isSortable = (Column?.Sortable.HasValue ?? false) && Column?.Sortable.Value == true;
-        var isSortByNull = Column?.SortBy is null;
-        var isColumnsCountGreaterThanZero = Grid._columns.Count > 0;
-
-        return isHeaderCell && !isButtonWithMenu && (isResizable || isNotResizableWithOptions) && !isSelectColumn && isColumnsCountGreaterThanZero && (!isSortable || isSortByNull);
-    }
 }


### PR DESCRIPTION
When not using `HeaderCellAsButtonWithMenu`, don't use display:flex on the header cell. Instead add a specific div in rendering the header content