### PR TITLE
[Autocomplete] Fix keyboard usage in Single mode

### DIFF
--- a/src/Core/Components/List/FluentAutocomplete.razor
+++ b/src/Core/Components/List/FluentAutocomplete.razor
@@ -216,7 +216,14 @@
 
                     if (Multiple == false)
                     {
-                        <FluentLabel tabindex="0" aria-label="@GetOptionText(item)" role="checkbox" aria-checked="true">@text</FluentLabel>
+                        <FluentLabel Id="@($"{Id}-single")"
+                                     tabindex="0"
+                                     aria-label="@GetOptionText(item)"
+                                     role="checkbox"
+                                     aria-checked="true"
+                                     @onkeydown="@(e => e.Code == "Delete" || e.Code == "Backspace" ? RemoveSelectedItemAsync(item) : Task.CompletedTask)">
+                            @text
+                        </FluentLabel>
                     }
                     else if (ReadOnly || Disabled)
                     {

--- a/src/Core/Components/List/FluentAutocomplete.razor.cs
+++ b/src/Core/Components/List/FluentAutocomplete.razor.cs
@@ -558,6 +558,13 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
         await RaiseValueTextChangedAsync(ValueText);
 
         await base.OnSelectedItemChangedHandlerAsync(item);
+
+        // In Single mode, set the focus on the input field
+        if (!Multiple && Module != null)
+        {
+            await Module.InvokeVoidAsync("focusOn", $"{Id}-single");
+        }
+
         await DisplayLastSelectedItemAsync();
 
         if (MustBeClosed())

--- a/src/Core/Components/List/FluentAutocomplete.razor.cs
+++ b/src/Core/Components/List/FluentAutocomplete.razor.cs
@@ -327,7 +327,7 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
         Items = args.Items?.Take(MaximumOptionsSearch);
 
         SelectableItem = Items != null
-            ? Items.FirstOrDefault()
+            ? Items.FirstOrDefault(i => OptionDisabled is null ? true : OptionDisabled.Invoke(i) == false)
             : default;
 
         if (VirtualizationContainer != null)

--- a/src/Core/Components/List/ListComponentBase.razor.cs
+++ b/src/Core/Components/List/ListComponentBase.razor.cs
@@ -568,6 +568,14 @@ public abstract partial class ListComponentBase<TOption> : FluentInputBase<strin
                 InternalValue = GetOptionValue(item);
                 await RaiseChangedEventsAsync();
             }
+
+            // For Autocomplete, allow to unselect the item if it is already selected
+            else if (this is FluentAutocomplete<TOption>)
+            {
+                SelectedOption = default;
+                InternalValue = GetOptionValue(default);
+                await RaiseChangedEventsAsync();
+            }
         }
     }
 
@@ -630,6 +638,12 @@ public abstract partial class ListComponentBase<TOption> : FluentInputBase<strin
         if (item == null)
         {
             return false;
+        }
+
+        if (this is FluentAutocomplete<TOption> && SelectedOption is not null)
+        {
+            SelectedOption = default;
+            InternalValue = GetOptionValue(default);
         }
 
         return _selectedOptions.Remove(item);


### PR DESCRIPTION
# Fix Autocomplete Keyboard in Single mode

1. Allow an item to be deselected using the `Delete` or `Backspace` keys.
2. Update the **SelectableItem** item to get the first “not disabled” item.`

In this example, all items are selected using the keyboard only (arrows, Delete, Backspace keys)

![peek_1](https://github.com/user-attachments/assets/472ddee5-120a-4c51-9720-15863cdb62aa)

## Unit Tests

No change