### PR TITLE
Update README with demo website certificate notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# ⚠️ Notice: We are experiencing possible certificate renewal issues for the demo website https://www.fluentui-blazor.net/.
+If you encounter any problems, you can use the backup site: http://fluentui-blazor.azurewebsites.net/
+
 # Microsoft Fluent UI Blazor library
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -164,7 +167,7 @@ The `app-name` attribute needs to match your app's assembly name - initializersL
 initializersLoader replaces standard `fetch` function with one which provides the correct file in place of the empty `blazor.modules.json`. `fetch` is restored to its original state once `_framework/blazor.modules.json` request is intercepted.
 
 For more information regarding the bug, see issue [15234](https://github.com/dotnet/maui/issues/15234) in the MAUI repo.
-	
+  
 ## Use the DataGrid component with EF Core or OData Client
 If you want to use the `<FluentDataGrid>` with data provided through EF Core or an OData Client, you need to install an additional package so the grid knows how to resolve queries asynchronously for efficiency.
 Please see the [DataGrid](https://www.fluentui-blazor.net/DataGrid) page for more information.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ⚠️ Notice: We are experiencing possible certificate renewal issues for the demo website https://www.fluentui-blazor.net/.
-If you encounter any problems, you can use the backup site: http://fluentui-blazor.azurewebsites.net/
+If you encounter any problems, you can use the backup site: https://fluentui-blazor.azurewebsites.net/
 
 # Microsoft Fluent UI Blazor library
 


### PR DESCRIPTION
Add a notice in the README about potential certificate renewal issues for the demo website and provide a backup site for users encountering problems.