### PR TITLE
Add `HeaderCellTitleTemplate` to `DataGrid` `ColumnBase`

### DIFF
--- a/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridCustomHeader.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/Examples/DataGridCustomHeader.razor
@@ -1,0 +1,52 @@
+﻿@using FluentUI.Demo.Shared.Pages.DataGrid.Examples
+@using Microsoft.FluentUI.AspNetCore.Components
+
+<FluentDataGrid Items="@people">
+    <PropertyColumn Property="@(p => p.PersonId)" Sortable="true" Title="Identity">
+        <HeaderCellTitleTemplate>
+            <FluentStack Orientation="Orientation.Horizontal"
+                         VerticalAlignment="VerticalAlignment.Center">
+                <FluentIcon Icon="Icons.Regular.Size20.Person" />
+                @context.Title
+            </FluentStack>
+        </HeaderCellTitleTemplate>
+    </PropertyColumn>
+    <PropertyColumn Property="@(p => p.Name)" Sortable="true" Title="Full _name" />
+    <PropertyColumn Property="@(p => p.BirthDate)" Format="yyyy-MM-dd" Sortable="true">
+        <HeaderCellTitleTemplate>
+            <FluentStack Orientation="Orientation.Horizontal"
+                         VerticalAlignment="VerticalAlignment.Center">
+                <FluentIcon Icon="Icons.Regular.Size20.Calendar" />
+                Birth date
+            </FluentStack>
+        </HeaderCellTitleTemplate>
+    </PropertyColumn>
+</FluentDataGrid>
+
+@code {
+    public class Person
+    {
+        public Person(int personId, string name, DateOnly birthDate)
+        {
+            PersonId = personId;
+            Name = name;
+            BirthDate = birthDate;
+        }
+
+        public int PersonId { get; set; }
+
+        public string Name { get; set; }
+
+        public DateOnly BirthDate { get; set; }
+    }
+
+    IQueryable<Person> people = new[]
+    {
+        new Person(10895, "Jean Martin", new DateOnly(1985, 3, 16)),
+        new Person(10944, "António Langa", new DateOnly(1991, 12, 1)),
+        new Person(11203, "Julie Smith", new DateOnly(1958, 10, 10)),
+        new Person(11205, "Nur Sari", new DateOnly(1922, 4, 27)),
+        new Person(11898, "Jose Hernandez", new DateOnly(2011, 5, 3)),
+        new Person(12130, "Kenji Sato", new DateOnly(2004, 1, 9)),
+    }.AsQueryable();
+}

--- a/examples/Demo/Shared/Pages/DataGrid/Pages/DataGridColumnHeaderGenerationPage.razor
+++ b/examples/Demo/Shared/Pages/DataGrid/Pages/DataGridColumnHeaderGenerationPage.razor
@@ -11,3 +11,12 @@
         See the 'Razor' tab on how these attributes have been applied to the class properties.
     </Description>
 </DemoSection>
+
+<DemoSection Title="Custom headers" Component="@typeof(DataGridCustomHeader)">
+    <Description>
+        The DataGrid can display custom column header titles by setting the <code>HeaderCellTitleTemplate</code> property on columns
+        shown in the grid.
+        <br />
+        See the 'Razor' tab on how these properties have been applied to the columns.
+    </Description>
+</DemoSection>

