### PR TITLE
[dev-v5] Add mediaChanged, themeChanged, hidden-when and theme features

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Grid/FluentGrid.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Grid/FluentGrid.md
@@ -51,12 +51,9 @@ To display an element only on a given range of screen sizes, you can combine a t
 e.g. `GridItemHidden.Md | GridItemHidden.Lg` will display the element for all screen sizes,
 except on medium and large devices.
 
-`AdaptiveRendering` allows for not generating HTML code in a `FluentGridItem` based on the value of the `HiddenWhen` parameter.
-In other words, when `AdaptiveRendering=false` (default), the content of the `FluentGridItem` is simply hidden by CSS styles,
-whereas if `AdaptiveRendering=true`, the content of the `FluentGridItem` is not rendered by Blazor.
-This allows for fine-grained control over when HTML is generated or not, for example in a case where rendering
-the grid item takes a lot of time or leads to a lot of data being transferred.
-
+> [!TIP] You can also use the HTML `hidden-when` attribute to hide **any elements** when the screen size matches the specified breakpoints.  
+> Example: `<div hidden-when="sm md">...</div>` will hide the element on small and medium devices.
+> Only the values `xs sm, md, lg, xl, xxl` are supported, but you can combine them.
 
 <div class="grid-item-hidden" style="overflow-x: auto; margin-bottom: 24px;">
 
@@ -83,6 +80,15 @@ the grid item takes a lot of time or leads to a lot of data being transferred.
 | `XxlAndUp`   |                 | <div />         | <div />         | <div />         | <div />         | <div checked /> |
 
 </div>
+
+## AdaptiveRendering
+
+`AdaptiveRendering` allows for **not generating** HTML code in a `FluentGridItem` based on the value of the `HiddenWhen` parameter.
+In other words, when `AdaptiveRendering=false` (default), the content of the `FluentGridItem` is simply hidden by CSS styles `display: none;`,
+whereas if `AdaptiveRendering=true`, the content of the `FluentGridItem` is not rendered by Blazor.
+
+This allows for fine-grained control over when HTML is generated or not, for example in a case where rendering
+the grid item takes a lot of time or leads to a lot of data being transferred.
 
 ## body data-media
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Grid/FluentGrid.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Grid/FluentGrid.md
@@ -58,7 +58,7 @@ This allows for fine-grained control over when HTML is generated or not, for exa
 the grid item takes a lot of time or leads to a lot of data being transferred.
 
 
-<div class="grid-item-hidden" style="overflow-x: auto;">
+<div class="grid-item-hidden" style="overflow-x: auto; margin-bottom: 24px;">
 
 |GridItemHidden|X Small<br/><sup>< 600px</sup>|Small<br/><sup>600px - 959px</sup>|Medium<br/><sup>960px - 1279px</sup>|Large<br/><sup>1280px - 1919px</sup>|X Large<br/><sup>1920px - 2559px</sup>|XX Large<br/><sup>≥ 2560px</sup>|
 |--------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|
@@ -83,6 +83,41 @@ the grid item takes a lot of time or leads to a lot of data being transferred.
 | `XxlAndUp`   |                 | <div />         | <div />         | <div />         | <div />         | <div checked /> |
 
 </div>
