### PR TITLE
Add VSCode Tasks and Launch steps

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,54 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    // Now when you press F5, VS Code will:
+    //   - Build the FluentUI Demo project in Debug mode
+    //   - Launch the application with the debugger attached
+    //   - Automatically open your browser to the application URL
+    //
+    // You can manually select which configuration to use by going 
+    // to the Run and Debug panel (Ctrl+Shift+D) and choosing from the dropdown.
     "version": "0.2.0",
-    "configurations": []
+    "configurations": [
+        // Watch the FluentUI Demo project for changes and launch with hot reload
+        {
+            "name": "Watch FluentUI Demo",
+            "type": "coreclr",
+            "request": "launch",
+            "program": "dotnet",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "${workspaceFolder}/examples/Demo/FluentUI.Demo/FluentUI.Demo.csproj"
+            ],
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "stopAtEntry": false,
+            "serverReadyAction": {
+                "action": "openExternally",
+                "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            }
+        },
+        // Launch the FluentUI Demo project in Debug mode
+        {
+            "name": "Debug FluentUI Demo",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build-demo",
+            "program": "${workspaceFolder}/examples/Demo/FluentUI.Demo/bin/Debug/net9.0/FluentUI.Demo.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/examples/Demo/FluentUI.Demo",
+            "console": "integratedTerminal",
+            "stopAtEntry": false,
+            "serverReadyAction": {
+                "action": "openExternally",
+                "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            }
+        }  
+    ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,250 @@
+{
+    // Ctrl+Shift+P → "Tasks: Run Task" to run any specific task
+    // Ctrl+Shift+B → To run the default build task (build-solution)
+    "version": "2.0.0",
+    "tasks": [
+        // Build Microsoft.FluentUI-v5.sln.
+        // Default build task
+        {
+            "label": "build-solution",
+            "type": "shell",
+            "command": "dotnet",
+            "args": [
+                "build",
+                "Microsoft.FluentUI-v5.sln",
+                "--configuration",
+                "Debug"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": "$msCompile",
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": false
+            },
+            "options": {
+                "cwd": "${workspaceFolder}"
+            }
+        },
+        
+        // Build Components project only
+        {
+            "label": "build-core-components",
+            "type": "shell",
+            "command": "dotnet",
+            "args": [
+                "build",
+                "src/Core/Microsoft.FluentUI.AspNetCore.Components.csproj",
+                "--configuration",
+                "Debug"
+            ],
+            "group": "build",
+            "problemMatcher": "$msCompile",
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": false
+            },
+            "options": {
+                "cwd": "${workspaceFolder}"
+            }
+        },
+
+        // Build Demo project
+        {
+            "label": "build-demo",
+            "type": "shell",
+            "command": "dotnet",
+            "args": [
+                "build",
+                "examples/Demo/FluentUI.Demo/FluentUI.Demo.csproj",
+                "--configuration",
+                "Debug"
+            ],
+            "group": "build",
+            "problemMatcher": "$msCompile",
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": false
+            },
+            "options": {
+                "cwd": "${workspaceFolder}"
+            }
+        },
+
+        // Build Demo project in Release mode
+        {
+            "label": "build-demo-release",
+            "type": "shell",
+            "command": "dotnet",
+            "args": [
+                "build",
+                "examples/Demo/FluentUI.Demo/FluentUI.Demo.csproj",
+                "--configuration",
+                "Release"
+            ],
+            "group": "build",
+            "problemMatcher": "$msCompile",
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": false
+            },
+            "options": {
+                "cwd": "${workspaceFolder}"
+            }
+        },
+
+        // Clean solution
+        {
+            "label": "clean-solution",
+            "type": "shell",
+            "command": "dotnet",
+            "args": [
+                "clean",
+                "Microsoft.FluentUI-v5.sln"
+            ],
+            "group": "build",
+            "problemMatcher": "$msCompile",
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": false
+            },
+            "options": {
+                "cwd": "${workspaceFolder}"
+            }
+        },
+
+        // Restore solution
+        {
+            "label": "restore-solution",
+            "type": "shell",
+            "command": "dotnet",
+            "args": [
+                "restore",
+                "Microsoft.FluentUI-v5.sln"
+            ],
+            "group": "build",
+            "problemMatcher": "$msCompile",
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": false
+            },
+            "options": {
+                "cwd": "${workspaceFolder}"
+            }
+        },
+
+        // Run the demo application
+        {
+            "label": "run-demo",
+            "type": "shell",
+            "command": "dotnet",
+            "args": [
+                "run",
+                "--project",
+                "examples/Demo/FluentUI.Demo/FluentUI.Demo.csproj"
+            ],
+            "group": "test",
+            "isBackground": true,
+            "problemMatcher": "$msCompile",
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": false
+            },
+            "options": {
+                "cwd": "${workspaceFolder}"
+            }
+        },
+
+        // Run unit tests for Core Components
+        {
+            "label": "test-core",
+            "type": "shell",
+            "command": "dotnet",
+            "args": [
+                "test",
+                "tests/Core/Components.Tests.csproj",
+                "--configuration",
+                "Debug"
+            ],
+            "group": "test",
+            "problemMatcher": "$msCompile",
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": false
+            },
+            "options": {
+                "cwd": "${workspaceFolder}"
+            }
+        },
+
+        // Watch for changes in Demo project and rebuild automatically
+        {
+            "label": "watch-demo",
+            "type": "shell",
+            "command": "dotnet",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "examples/Demo/FluentUI.Demo/FluentUI.Demo.csproj"
+            ],
+            "group": "build",
+            "isBackground": true,
+            "problemMatcher": [
+                {
+                    "base": "$msCompile",
+                    "background": {
+                        "activeOnStart": true,
+                        "beginsPattern": "^\\s*Watching for file changes",
+                        "endsPattern": "^\\s*Application started\\.|^\\s*dotnet watch : Exited"
+                    }
+                }
+            ],
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": false
+            },
+            "options": {
+                "cwd": "${workspaceFolder}"
+            }
+        },       
+    ]
+}


### PR DESCRIPTION
# Add VSCode Tasks and Launch steps

This PR add these tasks to simplify the build processes:
- **build-solution**: `dotnet build Microsoft.FluentUI-v5.sln`
- **build-core-components**: `dotnet build Microsoft.FluentUI.AspNetCore.Components.csproj`
- **build-demo**: `dotnet build FluentUI.Demo.csproj`
- **build-demo-release**: `dotnet build FluentUI.Demo.csproj --configuration Release
- **clean-solution**: `dotnet clean Microsoft.FluentUI-v5.sln`
- **restore-solution**: `dotnet restore Microsoft.FluentUI-v5.sln`
- **run-demo**: `dotnet run FluentUI.Demo.csproj`
- **test-core**: `dotnet test Components.Tests.csproj`
watch-demo = dotnet watch run --project examples/Demo/FluentUI.Demo/FluentUI.Demo.csproj

And some Launch actions:
- **Watch FluentUI Demo**: `dotnet watch run FluentUI.Demo.csproj`
- **Debug FluentUI Demo**: `dotnet run FluentUI.Demo.csproj`