### PR TITLE
[dev-v5] Make anchors block elements

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Layout/DemoNavMenu.razor.css
+++ b/examples/Demo/FluentUI.Demo.Client/Layout/DemoNavMenu.razor.css
@@ -6,7 +6,6 @@ ul {
 
 li {
   font-weight: 600;
-  padding: 8px 10px;
 }
 
   li li {
@@ -22,4 +21,6 @@ li {
 a {
   text-decoration: none;
   color: var(--colorNeutralForeground2);
+  display: block;
+  padding: 8px 10px;
 }

--- a/examples/Demo/FluentUI.Demo.Client/Layout/DemoNavMenu.razor.css
+++ b/examples/Demo/FluentUI.Demo.Client/Layout/DemoNavMenu.razor.css
@@ -8,6 +8,10 @@ li {
   font-weight: 600;
 }
 
+  li:not(:has(> a)) {
+    padding: 8px 10px;
+  }
+
   li li {
     font-weight: 400;
     padding-left: 24px;


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR makes switches the anchor elements within the navigation in the v5 demo to block elements to allow the user to click on the entire block instead of the text only.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
