### PR TITLE
[DataGrid] Refine logic that determines if the DataGrid data needs to be reloaded

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -1241,6 +1241,12 @@
             If not specified, the default header template includes the <see cref="P:Microsoft.FluentUI.AspNetCore.Components.ColumnBase`1.Title" /> along with any applicable sort indicators and options buttons.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.ColumnBase`1.HeaderCellTitleTemplate">
+            <summary>
+            Gets or sets a template for the title content of this column's header cell.
+            If not specified, the default header template includes the <see cref="P:Microsoft.FluentUI.AspNetCore.Components.ColumnBase`1.Title" />.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.ColumnBase`1.ColumnOptions">
              <summary>
              If specified, indicates that this column has this associated options UI. A button to display this
@@ -1347,6 +1353,14 @@
             Gets or sets a <see cref="T:Microsoft.AspNetCore.Components.RenderFragment" /> that will be rendered for this column's header cell.
             This allows derived components to change the header output. However, derived components are then
             responsible for using <see cref="P:Microsoft.FluentUI.AspNetCore.Components.ColumnBase`1.HeaderCellItemTemplate" /> within that new output if they want to continue
+            respecting that option.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.ColumnBase`1.HeaderTitleContent">
+            <summary>
+            Gets or sets a <see cref="T:Microsoft.AspNetCore.Components.RenderFragment" /> that will be rendered for this column's header title.
+            This allows derived components to change the header title output. However, derived components are then
+            responsible for using <see cref="P:Microsoft.FluentUI.AspNetCore.Components.ColumnBase`1.HeaderCellTitleTemplate" /> within that new output if they want to continue
             respecting that option.
             </summary>
         </member>
@@ -2254,6 +2268,12 @@
             If no value is specified, the default value is "1fr" for each column.
             </summary>
             <returns></returns>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDataGrid`1.ComputeItemsHash(System.Collections.Generic.IEnumerable{`0},System.Int32)">
+            <summary>
+            Computes a hash code for the given items.
+            To limit the effect on performance, only the given maximum number (default 250) of items will be considered.
+            </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDataGridCell`1.Item">
             <summary>

--- a/examples/Demo/Shared/Pages/Menu/MenuPage.razor
+++ b/examples/Demo/Shared/Pages/Menu/MenuPage.razor
@@ -40,7 +40,7 @@
     <p>
         With version 4.9.4 of the library, we introduced the <code>FluentMenuProvider</code> component. The Menu component has been updated to use this provider.
         The <code>&lt;FluentMenuProvider /&gt;</code> needs to be placed at the <b>bottom</b> of your HTML page (just like the other <b>...Providers</b> components).
-        It will renders all menus (and menu items) at the provider location in the HTML structure. This allows for menus to appear <b>on top</b> other components.
+        It will render all menus (and menu items) at the provider location in the HTML structure. This allows for menus to appear <b>above</b> of other components.
     </p>
     <p>
         You can disable this feature by adding the <code>UseMenuService</code> parameter (with a value of "false") to you FluentMenu component. In this case, the menu will be rendered at the location it is placed at in the page.

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -365,6 +365,7 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     // things have changed, and to discard earlier load attempts that were superseded.
     private PaginationState? _lastRefreshedPaginationState;
     private IQueryable<TGridItem>? _lastAssignedItems;
+    private int _lastAssignedItemsHashCode;
     private GridItemsProvider<TGridItem>? _lastAssignedItemsProvider;
     private CancellationTokenSource? _pendingDataLoadCancellationTokenSource;
 
@@ -425,14 +426,18 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
             throw new InvalidOperationException($"FluentDataGrid cannot use both {nameof(Virtualize)} and {nameof(MultiLine)} at the same time.");
         }
 
+        var currentItemsHash = FluentDataGrid<TGridItem>.ComputeItemsHash(Items);
+        var itemsChanged = currentItemsHash != _lastAssignedItemsHashCode;
+
         // Perform a re-query only if the data source or something else has changed
-        var dataSourceHasChanged = !Equals(Items, _lastAssignedItems) || !Equals(ItemsProvider, _lastAssignedItemsProvider);
+        var dataSourceHasChanged = itemsChanged || !Equals(ItemsProvider, _lastAssignedItemsProvider);
         if (dataSourceHasChanged)
         {
             _scope?.Dispose();
             _scope = ScopeFactory.CreateAsyncScope();
             _lastAssignedItemsProvider = ItemsProvider;
             _lastAssignedItems = Items;
+            _lastAssignedItemsHashCode = currentItemsHash;
             _asyncQueryExecutor = AsyncQueryExecutorSupplier.GetAsyncQueryExecutor(_scope.Value.ServiceProvider, Items);
         }
 
@@ -1093,4 +1098,31 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
             await Module.InvokeVoidAsync("resetColumnWidths", _gridReference);
         }
     }
+
+    /// <summary>
+    /// Computes a hash code for the given items.
+    /// To limit the effect on performance, only the given maximum number (default 250) of items will be considered.
+    /// </summary>
+    private static int ComputeItemsHash(IEnumerable<TGridItem>? items, int maxItems = 250)
+    {
+        if (items == null)
+        {
+            return 0;
+        }
+        unchecked
+        {
+            var hash = 19;
+            var count = 0;
+            foreach (var item in items)
+            {
+                if (++count > maxItems)
+                {
+                    break;
+                }
+                hash = (hash * 31) + (item?.GetHashCode() ?? 0);
+            }
+            return hash;
+        }
+    }
 }
+


### PR DESCRIPTION
Refine the logic that determines if the DataGrid data needs to be reloaded by implementing a hash calculation on the data. To limit the effect on performance, the hash will only be computed for the given maximum number of items, which is set to 250 by default.
Fix #3847 