--- a/src/Core/Components/DataGrid/Columns/ColumnBase.razor
+++ b/src/Core/Components/DataGrid/Columns/ColumnBase.razor
@@ -22,7 +22,16 @@
                 @if (AnyColumnActionEnabled)
                 {
                     <FluentButton Disabled="@(!AnyColumnActionEnabled)" Id="@_columnId" Appearance="Appearance.Stealth" Class="col-sort-button" Style="width: calc(100% - 10px);" @onclick="@HandleColumnHeaderClickedAsync" aria-label="@tooltip" title="@tooltip">
-                        <div class="col-title-text" title="@tooltip">@Title</div>
+                        <div class="col-title-text" title="@tooltip">
+                            @if (HeaderCellTitleTemplate is not null)
+                            {
+                                @HeaderCellTitleTemplate(this)
+                            }
+                            else
+                            {
+                                @Title
+                            }
+                        </div>
 
                         @if (Grid.SortByAscending.HasValue && IsActiveSortColumn)
                         {
@@ -44,7 +53,16 @@
                 else
                 {
                     <div class="col-title">
-                        <div class="col-title-text" title="@tooltip">@Title</div>
+                        <div class="col-title-text" title="@tooltip">
+                            @if (HeaderCellTitleTemplate is not null)
+                            {
+                                @HeaderCellTitleTemplate(this)
+                            }
+                            else
+                            {
+                                @Title
+                            }
+                        </div>
                     </div>
                 }
                 <FluentMenu Anchor="@_columnId" @bind-Open="@_isMenuOpen" HorizontalViewportLock="false" HorizontalPosition="HorizontalPosition.End">
@@ -122,7 +140,16 @@
                 {
                     <FluentKeyCode Only="new[] { KeyCode.Ctrl, KeyCode.Enter }" OnKeyDown="HandleKeyDown" class="keycapture" style="width: 100%;" StopPropagation="true" @oncontextmenu="@(() => Grid.RemoveSortByColumnAsync(this))">
                         <FluentButton Appearance="Appearance.Stealth" Class="col-sort-button" Style="@($"width: calc(100% - {wdelta});")" @onclick="@(() => Grid.SortByColumnAsync(this))" aria-label="@tooltip" title="@tooltip">
-                            <div class="col-title-text" title="@tooltip">@Title</div>
+                            <div class="col-title-text" title="@tooltip">
+                                @if (HeaderCellTitleTemplate is not null)
+                                {
+                                    @HeaderCellTitleTemplate(this)
+                                }
+                                else
+                                {
+                                    @Title
+                                }
+                            </div>
 
                             @if (Grid.SortByAscending.HasValue && IsActiveSortColumn)
                             {

--- a/src/Core/Components/DataGrid/Columns/ColumnBase.razor
+++ b/src/Core/Components/DataGrid/Columns/ColumnBase.razor
@@ -7,6 +7,18 @@
 }
 @code
 {
+    private void RenderDefaultHeaderTitle(RenderTreeBuilder __builder)
+    {
+        @if (HeaderCellTitleTemplate is not null)
+        {
+            @HeaderCellTitleTemplate(this)
+        }
+        else
+        {
+            @Title
+        }
+    }
+
     private void RenderDefaultHeaderContent(RenderTreeBuilder __builder)
     {
         @if (HeaderCellItemTemplate is not null)
@@ -23,14 +35,7 @@
                 {
                     <FluentButton Disabled="@(!AnyColumnActionEnabled)" Id="@_columnId" Appearance="Appearance.Stealth" Class="col-sort-button" Style="width: calc(100% - 10px);" @onclick="@HandleColumnHeaderClickedAsync" aria-label="@tooltip" title="@tooltip">
                         <div class="col-title-text" title="@tooltip">
-                            @if (HeaderCellTitleTemplate is not null)
-                            {
-                                @HeaderCellTitleTemplate(this)
-                            }
-                            else
-                            {
-                                @Title
-                            }
+                            @HeaderTitleContent
                         </div>
 
                         @if (Grid.SortByAscending.HasValue && IsActiveSortColumn)
@@ -54,14 +59,7 @@
                 {
                     <div class="col-title">
                         <div class="col-title-text" title="@tooltip">
-                            @if (HeaderCellTitleTemplate is not null)
-                            {
-                                @HeaderCellTitleTemplate(this)
-                            }
-                            else
-                            {
-                                @Title
-                            }
+                            @HeaderTitleContent
                         </div>
                     </div>
                 }
@@ -141,14 +139,7 @@
                     <FluentKeyCode Only="new[] { KeyCode.Ctrl, KeyCode.Enter }" OnKeyDown="HandleKeyDown" class="keycapture" style="width: 100%;" StopPropagation="true" @oncontextmenu="@(() => Grid.RemoveSortByColumnAsync(this))">
                         <FluentButton Appearance="Appearance.Stealth" Class="col-sort-button" Style="@($"width: calc(100% - {wdelta});")" @onclick="@(() => Grid.SortByColumnAsync(this))" aria-label="@tooltip" title="@tooltip">
                             <div class="col-title-text" title="@tooltip">
-                                @if (HeaderCellTitleTemplate is not null)
-                                {
-                                    @HeaderCellTitleTemplate(this)
-                                }
-                                else
-                                {
-                                    @Title
-                                }
+                                @HeaderTitleContent
                             </div>
 
                             @if (Grid.SortByAscending.HasValue && IsActiveSortColumn)
@@ -173,7 +164,7 @@
                 {
                     <div class="col-title" style="@($"width: calc(100% - {wdelta});")">
                         <div class="col-title-text" title="@tooltip">
-                            @Title
+                            @HeaderTitleContent
                             @if (ColumnOptions is not null && Filtered.GetValueOrDefault() && Grid.ResizeType.HasValue)
                             {
                                 <span style="padding: 0 5px;">

--- a/src/Core/Components/DataGrid/Columns/ColumnBase.razor.cs
+++ b/src/Core/Components/DataGrid/Columns/ColumnBase.razor.cs
@@ -228,6 +228,8 @@ public abstract partial class ColumnBase<TGridItem>
     /// </summary>
     protected internal RenderFragment HeaderContent { get; protected set; }
 
+    protected internal RenderFragment HeaderTitleContent { get; protected set; }
+
     /// <summary>
     /// Gets a value indicating whether this column should act as sortable if no value was set for the
     /// <see cref="ColumnBase{TGridItem}.Sortable" /> parameter. The default behavior is not to be
@@ -254,6 +256,7 @@ public abstract partial class ColumnBase<TGridItem>
     public ColumnBase()
     {
         HeaderContent = RenderDefaultHeaderContent;
+        HeaderTitleContent = RenderDefaultHeaderTitle;
     }
 
     private async Task HandleColumnHeaderClickedAsync()

--- a/src/Core/Components/DataGrid/Columns/ColumnBase.razor.cs
+++ b/src/Core/Components/DataGrid/Columns/ColumnBase.razor.cs
@@ -228,6 +228,12 @@ public abstract partial class ColumnBase<TGridItem>
     /// </summary>
     protected internal RenderFragment HeaderContent { get; protected set; }
 
+    /// <summary>
+    /// Gets or sets a <see cref="RenderFragment" /> that will be rendered for this column's header title.
+    /// This allows derived components to change the header title output. However, derived components are then
+    /// responsible for using <see cref="HeaderCellTitleTemplate" /> within that new output if they want to continue
+    /// respecting that option.
+    /// </summary>
     protected internal RenderFragment HeaderTitleContent { get; protected set; }
 
     /// <summary>

--- a/src/Core/Components/DataGrid/Columns/ColumnBase.razor.cs
+++ b/src/Core/Components/DataGrid/Columns/ColumnBase.razor.cs
@@ -84,6 +84,13 @@ public abstract partial class ColumnBase<TGridItem>
     public RenderFragment<ColumnBase<TGridItem>>? HeaderCellItemTemplate { get; set; }
 
     /// <summary>
+    /// Gets or sets a template for the title content of this column's header cell.
+    /// If not specified, the default header template includes the <see cref="Title" />.
+    /// </summary>
+    [Parameter]
+    public RenderFragment<ColumnBase<TGridItem>>? HeaderCellTitleTemplate { get; set; }
+
+    /// <summary>
     /// If specified, indicates that this column has this associated options UI. A button to display this
     /// UI will be included in the header cell by default.
     ///


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

Adds a `HeaderCellTitleTemplate` property to the `ColumnBase` type of `FluentDataGrid`.  This allows users to customize the column header text beyond just text, but without having to take ownership of the resize/sort/filter column options UX required when using the `HeaderCellTemplate` property.  If not set, then the column `Title` is displayed as plain text as before.

A new section of the guide/docs site was added to demonstrate this new feature.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

* #3850

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

There doesn't seem to be any existing unit/integration tests related to `FluentDataGrid` header generation, so testing of this change has been ad-hoc, mostly via the generated docs page.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [ ] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
