### PR TITLE
[Tabs] Implement proper tab sizing

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -7744,19 +7744,6 @@
             Gets or sets a callback that is triggered whenever <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentNavGroup.Expanded"/> changes.
             </summary>
         </member>
-        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentNavLink.OnParametersSet">
-            <inheritdoc />
-        </member>
-        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentNavLink.ShouldMatch(System.String)">
-            <summary>
-            Determines whether the current URI should match the link.
-            </summary>
-            <param name="uriAbsolute">The absolute URI of the current location.</param>
-            <returns>True if the link should be highlighted as active; otherwise, false.</returns>
-        </member>
-        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentNavLink.Dispose">
-            <inheritdoc />
-        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentNavMenu.ExpanderContent">
             <summary>
             Gets or sets the content to be rendered for the collapse icon when the menu is collapsible.

--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -7744,6 +7744,19 @@
             Gets or sets a callback that is triggered whenever <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentNavGroup.Expanded"/> changes.
             </summary>
         </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentNavLink.OnParametersSet">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentNavLink.ShouldMatch(System.String)">
+            <summary>
+            Determines whether the current URI should match the link.
+            </summary>
+            <param name="uriAbsolute">The absolute URI of the current location.</param>
+            <returns>True if the link should be highlighted as active; otherwise, false.</returns>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentNavLink.Dispose">
+            <inheritdoc />
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentNavMenu.ExpanderContent">
             <summary>
             Gets or sets the content to be rendered for the collapse icon when the menu is collapsible.

--- a/examples/Demo/Shared/Pages/Tabs/Examples/TabsDefault.razor
+++ b/examples/Demo/Shared/Pages/Tabs/Examples/TabsDefault.razor
@@ -1,9 +1,15 @@
-﻿<FluentSwitch @bind-Value="@DeferredLoading">Use deferred loading</FluentSwitch>
+﻿<FluentSelect Label="Size"
+              Items="@(Enum.GetValues<TabSize>())"
+              @bind-SelectedOption="@size" />
+
+<FluentSwitch @bind-Value="@DeferredLoading">Use deferred loading</FluentSwitch>
 <p>
 If checked, the contents of Tab two and three will be loaded after 1 second of processing (to simulate a long running process). <br />
 </p>
 
-<FluentTabs @bind-ActiveTabId="@activeid" OnTabChange="HandleOnTabChange" >
+<FluentDivider />
+
+<FluentTabs @bind-ActiveTabId="@activeid" OnTabChange="HandleOnTabChange" Size="@size" >
     <FluentTab Label="Tab one" Icon="@(new Icons.Regular.Size24.LeafOne())" Id="tab-1">
         Tab one content. This is for testing.
     </FluentTab>
@@ -36,7 +42,7 @@ If checked, the contents of Tab two and three will be loaded after 1 second of p
 <p>Active tab changed to: @changedto?.Label</p>
 
 <h4>Vertical</h4>
-<FluentTabs Orientation="Orientation.Vertical" ActiveTabId="tab-v1" Style="height: 200px;">
+<FluentTabs Orientation="Orientation.Vertical" Style="height: 200px;" Size="@size">
     <FluentTab Label="Tab one" Id="tab-v1">
         Tab one content. This is for testing.
     </FluentTab>
@@ -50,6 +56,8 @@ If checked, the contents of Tab two and three will be loaded after 1 second of p
 
 @code {
     bool DeferredLoading = false;
+
+    TabSize size;
 
     string? activeid = "tab-3";
     FluentTab? changedto;

--- a/src/Core/Components/Tabs/FluentTab.razor.css
+++ b/src/Core/Components/Tabs/FluentTab.razor.css
@@ -44,12 +44,13 @@ fluent-tabs fluent-tab-panel {
     --density: 0;
 }
 
-fluent-tabs:has(.medium) fluent-tab {
+
+fluent-tabs.medium fluent-tab {
     font-size: var(--type-ramp-base-font-size);
     padding: 0 10px;
 }
 
-fluent-tabs:has(.large) fluent-tab {
+fluent-tabs.large fluent-tab {
     font-size: var(--type-ramp-plus-1-font-size);
     padding: 0 16px;
 }

--- a/src/Core/Components/Tabs/FluentTab.razor.css
+++ b/src/Core/Components/Tabs/FluentTab.razor.css
@@ -39,3 +39,17 @@ fluent-tab {
 ::deep fluent-tab[aria-selected="true"] {
     font-variation-settings: normal;
 }
+
+fluent-tabs fluent-tab-panel {
+    --density: 0;
+}
+
+fluent-tabs:has(.medium) fluent-tab {
+    font-size: var(--type-ramp-base-font-size);
+    padding: 0 10px;
+}
+
+fluent-tabs:has(.large) fluent-tab {
+    font-size: var(--type-ramp-plus-1-font-size);
+    padding: 0 16px;
+}

--- a/src/Core/Components/Tabs/FluentTabs.razor.cs
+++ b/src/Core/Components/Tabs/FluentTabs.razor.cs
@@ -23,13 +23,14 @@ public partial class FluentTabs : FluentComponentBase
 
     /// <summary />
     protected string? ClassValue => new CssBuilder(Class)
+        .AddClass(Size.ToAttributeValue(), Size != TabSize.Small)
+        .AddClass(Orientation.ToAttributeValue(), Orientation == Orientation.Vertical)
         .Build();
 
     /// <summary />
     protected string? StyleValue => new StyleBuilder(Style)
-        .AddStyle("padding", "6px", () => Size == TabSize.Small)
-        .AddStyle("padding", "12px 10px", () => Size == TabSize.Medium)
-        .AddStyle("padding", "16px 10px", () => Size == TabSize.Large)
+        .AddStyle("--density", "2", () => Size == TabSize.Medium)
+        .AddStyle("--density", "4", () => Size == TabSize.Large)
         .AddStyle("width", Width, () => !string.IsNullOrEmpty(Width))
         .AddStyle("height", Height, () => !string.IsNullOrEmpty(Height))
         .Build();
@@ -79,7 +80,7 @@ public partial class FluentTabs : FluentComponentBase
     /// Gets or sets the width of the tab items.
     /// </summary>
     [Parameter]
-    public TabSize? Size { get; set; } = TabSize.Medium;
+    public TabSize? Size { get; set; } = TabSize.Small;
 
     /// <summary>
     /// Gets or sets the width of the tabs component.


### PR DESCRIPTION
This is a proper fix for #3325 

Default sample has been adapted to allow for sizing option:

![tabs-sizing](https://github.com/user-attachments/assets/33605fdb-fbd7-4bce-8390-c56d69c492d7)


`TabSize` default is changed from `Medium` to `Small` but as it was not working before anyway expected impact should be minimal.