### PR TITLE
[dev-v5] Small styling fix

### DIFF
--- a/src/Core/Components/Layout/FluentLayoutItem.razor.css
+++ b/src/Core/Components/Layout/FluentLayoutItem.razor.css
@@ -56,7 +56,8 @@
   }
 
     .fluent-layout-item[area="aside"][sticky] {
-      height: fit-content;
+      height: 100%;
+      max-height: fit-content;
     }
 
 .fluent-layout[global-scrollbar] .fluent-layout-item:not([area="header"]):not([area="footer"]) {


### PR DESCRIPTION

# Pull Request

## 📖 Description

I saw a small bug in the demo for the migration changes, when the list of the sidepanel is too large to fit the screen, it will cause the entire layout to move up a little bit, even blow the footer. I will provide a screen shot of it down below. 

![image](https://github.com/user-attachments/assets/09f90f27-9e3d-4ced-9c75-f94bc4607c7e)

Now with an additional style, telling it to grow to whatever is available, but never larger then fit-content

![image](https://github.com/user-attachments/assets/dadc63b6-9720-4aff-bc27-6dc573576626)


Also, i just noticed that before it didnt give a scrollable view for the side panel. 

Just a small fix :)

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.