### PR TITLE
[MainLayout] Remove double header reduction

### DIFF
--- a/src/Core/Components/MainLayout/FluentMainLayout.razor
+++ b/src/Core/Components/MainLayout/FluentMainLayout.razor
@@ -7,17 +7,20 @@
         @Header
     </FluentHeader>
 
-    @SubHeader
+    <FluentStack Orientation="Orientation.Vertical" VerticalGap="0" Style="height: 100%;">
 
-    <FluentStack Orientation="Orientation.Horizontal" style="height:calc(100% - var(--header-height))" HorizontalGap="0">
-        @if (NavMenuContent != null)
-        {
-            <FluentNavMenu Width="@NavMenuWidth" Collapsible="true" Class="main-layout-navmenu" Title="@NavMenuTitle">
-                @NavMenuContent
-            </FluentNavMenu>
-        }
-        <FluentBodyContent>
-            @Body
-        </FluentBodyContent>
+        @SubHeader
+
+        <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="0" Style="height: 100%;">
+            @if (NavMenuContent != null)
+            {
+                <FluentNavMenu Width="@NavMenuWidth" Collapsible="true" Class="main-layout-navmenu" Title="@NavMenuTitle">
+                    @NavMenuContent
+                </FluentNavMenu>
+            }
+            <FluentBodyContent>
+                @Body
+            </FluentBodyContent>
+        </FluentStack>
     </FluentStack>
 </FluentLayout>

--- a/src/Core/Components/MainLayout/FluentMainLayout.razor.cs
+++ b/src/Core/Components/MainLayout/FluentMainLayout.razor.cs
@@ -10,7 +10,6 @@ public partial class FluentMainLayout : FluentComponentBase
 
     protected string? StyleValue => new StyleBuilder(Style)
         .AddStyle("--header-height", $"{HeaderHeight}px", () => HeaderHeight.HasValue)
-        .AddStyle("height", $"calc(100% - {HeaderHeight}px)")
         .Build();
 
     /// <summary>

--- a/tests/Core/_ToDo/MainLayout/FluentMainLayoutTests.FluentMainLayout_Default.verified.html
+++ b/tests/Core/_ToDo/MainLayout/FluentMainLayoutTests.FluentMainLayout_Default.verified.html
@@ -1,27 +1,29 @@
 
-<div class="layout" style="height: calc(100% - px);" b-emdrz8ckod="" blazor:elementreference="xxx">
-  <header class="header" b-wxpnc5dx1o="" blazor:elementreference="xxx">
-    <div class="header-gutters" b-wxpnc5dx1o="">
-      <b>render me</b>
-    </div>
-  </header>
-  <b>render me</b>
-  <div class="stack-horizontal" style="justify-content: start; align-items: start; column-gap: 0px; row-gap: 10px; width: 100%; height:calc(100% - var(--header-height));" b-0nr62qx0mz="">
-      <fluent-page-script src="./_content/Microsoft.FluentUI.AspNetCore.Components/Components/NavMenu/FluentNavMenu.razor.js" style="display:none;"></fluent-page-script>
-    <div id="xxx" class="main-layout-navmenu fluent-nav-menu" style="width: 320px;" role="menu" aria-expanded="" b-vs37bumpa7="" blazor:elementreference="xxx">
-      <div aria-expanded="true" role="menuitem" class="fluent-nav-item expander" tabindex="0" blazor:onclick="1" blazor:onkeydown="2" b-vs37bumpa7="">
-        <div class="positioning-region" b-vs37bumpa7="">
-          <div class="content-region" b-vs37bumpa7="">
-            <svg style="width: 20px; fill: var(--accent-fill-rest);" focusable="false" viewBox="0 0 24 24" aria-hidden="true" blazor:onclick="3">
-              <path d="M2.75 18h18.5a.75.75 0 0 1 .1 1.5H2.75a.75.75 0 0 1-.1-1.5h18.6-18.5Zm0-6.5h18.5a.75.75 0 0 1 .1 1.5H2.75a.75.75 0 0 1-.1-1.5h18.6-18.5Zm0-6.5h18.5a.75.75 0 0 1 .1 1.5H2.75a.75.75 0 0 1-.1-1.49h18.6-18.5Z"></path>
-            </svg>
-          </div>
+<div class="layout" b-emdrz8ckod="" blazor:elementreference="xxx">
+    <header class="header" b-wxpnc5dx1o="" blazor:elementreference="xxx">
+        <div class="header-gutters" b-wxpnc5dx1o="">
+            <b>render me</b>
         </div>
