### PR TITLE
[Toast] Add DynamicDependency to prevent trimming errors

### DIFF
--- a/src/Core/Components/Toast/ContentComponents/CommunicationToast.razor.cs
+++ b/src/Core/Components/Toast/ContentComponents/CommunicationToast.razor.cs
@@ -2,10 +2,13 @@
 // This file is licensed to you under the MIT License.
 // ------------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
-public partial class CommunicationToast : IToastContentComponent<CommunicationToastContent>
+
+[method: DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(CommunicationToast))]
+public partial class CommunicationToast() : IToastContentComponent<CommunicationToastContent>
 {
 
     [Parameter]

--- a/src/Core/Components/Toast/ContentComponents/ConfirmationToast.razor.cs
+++ b/src/Core/Components/Toast/ContentComponents/ConfirmationToast.razor.cs
@@ -1,0 +1,13 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+[method: DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(ConfirmationToast))]
+public partial class ConfirmationToast()
+{
+
+}

--- a/src/Core/Components/Toast/ContentComponents/ProgressToast.razor.cs
+++ b/src/Core/Components/Toast/ContentComponents/ProgressToast.razor.cs
@@ -2,13 +2,14 @@
 // This file is licensed to you under the MIT License.
 // ------------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
-public partial class ProgressToast : IToastContentComponent<ProgressToastContent>
+[method: DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(ProgressToast))]
+public partial class ProgressToast() : IToastContentComponent<ProgressToastContent>
 {
-
     [Parameter]
     public ProgressToastContent Content { get; set; } = default!;
 


### PR DESCRIPTION
This pull request introduces changes to enhance compatibility with trimming tools by adding `DynamicDependency` attributes to several toast components. These changes ensure that the public constructors of the components are preserved during trimming.

### Enhancements for trimming compatibility:

* [`src/Core/Components/Toast/ContentComponents/CommunicationToast.razor.cs`](diffhunk://#diff-8006d745de9bb35cabdf9820848aa19816712c6fc1a2e26cdc3df9ce82648733R5-R11): Added a `[DynamicDependency]` attribute to preserve public constructors of the `CommunicationToast` class during trimming.
* [`src/Core/Components/Toast/ContentComponents/ConfirmationToast.razor.cs`](diffhunk://#diff-cc625a3374bb5cd698fa6d248a3a0823301803ce25fd541254c200f4f25abd74R1-R13): Introduced a new `ConfirmationToast` class with a `[DynamicDependency]` attribute to ensure public constructors are retained.
* [`src/Core/Components/Toast/ContentComponents/ProgressToast.razor.cs`](diffhunk://#diff-bb4c2b40214a11e7aff49f6a834cd17f51768ee8db83ef045b9c44afe0f1dc5bR5-L11): Added a `[DynamicDependency]` attribute to the `ProgressToast` class to preserve its public constructors during trimming.

Fix #3973