### PR TITLE
 [Autocomplete] Fix active highlight size for single-select mode

### DIFF
--- a/src/Core/Components/List/FluentAutocomplete.razor.css
+++ b/src/Core/Components/List/FluentAutocomplete.razor.css
@@ -54,6 +54,10 @@
     display: none;
 }
 
+.fluent-autocomplete-multiselect[single-select] ::deep fluent-text-field:not([disabled]):active::after {
+    width: 100%;
+}
+
 .fluent-autocomplete-multiselect[single-select] ::deep fluent-text-field::part(start) {
     max-width: calc(100% - 40px);
     text-overflow: ellipsis;


### PR DESCRIPTION
# Pull Request

## 📖 Description

This fixes the sizing behaviour for the active control when the `FluentAutoComplete` is being running in `single-select` mode.

Before:
![autocomplete_before](https://github.com/user-attachments/assets/babde00c-61b6-4ab6-80b0-e2e61de6c86d)

After:
![autocomplete_after](https://github.com/user-attachments/assets/0a2b651c-4093-4339-a00f-6951f0b4ee95)

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component
