### PR TITLE
[dev-v5] Fix documentation for Avatar and Badge components

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Avatar/FluentAvatar.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Avatar/FluentAvatar.md
@@ -3,7 +3,7 @@ title: Avatar
 route: /Avatar
 ---
 
-# Avatar 
+# Avatar
 
 The `Avatar` component is used to represent a user or entity. It can display an image, initials, or an icon.
 
@@ -71,6 +71,6 @@ You can provide an `Icon` to replace the default icon in the `FluentAvatar` when
 
 {{ FluentAvatarIcon }}
 
-## API FluentButton
+## API FluentAvatar
 
 {{ API Type=FluentAvatar }}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Badge/FluentBadge.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Badge/FluentBadge.md
@@ -37,10 +37,10 @@ There are two actions authors should consider taking when using Badge to improve
             Inbox
         </FluentButton>
     </FluentBadge>
-    ```     
+    ```
 
 ### Badge shouldn't rely only on color information
-Include meaningful descriptions when using color to represent meaning in a badge. If relying on color only, ensure that non-visual information is included in the parent's label or description. 
+Include meaningful descriptions when using color to represent meaning in a badge. If relying on color only, ensure that non-visual information is included in the parent's label or description.
 
 ### Text on Badge
 Badges are intented to have short text, small numerical values or status information. Long text is not supported and should not be used within a Badge.
@@ -84,7 +84,7 @@ The badge size be set to a value from  the `BadgeSize` enumeration.
 
 {{ BadgeSizes }}
 
-## API FluentButton
+## API FluentBadge
 
 {{ API Type=FluentBadge }}
 


### PR DESCRIPTION
# [dev-v5] Fix documentation for Avatar and Badge components
Fix documentation formatting and update API section titles for Avatar and Badge components

See #4119