### PR TITLE
[MAUI] Add DynamicDependency to right DesignTokenconstructor

### DIFF
--- a/src/Core/DesignTokens/DesignToken.razor.cs
+++ b/src/Core/DesignTokens/DesignToken.razor.cs
@@ -45,7 +45,6 @@ public partial class DesignToken<T> : ComponentBase, IDesignToken<T>, IAsyncDisp
     /// Constructs an instance of a DesignToken.
     /// </summary>
     [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Swatch))]
-
     public DesignToken()
     {
 
@@ -54,6 +53,7 @@ public partial class DesignToken<T> : ComponentBase, IDesignToken<T>, IAsyncDisp
     /// <summary>
     /// Constructs an instance of a DesignToken.
     /// </summary>
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Swatch))]
     public DesignToken(IJSRuntime jsRuntime, LibraryConfiguration libraryConfiguration)
     {
         JSRuntime = jsRuntime;


### PR DESCRIPTION
Fix #4004.  We already use the `[DynamicDependency]` attribute in the `DesignToken` class. Except it was only placed on the default constructor...

For v4.12.1, we are adding it to the non-default constructor as well. I've confirmed it is working now in the emulator:

<img width="574" height="1208" alt="Image" src="https://github.com/user-attachments/assets/f1a52f36-7d3b-4aa3-b03d-0263bb01805a" />

(before adding the code to the constructor, I got the error with a release build on the emulator as well)

