### PR TITLE
[dev-v5] Base Unit Tests - Add WithCascadingValue method and refactoring

### DIFF
--- a/tests/Core/Components/Base/ComponentBaseTests.cs
+++ b/tests/Core/Components/Base/ComponentBaseTests.cs
@@ -18,13 +18,13 @@ public class ComponentBaseTests : Bunit.TestContext
     /// <summary>
     /// List of components to exclude from the test.
     /// </summary>
-    private static readonly Type[] Excluded = new[]
-    {
+    private static readonly Type[] Excluded =
+    [
         typeof(AspNetCore.Components._Imports),
         typeof(DialogOptions),
         typeof(FluentRadio<>),  // TODO: To update
         typeof(FluentTab),      // Excluded because the Tab content in rendered in the parent FluentTabs component
-    };
+    ];
 
     /// <summary>
     /// List of customized actions to initialize the component with a specific type and optional required parameters.
@@ -36,11 +36,10 @@ public class ComponentBaseTests : Bunit.TestContext
         { typeof(FluentCombobox<>), Loader.MakeGenericType(typeof(int))},
         { typeof(FluentSlider<>), Loader.MakeGenericType(typeof(int))},
         { typeof(FluentRadioGroup<>), Loader.MakeGenericType(typeof(string)) },
-        //{ typeof(FluentRadio<>), Loader.MakeGenericType(typeof(string)) },
         { typeof(FluentTooltip), Loader.Default.WithRequiredParameter("Anchor", "MyButton").WithRequiredParameter("UseTooltipService", false)},
         { typeof(FluentHighlighter), Loader.Default.WithRequiredParameter("HighlightedText", "AB").WithRequiredParameter("Text", "ABCDEF")},
         { typeof(FluentKeyCode), Loader.Default.WithRequiredParameter("ChildContent", (RenderFragment)(builder => builder.AddContent(0, "MyContent"))) },
-        { typeof(FluentPaginator), Loader.Default.WithRequiredParameter("State", new PaginationState()) }
+        { typeof(FluentPaginator), Loader.Default.WithRequiredParameter("State", new PaginationState()) },
     };
 
     /// <summary />
@@ -83,31 +82,57 @@ public class ComponentBaseTests : Bunit.TestContext
         foreach (var componentType in BaseHelpers.GetDerivedTypes<IFluentComponentBase>(except: Excluded))
         {
             // Convert to generic type if needed
-            var type = ComponentInitializer.ContainsKey(componentType)
-                     ? ComponentInitializer[componentType].ComponentType(componentType)
+            var type = ComponentInitializer.TryGetValue(componentType, out var value)
+                     ? value.ComponentType(componentType)
                      : componentType;
 
             // Arrange and Act
-            var renderedComponent = RenderComponent<DynamicComponent>(parameters =>
+            try
             {
-                parameters.Add(p => p.Type, type);
-                parameters.Add(p => p.Parameters, DictionaryExtensions.Union(
-                    new Dictionary<string, object>
+                var renderedComponent = RenderComponent<DynamicComponent>(parameters =>
+                {
+                    parameters.Add(p => p.Type, type);
+
+                    // Required parameters
+                    parameters.Add(p => p.Parameters, DictionaryExtensions.Union(
+                        new Dictionary<string, object>
+                        {
+                            { blazorAttribute.Name, blazorAttribute.Value }
+                        },
+                        ComponentInitializer.TryGetValue(componentType, out var valueRequired) ? valueRequired.RequiredParameters : null
+                    ));
+
+                    // Cascading values
+                    if (ComponentInitializer.TryGetValue(componentType, out var valueCascading))
                     {
-                        { blazorAttribute.Name, blazorAttribute.Value }
-                    },
-                    ComponentInitializer.ContainsKey(componentType) ? ComponentInitializer[componentType].RequiredParameters : null
-                ));
-            });
+                        foreach (var (Name, Value) in valueCascading.CascadingValues)
+                        {
+                            if (string.IsNullOrEmpty(Name))
+                            {
+                                parameters.AddCascadingValue(Value);
+                            }
+                            else
+                            {
+                                parameters.AddCascadingValue(Name, Value);
+                            }
+                        }
+                    }
+                });
 
