### PR TITLE
[Docs] Remove Autofocus to prevent scrolling in the docs (#3826)

### DIFF
--- a/examples/Demo/Shared/Pages/List/Autocomplete/Examples/AutocompleteCloseViaCode.razor
+++ b/examples/Demo/Shared/Pages/List/Autocomplete/Examples/AutocompleteCloseViaCode.razor
@@ -5,7 +5,6 @@
 <FluentAutocomplete @ref=_autocomplete
                     TOption="Country"
                     AutoComplete="off"
-                    Autofocus="true"
                     Label="Select a country"
                     Width="250px"
                     MaxAutoHeight="@(AutoHeight ? "200px" : null)"


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR removes the Autofocus from one of the Autocomplete examples to prevent scrolling within the documentation page.

### 🎫 Issues

Fixes #3826


## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.


