### PR TITLE
[Property Column] Remove boxing when formatting the property.

### DIFF
--- a/src/Core/Components/DataGrid/Columns/PropertyColumn.cs
+++ b/src/Core/Components/DataGrid/Columns/PropertyColumn.cs
@@ -64,7 +64,7 @@ public class PropertyColumn<TGridItem, TProp> : ColumnBase<TGridItem>, IBindable
 
             if (!string.IsNullOrEmpty(Format))
             {
-                _cellTextFunc =  CreateFormatter(compiledPropertyExpression, Format);
+                _cellTextFunc = CreateFormatter(compiledPropertyExpression, Format);
             }
             else
             {
@@ -138,22 +138,19 @@ public class PropertyColumn<TGridItem, TProp> : ColumnBase<TGridItem>, IBindable
         throw new InvalidOperationException($"A '{nameof(Format)}' parameter was supplied, but the type '{typeof(TProp)}' does not implement '{typeof(IFormattable)}'.");
     }
 
-    private static Func<TGridItem, string?> CreateReferenceTypeFormatter<T>(
-    Func<TGridItem, T?> getter, string format)
-    where T : class, IFormattable
+    private static Func<TGridItem, string?> CreateReferenceTypeFormatter<T>(Func<TGridItem, T?> getter, string format)
+        where T : class, IFormattable
     {
         return item => getter(item)?.ToString(format, null);
     }
 
-    private static Func<TGridItem, string?> CreateValueTypeFormatter<T>(
-        Func<TGridItem, T> getter, string format)
+    private static Func<TGridItem, string?> CreateValueTypeFormatter<T>(Func<TGridItem, T> getter, string format)
         where T : struct, IFormattable
     {
         return item => getter(item).ToString(format, null);
     }
 
-    private static Func<TGridItem, string?> CreateNullableValueTypeFormatter<T>(
-        Func<TGridItem, T?> getter, string format)
+    private static Func<TGridItem, string?> CreateNullableValueTypeFormatter<T>(Func<TGridItem, T?> getter, string format)
         where T : struct, IFormattable
     {
         return item => getter(item)?.ToString(format, null);

--- a/src/Core/Components/DataGrid/Columns/PropertyColumn.cs
+++ b/src/Core/Components/DataGrid/Columns/PropertyColumn.cs
@@ -105,8 +105,7 @@ public class PropertyColumn<TGridItem, TProp> : ColumnBase<TGridItem>, IBindable
         }
     }
 
-    private static Func<TGridItem, string?> CreateFormatter(
-     Func<TGridItem, TProp> getter, string format)
+    private static Func<TGridItem, string?> CreateFormatter(Func<TGridItem, TProp> getter, string format)
     {
         var closedType = typeof(PropertyColumn<,>).MakeGenericType(typeof(TGridItem), typeof(TProp));
 

--- a/src/Core/Components/DataGrid/Columns/PropertyColumn.cs
+++ b/src/Core/Components/DataGrid/Columns/PropertyColumn.cs
@@ -131,6 +131,7 @@ public class PropertyColumn<TGridItem, TProp> : ColumnBase<TGridItem>, IBindable
                 return (Func<TGridItem, string?>)method.Invoke(null, [getter, format])!;
             }
 
+            //Double cast required because CreateReferenceTypeFormatter required the TProp to be a reference type which implements IFormattable.
             return CreateReferenceTypeFormatter((Func<TGridItem, IFormattable?>)(object)getter, format);
         }
 

