### PR TITLE
[dev-v5] Add DialogService.RegisterInputFileAsync

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/InputFile/Examples/InputFileDialogService.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/InputFile/Examples/InputFileDialogService.razor
@@ -1,0 +1,50 @@
+﻿@inject IDialogService DialogService
+@implements IAsyncDisposable
+
+<FluentButton Id="OpenInputFile" Appearance="ButtonAppearance.Primary" Margin="@Margin.Vertical3">
+    Upload files
+</FluentButton>
+
+<FluentProgressBar Value="@LoadingPercentage" />
+
+<FluentLabel Weight="LabelWeight.Semibold">Files uploaded:</FluentLabel>
+<FluentLabel>@(string.Join("; ", Files.Select(i => i.Name)))</FluentLabel>
+
+@code
+{
+    int LoadingPercentage = 0;
+    FluentInputFileEventArgs[] Files = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        // Register the input file dialog with a button click.
+        await DialogService.RegisterInputFileAsync("OpenInputFile", OnCompletedAsync, options =>
+        {
+            options.Multiple = true;
+            options.OnFileErrorAsync = (e) => DialogService.ShowErrorAsync(e.ErrorMessage);
+            options.OnProgressChangeAsync = (e) =>
+            {
+                LoadingPercentage = e.ProgressPercent;
+                StateHasChanged();
+                return Task.CompletedTask;
+            };
+        });
+    }
+
+    private Task OnCompletedAsync(IEnumerable<FluentInputFileEventArgs> files)
+    {
+        Files = files.Where(i => !i.IsCancelled).ToArray();
+
+        // For the demo, delete these files.
+        Files.ToList().ForEach(file => file.LocalFile?.Delete());
+
+        // Show the files in UI.
+        LoadingPercentage = 100;
+        StateHasChanged();
+
+        return Task.CompletedTask;
+    }
+
+    // Unregister the input file
+    public async ValueTask DisposeAsync() => await DialogService.UnregisterInputFileAsync("OpenInputFile");
+}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/InputFile/FluentInputFile.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/InputFile/FluentInputFile.md
@@ -19,7 +19,9 @@ The component can be customized by adapting the `ChildContent`.
 The areas that need to be associated with the opening of the file selection dialog
 must be included in a `label for` that references the component `Id`: E.g. `<label for=“my-file-uploader”>browse...</label>`.
 
-> ℹ️ By default, this component uses the `SaveToTemporaryFolder` mode, which creates a local file. However, this might not always be possible depending on the user's permissions on the host system. You may need to change the `InputFileMode` based on your specific use case.
+> [!NOTE] By default, this component uses the `SaveToTemporaryFolder` mode, which creates a local file. However,
+> this might not always be possible depending on the user's permissions on the host system.
+> You may need to change the `InputFileMode` based on your specific use case.
 
 {{ InputFileDefault }}
 
@@ -29,6 +31,37 @@ By using the parameter `DragDropZoneVisible=“false”`, the component is compl
 specify the component that will trigger the opening of the file selection dialog.
 
 {{ InputFileByCode }}
+
+## DialogService
+
+A easy way to open the file selection dialog is to use the injected **DialogService** service.
+1. During the `OnInitialized` method, **register** your trigger HTML element 
+   using the method `MyFileInstance = DialogService.RegisterInputFileAsync(id)`.
+1. Set the `OnCompletedAsync` method to handle the files uploaded.
+1. Don't forget to **unregister** the trigger element in the `Dispose` method 
+   using `MyFileInstance.UnregisterAsync();` or `DialogService.UnregisterInputFileAsync(id)`.
+
+```csharp
+[Inject]
+public IDialogService DialogService { get; set; }
+
+protected override async Task OnInitializedAsync()
+{
+    await DialogService.RegisterInputFileAsync("MyButton", OnCompletedAsync, options => { /* ... */ });    
+}
+
+private Task OnCompletedAsync(IEnumerable<FluentInputFileEventArgs> files)
+{
+    // `files` contains the uploaded files
+}
+
+public async ValueTask DisposeAsync()
+{
+    await DialogService.UnregisterInputFileAsync("MyButton");
+}
+```
+
+{{ InputFileDialogService }}
 
 ## Mode = InputFileMode.Buffer
 
@@ -45,7 +78,7 @@ This mode is recommended if you can't store files locally, are working with smal
 If you want to transfer very large files and do not want to save your files locally (in a temporary folder, for example),
 you can retrieve the file stream from the `OnFileUploaded` event and the `file.Stream` property. Keep in mind that you will need to implement stream handling yourself.
 
-> ⚠️ Remember to always dispose each stream to prevent memory leaks!
+> [!WARNING] Remember to always dispose each stream to prevent memory leaks!
 
 {{ InputFileStream }}
 

