### PR TITLE
[dev-v5] Add FluentErrorBoundary

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/ErrorBoundary/Examples/FluentErrorBoundayDefault.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/ErrorBoundary/Examples/FluentErrorBoundayDefault.razor
@@ -1,0 +1,21 @@
+﻿<FluentErrorBoundary HideChildContentOnError="false">
+    <FluentButton OnClick="@(e => throw new InvalidOperationException("Invalid operation"))">
+        Throw Exception (no details)
+    </FluentButton>
+</FluentErrorBoundary>
+
+<FluentDivider Style="height: 30px;" />
+
+<FluentErrorBoundary DisplayErrorDetails="ErrorBoundaryDetails.ErrorMessage" HideChildContentOnError="false">
+    <FluentButton OnClick="@(e => throw new InvalidOperationException("Invalid operation"))">
+        Throw Exception (message only)
+    </FluentButton>
+</FluentErrorBoundary>
+
+<FluentDivider Style="height: 30px;" />
+
+<FluentErrorBoundary DisplayErrorDetails="ErrorBoundaryDetails.ErrorStack" HideChildContentOnError="false">
+    <FluentButton OnClick="@(e => throw new InvalidOperationException("Invalid operation"))">
+        Throw Exception (stack)
+    </FluentButton>
+</FluentErrorBoundary>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/ErrorBoundary/FluentErrorBoundary.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/ErrorBoundary/FluentErrorBoundary.md
@@ -1,0 +1,38 @@
+---
+title: Error Boundary
+route: /ErrorBoundary
+---
+
+# Error Boundary
+
+The **FluentErrorBoundary** component is used to catch errors in a component tree and display a fallback UI instead of crashing the entire application.
+_Error boundaries_ provide a convenient approach for handling exceptions.
+
+The **FluentErrorBoundary** component:
+
+  - Renders its child content when an error hasn't occurred.
+  - Renders error UI when an unhandled exception is thrown by any component within the error boundary.
+
+To define an error boundary, use the **FluentErrorBoundary** component to wrap one or more other components.
+The error boundary manages unhandled exceptions thrown by the components that it wraps.
+
+See [the Blazor handle errors using the error boundaries feature](https://learn.microsoft.com/aspnet/core/blazor/fundamentals/handle-errors#error-boundaries) for more details.
+
+## Example
+
+In this example, we demonstrate how to use the **FluentErrorBoundary** component to catch errors in a component tree,
+depending of the `DisplayErrorDetails` parameter (None, ErrorMessage
+
+- **None** displays a simple error message "An unhandled error has occurred. Please, contact your IT support."  
+  This is the default value and is recommended for production use.
+- **ErrorMessage** displays the error message.
+- **ErrorStack** displays the error message, stack trace, and the project source that caused the error.
+
+> [!NOTE] You can customize the error message by using the [localization](/localization) feature.
+> or using the `ErrorHeader` and `ErrorMessage` parameters.
+
+{{ FluentErrorBoundayDefault }}
+
+## API FluentErrorBoundary
+
+{{ API Type=FluentErrorBoundary }}

--- a/examples/Demo/FluentUI.Demo.Client/Layout/DemoMainLayout.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Layout/DemoMainLayout.razor
@@ -2,7 +2,8 @@
 
 <PageTitle>@App.PageTitle("Demo")</PageTitle>
 
-<FluentLayout @key="@GetLayoutKey()" Style="@LayoutStyleHeight" MenuDeferredLoading="true">
+<FluentErrorBoundary>
+    <FluentLayout @key="@GetLayoutKey()" Style="@LayoutStyleHeight" MenuDeferredLoading="true">
 
     @* ------------------- *@
     @*       Header        *@
@@ -106,6 +107,7 @@
     </FluentLayoutItem>
 
 </FluentLayout>
+</FluentErrorBoundary>
 
 <!-- FluentUI Service Providers -->
 <FluentProviders />

--- a/src/Core/Components/ErrorBoundary/FluentErrorBoundary.razor
+++ b/src/Core/Components/ErrorBoundary/FluentErrorBoundary.razor
@@ -1,0 +1,69 @@
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Rendering;
+@using Microsoft.FluentUI.AspNetCore.Components.Extensions
+@inherits FluentComponentBase
+
+<ErrorBoundary @ref="ErrorBoundary">
+    <ChildContent>
+        <div id="@Id" class="@DefaultClassBuilder.Build()" style="@DefaultStyleBuilder.Build()" @attributes="@AdditionalAttributes">
+            @ChildContent
+        </div>
+    </ChildContent>
+    <ErrorContent>
+        @if (!HideChildContentOnError)
+        {
+            <div id="@Id" class="@DefaultClassBuilder.Build()" style="@DefaultStyleBuilder.Build()" @attributes="@AdditionalAttributes">
+                @ChildContent
+            </div>
+        }
+
+        <fluent-dialog type="alert" @ondialogtoggle="@OnToggleAsync">
+            <fluent-dialog-body>
+                <div slot="title" style="display: flex; column-gap: 4px; align-items: center;">
+                    @if (ErrorHeader is null)
+                    {
+                        @TitleIcon.ToMarkup() @Localizer["ErrorBoundary_Title"]
+                    }
+                    else
+                    {
+                        @ErrorHeader
+                    }
+                </div>
+                <div>
+                    @if (ErrorContent is null)
+                    {
+                        switch (DisplayErrorDetails)
+                        {
+                            case ErrorBoundaryDetails.ErrorMessage:
+                                @context.Message
+                                break;
+
+                            case ErrorBoundaryDetails.ErrorStack:
+                                <div style="font-weight: bold;">@context.Message (@context.Source)</div>
+                                <pre style="overflow: auto; max-width: min(550px, calc(100vw - 50px)); max-height: 210px;">@(context.StackTrace)</pre>
+                            
+                                break;
+
+                            case ErrorBoundaryDetails.None:
+                            default:
+                                @Localizer["ErrorBoundary_Message"]
+                                break;
+                        }
+                    }
+                    else
+                    {
+                        @ErrorContent
+                    }
+                </div>
+                <fluent-button slot="action" appearance="primary" onclick="this.parentElement.parentElement.hide()">
+                    @Localizer["ErrorBoundary_Close"]
+                </fluent-button>
+            </fluent-dialog-body>
+        </fluent-dialog>
+
+        <script>
+            document.currentScript.previousElementSibling.show();
+        </script>
+
+    </ErrorContent>
+</ErrorBoundary>

--- a/src/Core/Components/ErrorBoundary/FluentErrorBoundary.razor
+++ b/src/Core/Components/ErrorBoundary/FluentErrorBoundary.razor
@@ -4,7 +4,7 @@
 @inherits FluentComponentBase
 
 <CascadingValue Value="this" IsFixed>
-    <ErrorBoundary @ref="ErrorBoundary">
+    <ErrorBoundary @ref="ErrorBoundary" MaximumErrorCount="@MaximumErrorCount">
         <ChildContent>
             <div id="@Id" class="@DefaultClassBuilder.Build()" style="@DefaultStyleBuilder.Build()" @attributes="@AdditionalAttributes">
                 @ChildContent

--- a/src/Core/Components/ErrorBoundary/FluentErrorBoundary.razor
+++ b/src/Core/Components/ErrorBoundary/FluentErrorBoundary.razor
@@ -3,67 +3,65 @@
 @using Microsoft.FluentUI.AspNetCore.Components.Extensions
 @inherits FluentComponentBase
 
-<ErrorBoundary @ref="ErrorBoundary">
-    <ChildContent>
-        <div id="@Id" class="@DefaultClassBuilder.Build()" style="@DefaultStyleBuilder.Build()" @attributes="@AdditionalAttributes">
-            @ChildContent
-        </div>
-    </ChildContent>
-    <ErrorContent>
-        @if (!HideChildContentOnError)
-        {
+<CascadingValue Value="this" IsFixed>
+    <ErrorBoundary @ref="ErrorBoundary">
+        <ChildContent>
             <div id="@Id" class="@DefaultClassBuilder.Build()" style="@DefaultStyleBuilder.Build()" @attributes="@AdditionalAttributes">
                 @ChildContent
             </div>
-        }
-
-        <fluent-dialog type="alert" @ondialogtoggle="@OnToggleAsync">
-            <fluent-dialog-body>
-                <div slot="title" style="display: flex; column-gap: 4px; align-items: center;">
-                    @if (ErrorHeader is null)
-                    {
-                        @TitleIcon.ToMarkup() @Localizer["ErrorBoundary_Title"]
-                    }
-                    else
-                    {
-                        @ErrorHeader
-                    }
+        </ChildContent>
+        <ErrorContent>
+            @if (!HideChildContentOnError)
+            {
+                <div error id="@Id" class="@DefaultClassBuilder.Build()" style="@DefaultStyleBuilder.Build()" @attributes="@AdditionalAttributes">
+                    @ChildContent
                 </div>
-                <div>
-                    @if (ErrorContent is null)
-                    {
-                        switch (DisplayErrorDetails)
+            }
+
+            <fluent-dialog type="alert" @ondialogtoggle="@OnToggleAsync">
+                <fluent-dialog-body>
+                    <div slot="title" style="display: flex; column-gap: 4px; align-items: center;">
+                        @if (ErrorHeader is null)
                         {
-                            case ErrorBoundaryDetails.ErrorMessage:
-                                @context.Message
-                                break;
-
-                            case ErrorBoundaryDetails.ErrorStack:
-                                <div style="font-weight: bold;">@context.Message (@context.Source)</div>
-                                <pre style="overflow: auto; max-width: min(550px, calc(100vw - 50px)); max-height: 210px;">@(context.StackTrace)</pre>
-                            
-                                break;
-
-                            case ErrorBoundaryDetails.None:
-                            default:
-                                @Localizer["ErrorBoundary_Message"]
-                                break;
+                            @TitleIcon.ToMarkup() @Localizer["ErrorBoundary_Title"]
                         }
-                    }
-                    else
-                    {
-                        @ErrorContent
-                    }
-                </div>
-                <fluent-button slot="action" appearance="primary" onclick="this.parentElement.parentElement.hide()">
-                    @Localizer["ErrorBoundary_Close"]
-                </fluent-button>
-            </fluent-dialog-body>
-        </fluent-dialog>
+                        else
+                        {
+                            @ErrorHeader
+                        }
+                    </div>
+                    <div>
+                        @if (ErrorContent is null)
+                        {
+                            switch (DisplayErrorDetails)
+                            {
+                                case ErrorBoundaryDetails.ErrorMessage:
+                                    @context.Message
+                                    break;
 
-        <script>
-            document.currentScript.previousElementSibling.show();
-        </script>
+                                case ErrorBoundaryDetails.ErrorStack:
+                                    <div style="font-weight: bold;">@context.Message (@context.Source)</div>
+                                    <pre style="overflow: auto; max-width: min(550px, calc(100vw - 50px)); max-height: 210px;">@(context.StackTrace)</pre>
+                            
+                                    break;
 
-    </ErrorContent>
+                                case ErrorBoundaryDetails.None:
+                                default:
+                                    @Localizer["ErrorBoundary_Message"]
+                                    break;
+                            }
+                        }
+                        else
+                        {
+                            @ErrorContent
+                        }
+                    </div>
+                    <fluent-button slot="action" appearance="primary" onclick="this.parentElement.parentElement.hide()">
+                        @Localizer["ErrorBoundary_Close"]
+                    </fluent-button>
+                </fluent-dialog-body>
+            </fluent-dialog>
+            <script>document.currentScript.previousElementSibling.show();</script>
+        </ErrorContent>
 </ErrorBoundary>
+</CascadingValue>

--- a/src/Core/Components/ErrorBoundary/FluentErrorBoundary.razor.cs
+++ b/src/Core/Components/ErrorBoundary/FluentErrorBoundary.razor.cs
@@ -1,0 +1,64 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// Provides a mechanism for handling errors in a fluent manner within a specific context.
+/// </summary>
+public partial class FluentErrorBoundary
+{
+    private ErrorBoundary? ErrorBoundary;
+
+    /// <summary>
+    /// Gets or sets the icon displayed in the title bar to indicate an error state.
+    /// </summary>
+    public static Icon TitleIcon { get; set; } = new CoreIcons.Filled.Size20.DismissCircle().WithColor(Color.Error);
+
+    /// <summary>
+    /// Gets or sets the content to be rendered inside the component.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether child content should be hidden when an error occurs.
+    /// </summary>
+    [Parameter]
+    public bool HideChildContentOnError { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the content to be rendered as the dialog header for error messages.
+    ///  This content will be rendered in place of the default dialog header when an error occurs within the boundary.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? ErrorHeader { get; set; }
+
+    /// <summary>
+    /// Gets or sets the content to be displayed when there is an error.
+    /// This content will be rendered in place of the default error message when an error occurs within the boundary.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? ErrorContent { get; set; }
+
+    /// <summary>
+    /// Gets or sets the details to display when an error occurs within the error boundary.
+    /// </summary>
+    [Parameter]
+    public ErrorBoundaryDetails DisplayErrorDetails { get; set; } = ErrorBoundaryDetails.None;
+
+    /// <summary />
+    private Task OnToggleAsync(DialogToggleEventArgs e)
+    {
+        if (string.Equals(e.NewState, "closed", StringComparison.Ordinal))
+        {
+            ErrorBoundary?.Recover();
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Core/Components/ErrorBoundary/FluentErrorBoundary.razor.cs
+++ b/src/Core/Components/ErrorBoundary/FluentErrorBoundary.razor.cs
@@ -41,7 +41,7 @@ public partial class FluentErrorBoundary : FluentComponentBase
     public RenderFragment? ErrorHeader { get; set; }
 
     /// <summary>
-    /// Gets or sets the content to be displayed when there is an error.
+    /// Gets or sets the content to be displayed when there is an error. This content will be rendered in a dialog box.
     /// This content will be rendered in place of the default error message when an error occurs within the boundary.
     /// </summary>
     [Parameter]
@@ -53,18 +53,34 @@ public partial class FluentErrorBoundary : FluentComponentBase
     [Parameter]
     public ErrorBoundaryDetails DisplayErrorDetails { get; set; } = ErrorBoundaryDetails.None;
 
+    /// <summary>
+    /// Gets or sets the maximum number of errors that can be handled. If more errors are received,
+    /// they will be treated as fatal. Calling <see cref="Recover"/> resets the count.
+    /// </summary>
+    [Parameter]
+    public int MaximumErrorCount { get; set; } = 100;
+
+    /// <summary>
+    /// Resets the error boundary to a non-errored state. If the error boundary is not
+    /// already in an errored state, the call has no effect.
+    /// </summary>
+    public void Recover()
+    {
+        try
+        {
+            ErrorBoundary?.Recover();
+        }
+        catch (Exception)
+        {
+        }
+    }
+
     /// <summary />
     internal Task OnToggleAsync(DialogToggleEventArgs e)
     {
         if (string.Equals(e.NewState, "closed", StringComparison.Ordinal))
         {
-            try
-            {
-                ErrorBoundary?.Recover();
-            }
-            catch (Exception)
-            {
-            }
+            Recover();
         }
 
         return Task.CompletedTask;

--- a/src/Core/Components/ErrorBoundary/FluentErrorBoundary.razor.cs
+++ b/src/Core/Components/ErrorBoundary/FluentErrorBoundary.razor.cs
@@ -10,7 +10,7 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// <summary>
 /// Provides a mechanism for handling errors in a fluent manner within a specific context.
 /// </summary>
-public partial class FluentErrorBoundary
+public partial class FluentErrorBoundary : FluentComponentBase
 {
     private ErrorBoundary? ErrorBoundary;
 
@@ -27,6 +27,8 @@ public partial class FluentErrorBoundary
 
     /// <summary>
     /// Gets or sets a value indicating whether child content should be hidden when an error occurs.
+    /// Using False is not recommended, as it may cause performance and security issues:
+    /// If the detected error is triggered when the content is displayed, there is a risk of an infinite loop.
     /// </summary>
     [Parameter]
     public bool HideChildContentOnError { get; set; } = true;
@@ -52,11 +54,17 @@ public partial class FluentErrorBoundary
     public ErrorBoundaryDetails DisplayErrorDetails { get; set; } = ErrorBoundaryDetails.None;
 
     /// <summary />
-    private Task OnToggleAsync(DialogToggleEventArgs e)
+    internal Task OnToggleAsync(DialogToggleEventArgs e)
     {
         if (string.Equals(e.NewState, "closed", StringComparison.Ordinal))
         {
-            ErrorBoundary?.Recover();
+            try
+            {
+                ErrorBoundary?.Recover();
+            }
+            catch (Exception)
+            {
+            }
         }
 
         return Task.CompletedTask;

--- a/src/Core/Enums/ErrorBoundaryDetails.cs
+++ b/src/Core/Enums/ErrorBoundaryDetails.cs
@@ -1,0 +1,26 @@
+// ------------------------------------------------------------------------
+// MIT License - Copyright (c) Microsoft Corporation. All rights reserved.
+// ------------------------------------------------------------------------
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// The details to display in the <see cref="FluentErrorBoundary" />.
+/// </summary>
+public enum ErrorBoundaryDetails
+{
+    /// <summary>
+    /// The error boundary does not display any details about the error.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// The error boundary displays the exception message about the error.
+    /// </summary>
+    ErrorMessage,
+
+    /// <summary>
+    /// The error boundary displays the stack trace of the error.
+    /// </summary>
+    ErrorStack,
+}

--- a/src/Core/Localization/LanguageResource.resx
+++ b/src/Core/Localization/LanguageResource.resx
@@ -219,4 +219,13 @@
   <data name="TreeItem_LoadingMessage" xml:space="preserve">
     <value>Loading...</value>
   </data>
+  <data name="ErrorBoundary_Close" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="ErrorBoundary_Title" xml:space="preserve">
+    <value>An error occured</value>
+  </data>
+  <data name="ErrorBoundary_Message" xml:space="preserve">
+    <value>An unhandled error has occurred. Please, contact your IT support.</value>
+  </data>
 </root>

--- a/tests/Core/Components/ErrorBoundary/Components/ThrowingExceptionComponent.razor
+++ b/tests/Core/Components/ErrorBoundary/Components/ThrowingExceptionComponent.razor
@@ -1,0 +1,18 @@
+﻿@ChildContent
+
+@code
+{
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    [Parameter]
+    public bool Throw { get; set; } = true;
+
+    protected override void OnInitialized()
+    {
+        if (Throw)
+        {
+            throw new InvalidOperationException("Test exception");
+        }
+    }
+}

--- a/tests/Core/Components/ErrorBoundary/Components/ThrowingExceptionComponent.razor
+++ b/tests/Core/Components/ErrorBoundary/Components/ThrowingExceptionComponent.razor
@@ -2,16 +2,23 @@
 
 @code
 {
+    private static readonly object ERROR_ALREADY_OCCURED = new();
+
+    [CascadingParameter]
+    public required FluentErrorBoundary FluentErrorBoundary { get; set; }
+
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
 
     [Parameter]
     public bool Throw { get; set; } = true;
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "BL0005:Component parameter should not be set outside of its component.", Justification = "Test component intentionally sets parameter for testing error boundary.")]
     protected override void OnInitialized()
     {
-        if (Throw)
+        if (Throw && FluentErrorBoundary.Data != ERROR_ALREADY_OCCURED)
         {
+            FluentErrorBoundary.Data = ERROR_ALREADY_OCCURED;
             throw new InvalidOperationException("Test exception");
         }
     }

--- a/tests/Core/Components/ErrorBoundary/FluentErrorBoundaryTests.FluentErrorBoundary_WithException.verified.razor.html
+++ b/tests/Core/Components/ErrorBoundary/FluentErrorBoundaryTests.FluentErrorBoundary_WithException.verified.razor.html
@@ -1,0 +1,13 @@
+
+<fluent-dialog type="alert" blazor:ondialogtoggle="1">
+  <fluent-dialog-body>
+    <div slot="title" style="display: flex; column-gap: 4px; align-items: center;">
+      <svg viewBox="0 0 20 20" width="20px" fill="var(--error)" style="background-color: var(--colorNeutralBackground1); width: 20px;" aria-hidden="true">
+        <path d="M10 2a8 8 0 1 1 0 16 8 8 0 0 1 0-16ZM7.8 7.11a.5.5 0 0 0-.63.06l-.06.07a.5.5 0 0 0 .06.64L9.3 10l-2.12 2.12-.06.07a.5.5 0 0 0 .06.64l.07.06c.2.13.47.11.64-.06L10 10.7l2.12 2.12.07.06c.2.13.46.11.64-.06l.06-.07a.5.5 0 0 0-.06-.64L10.7 10l2.12-2.12.06-.07a.5.5 0 0 0-.06-.64l-.07-.06a.5.5 0 0 0-.64.06L10 9.3 7.88 7.17l-.07-.06Z"></path>
+      </svg>An error occured
+    </div>
+    <div>My Error</div>
+    <fluent-button slot="action" appearance="primary" onclick="this.parentElement.parentElement.hide()">Close</fluent-button>
+  </fluent-dialog-body>
+</fluent-dialog>
+<script>document.currentScript.previousElementSibling.show();</script>

--- a/tests/Core/Components/ErrorBoundary/FluentErrorBoundaryTests.razor
+++ b/tests/Core/Components/ErrorBoundary/FluentErrorBoundaryTests.razor
@@ -1,0 +1,40 @@
+﻿@using Microsoft.FluentUI.AspNetCore.Components.Tests.Components.ErrorBoundary.Components
+@using Xunit;
+@inherits Bunit.TestContext
+@code
+{
+    public FluentErrorBoundaryTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddFluentUIComponents();
+    }
+    [Fact]
+    public void FluentErrorBoundary_WithoutException()
+    {
+        // Arrange
+        var cut = Render(@<ErrorBoundary>
+            <ChildContent>
+                <ThrowingExceptionComponent Throw="false">My content</ThrowingExceptionComponent>
+            </ChildContent>
+            <ErrorContent>My Error</ErrorContent>
+        </ErrorBoundary>);
+
+        // Assert
+        cut.MarkupMatches("My content");
+    }
+
+    [Fact]
+    public void FluentErrorBoundary_WithException()
+    {
+        // Arrange
+        var cut = Render(@<ErrorBoundary>
+            <ChildContent>
+                <ThrowingExceptionComponent Throw="true" />
+            </ChildContent>
+            <ErrorContent>My Error</ErrorContent>
+        </ErrorBoundary>);
+
+        // Assert
+        cut.MarkupMatches("My Error");
+    }
+}

--- a/tests/Core/Components/ErrorBoundary/FluentErrorBoundaryTests.razor
+++ b/tests/Core/Components/ErrorBoundary/FluentErrorBoundaryTests.razor
@@ -8,33 +8,106 @@
         JSInterop.Mode = JSRuntimeMode.Loose;
         Services.AddFluentUIComponents();
     }
+
     [Fact]
     public void FluentErrorBoundary_WithoutException()
     {
         // Arrange
-        var cut = Render(@<ErrorBoundary>
+        var cut = Render(@<FluentErrorBoundary>
             <ChildContent>
                 <ThrowingExceptionComponent Throw="false">My content</ThrowingExceptionComponent>
             </ChildContent>
             <ErrorContent>My Error</ErrorContent>
-        </ErrorBoundary>);
+        </FluentErrorBoundary>);
 
         // Assert
-        cut.MarkupMatches("My content");
+        cut.MarkupMatches("<div>My content</div>");
     }
 
     [Fact]
     public void FluentErrorBoundary_WithException()
     {
         // Arrange
-        var cut = Render(@<ErrorBoundary>
+        var cut = Render(@<FluentErrorBoundary>
             <ChildContent>
-                <ThrowingExceptionComponent Throw="true" />
+                <ThrowingExceptionComponent Throw="true">My content</ThrowingExceptionComponent>
             </ChildContent>
             <ErrorContent>My Error</ErrorContent>
-        </ErrorBoundary>);
+        </FluentErrorBoundary>);
 
         // Assert
-        cut.MarkupMatches("My Error");
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentErrorBoundary_HideChildContentOnError_True()
+    {
+        // Arrange
+        var cut = Render(@<FluentErrorBoundary HideChildContentOnError="true">
+            <ChildContent>
+                <ThrowingExceptionComponent>My content</ThrowingExceptionComponent>
+            </ChildContent>
+            <ErrorContent>My Error</ErrorContent>
+        </FluentErrorBoundary>);
+
+        // Assert
+        var hasContent = cut.Markup.Contains("My content");
+        Assert.False(hasContent);
+    }
+
+    [Fact]
+    public void FluentErrorBoundary_HideChildContentOnError_False()
+    {
+        // Arrange
+        var cut = Render(@<FluentErrorBoundary HideChildContentOnError="false">
+            <ChildContent>
+                <ThrowingExceptionComponent>My content</ThrowingExceptionComponent>
+            </ChildContent>
+            <ErrorContent>My Error</ErrorContent>
+        </FluentErrorBoundary>);
+
+        cut.FindComponent<FluentErrorBoundary>().Render();
+
+        // Assert
+        var hasContent = cut.Markup.Contains("My content");
+        Assert.True(hasContent);
+
+        // "error" attribute should be present
+        Assert.Contains("<div error>", cut.Markup);
+    }
+
+    [Theory]
+    [InlineData(ErrorBoundaryDetails.None, @"An unhandled error has occurred. Please, contact your IT support.")]
+    [InlineData(ErrorBoundaryDetails.ErrorMessage, @"Test exception")]
+    [InlineData(ErrorBoundaryDetails.ErrorStack, @"\ErrorBoundary\Components\ThrowingExceptionComponent.razor")]
+    [InlineData((ErrorBoundaryDetails)999, @"An unhandled error has occurred. Please, contact your IT support.")]
+    public void FluentErrorBoundary_DisplayErrorDetails_ErrorStack(ErrorBoundaryDetails errorDetails, string expectedHTML)
+    {
+        // Arrange
+        var cut = Render(@<FluentErrorBoundary DisplayErrorDetails="@errorDetails">
+            <ThrowingExceptionComponent>My content</ThrowingExceptionComponent>
+        </FluentErrorBoundary>);
+
+        // Assert
+        Assert.Contains(expectedHTML, cut.Markup);
+    }
+
+    [Theory]
+    [InlineData("open")]
+    [InlineData("closed")]
+    public void FluentErrorBoundary_OnToggleAsync(string newState)
+    {
+        // Arrange
+        var cut = Render(@<FluentErrorBoundary>
+            <ThrowingExceptionComponent>My content</ThrowingExceptionComponent>
+        </FluentErrorBoundary>);
+
+        // Act
+        cut.FindComponent<FluentErrorBoundary>().Instance.OnToggleAsync(new()
+            {
+                NewState = newState,
+            });
+
+        // No value to test, just ensure it doesn't throw an exception
     }
 }

--- a/tests/Core/Components/ErrorBoundary/FluentErrorBoundaryTests.razor
+++ b/tests/Core/Components/ErrorBoundary/FluentErrorBoundaryTests.razor
@@ -95,7 +95,7 @@
     [Theory]
     [InlineData(ErrorBoundaryDetails.None, @"An unhandled error has occurred. Please, contact your IT support.")]
     [InlineData(ErrorBoundaryDetails.ErrorMessage, @"Test exception")]
-    [InlineData(ErrorBoundaryDetails.ErrorStack, @"\ErrorBoundary\Components\ThrowingExceptionComponent.razor")]
+    [InlineData(ErrorBoundaryDetails.ErrorStack, @"ThrowingExceptionComponent.razor")]
     [InlineData((ErrorBoundaryDetails)999, @"An unhandled error has occurred. Please, contact your IT support.")]
     public void FluentErrorBoundary_DisplayErrorDetails_ErrorStack(ErrorBoundaryDetails errorDetails, string expectedHTML)
     {

--- a/tests/Core/Components/ErrorBoundary/FluentErrorBoundaryTests.razor
+++ b/tests/Core/Components/ErrorBoundary/FluentErrorBoundaryTests.razor
@@ -28,7 +28,7 @@
     public void FluentErrorBoundary_WithException()
     {
         // Arrange
-        var cut = Render(@<FluentErrorBoundary>
+        var cut = Render(@<FluentErrorBoundary MaximumErrorCount="10">
             <ChildContent>
                 <ThrowingExceptionComponent Throw="true">My content</ThrowingExceptionComponent>
             </ChildContent>
@@ -37,6 +37,22 @@
 
         // Assert
         cut.Verify();
+    }
+
+    [Fact]
+    public void FluentErrorBoundary_ErrorHeader()
+    {
+        // Arrange
+        var cut = Render(@<FluentErrorBoundary>
+            <ChildContent>
+                <ThrowingExceptionComponent>My content</ThrowingExceptionComponent>
+            </ChildContent>
+            <ErrorHeader>My Header</ErrorHeader>
+            <ErrorContent>My Error</ErrorContent>
+        </FluentErrorBoundary>);
+
+        // Assert
+        Assert.Contains("<div slot=\"title\" style=\"display: flex; column-gap: 4px; align-items: center;\">My Header</div>", cut.Markup);
     }
 
     [Fact]


### PR DESCRIPTION
# [dev-v5] Add FluentErrorBoundary

The **FluentErrorBoundary** component is used to catch errors in a component tree and display a fallback UI instead of crashing the entire application.
_Error boundaries_ provide a convenient approach for handling exceptions.

The **FluentErrorBoundary** component:

  - Renders its child content when an error hasn't occurred.
  - Renders error UI when an unhandled exception is thrown by any component within the error boundary.

To define an error boundary, use the **FluentErrorBoundary** component to wrap one or more other components.
The error boundary manages unhandled exceptions thrown by the components that it wraps.

See [the Blazor handle errors using the error boundaries feature](https://learn.microsoft.com/aspnet/core/blazor/fundamentals/handle-errors#error-boundaries) for more details.

## Example

In this example, we demonstrate how to use the **FluentErrorBoundary** component to catch errors in a component tree,
depending of the `DisplayErrorDetails` parameter (None, ErrorMessage

- **None** displays a simple error message "An unhandled error has occurred. Please, contact your IT support."  
  This is the default value and is recommended for production use.
- **ErrorMessage** displays the error message.
- **ErrorStack** displays the error message, stack trace, and the project source that caused the error.

> [!NOTE] You can customize the error message by using the [localization](/localization) feature.
> or using the `ErrorHeader` and `ErrorMessage` parameters.

```razor
<FluentErrorBoundary HideChildContentOnError="false">
    <FluentButton OnClick="@(e => throw new InvalidOperationException("Invalid operation"))">
        Throw Exception (no details)
    </FluentButton>
</FluentErrorBoundary>

<FluentDivider Style="height: 30px;" />

<FluentErrorBoundary DisplayErrorDetails="ErrorBoundaryDetails.ErrorMessage" HideChildContentOnError="false">
    <FluentButton OnClick="@(e => throw new InvalidOperationException("Invalid operation"))">
        Throw Exception (message only)
    </FluentButton>
</FluentErrorBoundary>

<FluentDivider Style="height: 30px;" />

<FluentErrorBoundary DisplayErrorDetails="ErrorBoundaryDetails.ErrorStack" HideChildContentOnError="false">
    <FluentButton OnClick="@(e => throw new InvalidOperationException("Invalid operation"))">
        Throw Exception (stack)
    </FluentButton>
</FluentErrorBoundary>
```


https://github.com/user-attachments/assets/8813cb50-54fa-4cc3-88af-9b6263d20e80

## Unit Tests

![{1FFD48DF-5712-4E1B-9144-397FE59461F7}](https://github.com/user-attachments/assets/85ab6afe-e868-4849-ae13-7a32806eca1f)