-            // Assert
-            var isMatch = renderedComponent.Markup.ContainsAttribute(htmlAttribute.Name, htmlAttribute.Value);
+                // Assert
+                var isMatch = renderedComponent.Markup.ContainsAttribute(htmlAttribute.Name, htmlAttribute.Value);
 
-            Output.WriteLine($"{(isMatch ? "✅" : "❌")} {componentType.Name}");
+                Output.WriteLine($"{(isMatch ? "✅" : "❌")} {componentType.Name}");
 
-            if (!isMatch)
+                if (!isMatch)
+                {
+                    var error = $"\"{componentType.Name}\" does not use the \"{blazorAttribute.Name}\" property/attribute (missing HTML attribute {htmlAttribute.Name}=\"{htmlAttribute.Value}\").";
+                    errors.AppendLine(error);
+                }
+            }
+            catch (Exception ex)
             {
-                var error = $"\"{componentType.Name}\" does not use the \"{blazorAttribute.Name}\" property/attribute (missing HTML attribute {htmlAttribute.Name}=\"{htmlAttribute.Value}\").";
+                var error = $"Error rendering component {componentType?.Name}. Update the `ComponentInitializer` dictionary: {Environment.NewLine}{Environment.NewLine}{ex.Message}{Environment.NewLine}{Environment.NewLine}{ex.InnerException?.Message}";
                 errors.AppendLine(error);
             }
         }
@@ -125,8 +150,8 @@ public class ComponentBaseTests : Bunit.TestContext
         foreach (var componentType in BaseHelpers.GetDerivedTypes<ITooltipComponent>(except: Excluded))
         {
             // Convert to generic type if needed
-            var type = ComponentInitializer.ContainsKey(componentType)
-                     ? ComponentInitializer[componentType].ComponentType(componentType)
+            var type = ComponentInitializer.TryGetValue(componentType, out var value)
+                     ? value.ComponentType(componentType)
                      : componentType;
 
             // Arrange and Act
@@ -141,7 +166,7 @@ public class ComponentBaseTests : Bunit.TestContext
                             { "Id", $"id-{type.Name}" },
                             { "Tooltip", $"My tooltip {type.Name}" },
                         },
-                        ComponentInitializer.ContainsKey(componentType) ? ComponentInitializer[componentType].RequiredParameters : null
+                        ComponentInitializer.TryGetValue(componentType, out var valueRequired) ? valueRequired.RequiredParameters : null
                     ));
                 });
                 stack.AddChildContent<FluentTooltipProvider>();
@@ -283,10 +308,23 @@ public class ComponentBaseTests : Bunit.TestContext
 
         public Dictionary<string, object> RequiredParameters { get; } = [];
 
+        public List<(string? Name, object Value)> CascadingValues { get; } = [];
+
         public Loader WithRequiredParameter(string key, object value)
         {
             RequiredParameters.Add(key, value);
             return this;
+        }
+
+        public Loader WithCascadingValue<TValue>(string? name, TValue cascadingValue) where TValue : notnull
+        {
+            CascadingValues.Add((name, cascadingValue));
+            return this;
+        }
+
+        public Loader WithCascadingValue<TValue>(TValue cascadingValue) where TValue : notnull
+        {
+            return WithCascadingValue(null, cascadingValue);
         }
     }
 


### PR DESCRIPTION
# [dev-v5] Base Unit Tests - Add WithCascadingValue method and refactoring

In the global Base Unit Tests:

1. Add a new `WithCascadingValue` method

   Example to use that:
   ```csharp
    { typeof(FluentDataGrid<>), Loader.MakeGenericType(typeof(string)) },
    { typeof(FluentDataGridRow<>), Loader.MakeGenericType(typeof(string)).WithCascadingValue(new InternalGridContext<string>(new FluentDataGrid<string>(new LibraryConfiguration()))) },
    { typeof(FluentDataGridCell<>), Loader.MakeGenericType(typeof(string))
                                          .WithCascadingValue(new InternalGridContext<string>(new FluentDataGrid<string>(new LibraryConfiguration())))
                                          .WithCascadingValue("OwningRow", new FluentDataGridRow<string>(new LibraryConfiguration()) { InternalGridContext = new InternalGridContext<string>(new FluentDataGrid<string>(new LibraryConfiguration())) }) },
   ```

3.  Refactoring the creation of an array