### PR TITLE
[dev-v5] Fix Slider - add ImmediateDelay

### DIFF
--- a/src/Core/Components/Slider/FluentSlider.razor.cs
+++ b/src/Core/Components/Slider/FluentSlider.razor.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.FluentUI.AspNetCore.Components.Extensions;
+using Microsoft.FluentUI.AspNetCore.Components.Utilities;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
@@ -16,6 +17,8 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 public partial class FluentSlider<TValue> : FluentInputBase<TValue>, ITooltipComponent
     where TValue : struct, IComparable<TValue>
 {
+    private readonly Debounce _debounce = new();
+
     /// <summary>
     /// Initializes a new instance of the <see cref="FluentSlider{TValue}"/> class.
     /// </summary>
@@ -80,6 +83,12 @@ public partial class FluentSlider<TValue> : FluentInputBase<TValue>, ITooltipCom
     [Parameter]
     public string? Tooltip { get; set; }
 
+    /// <summary>
+    /// Gets or sets the delay, in milliseconds, before to raise the change event.
+    /// </summary>
+    [Parameter]
+    public ushort ImmediateDelay { get; set; } = 60;
+
     /// <summary />
     protected override async Task OnInitializedAsync()
     {
@@ -105,6 +114,15 @@ public partial class FluentSlider<TValue> : FluentInputBase<TValue>, ITooltipCom
     {
         FocusLost = true;
         return Task.CompletedTask;
+    }
+
+    /// <summary />
+    protected override Task ChangeHandlerAsync(ChangeEventArgs e)
+    {
+        return _debounce.RunAsync(ImmediateDelay, () =>
+        {
+            return base.ChangeHandlerAsync(e);
+        });
     }
 
     /// <summary>

--- a/tests/Core/Components/Slider/FluentSliderTests.razor
+++ b/tests/Core/Components/Slider/FluentSliderTests.razor
@@ -131,7 +131,7 @@
     {
         // Arrange
         var step = (T)Convert.ChangeType(1, typeof(T));
-        var cut = Render(@<FluentSlider TValue="T" @bind-Value="@value" Step="@step" />);
+        var cut = Render(@<FluentSlider TValue="T" @bind-Value="@value" Step="@step" ImmediateDelay="0" />);
 
         var slider = cut.Find("fluent-slider");
         var valueAttribute = slider.GetAttribute("value");


### PR DESCRIPTION
# [dev-v5] Fix Slider - add ImmediateDelay

The **FluentSlider** sends a value change using the JS function `onchange`, but as an ‘oninput’ event: immediately after the cursor is moved. The delay in communicating with the Blazor server and updating the `value` attribute is therefore too long, which causes a loop.

We added a new parameter `ImmediateDelay` (default 60ms) to "debounce" the value.

> A future fix will use a JavaScript Debounce object to avoid sending the value from the client when it is not required.

See #3979