### PR TITLE
[Docs] Fix mismatch in accordion docs between the code and the description.

### DIFF
--- a/examples/Demo/Shared/Pages/Accordion/Examples/AccordionDefault.razor
+++ b/examples/Demo/Shared/Pages/Accordion/Examples/AccordionDefault.razor
@@ -8,7 +8,7 @@
         <div slot="end">
             #end#
         </div>
-        Panel two content, using the 'end' slot for extra header content (in this case an HTML button)
+        Panel two content, using the 'end' slot for extra header content
     </FluentAccordionItem>
     <FluentAccordionItem Expanded="true" Heading="Panel three">
         Panel three content


### PR DESCRIPTION

# Pull Request

## 📖 Description

This fixes a mismatch between the description in the content of the second accordion and the actual code.
There is no html button in the code.
The issue was located on the default accordion documentation page.

Before:
![image](https://github.com/user-attachments/assets/96098ec1-c3ed-4a5c-bc4e-3c581e899cc9)

After:
![image](https://github.com/user-attachments/assets/32e5138f-9269-4f3b-9a9e-d8f412a8c3bc)

