### PR TITLE
[AutoComplete] Fix using different height for MaxAutoHeight (#3793)

### DIFF
--- a/src/Core/Components/List/FluentAutocomplete.razor.css
+++ b/src/Core/Components/List/FluentAutocomplete.razor.css
@@ -44,13 +44,11 @@
 }
 
 .fluent-autocomplete-multiselect[auto-height] ::deep fluent-text-field::part(root) {
-    height: 100%;
-    padding: 6px 0px 4px 0px;
+    min-height: calc((var(--base-height-multiplier) + var(--density)) * var(--design-unit) * 1px);
+    height: auto;
+    padding: 4px 0;
 }
 
-.fluent-autocomplete-multiselect[auto-height] ::deep fluent-text-field::part(control) {
-    margin-bottom: 2px;
-}
 
 .fluent-autocomplete-multiselect[single-select] ::deep fluent-text-field::part(control) {
     display: none;


### PR DESCRIPTION

# Pull Request

## 📖 Description
This PR addresses the different default height behaviour for `FluentAutoComplete` when `MaxAutoHeight` is set to `true`

Before:
![auto_height_before](https://github.com/user-attachments/assets/b0fa7e0a-f7a1-41fd-b3c0-580a20c20972)

After:
![auto_height_after](https://github.com/user-attachments/assets/eb447780-9cba-4ff1-84b4-b644bf99c5c6)

### 🎫 Issues
Fixes: #3793

## 👩‍💻 Reviewer Notes

The movement below the component is happening because the wrapped tags need some padding.


## 📑 Test Plan

I've tested this changes in Firefox, Edge, Chrome and Safari.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

