### PR TITLE
[Dialog] Return focus to element when dialog is closed

### DIFF
--- a/src/Core.Scripts/src/Components/Dialog/FluentDialog.ts
+++ b/src/Core.Scripts/src/Components/Dialog/FluentDialog.ts
@@ -4,9 +4,11 @@ export namespace Microsoft.FluentUI.Blazor.Components.Dialog {
    * Display the fluent-dialog with the given id
    * @param id The id of the fluent-dialog to display
    */
-  export function Show(id: string): void {
+  export function Show(id: string): HTMLElement | null {
+    const previousElement = document.activeElement as HTMLElement;
     const dialog = document.getElementById(id) as any;
     dialog?.show();
+    return previousElement;
   }
 
   /**
@@ -16,5 +18,11 @@ export namespace Microsoft.FluentUI.Blazor.Components.Dialog {
   export function Hide(id: string): void {
     const dialog = document.getElementById(id) as any;
     dialog?.hide();
+  }
+
+  export function FocusPreviousElement(element: HTMLElement): void {
+    if (element) {
+      element.focus();
+    }
   }
 }

--- a/src/Core/Components/Dialog/FluentDialog.razor.cs
+++ b/src/Core/Components/Dialog/FluentDialog.razor.cs
@@ -12,7 +12,7 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 
 /// <summary>
 /// The dialog component is a window overlaid on either the primary window or another dialog window.
-/// Windows under a modal dialog are inert. 
+/// Windows under a modal dialog are inert.
 /// </summary>
 public partial class FluentDialog : FluentComponentBase
 {
@@ -76,11 +76,11 @@ public partial class FluentDialog : FluentComponentBase
     public EventCallback<DialogEventArgs> OnStateChange { get; set; }
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     /// <param name="firstRender"></param>
     /// <returns></returns>
-    protected override Task OnAfterRenderAsync(bool firstRender)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender && LaunchedFromService)
         {
@@ -90,10 +90,15 @@ public partial class FluentDialog : FluentComponentBase
                 instance.FluentDialog = this;
             }
 
-            return ShowAsync();
+            var pfe = await ShowAsync();
+
+            if (instance is not null)
+            {
+                instance.PreviouslyFocusedElement = pfe;
+            }
         }
 
-        return Task.CompletedTask;
+        return;
     }
 
     /// <summary />
@@ -145,9 +150,9 @@ public partial class FluentDialog : FluentComponentBase
     /// Displays the dialog.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public async Task ShowAsync()
+    public async Task<IJSObjectReference> ShowAsync()
     {
-        await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Components.Dialog.Show", Id);
+        return await JSRuntime.InvokeAsync<IJSObjectReference>("Microsoft.FluentUI.Blazor.Components.Dialog.Show", Id);
     }
 
     /// <summary>
@@ -157,6 +162,20 @@ public partial class FluentDialog : FluentComponentBase
     public async Task HideAsync()
     {
         await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Components.Dialog.Hide", Id);
+    }
+
+    /// <summary>
+    /// Set the focus back to the element that had focus before the dialog was opened.
+    /// </summary>
+    /// <returns></returns>
+    [ExcludeFromCodeCoverage]
+    public async Task FocusPreviousElementAsync()
+    {
+        if (Instance?.PreviouslyFocusedElement is not null)
+        {
+            await Task.Delay(50);
+            await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Components.Dialog.FocusPreviousElement", Instance.PreviouslyFocusedElement);
+        }
     }
 
     /// <summary />

--- a/src/Core/Components/Dialog/Services/DialogInstance.cs
+++ b/src/Core/Components/Dialog/Services/DialogInstance.cs
@@ -3,6 +3,7 @@
 // ------------------------------------------------------------------------
 
 using Microsoft.FluentUI.AspNetCore.Components.Utilities;
+using Microsoft.JSInterop;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
@@ -39,6 +40,9 @@ public class DialogInstance : IDialogInstance
 
     /// <inheritdoc cref="IDialogInstance.Result"/>
     public Task<DialogResult> Result => ResultCompletion.Task;
+
+    /// <inheritdoc cref="IDialogInstance.PreviouslyFocusedElement"/>"
+    public IJSObjectReference? PreviouslyFocusedElement { get; set; }
 
     /// <inheritdoc cref="IDialogInstance.Id"/>"
     public string Id { get; }

--- a/src/Core/Components/Dialog/Services/DialogService.cs
+++ b/src/Core/Components/Dialog/Services/DialogService.cs
@@ -3,6 +3,7 @@
 // ------------------------------------------------------------------------
 
 using System.Diagnostics.CodeAnalysis;
+
 using Microsoft.AspNetCore.Components;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
@@ -47,6 +48,9 @@ public partial class DialogService : FluentServiceBase<IDialogInstance>, IDialog
 
         // Raise the DialogState.Closed event
         dialogInstance?.FluentDialog?.RaiseOnStateChangeAsync(dialog, DialogState.Closed);
+
+        //Focus the previously focused element (if any)
+        dialogInstance?.FluentDialog?.FocusPreviousElementAsync();
     }
 
     /// <inheritdoc cref="IDialogService.ShowDialogAsync(Type, DialogOptions)"/>

--- a/src/Core/Components/Dialog/Services/IDialogInstance.cs
+++ b/src/Core/Components/Dialog/Services/IDialogInstance.cs
@@ -2,6 +2,8 @@
 // This file is licensed to you under the MIT License.
 // ------------------------------------------------------------------------
 
+using Microsoft.JSInterop;
+
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 /// <summary>
@@ -13,6 +15,11 @@ public interface IDialogInstance
     /// Gets the component type of the dialog.
     /// </summary>
     internal Type ComponentType { get; }
+
+    /// <summary>
+    /// Holds a reference to the previously focused element (before the dialog was opened).
+    /// </summary>
+    IJSObjectReference? PreviouslyFocusedElement { get; set; }
 
     /// <summary>
     /// Gets the unique identifier for the dialog.


### PR DESCRIPTION
This is an implementation of #4095 for V5. It works by capturing a reference to the focused element when `FluentDialog.ShowAsync()` is called and setting back the focus to that element at the end of the `DialogService.CloseAsync()` call.

Displaying the dialog is done in a method that has `[ExcludeFromCodeCoverage]` set so I don't think there are tests that need to be added