### PR TITLE
[FluentKeyCode] Fix DisposeAsync issue in MAUI

### DIFF
--- a/src/Core/Components/KeyCode/FluentKeyCode.razor.cs
+++ b/src/Core/Components/KeyCode/FluentKeyCode.razor.cs
@@ -197,7 +197,8 @@ public partial class FluentKeyCode : IAsyncDisposable
             }
         }
         catch (Exception ex) when (ex is JSDisconnectedException ||
-                                   ex is OperationCanceledException)
+                                   ex is OperationCanceledException||
+                                   ex is JSException)
         {
             // The JSRuntime side may routinely be gone already if the reason we're disposing is that
             // the client disconnected. This is not an error.

--- a/src/Core/Components/KeyCode/FluentKeyCode.razor.cs
+++ b/src/Core/Components/KeyCode/FluentKeyCode.razor.cs
@@ -197,7 +197,7 @@ public partial class FluentKeyCode : IAsyncDisposable
             }
         }
         catch (Exception ex) when (ex is JSDisconnectedException ||
-                                   ex is OperationCanceledException||
+                                   ex is OperationCanceledException ||
                                    ex is JSException)
         {
             // The JSRuntime side may routinely be gone already if the reason we're disposing is that

--- a/src/Core/Components/KeyCode/FluentKeyCode.razor.js
+++ b/src/Core/Components/KeyCode/FluentKeyCode.razor.js
@@ -77,19 +77,24 @@ export function RegisterKeyCode(globalDocument, eventNames, id, elementRef, only
 }
 
 export function UnregisterKeyCode(eventId) {
+    if (!document.fluentKeyCodeEvents) {
+        return;
+    }
 
-    if (document.fluentKeyCodeEvents != null) {
-        const keyEvent = document.fluentKeyCodeEvents[eventId];
-        const element = keyEvent.source;
+    const keyEvent = document.fluentKeyCodeEvents[eventId];
+    if (!keyEvent) {
+        return;
+    }
 
-        if (!!keyEvent.handlerKeydown) {
+    const element = keyEvent.source;
+    if (element) {
+        if (keyEvent.handlerKeydown) {
             element.removeEventListener("keydown", keyEvent.handlerKeydown);
         }
-
-        if (!!keyEvent.handlerKeyup) {
+        if (keyEvent.handlerKeyup) {
             element.removeEventListener("keyup", keyEvent.handlerKeyup);
         }
-
-        delete document.fluentKeyCodeEvents[eventId];
     }
+
+    delete document.fluentKeyCodeEvents[eventId];
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

Fixes JSException being thrown in `DIsposeAsync` in `FluentKeyCode`.

### 🎫 Issues

Fix: #4087 

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [ ] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