+
+## body data-media
+
+The `<body data-media>` attribute is used to specify the current media query state of the browser.
+This attribute is automatically updated to reflect the current screen size, each time the browser is resized.
+
+For example, open the browser DevTools and resize the browser window.
+You will see the `data-media` attribute change as you resize the window.
+
+**Client side**
+
+A JavaScript `mediaChanged` event is triggered each time the `data-media` attribute changes.
+
+```html
+<script>
+    document.body.addEventListener('mediaChanged', function (e) {
+        console.log('Media changed:', e.detail.media);
+    });
+</script>
+```
+
+**Blazor side**
+
+You can use the `FluentGrid.OnBreakpointEnter` event to handle media changes in Blazor.
+
+```razor
+<FluentGrid OnBreakpointEnter="@OnBreakpointEnterHandler" />
+
+@code {
+    void OnBreakpointEnterHandler(GridItemSize size)
+    {
+        Console.WriteLine($"Page Size: {size}");
+    }
+}
+```
 
 ## API FluentGrid
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Theme/Dark/ThemeDark.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Theme/Dark/ThemeDark.md
@@ -1,0 +1,66 @@
+---
+title: Theme / Light-Dark
+route: /theme/dark
+---
+
+# Light-Dark Themes
+
+FluentUI provides a **dark theme** that can be applied to your application. 
+This theme is designed to provide a visually appealing and comfortable user experience in low-light environments.
+
+You can easily switch between light and dark themes using the provided JavaScript functions: 
+`Blazor.theme.setDarkTheme` and `Blazor.theme.setLightTheme`.
+
+## Example
+
+```csharp
+[Inject]
+public required IJSRuntime JSRuntime { get; set; }
+
+private bool DarkTheme { get; set; };
+
+public async Task SwitchThemeAsync()
+{
+    DarkTheme = !DarkTheme;
+    await JSRuntime.InvokeVoidAsync(DarkTheme ? "Blazor.theme.setDarkTheme" : "Blazor.theme.setLightTheme");
+}
+```
+
+> [!NOTE] Soon you will be able to use the Blazor `FluentDesignTheme` component to manage themes in a more declarative way.
+
+#  body data-theme
+
+The `<body data-theme>` attribute is used to specify the current theme of the application.  
+When the dark theme is applied, this attribute will be set to `data-theme="dark"`.  
+When the light theme is applied, this attribute will be missing.  
+
+For example, open the browser DevTools and switch between light and dark themes using the top-right button.
+You will see the `data-theme` attribute change accordingly.
+
+**Style**
+
+This attribute lets you easily apply specific CSS styles based on the current theme.
+
+```css
+body {
+  background-color: #ffffff;
+  color: #000000;
+}
+
+body[data-theme="dark"] {
+  background-color: #121212;
+  color: #ffffff;
+}
+```
+
+**Client side**
+
+A JavaScript `themeChanged` event is triggered each time the `data-theme` attribute changes.
+
+```html
+<script>
+    document.body.addEventListener('themeChanged', function (e) {
+        console.log('Theme changed: isDark=', e.detail.isDark);
+    });
+</script>
+```

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Styles.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Styles.md
@@ -89,6 +89,7 @@ body {
   font-weight: var(--fontWeightRegular);
   color: var(--colorNeutralForeground1);
   background-color: var(--colorNeutralBackground1);
+  scrollbar-color: var(--colorNeutralForeground4) var(--colorNeutralBackground2);
 }
 ```
 

--- a/examples/Demo/FluentUI.Demo.Client/Layout/DemoMainLayout.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Layout/DemoMainLayout.razor
@@ -71,7 +71,7 @@
             @Body
         </FluentLayoutItem>
 
-        <FluentLayoutItem Area="@LayoutArea.Aside" Width="240px" Sticky="true">
+        <FluentLayoutItem Area="@LayoutArea.Aside" Width="240px" Sticky="true" hidden-when="sm">
             <DemoAsidePanel Page="@Navigation.ToBaseRelativePath(Navigation.Uri)" />
         </FluentLayoutItem>
     }

--- a/examples/Demo/FluentUI.Demo/Components/App.razor
+++ b/examples/Demo/FluentUI.Demo/Components/App.razor
@@ -21,10 +21,24 @@
     <script src="_framework/blazor.web.js"></script>
     
     <!-- Include highlight.js -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/styles/vs.min.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/styles/vs.min.css" title="highlight-light" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/styles/vs2015.min.css" title="highlight-dark" disabled="disabled" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/highlight.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/languages/csharp.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/highlightjs-cshtml-razor@2.1.1/dist/cshtml-razor.min.js"></script>
+
+    <script>
+        // Listen for the theme change event and toggle highlight.js styles
+        document.body.addEventListener('themeChanged', function (e) {
+            const linkLight = document.querySelector('link[title="highlight-light"]');
+            const linkDark = document.querySelector('link[title="highlight-dark"]');
+            
+            if (linkLight && linkDark) {
+                linkLight.disabled = e.detail.isDark;
+                linkDark.disabled = !e.detail.isDark;
+            }
+        });
+    </script>
 
 </body>
 </html>

--- a/examples/Tools/FluentUI.Demo.DocViewer/Components/MarkdownViewer.razor.css
+++ b/examples/Tools/FluentUI.Demo.DocViewer/Components/MarkdownViewer.razor.css
@@ -57,7 +57,7 @@
   /* Code */
   .doc-viewer ::deep code {
     font-weight: 500;
-    background-color: var(--colorNeutralBackground5);
+    background-color: var(--colorNeutralBackground3);
     padding: 0px 4px;
     overflow-wrap: anywhere
   }
@@ -71,7 +71,7 @@
       overflow-x: auto;
       display: block;
       padding: 1em;
-      background-color: rgb(243, 243, 243);
+      background-color: var(--colorNeutralBackground3);
       border: 1px solid silver;
       font-size: 13px;
       font-weight: bold;

--- a/src/Core.Scripts/src/Utilities/Theme.ts
+++ b/src/Core.Scripts/src/Utilities/Theme.ts
@@ -87,12 +87,25 @@ export namespace Microsoft.FluentUI.Blazor.Utilities.Theme {
       ];
     }
 
+    const dispatchMediaChanged = (bodyTag: HTMLElement) => {
+      // Dispatch a custom event when the media query changes
+      if (bodyTag) {
+        const event = new CustomEvent('mediaChanged', {
+          detail: {
+            media: bodyTag.getAttribute('data-media')
+          }
+        });
+        bodyTag.dispatchEvent(event);
+      }
+    }
+
     // Set the initial data-media attribute based on the current matching media query
     const bodyTag: HTMLElement = document?.body;
     if (bodyTag) {
       const matched = getMediaQueries().find(mq => window.matchMedia(mq.query).matches);
       if (matched) {
         bodyTag.setAttribute('data-media', matched.id);
+        dispatchMediaChanged(bodyTag);
       }
     }
 
@@ -103,6 +116,7 @@ export namespace Microsoft.FluentUI.Blazor.Utilities.Theme {
             const bodyTag: HTMLElement = document?.body;
             if (bodyTag && bodyTag.getAttribute('data-media') !== mediaQuery.id) {
               bodyTag.setAttribute('data-media', mediaQuery.id);
+              dispatchMediaChanged(bodyTag);
             }
           }
         });
@@ -119,6 +133,14 @@ export namespace Microsoft.FluentUI.Blazor.Utilities.Theme {
       } else {
         bodyTag.removeAttribute('data-theme');
       }
+
+      // Dispatch the custom event
+      const event = new CustomEvent('themeChanged', {
+        detail: {
+          isDark
+        }
+      });
+      bodyTag.dispatchEvent(event);
     }
   }
 }

--- a/src/Core/Components/Grid/FluentGrid.razor.css
+++ b/src/Core/Components/Grid/FluentGrid.razor.css
@@ -669,37 +669,37 @@
 /* Hidden */
 
 @media (max-width: 599.98px) {
-    .fluent-grid > div[hidden-when~="xs"] {
+    [hidden-when~="xs"] {
         display: none;
     }
 }
 
 @media (min-width: 600px) and (max-width: 959.98px) {
-    .fluent-grid > div[hidden-when~="sm"] {
+    [hidden-when~="sm"] {
         display: none;
     }
 }
 
 @media (min-width: 960px) and (max-width: 1279.98px) {
-    .fluent-grid > div[hidden-when~="md"] {
+    [hidden-when~="md"] {
         display: none;
     }
 }
 
 @media (min-width: 1280px) and (max-width: 1919.98px) {
-    .fluent-grid > div[hidden-when~="lg"] {
+    [hidden-when~="lg"] {
         display: none;
     }
 }
 
 @media (min-width: 1920px) and (max-width: 2559.98px) {
-    .fluent-grid > div[hidden-when~="xl"] {
+    [hidden-when~="xl"] {
         display: none;
     }
 }
 
 @media (min-width: 2560px) {
-    .fluent-grid > div[hidden-when~="xxl"] {
+    [hidden-when~="xxl"] {
         display: none;
     }
 }

--- a/src/Core/wwwroot/css/default-fuib.css
+++ b/src/Core/wwwroot/css/default-fuib.css
@@ -8,7 +8,7 @@
  */
 
 @media (prefers-reduced-motion: no-preference) {
-  : root {
+  :root {
     scroll-behavior: smooth;
   }
 }
@@ -24,6 +24,7 @@ body {
   font-weight: var(--fontWeightRegular);
   color: var(--colorNeutralForeground1);
   background-color: var(--colorNeutralBackground1);
+  scrollbar-color: var(--colorNeutralForeground4) var(--colorNeutralBackground2);
 }
 
 * {


### PR DESCRIPTION
# [dev-v5] Add mediaChanged, themeChanged, hidden-when and theme features

- Add an HTML `body.mediaChanged` event to detect browser size changes in JavaScript.
- Add an HTML `body.themeChanged` event to detect theme changes in JavaScript.
- Add `scrollbar-color: var(--colorNeutralForeground4) var(--colorNeutralBackground2);` in the default styles to display a scrollbar adapted to the theme
- Update the Grid styles to allow an HTML `hidden-when` attribute to hide any HTML elements when the screen size matches the specified breakpoints.
- Update the demo website to switch the Code Highlight styles between light and dark mode.

## hidden-when attribute

You can also use the HTML `hidden-when` attribute to hide **any elements** when the screen size matches the specified breakpoints.  
Example: `<div hidden-when="sm md">...</div>` will hide the element on small and medium devices.
Only the values `xs sm, md, lg, xl, xxl` are supported, but you can combine them.

## body data-media

The `<body data-media>` attribute is used to specify the current media query state of the browser.
This attribute is automatically updated to reflect the current screen size, each time the browser is resized.

For example, open the browser DevTools and resize the browser window.
You will see the `data-media` attribute change as you resize the window.

**Client side**

A JavaScript `mediaChanged` event is triggered each time the `data-media` attribute changes.

```html
<script>
    document.body.addEventListener('mediaChanged', function (e) {
        console.log('Media changed:', e.detail.media);
    });
