### PR TITLE
[DataGrid] Make Select/Deselect all more robust

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -1241,6 +1241,12 @@
             If not specified, the default header template includes the <see cref="P:Microsoft.FluentUI.AspNetCore.Components.ColumnBase`1.Title" /> along with any applicable sort indicators and options buttons.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.ColumnBase`1.HeaderCellTitleTemplate">
+            <summary>
+            Gets or sets a template for the title content of this column's header cell.
+            If not specified, the default header template includes the <see cref="P:Microsoft.FluentUI.AspNetCore.Components.ColumnBase`1.Title" />.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.ColumnBase`1.ColumnOptions">
              <summary>
              If specified, indicates that this column has this associated options UI. A button to display this
@@ -1347,6 +1353,14 @@
             Gets or sets a <see cref="T:Microsoft.AspNetCore.Components.RenderFragment" /> that will be rendered for this column's header cell.
             This allows derived components to change the header output. However, derived components are then
             responsible for using <see cref="P:Microsoft.FluentUI.AspNetCore.Components.ColumnBase`1.HeaderCellItemTemplate" /> within that new output if they want to continue
+            respecting that option.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.ColumnBase`1.HeaderTitleContent">
+            <summary>
+            Gets or sets a <see cref="T:Microsoft.AspNetCore.Components.RenderFragment" /> that will be rendered for this column's header title.
+            This allows derived components to change the header title output. However, derived components are then
+            responsible for using <see cref="P:Microsoft.FluentUI.AspNetCore.Components.ColumnBase`1.HeaderCellTitleTemplate" /> within that new output if they want to continue
             respecting that option.
             </summary>
         </member>

--- a/src/Core/Components/DataGrid/Columns/SelectColumn.cs
+++ b/src/Core/Components/DataGrid/Columns/SelectColumn.cs
@@ -528,9 +528,10 @@ public class SelectColumn<TGridItem> : ColumnBase<TGridItem>
             await SelectAllChanged.InvokeAsync(SelectAll);
         }
 
+        var count = SelectedItems.Count();
         // SelectedItems
         _selectedItems.Clear();
-        if (SelectAll == true)
+        if (SelectAll == true && count != InternalGridContext.TotalItemCount)
         {
             // Only add selectable items
             _selectedItems.AddRange((InternalGridContext.Grid.Items?.ToList() ?? InternalGridContext.Items)


### PR DESCRIPTION
When all rows are selected in a DataGrid with a `SelectColumn` (Multiple=true), the header checkbox would always select all items first. An extra click was then needed to deselect all items. This PR extends the logic to deselect all items if all items are already selected.
Fix #3845