### PR TITLE
[Docs] Use https instead of http for GitHub link

### DIFF
--- a/examples/Demo/Shared/Shared/DemoMainLayout.razor
+++ b/examples/Demo/Shared/Shared/DemoMainLayout.razor
@@ -37,7 +37,7 @@
 
             <div class="links">
                 <FluentAnchor Appearance="Appearance.Hypertext"
-                              Href="http://github.com/microsoft/fluentui-blazor" Target="_blank" Rel="noreferrer noopener"
+                              Href="https://github.com/microsoft/fluentui-blazor" Target="_blank" Rel="noreferrer noopener"
                               title="Fluent UI Blazor library source on GitHub" aria-label="Fluent UI Blazor library source on GitHub">
                     <FluentIcon Value="@(new DemoIcons.Size20.GitHub())" Color="Color.FillInverse" />
                 </FluentAnchor>


### PR DESCRIPTION
# Pull Request

## 📖 Description

Found this one while doing some work on the community project. 

This PR simply updates the GitHub link to https.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [ ] I have modified an existing component
- [ ] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component
