### PR TITLE
[dev-v5] Remove `:root scroll-behavior: smooth`

### DIFF
--- a/src/Core/wwwroot/css/default-fuib.css
+++ b/src/Core/wwwroot/css/default-fuib.css
@@ -7,12 +7,6 @@
  * You can disable this style by setting the attribute `no-fuib-style` on the `body` element, in your source code.
  */
 
-@media (prefers-reduced-motion: no-preference) {
-  :root {
-    scroll-behavior: smooth;
-  }
-}
-
 body {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
# [dev-v5] Remove `:root scroll-behavior: smooth`

The `default-fuib.css` file is based on `Normalize.css` and proposed this code.
This is not correct because some Libs (Gaps.JS) exploit this scrolling.
It is therefore not recommended to use it by default.

```css
@media (prefers-reduced-motion: no-preference) {
  :root {
    scroll-behavior: smooth;
  }
}
```