-      </div>
-      <b>render me</b>
+    </header>
+    <div class="stack-vertical" style="align-items: start; justify-content: start; column-gap: 10px; row-gap: 0px; width: 100%; height: 100%;" b-0nr62qx0mz="">
+        <b>render me</b>
+        <div class="stack-horizontal" style="justify-content: start; align-items: start; column-gap: 0px; row-gap: 10px; width: 100%; height: 100%" b-0nr62qx0mz="">
+            <fluent-page-script src="./_content/Microsoft.FluentUI.AspNetCore.Components/Components/NavMenu/FluentNavMenu.razor.js" style="display:none;"></fluent-page-script>
+            <div id="xxx" class="main-layout-navmenu fluent-nav-menu" style="width: 320px;" role="menu" aria-expanded="" b-vs37bumpa7="" blazor:elementreference="xxx">
+                <div aria-expanded="true" role="menuitem" class="fluent-nav-item expander" tabindex="0" blazor:onclick="1" blazor:onkeydown="2" b-vs37bumpa7="">
+                    <div class="positioning-region" b-vs37bumpa7="">
+                        <div class="content-region" b-vs37bumpa7="">
+                            <svg style="width: 20px; fill: var(--accent-fill-rest);" focusable="false" viewBox="0 0 24 24" aria-hidden="true" blazor:onclick="3">
+                                <path d="M2.75 18h18.5a.75.75 0 0 1 .1 1.5H2.75a.75.75 0 0 1-.1-1.5h18.6-18.5Zm0-6.5h18.5a.75.75 0 0 1 .1 1.5H2.75a.75.75 0 0 1-.1-1.5h18.6-18.5Zm0-6.5h18.5a.75.75 0 0 1 .1 1.5H2.75a.75.75 0 0 1-.1-1.49h18.6-18.5Z"></path>
+                            </svg>
+                        </div>
+                    </div>
+                </div>
+                <b>render me</b>
+            </div>
+            <div class="body-content" b-9l28a7kahd="" blazor:elementreference="xxx">
+                <b>render me</b>
+            </div>
+        </div>
+        </div>
     </div>
-    <div class="body-content" b-9l28a7kahd="" blazor:elementreference="xxx">
-      <b>render me</b>
-    </div>
-  </div>
-</div>

--- a/tests/Core/_ToDo/MainLayout/FluentMainLayoutTests.cs
+++ b/tests/Core/_ToDo/MainLayout/FluentMainLayoutTests.cs
@@ -36,5 +36,35 @@ public class FluentMainLayoutTests : TestBase
         //Assert
         cut.Verify();
     }
+
+    [Fact]
+    public void FluentMainLayout_MainContent_Should_HaveCorrectHeight()
+    {
+        //Arrange
+        int? headerHeight = 60;
+        var expectedHeightStyle = $"height: 100%;";
+        var header = "<b>render me</b>";
+        var subHeader = "<b>render me</b>";
+        var navMenuContent = "<b>render me</b>";
+        var body = "<b>render me</b>";
+        string navMenuTitle = default!;
+        var navMenuWidth = 320;
+        var cut = TestContext.RenderComponent<FluentMainLayout>(parameters => parameters
+            .Add(p => p.Header, header)
+            .Add(p => p.SubHeader, subHeader)
+            .Add(p => p.HeaderHeight, headerHeight)
+            .Add(p => p.NavMenuTitle, navMenuTitle)
+            .Add(p => p.NavMenuContent, navMenuContent)
+            .Add(p => p.NavMenuWidth, navMenuWidth)
+            .Add(p => p.Body, body)
+        );
+        //Act
+        var fullContentStack = cut.FindComponent<FluentStack>();
+        var mainContentStack = fullContentStack.FindComponent<FluentStack>();
+
+        //Assert
+        Assert.Equal(expectedHeightStyle, fullContentStack.Instance.Style, StringComparer.Ordinal);
+        Assert.Equal(expectedHeightStyle, mainContentStack.Instance.Style, StringComparer.Ordinal);
+    }
 }
 


### PR DESCRIPTION
Fix #3836

# Pull Request

## 📖 Description

Removed header height reductions from `Mainlayout`, added a vertical stack.
Stacks now always have 100% height.
I've kept the `--header-height` variable as it might be used by some users already.

### 🎫 Issues

#3836 

## 👩‍💻 Reviewer Notes

I think we should take cases in consideration when the navigation or main content exceeds the 100%.
We can either re-add the subtraction to the vertical stack and add a parameter to the component `SubHeaderHeight` and subtract this from the horizontal stack. 
Or we can let the user define the styles for these stacks themselves.

## 📑 Test Plan

Added test to check default styles of mainlayout stacks

## ✅ Checklist

### General

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific


- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component
