### PR TITLE
[Inputs] Fix wrong active size for mobile devices

### DIFF
--- a/src/Core.Assets/src/index.ts
+++ b/src/Core.Assets/src/index.ts
@@ -1,4 +1,4 @@
-export * from '@fluentui/web-components/dist/web-components'
+﻿export * from '@fluentui/web-components/dist/web-components'
 export { parseColorHexRGB } from '@microsoft/fast-colors'
 
 import { accentBaseColor, neutralBaseColor, SwatchRGB, } from '@fluentui/web-components/dist/web-components'
@@ -73,6 +73,15 @@ fluent-combobox::part(selected-value),
 fluent-number-field::part(control)
 {
     letter-spacing: inherit;
+}
+
+fluent-text-area:not([disabled]):active::after,
+fluent-text-field:not([disabled]):active::after,
+fluent-search:not([disabled]):active::after,
+fluent-combobox:not([disabled]):active::after,
+fluent-number-field:not([disabled]):active::after
+{
+	width: 100%; /* Fixes :active misplacement for touch devices */
 }
 `;
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR fixes the active indicator size on mobile devices for

- FluentTextArea
- FluentTextField
- FluentSearch
- FluentComboBox
- FluentNumberField

Before:
<img width="1092" height="701" alt="before" src="https://github.com/user-attachments/assets/9c99165f-8309-4249-b69e-59fbed88f8b5" />

After:
<img width="1000" height="685" alt="after" src="https://github.com/user-attachments/assets/17cafb5d-63de-4d00-84d0-878f9f040b9a" />


### 🎫 Issues

Fix #4073

## 👩‍💻 Reviewer Notes

This was only really visible on touch devices.

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