--- a/src/Core/Components/Dialog/FluentDialogProvider.razor
+++ b/src/Core/Components/Dialog/FluentDialogProvider.razor
@@ -6,32 +6,35 @@
     {
         @foreach (var dialog in DialogService.Items.Values.OrderBy(i => i.Index))
         {
+            @* FluentInputFile *@
             if (dialog.ComponentType == typeof(Microsoft.AspNetCore.Components.Forms.InputFile))
             {
                 var anchorId = dialog.Options?.Parameters["ElementId"] as string;
                 var options = dialog.Options?.Parameters["Options"] as InputFileOptions ?? new InputFileOptions();
-                var onCompleted = dialog.Options?.Parameters["OnCompletedAsync"] as Func<IEnumerable<FluentInputFileEventArgs>, Task>;
-                var onFileUploaded = dialog.Options?.Parameters["OnFileUploadedAsync"] as Func<FluentInputFileEventArgs, Task>;
-                var onProgressChange = dialog.Options?.Parameters["OnProgressChangeAsync"] as Func<FluentInputFileEventArgs, Task>;
-                var onFileError = dialog.Options?.Parameters["OnFileErrorAsync"] as Func<FluentInputFileErrorEventArgs, Task>;
+                var onCompleted = dialog.Options?.Parameters["OnCompletedAsync"] as Func<IEnumerable<FluentInputFileEventArgs>, Task> ?? (_ => Task.CompletedTask);
+                var onFileUploaded = dialog.Options?.Parameters["OnFileUploadedAsync"] as Func<FluentInputFileEventArgs, Task> ?? (_ => Task.CompletedTask);
+                var onProgressChange = dialog.Options?.Parameters["OnProgressChangeAsync"] as Func<FluentInputFileEventArgs, Task> ?? (_ => Task.CompletedTask);
+                var onFileError = dialog.Options?.Parameters["OnFileErrorAsync"] as Func<FluentInputFileErrorEventArgs, Task> ?? (_ => Task.CompletedTask);
 
                 if (!string.IsNullOrEmpty(anchorId))
                 {
                     <FluentInputFile Id="@dialog.Id"
                                      DragDropZoneVisible="false"
                                      AnchorId="@anchorId"
-                                     OnCompleted="@(e => onCompleted is null ? Task.CompletedTask : onCompleted.Invoke(e))"
+                                     OnCompleted="@(e => onCompleted.Invoke(e))"
                                      Accept="@options.Accept"
                                      Multiple="@options.Multiple"
                                      MaximumFileCount="@options.MaximumFileCount"
                                      MaximumFileSize="@options.MaximumFileSize"
                                      BufferSize="@options.BufferSize"
                                      Mode="@options.Mode"
-                                     OnFileUploaded="@(e => onFileUploaded is null ? Task.CompletedTask : onFileUploaded.Invoke(e))"
-                                     OnProgressChange="@(e => onProgressChange is null ? Task.CompletedTask : onProgressChange.Invoke(e))"
-                                     OnFileError="@(e => onFileError is null ? Task.CompletedTask : onFileError.Invoke(e))" />
+                                     OnFileUploaded="@(e => onFileUploaded.Invoke(e))"
+                                     OnProgressChange="@(e => onProgressChange.Invoke(e))"
+                                     OnFileError="@(e => onFileError.Invoke(e))" />
                 }
             }
+
+            @* FluentDialog *@
             else
             {
                 <FluentDialog Id="@dialog.Id"

--- a/src/Core/Components/Dialog/FluentDialogProvider.razor
+++ b/src/Core/Components/Dialog/FluentDialogProvider.razor
@@ -8,15 +8,29 @@
         {
             if (dialog.ComponentType == typeof(Microsoft.AspNetCore.Components.Forms.InputFile))
             {
-                var anchorId = dialog.Options?.Parameters[Microsoft.FluentUI.AspNetCore.Components.DialogService.InputFileElementId] as string;
-                var onCompleted = dialog.Options?.Parameters[Microsoft.FluentUI.AspNetCore.Components.DialogService.InputFileOnCompleted] as Func<IEnumerable<FluentInputFileEventArgs>, Task>;
-                var options = dialog.Options?.Parameters[Microsoft.FluentUI.AspNetCore.Components.DialogService.InputFileOptions] as InputFileOptions;
+                var anchorId = dialog.Options?.Parameters["ElementId"] as string;
+                var options = dialog.Options?.Parameters["Options"] as InputFileOptions ?? new InputFileOptions();
+                var onCompleted = dialog.Options?.Parameters["OnCompletedAsync"] as Func<IEnumerable<FluentInputFileEventArgs>, Task>;
+                var onFileUploaded = dialog.Options?.Parameters["OnFileUploadedAsync"] as Func<FluentInputFileEventArgs, Task>;
+                var onProgressChange = dialog.Options?.Parameters["OnProgressChangeAsync"] as Func<FluentInputFileEventArgs, Task>;
+                var onFileError = dialog.Options?.Parameters["OnFileErrorAsync"] as Func<FluentInputFileErrorEventArgs, Task>;
 
-                <FluentInputFile Id="@dialog.Id"
-                                 DragDropZoneVisible="false"
-                                 AnchorId="@anchorId"
-                                 OnCompleted="@(e => onCompleted is null ? Task.CompletedTask : onCompleted.Invoke(e))"
-                                 Accept="@options?.Accept" />
+                if (!string.IsNullOrEmpty(anchorId))
+                {
+                    <FluentInputFile Id="@dialog.Id"
+                                     DragDropZoneVisible="false"
+                                     AnchorId="@anchorId"
+                                     OnCompleted="@(e => onCompleted is null ? Task.CompletedTask : onCompleted.Invoke(e))"
+                                     Accept="@options.Accept"
+                                     Multiple="@options.Multiple"
+                                     MaximumFileCount="@options.MaximumFileCount"
+                                     MaximumFileSize="@options.MaximumFileSize"
+                                     BufferSize="@options.BufferSize"
+                                     Mode="@options.Mode"
+                                     OnFileUploaded="@(e => onFileUploaded is null ? Task.CompletedTask : onFileUploaded.Invoke(e))"
+                                     OnProgressChange="@(e => onProgressChange is null ? Task.CompletedTask : onProgressChange.Invoke(e))"
+                                     OnFileError="@(e => onFileError is null ? Task.CompletedTask : onFileError.Invoke(e))" />
+                }
             }
             else
             {

--- a/src/Core/Components/Dialog/FluentDialogProvider.razor
+++ b/src/Core/Components/Dialog/FluentDialogProvider.razor
@@ -6,13 +6,28 @@
     {
         @foreach (var dialog in DialogService.Items.Values.OrderBy(i => i.Index))
         {
-            <FluentDialog Id="@dialog.Id"
-                          Class="@dialog.Options?.ClassValue"
-                          Style="@dialog.Options?.StyleValue"
-                          Data="@dialog.Options?.Data"
-                          Instance="@dialog"
-                          OnStateChange="@(dialog.Options?.OnStateChange ?? EmptyOnStateChange)"
-                          @attributes="@AdditionalAttributes" />
+            if (dialog.ComponentType == typeof(Microsoft.AspNetCore.Components.Forms.InputFile))
+            {
+                var anchorId = dialog.Options?.Parameters[Microsoft.FluentUI.AspNetCore.Components.DialogService.InputFileElementId] as string;
+                var onCompleted = dialog.Options?.Parameters[Microsoft.FluentUI.AspNetCore.Components.DialogService.InputFileOnCompleted] as Func<IEnumerable<FluentInputFileEventArgs>, Task>;
+                var options = dialog.Options?.Parameters[Microsoft.FluentUI.AspNetCore.Components.DialogService.InputFileOptions] as InputFileOptions;
+
+                <FluentInputFile Id="@dialog.Id"
+                                 DragDropZoneVisible="false"
+                                 AnchorId="@anchorId"
+                                 OnCompleted="@(e => onCompleted is null ? Task.CompletedTask : onCompleted.Invoke(e))"
+                                 Accept="@options?.Accept" />
+            }
+            else
+            {
+                <FluentDialog Id="@dialog.Id"
+                              Class="@dialog.Options?.ClassValue"
+                              Style="@dialog.Options?.StyleValue"
+                              Data="@dialog.Options?.Data"
+                              Instance="@dialog"
+                              OnStateChange="@(dialog.Options?.OnStateChange ?? EmptyOnStateChange)"
+                              @attributes="@AdditionalAttributes" />
+            }
         }
     }
 </div>

--- a/src/Core/Components/Dialog/InputFile/DialogService.cs
+++ b/src/Core/Components/Dialog/InputFile/DialogService.cs
@@ -1,0 +1,42 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Components.Forms;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+public partial class DialogService : IDialogService
+{
+    internal const string InputFileElementId = "ElementId";
+    internal const string InputFileOnCompleted = "OnCompleted";
+    internal const string InputFileOptions = "Options";
+
+    /// <see cref="IDialogService.RegisterInputFileAsync(string, Func{IEnumerable{FluentInputFileEventArgs}, Task}, Action{InputFileOptions}?)"/>
+    public virtual async Task RegisterInputFileAsync(string elementId, Func<IEnumerable<FluentInputFileEventArgs>, Task> onCompletedAsync, Action<InputFileOptions>? options = null)
+    {
+        if (this.ProviderNotAvailable())
+        {
+            throw new FluentServiceProviderException<FluentDialogProvider>();
+        }
+
+        // Options
+        var config = new InputFileOptions();
+        options?.Invoke(config);
+
+        // Register the dialog
+        var instance = new DialogInstance(this, typeof(InputFile), new DialogOptions()
+        {
+            Parameters = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                { InputFileElementId, elementId },
+                { InputFileOnCompleted, onCompletedAsync },
+                { InputFileOptions, config},
+            },
+        });
+
+        // Add the dialog to the service, and render it.
+        ServiceProvider.Items.TryAdd(instance?.Id ?? "", instance ?? throw new InvalidOperationException("Failed to register an InputFile."));
+        await ServiceProvider.OnUpdatedAsync.Invoke(instance);
+    }
+}

--- a/src/Core/Components/Dialog/InputFile/DialogService.cs
+++ b/src/Core/Components/Dialog/InputFile/DialogService.cs
@@ -9,7 +9,7 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 public partial class DialogService : IDialogService
 {
     /// <see cref="IDialogService.RegisterInputFileAsync(string, Func{IEnumerable{FluentInputFileEventArgs}, Task}, Action{InputFileOptions}?)"/>
-    public virtual async Task RegisterInputFileAsync(string elementId, Func<IEnumerable<FluentInputFileEventArgs>, Task> onCompletedAsync, Action<InputFileOptions>? options = null)
+    public virtual async Task<InputFileInstance> RegisterInputFileAsync(string elementId, Func<IEnumerable<FluentInputFileEventArgs>, Task> onCompletedAsync, Action<InputFileOptions>? options = null)
     {
         if (this.ProviderNotAvailable())
         {
@@ -23,6 +23,7 @@ public partial class DialogService : IDialogService
         // Register the dialog
         var instance = new DialogInstance(this, typeof(InputFile), new DialogOptions()
         {
+            // These parameters are passed to the `FluentDialogProvider` component
             Parameters = new Dictionary<string, object?>(StringComparer.Ordinal)
             {
                 { "ElementId", elementId },
@@ -34,8 +35,12 @@ public partial class DialogService : IDialogService
             },
         });
 
+        var fileInstance = new InputFileInstance(ServiceProvider, instance, elementId);
+
         // Add the dialog to the service, and render it.
-        ServiceProvider.Items.TryAdd(instance?.Id ?? "", instance ?? throw new InvalidOperationException("Failed to register an InputFile."));
+        ServiceProvider.Items.TryAdd(fileInstance.Id, instance ?? throw new InvalidOperationException("Failed to register an InputFile."));
         await ServiceProvider.OnUpdatedAsync.Invoke(instance);
+
+        return fileInstance;
     }
 }

--- a/src/Core/Components/Dialog/InputFile/DialogService.cs
+++ b/src/Core/Components/Dialog/InputFile/DialogService.cs
@@ -8,10 +8,6 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 
 public partial class DialogService : IDialogService
 {
-    internal const string InputFileElementId = "ElementId";
-    internal const string InputFileOnCompleted = "OnCompleted";
-    internal const string InputFileOptions = "Options";
-
     /// <see cref="IDialogService.RegisterInputFileAsync(string, Func{IEnumerable{FluentInputFileEventArgs}, Task}, Action{InputFileOptions}?)"/>
     public virtual async Task RegisterInputFileAsync(string elementId, Func<IEnumerable<FluentInputFileEventArgs>, Task> onCompletedAsync, Action<InputFileOptions>? options = null)
     {
@@ -29,9 +25,12 @@ public partial class DialogService : IDialogService
         {
             Parameters = new Dictionary<string, object?>(StringComparer.Ordinal)
             {
-                { InputFileElementId, elementId },
-                { InputFileOnCompleted, onCompletedAsync },
-                { InputFileOptions, config},
+                { "ElementId", elementId },
+                { "OnCompletedAsync", onCompletedAsync },
+                { "OnFileUploadedAsync", config.OnFileUploadedAsync },
+                { "OnProgressChangeAsync", config.OnProgressChangeAsync },
+                { "OnFileErrorAsync", config.OnFileErrorAsync },
+                { "Options", config},
             },
         });
 

--- a/src/Core/Components/Dialog/InputFile/DialogService.cs
+++ b/src/Core/Components/Dialog/InputFile/DialogService.cs
@@ -43,4 +43,21 @@ public partial class DialogService : IDialogService
 
         return fileInstance;
     }
+
+    /// <see cref="IDialogService.UnregisterInputFileAsync(string)"/>
+    public virtual async Task UnregisterInputFileAsync(string elementId)
+    {
+        var instances = ServiceProvider.Items
+                                       .Where(x => x.Value.Options.Parameters.ContainsKey("ElementId") &&
+                                                   string.Equals(x.Value.Options.Parameters["ElementId"]?.ToString(), elementId, StringComparison.Ordinal))
+                                       .ToList();
+
+        foreach (var instance in instances)
+        {
+            if (ServiceProvider.Items.TryRemove(instance.Value.Id, out var dialogInstance))
+            {
+                await ServiceProvider.OnUpdatedAsync.Invoke(dialogInstance);
+            }
+        }
+    }
 }

--- a/src/Core/Components/Dialog/InputFile/IDialogService.cs
+++ b/src/Core/Components/Dialog/InputFile/IDialogService.cs
@@ -8,11 +8,17 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 public partial interface IDialogService
 {
     /// <summary>
-    /// Registers a new <see cref="FluentInputFile">element</see> based on the trigger element.
+    /// Registers a new <see cref="FluentInputFile">element</see> based on the trigger element id.
     /// </summary>
     /// <param name="elementId">HTML element identifier.</param>
     /// <param name="onCompletedAsync">Callback to be invoked when the file upload is completed. Call `StateHasChanged` in your method to refresh your UI.</param>
     /// <param name="options">Options for the <see cref="FluentInputFile">element</see>.</param>
     /// <returns></returns>
     Task<InputFileInstance> RegisterInputFileAsync(string elementId, Func<IEnumerable<FluentInputFileEventArgs>, Task> onCompletedAsync, Action<InputFileOptions>? options = null);
+
+    /// <summary>
+    /// Unregisters the <see cref="FluentInputFile">element</see> based on the trigger element id.
+    /// </summary>
+    /// <param name="elementId"></param>
+    Task UnregisterInputFileAsync(string elementId);
 }

--- a/src/Core/Components/Dialog/InputFile/IDialogService.cs
+++ b/src/Core/Components/Dialog/InputFile/IDialogService.cs
@@ -14,5 +14,5 @@ public partial interface IDialogService
     /// <param name="onCompletedAsync">Callback to be invoked when the file upload is completed. Call `StateHasChanged` in your method to refresh your UI.</param>
     /// <param name="options">Options for the <see cref="FluentInputFile">element</see>.</param>
     /// <returns></returns>
-    Task RegisterInputFileAsync(string elementId, Func<IEnumerable<FluentInputFileEventArgs>, Task> onCompletedAsync, Action<InputFileOptions>? options = null);
+    Task<InputFileInstance> RegisterInputFileAsync(string elementId, Func<IEnumerable<FluentInputFileEventArgs>, Task> onCompletedAsync, Action<InputFileOptions>? options = null);
 }

--- a/src/Core/Components/Dialog/InputFile/IDialogService.cs
+++ b/src/Core/Components/Dialog/InputFile/IDialogService.cs
@@ -10,9 +10,9 @@ public partial interface IDialogService
     /// <summary>
     /// Registers a new <see cref="FluentInputFile">element</see> based on the trigger element.
     /// </summary>
-    /// <param name="elementId">HTML element identifier</param>
-    /// <param name="onCompletedAsync">Callback to be invoked when the file upload is completed</param>
-    /// <param name="options">Options for the <see cref="FluentInputFile">element</see></param>
+    /// <param name="elementId">HTML element identifier.</param>
+    /// <param name="onCompletedAsync">Callback to be invoked when the file upload is completed. Call `StateHasChanged` in your method to refresh your UI.</param>
+    /// <param name="options">Options for the <see cref="FluentInputFile">element</see>.</param>
     /// <returns></returns>
     Task RegisterInputFileAsync(string elementId, Func<IEnumerable<FluentInputFileEventArgs>, Task> onCompletedAsync, Action<InputFileOptions>? options = null);
 }

--- a/src/Core/Components/Dialog/InputFile/IDialogService.cs
+++ b/src/Core/Components/Dialog/InputFile/IDialogService.cs
@@ -1,0 +1,18 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary />
+public partial interface IDialogService
+{
+    /// <summary>
+    /// Registers a new <see cref="FluentInputFile">element</see> based on the trigger element.
+    /// </summary>
+    /// <param name="elementId">HTML element identifier</param>
+    /// <param name="onCompletedAsync">Callback to be invoked when the file upload is completed</param>
+    /// <param name="options">Options for the <see cref="FluentInputFile">element</see></param>
+    /// <returns></returns>
+    Task RegisterInputFileAsync(string elementId, Func<IEnumerable<FluentInputFileEventArgs>, Task> onCompletedAsync, Action<InputFileOptions>? options = null);
+}

--- a/src/Core/Components/Dialog/InputFile/InputFileInstance.cs
+++ b/src/Core/Components/Dialog/InputFile/InputFileInstance.cs
@@ -1,0 +1,52 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// Instance of an input file.
+/// </summary>
+public class InputFileInstance : IAsyncDisposable
+{
+    private readonly IFluentServiceBase<IDialogInstance> _serviceProvider;
+    private readonly IDialogInstance _dialogInstance;
+
+    /// <summary />
+    internal InputFileInstance(IFluentServiceBase<IDialogInstance> serviceProvider, IDialogInstance instance, string anchorId)
+    {
+        _serviceProvider = serviceProvider;
+        _dialogInstance = instance;
+        AnchorId = anchorId;
+
+        Id = _dialogInstance.Id;
+    }
+
+    /// <summary>
+    /// Gets the identifier of the input file instance.
+    /// </summary>
+    public string Id { get; }
+
+    /// <summary>
+    /// Gets the identifier of the anchor element.
+    /// </summary>
+    public string AnchorId { get; }
+
+    /// <summary>
+    /// Removes the <see cref="FluentInputFile"/> from the <see cref="FluentDialogProvider"/>.
+    /// </summary>
+    public async ValueTask UnregisterAsync()
+    {
+        _serviceProvider.Items.TryRemove(Id, out _);
+        await _serviceProvider.OnUpdatedAsync.Invoke(_dialogInstance);
+    }
+
+    /// <summary>
+    /// Disposes the <see cref="FluentInputFile"/> from the <see cref="FluentDialogProvider"/>.
+    /// </summary>
+    /// <returns></returns>
+    public async ValueTask DisposeAsync()
+    {
+        await UnregisterAsync();
+    }
+}

--- a/src/Core/Components/Dialog/InputFile/InputFileInstance.cs
+++ b/src/Core/Components/Dialog/InputFile/InputFileInstance.cs
@@ -10,16 +10,14 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 public class InputFileInstance : IAsyncDisposable
 {
     private readonly IFluentServiceBase<IDialogInstance> _serviceProvider;
-    private readonly IDialogInstance _dialogInstance;
 
     /// <summary />
     internal InputFileInstance(IFluentServiceBase<IDialogInstance> serviceProvider, IDialogInstance instance, string anchorId)
     {
         _serviceProvider = serviceProvider;
-        _dialogInstance = instance;
         AnchorId = anchorId;
 
-        Id = _dialogInstance.Id;
+        Id = instance.Id;
     }
 
     /// <summary>
@@ -37,8 +35,10 @@ public class InputFileInstance : IAsyncDisposable
     /// </summary>
     public async ValueTask UnregisterAsync()
     {
-        _serviceProvider.Items.TryRemove(Id, out _);
-        await _serviceProvider.OnUpdatedAsync.Invoke(_dialogInstance);
+        if (_serviceProvider.Items.TryRemove(Id, out var dialogInstance))
+        {
+            await _serviceProvider.OnUpdatedAsync.Invoke(dialogInstance);
+        }
     }
 
     /// <summary>

--- a/src/Core/Components/Dialog/InputFile/InputFileOptions.cs
+++ b/src/Core/Components/Dialog/InputFile/InputFileOptions.cs
@@ -1,0 +1,43 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Components;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// Represents configuration options for handling file input and upload functionality.
+/// </summary>
+public class InputFileOptions : IInputFileOptions
+{
+    /// <inheritdoc cref="IInputFileOptions.Multiple" />
+    public bool Multiple { get; set; }
+
+    /// <inheritdoc cref="IInputFileOptions.MaximumFileCount" />
+    public int MaximumFileCount { get; set; } = 10;
+
+    /// <inheritdoc cref="IInputFileOptions.MaximumFileSize" />
+    public long MaximumFileSize { get; set; } = 10 * 1024 * 1024;
+
+    /// <inheritdoc cref="IInputFileOptions.BufferSize" />
+    public uint BufferSize { get; set; } = 10 * 1024;
+
+    /// <inheritdoc cref="IInputFileOptions.Accept" />
+    public string Accept { get; set; } = string.Empty;
+
+    /// <inheritdoc cref="IInputFileOptions.Disabled" />
+    public bool Disabled { get; set; }
+
+    /// <inheritdoc cref="IInputFileOptions.Mode" />
+    public InputFileMode Mode { get; set; }
+
+    /// <inheritdoc cref="IInputFileOptions.OnFileUploaded" />
+    public EventCallback<FluentInputFileEventArgs> OnFileUploaded { get; set; }
+
+    /// <inheritdoc cref="IInputFileOptions.OnProgressChange" />
+    public EventCallback<FluentInputFileEventArgs> OnProgressChange { get; set; }
+
+    /// <inheritdoc cref="IInputFileOptions.OnFileError" />
+    public EventCallback<FluentInputFileErrorEventArgs> OnFileError { get; set; }
+}

--- a/src/Core/Components/Dialog/InputFile/InputFileOptions.cs
+++ b/src/Core/Components/Dialog/InputFile/InputFileOptions.cs
@@ -2,8 +2,6 @@
 // MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
 // ------------------------------------------------------------------------
 
-using Microsoft.AspNetCore.Components;
-
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 /// <summary>
@@ -26,18 +24,21 @@ public class InputFileOptions : IInputFileOptions
     /// <inheritdoc cref="IInputFileOptions.Accept" />
     public string Accept { get; set; } = string.Empty;
 
-    /// <inheritdoc cref="IInputFileOptions.Disabled" />
-    public bool Disabled { get; set; }
-
     /// <inheritdoc cref="IInputFileOptions.Mode" />
     public InputFileMode Mode { get; set; }
 
-    /// <inheritdoc cref="IInputFileOptions.OnFileUploaded" />
-    public EventCallback<FluentInputFileEventArgs> OnFileUploaded { get; set; }
+    /// <summary>
+    /// Raise when a file is completely uploaded.
+    /// </summary>
+    public Func<FluentInputFileEventArgs, Task>? OnFileUploadedAsync { get; set; }
 
-    /// <inheritdoc cref="IInputFileOptions.OnProgressChange" />
-    public EventCallback<FluentInputFileEventArgs> OnProgressChange { get; set; }
+    /// <summary>
+    /// Raise when a progression step is updated.
+    /// </summary>
+    public Func<FluentInputFileEventArgs, Task>? OnProgressChangeAsync { get; set; }
 
-    /// <inheritdoc cref="IInputFileOptions.OnFileError" />
-    public EventCallback<FluentInputFileErrorEventArgs> OnFileError { get; set; }
+    /// <summary>
+    /// Raise when a file raised an error.
+    /// </summary>
+    public Func<FluentInputFileErrorEventArgs, Task>? OnFileErrorAsync { get; set; }
 }

--- a/src/Core/Components/InputFile/FluentInputFile.razor.cs
+++ b/src/Core/Components/InputFile/FluentInputFile.razor.cs
@@ -22,7 +22,7 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// cref="Mode"/> property to specify the file reading mode, such as buffering, saving to a temporary folder, or
 /// streaming. The <see cref="OnFileUploaded"/> and <see cref="OnCompleted"/> events can be used to handle file upload
 /// completion.</remarks>
-public partial class FluentInputFile : FluentComponentBase, IAsyncDisposable
+public partial class FluentInputFile : FluentComponentBase, IAsyncDisposable, IInputFileOptions
 {
     private const string JAVASCRIPT_FILE = FluentJSModule.JAVASCRIPT_ROOT + "InputFile/FluentInputFile.razor.js";
     private ElementReference? _containerElement;

--- a/src/Core/Components/InputFile/IInputFileOptions.cs
+++ b/src/Core/Components/InputFile/IInputFileOptions.cs
@@ -1,0 +1,70 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Components;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+internal interface IInputFileOptions
+{
+    /// <summary>
+    /// To enable multiple file selection and upload, set the Multiple property to true.
+    /// Set <see cref="MaximumFileCount"/> to change the number of allowed files.
+    /// </summary>
+    bool Multiple { get; set; }
+
+    /// <summary>
+    /// To select multiple files, set the maximum number of files allowed to be uploaded.
+    /// Default value is 10.
+    /// </summary>
+    int MaximumFileCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum size of a file to be uploaded (in bytes).
+    /// Default value is 10 MiB.
+    /// </summary>
+    long MaximumFileSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the sze of buffer to read bytes from uploaded file (in bytes).
+    /// Default value is 10 KiB.
+    /// </summary>
+    uint BufferSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the filter for what file types the user can pick from the file input dialog box.
+    /// Example: ".gif, .jpg, .png, .doc", "audio/*", "video/*", "image/*"
+    /// See <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept">https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept</see>
+    /// for more information.
+    /// </summary>
+    string Accept { get; set; }
+
+    /// <summary>
+    /// Disables the form control, ensuring it doesn't participate in form submission.
+    /// </summary>
+    bool Disabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets the type of file reading.
+    /// For SaveToTemporaryFolder, use <see cref="FluentInputFileEventArgs.LocalFile" /> to retrieve the file.
+    /// For Buffer, use <see cref="FluentInputFileEventArgs.Buffer" /> to retrieve bytes.
+    /// For Stream, use <see cref="FluentInputFileEventArgs.Stream"/> to have full control over retrieving the file.
+    /// </summary>
+    InputFileMode Mode { get; set; }
+
+    /// <summary>
+    /// Raise when a file is completely uploaded.
+    /// </summary>
+    EventCallback<FluentInputFileEventArgs> OnFileUploaded { get; set; }
+
+    /// <summary>
+    /// Raise when a progression step is updated.
+    /// </summary>
+    EventCallback<FluentInputFileEventArgs> OnProgressChange { get; set; }
+
+    /// <summary>
+    /// Raise when a file raised an error.
+    /// </summary>
+    public EventCallback<FluentInputFileErrorEventArgs> OnFileError { get; set; }
+}

--- a/src/Core/Components/InputFile/IInputFileOptions.cs
+++ b/src/Core/Components/InputFile/IInputFileOptions.cs
@@ -2,8 +2,6 @@
 // MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
 // ------------------------------------------------------------------------
 
-using Microsoft.AspNetCore.Components;
-
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 internal interface IInputFileOptions
@@ -41,30 +39,10 @@ internal interface IInputFileOptions
     string Accept { get; set; }
 
     /// <summary>
-    /// Disables the form control, ensuring it doesn't participate in form submission.
-    /// </summary>
-    bool Disabled { get; set; }
-
-    /// <summary>
     /// Gets or sets the type of file reading.
     /// For SaveToTemporaryFolder, use <see cref="FluentInputFileEventArgs.LocalFile" /> to retrieve the file.
     /// For Buffer, use <see cref="FluentInputFileEventArgs.Buffer" /> to retrieve bytes.
     /// For Stream, use <see cref="FluentInputFileEventArgs.Stream"/> to have full control over retrieving the file.
     /// </summary>
     InputFileMode Mode { get; set; }
-
-    /// <summary>
-    /// Raise when a file is completely uploaded.
-    /// </summary>
-    EventCallback<FluentInputFileEventArgs> OnFileUploaded { get; set; }
-
-    /// <summary>
-    /// Raise when a progression step is updated.
-    /// </summary>
-    EventCallback<FluentInputFileEventArgs> OnProgressChange { get; set; }
-
-    /// <summary>
-    /// Raise when a file raised an error.
-    /// </summary>
-    public EventCallback<FluentInputFileErrorEventArgs> OnFileError { get; set; }
 }

--- a/tests/Core/Components/Dialog/FluentDialogTests.razor
+++ b/tests/Core/Components/Dialog/FluentDialogTests.razor
@@ -80,12 +80,12 @@
         // Arrange
         var renderOptions = new Templates.DialogRenderOptions();
         var toggleArgs = new DialogToggleEventArgs()
-            {
-                Id = "my-id",
-                Type = eventType,
-                OldState = oldState,
-                NewState = newState,
-            };
+        {
+            Id = "my-id",
+            Type = eventType,
+            OldState = oldState,
+            NewState = newState,
+        };
 
         DialogEventArgs? dialogEventArgs = null;
 
@@ -108,7 +108,8 @@
 
         // Find the dialog and close it
         var dialog = DialogProvider.FindComponent<FluentDialog>();
-        await dialog.Instance.OnToggleAsync(toggleArgs);
+        await dialog.Instance.OnToggleAsync(new() { Id = "NotCorrectId" });    // Incorrect dialog instance
+        await dialog.Instance.OnToggleAsync(toggleArgs);                       // Correct dialog instance
 
         // Assert
         Assert.NotNull(dialogEventArgs?.Instance);
@@ -121,9 +122,9 @@
     {
         // Arrange
         var renderOptions = new Templates.DialogRenderOptions()
-            {
-                AutoClose = true,
-            };
+        {
+            AutoClose = true,
+        };
 
         // Act
         var dialogTask = DialogService.ShowDialogAsync<Templates.DialogRender>(options =>
@@ -209,11 +210,11 @@
     {
         // Arrange
         var renderOptions = new Templates.DialogRenderOptions()
-            {
-                AutoClose = true,
-                AutoCloseDelay = 200,
-                AutoCloseResult = DialogResult.Ok("AUTO_CLOSED"),
-            };
+        {
+            AutoClose = true,
+            AutoCloseDelay = 200,
+            AutoCloseResult = DialogResult.Ok("AUTO_CLOSED"),
+        };
 
         // Act
         var dialogTask = DialogService.ShowDialogAsync<Templates.DialogRender>(options =>
@@ -478,12 +479,12 @@
         var renderOptions = new Templates.DialogRenderOptions();
 
         var dialogOptions = new DialogOptions()
-            {
-                Class = "my-class",
-                Style = "border: 1px solid red;",
-                Margin = "10px",
-                Padding = "20px",
-            };
+        {
+            Class = "my-class",
+            Style = "border: 1px solid red;",
+            Margin = "10px",
+            Padding = "20px",
+        };
         dialogOptions.Parameters.Add(nameof(Templates.DialogRender.Options), renderOptions);
         dialogOptions.Parameters.Add(nameof(Templates.DialogRender.Name), "John");
 

--- a/tests/Core/Components/InputFile/FluentInputFileDialogServiceTests.FluentInputFile_DialogService_Register.verified.razor.html
+++ b/tests/Core/Components/InputFile/FluentInputFileDialogServiceTests.FluentInputFile_DialogService_Register.verified.razor.html
@@ -1,0 +1,14 @@
+
+<div id="xxx" class="fluent-dialog-provider" style="z-index: 999;">
+  <div class="fluent-inputfile-container" style="display: none;" blazor:elementreference="xxx">
+    <div class="inputfile-content" style="z-index: 991">
+      <div class="inputfile-progress" style="visibility: hidden;">
+        <fluent-progress-bar min="0" max="100" value="0"></fluent-progress-bar>
+        <br>
+      </div>
+    </div>
+    <div style="grid-column: 1; grid-row: 1; ">
+      <input id="xxx" accept="" type="file" blazor:elementreference="xxx">
+    </div>
+  </div>
+</div>

--- a/tests/Core/Components/InputFile/FluentInputFileDialogServiceTests.razor
+++ b/tests/Core/Components/InputFile/FluentInputFileDialogServiceTests.razor
@@ -87,6 +87,42 @@
     }
 
     [Fact]
+    public async Task FluentInputFile_DialogService_FileError()
+    {
+        var errorDetected = false;
+        var fileToUpload = InputFileContent.CreateFromText("Text content", "Filename.txt");
+        var filesDownloaded = new List<FluentInputFileEventArgs>();
+
+        // Arrange
+        await DialogService.RegisterInputFileAsync("MyButton", CompletedAsync, options =>
+        {
+            options.MaximumFileSize = 3;    // Set a small size to trigger an error
+            options.OnFileErrorAsync = (e) => ErrorAsync(e);
+        });
+
+        // Act
+        var inputFile = DialogProvider.FindComponent<InputFile>();
+        inputFile.UploadFiles(fileToUpload);
+
+        // Assert
+        Assert.Single(filesDownloaded);
+        Assert.Equal("The maximum size allowed is reached", filesDownloaded[0].ErrorMessage);
+        Assert.True(errorDetected);
+
+        async Task CompletedAsync(IEnumerable<FluentInputFileEventArgs> args)
+        {
+            filesDownloaded = args.ToList();
+            await Task.CompletedTask;
+        }
+
+        async Task ErrorAsync(FluentInputFileErrorEventArgs args)
+        {
+            errorDetected = true;
+            await Task.CompletedTask;
+        }
+    }
+
+    [Fact]
     public async Task FluentInputFile_DialogService_Unregister()
     {
         // Arrange

--- a/tests/Core/Components/InputFile/FluentInputFileDialogServiceTests.razor
+++ b/tests/Core/Components/InputFile/FluentInputFileDialogServiceTests.razor
@@ -1,0 +1,138 @@
+﻿@using Xunit;
+@inherits Bunit.TestContext
+@code
+{
+    public FluentInputFileDialogServiceTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddFluentUIComponents();
+
+        DialogService = Services.GetRequiredService<IDialogService>();
+        DialogProvider = RenderComponent<FluentDialogProvider>();
+    }
+
+    /// <summary>
+    /// Gets the dialog service.
+    /// </summary>
+    public IDialogService DialogService { get; }
+
+    /// <summary>
+    /// Gets the dialog provider.
+    /// </summary>
+    public IRenderedComponent<FluentDialogProvider> DialogProvider { get; }
+
+    [Fact]
+    public async Task FluentInputFile_DialogService_Register()
+    {
+        // Arrange
+        await DialogService.RegisterInputFileAsync("MyButton", (args) => Task.CompletedTask);
+
+        // Assert
+        DialogProvider.Verify();
+    }
+
+    [Fact]
+    public async Task FluentInputFile_DialogService_Options()
+    {
+        // Arrange
+        await DialogService.RegisterInputFileAsync("MyButton", (args) => Task.CompletedTask, options =>
+        {
+            options.Accept = "image/*";
+            options.Multiple = true;
+            options.MaximumFileSize = 12_345;
+            options.MaximumFileCount = 5;
+            options.BufferSize = 1_234;
+            options.Mode = InputFileMode.Stream;
+            options.OnFileErrorAsync = (args) => Task.CompletedTask;
+            options.OnFileUploadedAsync = (args) => Task.CompletedTask;
+            options.OnProgressChangeAsync = (args) => Task.CompletedTask;
+        });
+
+        // Assert
+        var inputFile = DialogProvider.FindComponent<FluentInputFile>();
+
+        Assert.Equal("image/*", inputFile.Instance.Accept);
+        Assert.True(inputFile.Instance.Multiple);
+        Assert.Equal(12_345, inputFile.Instance.MaximumFileSize);
+        Assert.Equal(5, inputFile.Instance.MaximumFileCount);
+        Assert.Equal(1_234u, inputFile.Instance.BufferSize);
+        Assert.Equal(InputFileMode.Stream, inputFile.Instance.Mode);
+    }
+
+    [Fact]
+    public async Task FluentInputFile_DialogService_UploadCompleted()
+    {
+        //int ProgressPercent = 0;
+        var fileToUpload = InputFileContent.CreateFromText("Text content", "Filename.txt");
+        var filesDownloaded = new List<FluentInputFileEventArgs>();
+
+        // Arrange
+        await DialogService.RegisterInputFileAsync("MyButton", CompletedAsync, options => { options.Multiple = true; });
+
+        // Act
+        var inputFile = DialogProvider.FindComponent<InputFile>();
+        inputFile.UploadFiles(fileToUpload);
+
+        // Assert
+        Assert.Single(filesDownloaded);
+        Assert.Equal(0, filesDownloaded[0].Index);
+        Assert.False(filesDownloaded[0].IsCancelled);
+        Assert.Equal("Filename.txt", filesDownloaded[0].Name);
+
+        async Task CompletedAsync(IEnumerable<FluentInputFileEventArgs> args)
+        {
+            filesDownloaded = args.ToList();
+            await Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task FluentInputFile_DialogService_Unregister()
+    {
+        // Arrange
+        await DialogService.RegisterInputFileAsync("MyButton", (args) => Task.CompletedTask);
+
+        // Assert
+        DialogProvider.Markup.Contains("<input");
+
+        // Act
+        await DialogService.UnregisterInputFileAsync("MyButton");
+
+        // Assert
+        Assert.Empty(DialogProvider.Find(".fluent-dialog-provider").InnerHtml);
+    }
+
+    [Fact]
+    public async Task FluentInputFile_DialogService_Instance()
+    {
+        // Arrange
+        var instance = await DialogService.RegisterInputFileAsync("MyButton", (args) => Task.CompletedTask);
+
+        // Assert
+        Assert.Equal("MyButton", instance.AnchorId);
+        Assert.NotEmpty(instance.Id);
+
+        // Act
+        await instance.UnregisterAsync();
+
+        // Assert
+        Assert.Empty(DialogProvider.Find(".fluent-dialog-provider").InnerHtml);
+
+        await instance.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task FluentInputFile_DialogService_RegisterWithoutProvider()
+    {
+        // Arrange
+        DialogProvider.Instance.UpdateId(null);
+
+        // Act
+        await Assert.ThrowsAsync<FluentServiceProviderException<FluentDialogProvider>>(async () =>
+        {
+            await DialogService.RegisterInputFileAsync("MyButton", (args) => Task.CompletedTask);
+        });
+
+        await ((DialogService)DialogService).RemoveDialogFromProviderAsync(null);
+    }
+}

--- a/tests/Core/Components/TextArea/KeyPressTests.cs
+++ b/tests/Core/Components/TextArea/KeyPressTests.cs
@@ -1,0 +1,62 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using Microsoft.FluentUI.AspNetCore.Components;
+using Xunit;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Tests.Components.TextArea;
+
+public class FluentTextArea_KeyPress
+{
+    [Fact]
+    public void FluentTextArea_KeyPress_Combined_True()
+    {
+        var keys = KeyPress.For(AspNetCore.Components.KeyCode.KeyA)
+                           .AndAltKey()
+                           .AndCtrlKey()
+                           .AndMetaKey()
+                           .AndShiftKey()
+                           .WithPreventDefault();
+
+        Assert.True(keys.AltKey);
+        Assert.True(keys.CtrlKey);
+        Assert.True(keys.ShiftKey);
+        Assert.True(keys.MetaKey);
+        Assert.False(keys.PreventDefault);
+    }
+
+    [Fact]
+    public void FluentTextArea_KeyPress_Combined_False()
+    {
+        var keys = KeyPress.For(AspNetCore.Components.KeyCode.KeyA)
+                           .AndAltKey(pressed: false)
+                           .AndCtrlKey(pressed: false)
+                           .AndMetaKey(pressed: false)
+                           .AndShiftKey(pressed: false)
+                           .WithPreventDefault(prevent: true);
+
+        Assert.False(keys.AltKey);
+        Assert.False(keys.CtrlKey);
+        Assert.False(keys.ShiftKey);
+        Assert.False(keys.MetaKey);
+        Assert.True(keys.PreventDefault);
+    }
+
+    [Fact]
+    public void FluentTextArea_KeyPress_MultipleCombined()
+    {
+        var keys = KeyPress.For(AspNetCore.Components.KeyCode.KeyA)
+                           .AndAltKey(pressed: true).AndAltKey(pressed: false)
+                           .AndCtrlKey(pressed: true).AndCtrlKey(pressed: false).AndCtrlKey(pressed: true)
+                           .AndMetaKey(pressed: true).AndMetaKey(pressed: false)
+                           .AndShiftKey(pressed: true).AndShiftKey(pressed: false).AndShiftKey(pressed: true)
+                           .WithPreventDefault().WithPreventDefault(prevent: true);
+
+        Assert.False(keys.AltKey);
+        Assert.True(keys.CtrlKey);
+        Assert.False(keys.MetaKey);
+        Assert.True(keys.ShiftKey);
+        Assert.True(keys.PreventDefault);
+    }
+}


### PR DESCRIPTION
# [dev-v5] Add DialogService.RegisterInputFileAsync

A easy way to open the file selection dialog is to use the injected **DialogService** service.
1. During the `OnInitialized` method, **register** your trigger HTML element 
   using the method `MyFileInstance = DialogService.RegisterInputFileAsync(id)`.
1. Set the `OnCompletedAsync` method to handle the files uploaded.
1. Don't forget to **unregister** the trigger element in the `Dispose` method 
   using `MyFileInstance.UnregisterAsync();` or `DialogService.UnregisterInputFileAsync(id)`.

```xml
<FluentButton Id="MyButton">Upload files</FluentButton>
```

```csharp
[Inject]
public IDialogService DialogService { get; set; }

protected override async Task OnInitializedAsync()
{
    await DialogService.RegisterInputFileAsync("MyButton", OnCompletedAsync, options => { /* ... */ });    
}

private Task OnCompletedAsync(IEnumerable<FluentInputFileEventArgs> files)
{
    // `files` contains the uploaded files
}

public async ValueTask DisposeAsync()
{
    await DialogService.UnregisterInputFileAsync("MyButton");
}
```

## Unit tests

![{49302F50-B24E-4B64-89B9-824ADA106330}](https://github.com/user-attachments/assets/fca45e59-105a-4d44-932e-910d523d555c)