--- a/src/Core/Components/DataGrid/Columns/PropertyColumn.cs
+++ b/src/Core/Components/DataGrid/Columns/PropertyColumn.cs
@@ -64,18 +64,7 @@ public class PropertyColumn<TGridItem, TProp> : ColumnBase<TGridItem>, IBindable
 
             if (!string.IsNullOrEmpty(Format))
             {
-                // TODO: Consider using reflection to avoid having to box every value just to call IFormattable.ToString
-                // For example, define a method "string Type<U>(Func<TGridItem, U> property) where U: IFormattable", and
-                // then construct the closed type here with U=TProp when we know TProp implements IFormattable
-
-                // If the type is nullable, we're interested in formatting the underlying type
-                var nullableUnderlyingTypeOrNull = Nullable.GetUnderlyingType(typeof(TProp));
-                if (!typeof(IFormattable).IsAssignableFrom(nullableUnderlyingTypeOrNull ?? typeof(TProp)))
-                {
-                    throw new InvalidOperationException($"A '{nameof(Format)}' parameter was supplied, but the type '{typeof(TProp)}' does not implement '{typeof(IFormattable)}'.");
-                }
-
-                _cellTextFunc = item => ((IFormattable?)compiledPropertyExpression!(item))?.ToString(Format, null);
+                _cellTextFunc =  CreateFormatter(compiledPropertyExpression, Format);
             }
             else
             {
@@ -87,10 +76,8 @@ public class PropertyColumn<TGridItem, TProp> : ColumnBase<TGridItem>, IBindable
                     {
                         return (value as Enum)?.GetDisplayName();
                     }
-                    else
-                    {
-                        return value?.ToString();
-                    }
+
+                    return value?.ToString();
                 };
             }
             if (Sortable.HasValue)
@@ -116,6 +103,62 @@ public class PropertyColumn<TGridItem, TProp> : ColumnBase<TGridItem>, IBindable
                 }
             }
         }
+    }
+
+    private static Func<TGridItem, string?> CreateFormatter(
+     Func<TGridItem, TProp> getter, string format)
+    {
+        var closedType = typeof(PropertyColumn<,>).MakeGenericType(typeof(TGridItem), typeof(TProp));
+
+        //Nullable struct
+        if (Nullable.GetUnderlyingType(typeof(TProp)) is Type underlying &&
+            typeof(IFormattable).IsAssignableFrom(underlying))
+        {
+            var method = closedType
+                .GetMethod(nameof(CreateNullableValueTypeFormatter), BindingFlags.NonPublic | BindingFlags.Static)!
+                .MakeGenericMethod(underlying);
+            return (Func<TGridItem, string?>)method.Invoke(null, [getter, format])!;
+        }
+
+
+        if (typeof(IFormattable).IsAssignableFrom(typeof(TProp)))
+        {
+            //Struct
+            if (typeof(TProp).IsValueType)
+            {
+                var method = closedType
+                    .GetMethod(nameof(CreateValueTypeFormatter), BindingFlags.NonPublic | BindingFlags.Static)!
+                    .MakeGenericMethod(typeof(TProp));
+                return (Func<TGridItem, string?>)method.Invoke(null, [getter, format])!;
+            }
+            else
+            {
+                return CreateReferenceTypeFormatter((Func<TGridItem, IFormattable?>)(object)getter, format);
+            }
+        }
+
+        throw new InvalidOperationException($"A '{nameof(Format)}' parameter was supplied, but the type '{typeof(TProp)}' does not implement '{typeof(IFormattable)}'.");
+    }
+
+    private static Func<TGridItem, string?> CreateReferenceTypeFormatter<T>(
+    Func<TGridItem, T?> getter, string format)
+    where T : class, IFormattable
+    {
+        return item => getter(item)?.ToString(format, null);
+    }
+
+    private static Func<TGridItem, string?> CreateValueTypeFormatter<T>(
+        Func<TGridItem, T> getter, string format)
+        where T : struct, IFormattable
+    {
+        return item => getter(item).ToString(format, null);
+    }
+
+    private static Func<TGridItem, string?> CreateNullableValueTypeFormatter<T>(
+        Func<TGridItem, T?> getter, string format)
+        where T : struct, IFormattable
+    {
+        return item => getter(item)?.ToString(format, null);
     }
 
     /// <inheritdoc />

--- a/src/Core/Components/DataGrid/Columns/PropertyColumn.cs
+++ b/src/Core/Components/DataGrid/Columns/PropertyColumn.cs
@@ -131,10 +131,8 @@ public class PropertyColumn<TGridItem, TProp> : ColumnBase<TGridItem>, IBindable
                     .MakeGenericMethod(typeof(TProp));
                 return (Func<TGridItem, string?>)method.Invoke(null, [getter, format])!;
             }
