### PR TITLE
[dev-v5] Add FluentErrorBoundary.OnCloseRedirectUrl parameter

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Layout/DemoMainLayout.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Layout/DemoMainLayout.razor
@@ -67,7 +67,9 @@
 else
 {
     <FluentLayoutItem Area="@LayoutArea.Content">
-        @Body
+        <FluentErrorBoundary DisplayErrorDetails="ErrorBoundaryDetails.ErrorMessage" OnCloseRedirectUrl="/">
+            @Body
+        </FluentErrorBoundary>
     </FluentLayoutItem>
 
     <FluentLayoutItem Area="@LayoutArea.Aside" Width="240px" Sticky="true" hidden-when="sm">

--- a/src/Core/Components/ErrorBoundary/FluentErrorBoundary.razor
+++ b/src/Core/Components/ErrorBoundary/FluentErrorBoundary.razor
@@ -56,7 +56,7 @@
                             @ErrorContent
                         }
                     </div>
-                    <fluent-button slot="action" appearance="primary" onclick="this.parentElement.parentElement.hide()">
+                    <fluent-button slot="action" appearance="primary" onclick="@GetOnclickJavaScript()">
                         @Localizer["ErrorBoundary_Close"]
                     </fluent-button>
                 </fluent-dialog-body>

--- a/src/Core/Components/ErrorBoundary/FluentErrorBoundary.razor.cs
+++ b/src/Core/Components/ErrorBoundary/FluentErrorBoundary.razor.cs
@@ -64,6 +64,12 @@ public partial class FluentErrorBoundary : FluentComponentBase
     public int MaximumErrorCount { get; set; } = 100;
 
     /// <summary>
+    /// Gets or sets the URL to navigate to after an error occurs.
+    /// </summary>
+    [Parameter]
+    public string? OnCloseRedirectUrl { get; set; }
+
+    /// <summary>
     /// Resets the error boundary to a non-errored state. If the error boundary is not
     /// already in an errored state, the call has no effect.
     /// </summary>
@@ -87,5 +93,17 @@ public partial class FluentErrorBoundary : FluentComponentBase
         }
 
         return Task.CompletedTask;
+    }
+
+    /// <summary />
+    private string GetOnclickJavaScript()
+    {
+        if (string.IsNullOrEmpty(OnCloseRedirectUrl))
+        {
+            return "this.parentElement.parentElement.hide()";
+        }
+
+        var encodedUrl = System.Web.HttpUtility.JavaScriptStringEncode(OnCloseRedirectUrl);
+        return $"window.location.href='{encodedUrl}'";
     }
 }

--- a/tests/Core/Components/ErrorBoundary/FluentErrorBoundaryTests.razor
+++ b/tests/Core/Components/ErrorBoundary/FluentErrorBoundaryTests.razor
@@ -126,4 +126,19 @@
 
         // No value to test, just ensure it doesn't throw an exception
     }
+
+    [Fact]
+    public void FluentErrorBoundary_OnCloseRedirectUrl()
+    {
+        // Arrange
+        var cut = Render(@<FluentErrorBoundary OnCloseRedirectUrl="/">
+            <ChildContent>
+                <ThrowingExceptionComponent Throw="true">My content</ThrowingExceptionComponent>
+            </ChildContent>
+            <ErrorContent>My Error</ErrorContent>
+        </FluentErrorBoundary>);
+
+        // Assert
+        Assert.Contains("window.location.href='/'", cut.Markup);
+    }
 }


### PR DESCRIPTION
# [dev-v5] Add FluentErrorBoundary.OnCloseRedirectUrl parameter

When an error occurs on a page, this dialog box appears. However, when the user clicks [Close], the same page appears and the same error occurs. This is a loop.

Adding a `OnCloseRedirectUrl="/"` can solve this issue, redirecting the user to a specific "safe" page.

![{7765582C-0F43-44F5-939F-72566AFC14CB}](https://github.com/user-attachments/assets/80820db8-ad26-48f4-9def-7b991551bbcd)

## Unit Tests

Updated