### PR TITLE
[Select] Use correct CSS variable for placeholder color

### DIFF
--- a/src/Core/Components/List/FluentSelect.razor.cs
+++ b/src/Core/Components/List/FluentSelect.razor.cs
@@ -24,7 +24,7 @@ public partial class FluentSelect<TOption> : ListComponentBase<TOption> where TO
         .AddStyle($"#{Id}::part(selected-value)", "white-space", "nowrap")
         .AddStyle($"#{Id}::part(selected-value)", "overflow", "hidden")
         .AddStyle($"#{Id}::part(selected-value)", "text-overflow", "ellipsis")
-        .AddStyle($"#{Id}::part(selected-value)", "color", "var(--neutral-base-color)", when: !string.IsNullOrEmpty(Placeholder) && SelectedOption is null)
+        .AddStyle($"#{Id}::part(selected-value)", "color", "var(--input-placeholder-rest)", when: !string.IsNullOrEmpty(Placeholder) && SelectedOption is null)
         .BuildMarkupString();
 
     protected override string? StyleValue => new StyleBuilder(base.StyleValue)

--- a/tests/Core/List/FluentSelectTests.FluentSelect_Placeholder.verified.razor.html
+++ b/tests/Core/List/FluentSelectTests.FluentSelect_Placeholder.verified.razor.html
@@ -1,12 +1,12 @@
 
 <style>
 #myselect::part(listbox) { z-index: 9995; }
-#myselect::part(selected-value) { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: var(--neutral-base-color); }
+#myselect::part(selected-value) { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: var(--input-placeholder-rest); }
 
 </style>
 <fluent-select id="xxx" blazor:onchange="1" blazor:onkeydown="2" blazor:elementreference="xxx">
   <fluent-option id="xxx" style="display:none;" value="" aria-selected="false" blazor:onclick="3" aria-hidden="true" blazor:elementreference="xxx">Make a selection...</fluent-option>
-  <fluent-option id="xxx" value="1-Denis Voituron" aria-selected="false" blazor:onclick="4" blazor:elementreference="xxx">1-Denis Voituron</fluent-option>
-  <fluent-option id="xxx" value="2-Vincent Baaij" aria-selected="false" blazor:onclick="5" blazor:elementreference="xxx">2-Vincent Baaij</fluent-option>
-  <fluent-option id="xxx" value="3-Bill Gates" aria-selected="false" blazor:onclick="6" blazor:elementreference="xxx">3-Bill Gates</fluent-option>
+  <fluent-option id="xxx" value="1-Denis Voituron" blazor:onclick="4" aria-selected="false" blazor:elementreference="xxx">1-Denis Voituron</fluent-option>
+  <fluent-option id="xxx" value="2-Vincent Baaij" blazor:onclick="5" aria-selected="false" blazor:elementreference="xxx">2-Vincent Baaij</fluent-option>
+  <fluent-option id="xxx" value="3-Bill Gates" blazor:onclick="6" aria-selected="false" blazor:elementreference="xxx">3-Bill Gates</fluent-option>
 </fluent-select>


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR changes the CSS variable which is being used to set the text color for the placeholder in `FluentSelect`.

Every other input uses `--input-placeholder-rest` for the text color. `FluentSelect` has been using `--neutral-base-color` before which has a slight darker gray tone.

Before:
![dialog-before](https://github.com/user-attachments/assets/014d4661-e03a-4e69-8f6d-e85707fed750)

After:
![dialog-after](https://github.com/user-attachments/assets/1281ebee-b7ee-481f-a36f-5663f52f154a)


## 👩‍💻 Reviewer Notes

I have updated the `FluentSelectTests.FluentSelect_Placeholder.verified.razor.html` unit test to reflect this change.


## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