-            else
-            {
-                return CreateReferenceTypeFormatter((Func<TGridItem, IFormattable?>)(object)getter, format);
-            }
+
+            return CreateReferenceTypeFormatter((Func<TGridItem, IFormattable?>)(object)getter, format);
         }
 
         throw new InvalidOperationException($"A '{nameof(Format)}' parameter was supplied, but the type '{typeof(TProp)}' does not implement '{typeof(IFormattable)}'.");

--- a/tests/Core/PropertyColumn/PropertyColumnFormatterTests.razor
+++ b/tests/Core/PropertyColumn/PropertyColumnFormatterTests.razor
@@ -1,0 +1,57 @@
+﻿@using Xunit;
+@inherits TestContext
+@code
+{
+    [Fact]
+    public void PropertyGrid_Should_Format_ValueTypes()
+    {
+        var cut = Render(
+            @<FluentDataGrid Items="@People" TGridItem="Person">
+                <PropertyColumn Property="@(p => p.PersonId)" Format="D4" />
+            </FluentDataGrid>
+        );
+
+        var firstCellText = cut.Find("td").TextContent;
+        Assert.Equal("0001", firstCellText);
+    }
+
+    [Fact]
+    public void PropertyGrid_Should_Format_NullableValueTypes()
+    {
+        var cut = Render(
+            @<FluentDataGrid Items="@People" TGridItem="Person">
+                <PropertyColumn Property="@(p => p.BirthDate)" Format="m" />
+            </FluentDataGrid>
+        );
+
+        var firstCellText = cut.Find("td").TextContent;
+        Assert.Equal(_people[0].BirthDate!.Value.ToString("m"), firstCellText);
+    }
+
+    [Fact]
+    public void PropertyGrid_Should_Format_ReferenceTypes()
+    {
+        var cut = Render(
+            @<FluentDataGrid Items="@People" TGridItem="Person">
+                <PropertyColumn Property="@(p => p.Name)" Format="{0} test" />
+            </FluentDataGrid>
+        );
+
+        var firstCellText = cut.Find("td").TextContent;
+        Assert.Equal(string.Format("{0} test", _people[0].Name), firstCellText);
+    }
+
+
+    [Fact]
+    public void PropertyGrid_Should_Throw_When_FormatUsedOnNonFormattableProperty()
+    {
+        Assert.Throws<InvalidOperationException>(() => Render(
+            @<FluentDataGrid Items="@People" TGridItem="Person">
+                <PropertyColumn Property="@(p => p.NickName)" Format="{0} test" />
+            </FluentDataGrid>
+        ));
+    }
+
+    
+}
+

--- a/tests/Core/PropertyColumn/PropertyColumnFormatterTests.razor.cs
+++ b/tests/Core/PropertyColumn/PropertyColumnFormatterTests.razor.cs
@@ -1,0 +1,41 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Tests.PropertyColumn;
+public partial class PropertyColumnFormatterTests
+{
+    private protected record Person(int PersonId, CustomFormattable Name, DateOnly? BirthDate, string NickName)
+    {
+        public bool Selected { get; set; }
+    };
+
+    private protected class CustomFormattable : IFormattable
+    {
+        private readonly string _value;
+        public CustomFormattable(string value) => _value = value;
+        public string ToString(string? format, IFormatProvider? provider) =>
+            string.IsNullOrEmpty(format) ? _value : string.Format(format, _value);
+    }
+
+    private readonly IList<Person> _people =
+    [
+        new Person(1, new("Jean Martin"), new DateOnly(1985, 3, 16), string.Empty),
+        new Person(2, new("Kenji Sato"), new DateOnly(2004, 1, 9), string.Empty),
+        new Person(3, new("Julie Smith"), new DateOnly(1958, 10, 10), string.Empty),
+    ];
+
+    private protected IQueryable<Person> People => _people.AsQueryable();
+
+    public PropertyColumnFormatterTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddSingleton(LibraryConfiguration.ForUnitTests);
+
+        var keycodeService = new KeyCodeService();
+        Services.AddScoped<IKeyCodeService>(factory => keycodeService);
+    }
+}


### PR DESCRIPTION
# Pull Request

## 📖 Description

This pr will remove the TODO from the property column about boxing value types when using a format.


## 📑 Test Plan

Added test cases for each type of format (nullable value types, value types and reference types).
Also added test to check if exception is thrown.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component
