### PR TITLE
[DataGrid] Fix header not being sticky in certain situations

### DIFF
--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.js
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.js
@@ -192,7 +192,6 @@ export function enableColumnResizing(gridElement) {
 
         const div = createDiv(tableHeight, isRTL);
         header.appendChild(div);
-        header.style.position = 'relative';
         setListeners(div, isRTL);
     });
 


### PR DESCRIPTION
Fix #3888 by not adding `position: relative`. It is already defined in header class and there are situations it needs to be overridden (sticky header)

