### PR TITLE
[AutoComplete] Do not show previous/next when no option is selected

### DIFF
--- a/src/Core/Components/List/FluentAutocomplete.razor
+++ b/src/Core/Components/List/FluentAutocomplete.razor
@@ -32,7 +32,7 @@
                          autofocus="@Autofocus"
                          Style="@ComponentWidth">
             @* Selected Items *@
-            @if (this.SelectedOptions?.Any() == true || this.SelectedOption is not null)
+            @if ((Multiple && this.SelectedOptions?.Any() == true) || (!Multiple && this.SelectedOption is not null))
             {
                 @* Normal (single) line height *@
                 if (string.IsNullOrEmpty(MaxAutoHeight))


### PR DESCRIPTION
# Fix the Autocomplete Previous/Next when no option is selected

See #3775 