</script>
```

**Blazor side**

You can use the `FluentGrid.OnBreakpointEnter` event to handle media changes in Blazor.

```razor
<FluentGrid OnBreakpointEnter="@OnBreakpointEnterHandler" />
@code {
    void OnBreakpointEnterHandler(GridItemSize size)
    {
        Console.WriteLine($"Page Size: {size}");
    }
}
```

## Light-Dark Themes

FluentUI provides a **dark theme** that can be applied to your application. 
This theme is designed to provide a visually appealing and comfortable user experience in low-light environments.

You can easily switch between light and dark themes using the provided JavaScript functions: 
`Blazor.theme.setDarkTheme` and `Blazor.theme.setLightTheme`.

### Example

```csharp
[Inject]
public required IJSRuntime JSRuntime { get; set; }

private bool DarkTheme { get; set; };

public async Task SwitchThemeAsync()
{
    DarkTheme = !DarkTheme;
    await JSRuntime.InvokeVoidAsync(DarkTheme ? "Blazor.theme.setDarkTheme" : "Blazor.theme.setLightTheme");
}
```

## body data-theme

The `<body data-theme>` attribute is used to specify the current theme of the application.  
When the dark theme is applied, this attribute will be set to `data-theme="dark"`.  
When the light theme is applied, this attribute will be missing.  

For example, open the browser DevTools and switch between light and dark themes using the top-right button.
You will see the `data-theme` attribute change accordingly.

**Style**

This attribute lets you easily apply specific CSS styles based on the current theme.

```css
body {
  background-color: #ffffff;
  color: #000000;
}

body[data-theme="dark"] {
  background-color: #121212;
  color: #ffffff;
}
```

**Client side**

A JavaScript `themeChanged` event is triggered each time the `data-theme` attribute changes.

```html
<script>
    document.body.addEventListener('themeChanged', function (e) {
        console.log('Theme changed: isDark=', e.detail.isDark);
    });
</script>
```