### PR TITLE
[General] Re-add net10.0 TFM and update to latest SDKs/NuGet packages

### DIFF
--- a/.github/workflows/build-core-lib.yml
+++ b/.github/workflows/build-core-lib.yml
@@ -25,7 +25,7 @@ on:
 env:
   PROJECTS: "./src/Core/Microsoft.FluentUI.AspNetCore.Components.csproj"
   TESTS: "./tests/Core/Microsoft.FluentUI.AspNetCore.Components.Tests.csproj"
-  DOTNET_VERSION: "net9.0"
+  DOTNET_VERSION: "net10.0"
 
 jobs:
   Build:

--- a/.github/workflows/build-core-lib.yml
+++ b/.github/workflows/build-core-lib.yml
@@ -134,7 +134,7 @@ jobs:
      - name: Report Generator
        uses: danielpalme/ReportGenerator-GitHub-Action@5.2.4
        with:
-         reports: '**/coverage.cobertura.xml;**/coverage.net8.0.cobertura.xml;**/coverage.net9.0.cobertura.xml;**/coverage.ne10.0.cobertura.xml'
+         reports: '**/coverage.cobertura.xml;**/coverage.net8.0.cobertura.xml;**/coverage.net9.0.cobertura.xml;**/coverage.net10.0.cobertura.xml'
          targetdir: 'CoverageReports'
          title: 'Unit Tests Code Coverage'
          classfilters: '-Microsoft.FluentUI.AspNetCore.Components.DesignTokens.*'

--- a/.github/workflows/build-core-lib.yml
+++ b/.github/workflows/build-core-lib.yml
@@ -48,17 +48,17 @@ jobs:
      #    dotnet-version: 8.0.x
      #    dotnet-quality: ga
 
-     - name: Setup .NET 9.0
-       uses: actions/setup-dotnet@v4
-       with:
-        dotnet-version: 9.0.x
-        dotnet-quality: ga
-
-     # - name: Setup .NET 10.0
+     # - name: Setup .NET 9.0
      #   uses: actions/setup-dotnet@v4
      #   with:
-     #    dotnet-version: 10.0.x
-     #    dotnet-quality: preview
+     #    dotnet-version: 9.0.x
+     #    dotnet-quality: ga
+
+     - name: Setup .NET 10.0
+       uses: actions/setup-dotnet@v4
+       with:
+        dotnet-version: 10.0.x
+        dotnet-quality: preview
 
      # Build
 

--- a/.github/workflows/build-core-lib.yml
+++ b/.github/workflows/build-core-lib.yml
@@ -51,8 +51,8 @@ jobs:
      - name: Setup .NET 9.0
        uses: actions/setup-dotnet@v4
        with:
-        dotnet-version: 9.0.205
-        # dotnet-quality: ga
+        dotnet-version: 9.0.x
+        dotnet-quality: ga
 
      # - name: Setup .NET 10.0
      #   uses: actions/setup-dotnet@v4

--- a/.github/workflows/build-core-lib.yml
+++ b/.github/workflows/build-core-lib.yml
@@ -134,7 +134,7 @@ jobs:
      - name: Report Generator
        uses: danielpalme/ReportGenerator-GitHub-Action@5.2.4
        with:
-         reports: '**/coverage.cobertura.xml;**/coverage.net8.0.cobertura.xml;**/coverage.net9.0.cobertura.xml'
+         reports: '**/coverage.cobertura.xml;**/coverage.net8.0.cobertura.xml;**/coverage.net9.0.cobertura.xml;**/coverage.ne10.0.cobertura.xml'
          targetdir: 'CoverageReports'
          title: 'Unit Tests Code Coverage'
          classfilters: '-Microsoft.FluentUI.AspNetCore.Components.DesignTokens.*'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,7 +41,8 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.0.205
+        dotnet-version: 9.0.x
+        dotnet-quality: ga
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/deploy_demo.yml
+++ b/.github/workflows/deploy_demo.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and deploy Demo site
     env:
-      DOTNET_VERSION: "net9.0"
+      DOTNET_VERSION: "net10.0"
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_NOLOGO: true

--- a/.github/workflows/deploy_demo.yml
+++ b/.github/workflows/deploy_demo.yml
@@ -37,17 +37,17 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
-      - name: .NET Setup SDKs
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 9.0.x
-          dotnet-quality: ga
-
-      # - name: Setup .NET 10.0
+      # - name: .NET Setup SDKs
       #   uses: actions/setup-dotnet@v4
       #   with:
-      #     dotnet-version: 10.0.x
-      #     dotnet-quality: preview
+      #     dotnet-version: 9.0.x
+      #     dotnet-quality: ga
+
+      - name: Setup .NET 10.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+          dotnet-quality: preview
 
       - name: NPM Install
         uses: actions/setup-node@v4

--- a/.github/workflows/deploy_demo.yml
+++ b/.github/workflows/deploy_demo.yml
@@ -40,8 +40,8 @@ jobs:
       - name: .NET Setup SDKs
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 9.0.205
-          # dotnet-quality: ga
+          dotnet-version: 9.0.x
+          dotnet-quality: ga
 
       # - name: Setup .NET 10.0
       #   uses: actions/setup-dotnet@v4

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and deploy Demo site
     env:
-      DOTNET_VERSION: "net9.0"
+      DOTNET_VERSION: "net10.0"
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_NOLOGO: true
@@ -38,17 +38,17 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
-      - name: .NET Setup SDKs
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 9.0.205
-          # dotnet-quality: ga
-
-      # - name: Setup .NET 10.0
+      # - name: .NET Setup SDKs
       #   uses: actions/setup-dotnet@v4
       #   with:
-      #     dotnet-version: 10.0.x
-      #     dotnet-quality: preview
+      #     dotnet-version: 9.0.205
+      #     dotnet-quality: ga
+
+      - name: Setup .NET 10.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+          dotnet-quality: preview
 
       - name: NPM Install
         uses: actions/setup-node@v4

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,14 +2,14 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <RuntimeVersion8>8.0.0</RuntimeVersion8>
-    <AspNetCoreVersion8>8.0.18</AspNetCoreVersion8>
-    <EfCoreVersion8>8.0.18</EfCoreVersion8>
-    <RuntimeVersion9>9.0.7</RuntimeVersion9>
-    <AspNetCoreVersion9>9.0.7</AspNetCoreVersion9>
-    <EfCoreVersion9>9.0.7</EfCoreVersion9>
-    <RuntimeVersion10>10.0.0-preview.6.25358.103</RuntimeVersion10>
-    <AspNetCoreVersion10>10.0.0-preview.6.25358.103</AspNetCoreVersion10>
-    <EfCoreVersion10>10.0.0-preview.6.25358.103</EfCoreVersion10>
+    <AspNetCoreVersion8>8.0.20</AspNetCoreVersion8>
+    <EfCoreVersion8>8.0.20</EfCoreVersion8>
+    <RuntimeVersion9>9.0.9</RuntimeVersion9>
+    <AspNetCoreVersion9>9.0.9</AspNetCoreVersion9>
+    <EfCoreVersion9>9.0.9</EfCoreVersion9>
+    <RuntimeVersion10>10.0.0-rc.1.25451.107</RuntimeVersion10>
+    <AspNetCoreVersion10>10.0.0-rc.1.25451.107</AspNetCoreVersion10>
+    <EfCoreVersion10>10.0.0-rc.1.25451.107</EfCoreVersion10>
   </PropertyGroup>
   <ItemGroup>
     <!-- For Sample Apps -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,27 +14,27 @@
   <ItemGroup>
     <!-- For Sample Apps -->
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.12.0" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" version="4.12.0" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="4.12.0" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" version="4.12.1" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="4.12.1" />
     <!-- Test dependencies -->
     <PackageVersion Include="bunit" Version="1.38.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <!-- Shared dependencies -->
-    <PackageVersion Include="Markdig.Signed" Version="0.41.0" />
+    <PackageVersion Include="Markdig.Signed" Version="0.41.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
-    <PackageVersion Include="Microsoft.OData.Client" Version="8.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.OData.Client" Version="8.4.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" />
     <PackageVersion Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="$(RuntimeVersion8)" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="$(RuntimeVersion8)" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.6" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net8.0'">
     <!-- Build dependencies -->

--- a/Microsoft.FluentUI.sln
+++ b/Microsoft.FluentUI.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.7.33808.371
+# Visual Studio Version 18
+VisualStudioVersion = 18.0.11010.61 d18.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{141FEF3E-C665-4D50-8E51-B9507C98040E}"
 EndProject

--- a/eng/pipelines/build-all-lib.yml
+++ b/eng/pipelines/build-all-lib.yml
@@ -131,7 +131,7 @@ extends:
         - task: UseDotNet@2
           displayName: 'Install .NET 9.0'
           inputs:
-            version: 9.0.205
+            version: 9.0.x
             includePreviewVersions: false
 
         - task: UseDotNet@2

--- a/eng/pipelines/build-core-lib.yml
+++ b/eng/pipelines/build-core-lib.yml
@@ -164,7 +164,7 @@ extends:
         - task: UseDotNet@2
           displayName: 'Install .NET 9.0'
           inputs:
-            version: 9.0.205
+            version: 9.0.x
             includePreviewVersions: false
 
         - task: UseDotNet@2

--- a/examples/Demo/AssetExplorer/FluentUI.Demo.AssetExplorer.csproj
+++ b/examples/Demo/AssetExplorer/FluentUI.Demo.AssetExplorer.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/examples/Demo/Client/FluentUI.Demo.Client.csproj
+++ b/examples/Demo/Client/FluentUI.Demo.Client.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>latest</LangVersion>

--- a/examples/Demo/Server/FluentUI.Demo.Server.csproj
+++ b/examples/Demo/Server/FluentUI.Demo.Server.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-      <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+      <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>latest</LangVersion>

--- a/examples/Demo/Shared/FluentUI.Demo.Shared.csproj
+++ b/examples/Demo/Shared/FluentUI.Demo.Shared.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
 	<PropertyGroup>
-      <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+      <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>latest</LangVersion>

--- a/global.bak
+++ b/global.bak
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.301",
+    "version": "9.0.305",
     "allowPrerelease": true,
     "rollForward": "latestPatch"
   }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,0 @@
-{
-  "sdk": {
-    "version": "9.0.205",
-    "allowPrerelease": true,
-    "rollForward": "latestPatch"
-  }
-}

--- a/src/Core/Microsoft.FluentUI.AspNetCore.Components.csproj
+++ b/src/Core/Microsoft.FluentUI.AspNetCore.Components.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <PackageId>Microsoft.FluentUI.AspNetCore.Components</PackageId>
 
     <Summary>A Blazor component library leveraging Microsoft’s Fluent Design System UI. Use the look of modern Microsoft products in your Blazor applications</Summary>

--- a/src/Extensions/DataGrid.EntityFrameworkAdapter/Microsoft.FluentUI.AspNetCore.Components.DataGrid.EntityFrameworkAdapter.csproj
+++ b/src/Extensions/DataGrid.EntityFrameworkAdapter/Microsoft.FluentUI.AspNetCore.Components.DataGrid.EntityFrameworkAdapter.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <PackageId>Microsoft.FluentUI.AspNetCore.Components.DataGrid.EntityFrameworkAdapter</PackageId>
     <Authors>Microsoft</Authors>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>

--- a/src/Extensions/DataGrid.ODataAdapter/Microsoft.FluentUI.AspNetCore.Components.DataGrid.ODataAdapter.csproj
+++ b/src/Extensions/DataGrid.ODataAdapter/Microsoft.FluentUI.AspNetCore.Components.DataGrid.ODataAdapter.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <PackageId>Microsoft.FluentUI.AspNetCore.Components.DataGrid.ODataAdapter</PackageId>
     <Authors>Microsoft</Authors>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>

--- a/src/Templates/templates/blazorweb-csharp-10/.template.config/dotnetcli.host.json
+++ b/src/Templates/templates/blazorweb-csharp-10/.template.config/dotnetcli.host.json
@@ -53,6 +53,10 @@
     "UseProgramMain": {
       "longName": "use-program-main",
       "shortName": ""
+    },
+    "LocalhostTld": {
+      "longName": "localhost-tld",
+      "shortName": ""
     }
   },
   "usageExamples": [

--- a/src/Templates/templates/blazorweb-csharp-10/.template.config/ide.host.json
+++ b/src/Templates/templates/blazorweb-csharp-10/.template.config/ide.host.json
@@ -25,6 +25,12 @@
       "isVisible": true,
       "persistenceScope": "shared",
       "persistenceScopeName": "Microsoft"
+    },
+    {
+      "id": "LocalhostTld",
+      "isVisible": true,
+      "persistenceScope": "shared",
+      "persistenceScopeName": "Microsoft"
     }
   ]
 }

--- a/src/Templates/templates/blazorweb-csharp-10/.template.config/localize/templatestrings.cs.json
+++ b/src/Templates/templates/blazorweb-csharp-10/.template.config/localize/templatestrings.cs.json
@@ -39,6 +39,8 @@
   "symbols/NoHttps/description": "Určuje, jestli se má vypnout protokol HTTPS. Tato možnost platí jenom v případě, že se pro --auth nepoužívá jednotlivec.",
   "symbols/UseProgramMain/displayName": "Nepoužívat _příkazy nejvyšší úrovně",
   "symbols/UseProgramMain/description": "Určuje, jestli se má místo příkazů nejvyšší úrovně generovat explicitní třída Program a metoda Main.",
+  "symbols/LocalhostTld/displayName": "Použití TLD .dev.localhost v adrese URL aplikace",
+  "symbols/LocalhostTld/description": "Určuje, jestli se má název projektu zkombinovat s TLD .dev.localhost v adrese URL aplikace pro místní vývoj, například https://myapp.dev.localhost:12345.",
   "postActions/restore/description": "Obnoví balíčky NuGet vyžadované tímto projektem.",
   "postActions/restore/manualInstructions/default/text": "Spustit dotnet restore"
 }

--- a/src/Templates/templates/blazorweb-csharp-10/.template.config/localize/templatestrings.de.json
+++ b/src/Templates/templates/blazorweb-csharp-10/.template.config/localize/templatestrings.de.json
@@ -39,6 +39,8 @@
   "symbols/NoHttps/description": "Ob HTTPS deaktiviert werden soll. Diese Option gilt nur, wenn \"Individual\" nicht für \"--auth\" verwendet wird.",
   "symbols/UseProgramMain/displayName": "Keine Anweisungen_der obersten Ebene verwenden",
   "symbols/UseProgramMain/description": "Gibt an, ob anstelle von Anweisungen der obersten Ebene eine explizite Programmklasse und eine Main-Methode generiert werden soll.",
+  "symbols/LocalhostTld/displayName": "Verwenden der .dev.localhost-TLD in der Anwendungs-URL",
+  "symbols/LocalhostTld/description": "Gibt an, ob der Projektname mit der .dev.localhost-TLD in der Anwendungs-URL für die lokale Entwicklung kombiniert werden soll, z. B. https://myapp.dev.localhost:12345.",
   "postActions/restore/description": "„NuGet-Pakete“ wiederherstellen, die für dieses Projekt erforderlich sind.",
   "postActions/restore/manualInstructions/default/text": "„dotnet restore“ ausführen"
 }

--- a/src/Templates/templates/blazorweb-csharp-10/.template.config/localize/templatestrings.en.json
+++ b/src/Templates/templates/blazorweb-csharp-10/.template.config/localize/templatestrings.en.json
@@ -39,6 +39,8 @@
   "symbols/NoHttps/description": "Whether to turn off HTTPS. This option only applies if Individual isn't used for --auth.",
   "symbols/UseProgramMain/displayName": "Do not use _top-level statements",
   "symbols/UseProgramMain/description": "Whether to generate an explicit Program class and Main method instead of top-level statements.",
+  "symbols/LocalhostTld/displayName": "Use the .dev.localhost TLD in the application URL",
+  "symbols/LocalhostTld/description": "Whether to combine the project name with the .dev.localhost TLD in the application URL for local development, e.g. https://myapp.dev.localhost:12345.",
   "postActions/restore/description": "Restore NuGet packages required by this project.",
   "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'"
 }

--- a/src/Templates/templates/blazorweb-csharp-10/.template.config/localize/templatestrings.es.json
+++ b/src/Templates/templates/blazorweb-csharp-10/.template.config/localize/templatestrings.es.json
@@ -39,6 +39,8 @@
   "symbols/NoHttps/description": "Si se va a desactivar HTTPS. Esta opción solo se aplica si individual no se usa para --auth.",
   "symbols/UseProgramMain/displayName": "No usar instrucciones de _nivel superior",
   "symbols/UseProgramMain/description": "Indica si se debe generar una clase Program explícita y un método Main en lugar de instrucciones de nivel superior.",
+  "symbols/LocalhostTld/displayName": "Usar el TLD .dev.localhost en la dirección URL de la aplicación",
+  "symbols/LocalhostTld/description": "Indica si se debe combinar el nombre del proyecto con el TLD .dev.localhost en la dirección URL de la aplicación para el desarrollo local, por ejemplo, https://myapp.dev.localhost:12345.",
   "postActions/restore/description": "Restaure los paquetes NuGet necesarios para este proyecto.",
   "postActions/restore/manualInstructions/default/text": "Ejecutar \"dotnet restore\""
 }

--- a/src/Templates/templates/blazorweb-csharp-10/.template.config/localize/templatestrings.fr.json
+++ b/src/Templates/templates/blazorweb-csharp-10/.template.config/localize/templatestrings.fr.json
@@ -39,6 +39,8 @@
   "symbols/NoHttps/description": "Indique s’il faut désactiver HTTPS. Cette option s’applique uniquement si Individual n’est pas utilisé pour --auth.",
   "symbols/UseProgramMain/displayName": "N’utilisez pas _d’instructions de niveau supérieur.",
   "symbols/UseProgramMain/description": "Indique s’il faut générer une classe Programme explicite et une méthode Main au lieu d’instructions de niveau supérieur.",
+  "symbols/LocalhostTld/displayName": "Utilisez le TLD .dev.localhost dans l’URL de l’application",
+  "symbols/LocalhostTld/description": "Indique s’il faut combiner le nom du projet avec le TLD .dev.localhost dans l’URL de l’application pour le développement local, par exemple https://myapp.dev.localhost:12345.",
   "postActions/restore/description": "Restaurez les packages NuGet requis par ce projet.",
   "postActions/restore/manualInstructions/default/text": "Exécuter « dotnet restore »"
 }

--- a/src/Templates/templates/blazorweb-csharp-10/.template.config/localize/templatestrings.it.json
+++ b/src/Templates/templates/blazorweb-csharp-10/.template.config/localize/templatestrings.it.json
@@ -39,6 +39,8 @@
   "symbols/NoHttps/description": "Indica se disattivare HTTPS. Questa opzione si applica solo se Individual non viene usata per --auth.",
   "symbols/UseProgramMain/displayName": "Non usare_istruzioni di primo livello",
   "symbols/UseProgramMain/description": "Indica se generare una classe Program esplicita e un metodo Main anziché istruzioni di primo livello.",
+  "symbols/LocalhostTld/displayName": "Usa il TLD .dev.localhost nell'URL dell'applicazione",
+  "symbols/LocalhostTld/description": "Indicare se combinare il nome del progetto con il TLD .dev.localhost nell'URL dell'applicazione per lo sviluppo in locale, ad esempio https://myapp.dev.localhost:12345.",
   "postActions/restore/description": "Ripristina i pacchetti NuGet richiesti da questo progetto.",
   "postActions/restore/manualInstructions/default/text": "Esegui 'dotnet restore'"
 }

--- a/src/Templates/templates/blazorweb-csharp-10/.template.config/localize/templatestrings.ja.json
+++ b/src/Templates/templates/blazorweb-csharp-10/.template.config/localize/templatestrings.ja.json
@@ -39,6 +39,8 @@
   "symbols/NoHttps/description": "HTTPS をオフにするかどうか。このオプションは、Individual が --auth に使用されていない場合にのみ適用されます。",
   "symbols/UseProgramMain/displayName": "最上位レベルのステートメントを使用しない(_T)",
   "symbols/UseProgramMain/description": "最上位レベルのステートメントではなく、明示的な Program クラスと Main メソッドを生成するかどうか。",
+  "symbols/LocalhostTld/displayName": "アプリケーション URL で .dev.localhost TLD を使用する",
+  "symbols/LocalhostTld/description": "ローカル開発用のアプリケーション URL 内で、プロジェクト名を .dev.localhost TLD と組み合わせるかどうか (例: https://myapp.dev.localhost:12345)。",
   "postActions/restore/description": "このプロジェクトに必要な NuGet パッケージを復元します。",
   "postActions/restore/manualInstructions/default/text": "'dotnet restore' を実行する"
 }

--- a/src/Templates/templates/blazorweb-csharp-10/.template.config/localize/templatestrings.ko.json
+++ b/src/Templates/templates/blazorweb-csharp-10/.template.config/localize/templatestrings.ko.json
@@ -39,6 +39,8 @@
   "symbols/NoHttps/description": "HTTPS를 끌지 여부입니다. 이 옵션은 개별 항목이 --auth에 사용되지 않는 경우에만 적용됩니다.",
   "symbols/UseProgramMain/displayName": "최상위 문 사용 안 함(_T)",
   "symbols/UseProgramMain/description": "최상위 문 대신 명시적 Program 클래스 및 Main 메서드를 생성할지 여부입니다.",
+  "symbols/LocalhostTld/displayName": "애플리케이션 URL에서 .dev.localhost TLD를 사용하세요.",
+  "symbols/LocalhostTld/description": "로컬 개발을 위한 애플리케이션 URL에서 프로젝트 이름과 .dev.localhost TLD를 결합할지 여부, 예를 들어 https://myapp.dev.localhost:12345.",
   "postActions/restore/description": "이 프로젝트에 필요한 NuGet 패키지를 복원합니다.",
   "postActions/restore/manualInstructions/default/text": "'dotnet restore' 실행"
 }

--- a/src/Templates/templates/blazorweb-csharp-10/.template.config/localize/templatestrings.pl.json
+++ b/src/Templates/templates/blazorweb-csharp-10/.template.config/localize/templatestrings.pl.json
@@ -39,6 +39,8 @@
   "symbols/NoHttps/description": "Określa, czy wyłączyć protokół HTTPS. Ta opcja ma zastosowanie tylko wtedy, gdy opcja Individual nie została użyta dla opcji --auth.",
   "symbols/UseProgramMain/displayName": "Nie używaj ins_trukcji najwyższego poziomu",
   "symbols/UseProgramMain/description": "Określa, czy wygenerować jawną klasę Program i metodę Main zamiast instrukcji najwyższego poziomu.",
+  "symbols/LocalhostTld/displayName": "Użyj pliku .dev.localhost TLD w adresie URL aplikacji",
+  "symbols/LocalhostTld/description": "Określa, czy połączyć nazwę projektu z domeną najwyższego poziomu .dev.localhost w adresie URL aplikacji na potrzeby programowania lokalnego, np. https://myapp.dev.localhost:12345.",
   "postActions/restore/description": "Przywróć pakiety NuGet wymagane przez ten projekt.",
   "postActions/restore/manualInstructions/default/text": "Uruchom polecenie \"dotnet restore\""
 }

--- a/src/Templates/templates/blazorweb-csharp-10/.template.config/localize/templatestrings.pt-BR.json
+++ b/src/Templates/templates/blazorweb-csharp-10/.template.config/localize/templatestrings.pt-BR.json
@@ -39,6 +39,8 @@
   "symbols/NoHttps/description": "Se deve desligar o HTTPS. Essa opção só se aplica se Individual não for usado para --auth.",
   "symbols/UseProgramMain/displayName": "Não use ins_truções de nível superior",
   "symbols/UseProgramMain/description": "Se deve gerar uma classe de Programa explícita e um método principal em vez de instruções de nível superior.",
+  "symbols/LocalhostTld/displayName": "Usar o TLD .dev.localhost na URL do aplicativo",
+  "symbols/LocalhostTld/description": "Se deseja combinar o nome do projeto com o TLD .dev.localhost na URL do aplicativo para desenvolvimento local, por exemplo, https://myapp.dev.localhost:12345.",
   "postActions/restore/description": "Restaure os pacotes NuGet exigidos por este projeto.",
   "postActions/restore/manualInstructions/default/text": "Executa 'dotnet restore'"
 }

--- a/src/Templates/templates/blazorweb-csharp-10/.template.config/localize/templatestrings.ru.json
+++ b/src/Templates/templates/blazorweb-csharp-10/.template.config/localize/templatestrings.ru.json
@@ -39,6 +39,8 @@
   "symbols/NoHttps/description": "Следует ли отключить HTTPS. Этот параметр применяется только в том случае, если для аргумента --auth не используется значение Individual.",
   "symbols/UseProgramMain/displayName": "Не использовать _операторы верхнего уровня",
   "symbols/UseProgramMain/description": "Следует ли создавать явный класс Program и метод Main вместо операторов верхнего уровня.",
+  "symbols/LocalhostTld/displayName": "Используйте домен верхнего уровня .dev.localhost в URL-адресе приложения",
+  "symbols/LocalhostTld/description": "Следует ли объединять имя проекта с TLD .dev.localhost в URL-адресе приложения для локальной разработки, например, https://myapp.dev.localhost:12345.",
   "postActions/restore/description": "Восстановление пакетов NuGet, необходимых для этого проекта.",
   "postActions/restore/manualInstructions/default/text": "Выполнить команду \"dotnet restore\""
 }

--- a/src/Templates/templates/blazorweb-csharp-10/.template.config/localize/templatestrings.tr.json
+++ b/src/Templates/templates/blazorweb-csharp-10/.template.config/localize/templatestrings.tr.json
@@ -39,6 +39,8 @@
   "symbols/NoHttps/description": "HTTPS'nin kapatılıp kapatılmayacağı. Bu seçenek yalnızca Bireysel --auth için kullanılmadığında geçerlidir.",
   "symbols/UseProgramMain/displayName": "_Üst düzey deyimler kullanmayın",
   "symbols/UseProgramMain/description": "Üst düzey deyimler yerine açık bir Program sınıfı ve Ana yöntem oluşturup oluşturulmayacağını belirtir.",
+  "symbols/LocalhostTld/displayName": "Uygulama URL'sinde .dev.localhost TLD'sini kullanın",
+  "symbols/LocalhostTld/description": "Yerel geliştirme için uygulama URL'sinde proje adını .dev.localhost TLD ile birleştirip birleştirmeyeceğinizi seçin, örneğin https://myapp.dev.localhost:12345.",
   "postActions/restore/description": "Bu projenin gerektirdiği NuGet paketlerini geri yükleyin.",
   "postActions/restore/manualInstructions/default/text": "'dotnet restore' çalıştır"
 }

--- a/src/Templates/templates/blazorweb-csharp-10/.template.config/localize/templatestrings.zh-Hans.json
+++ b/src/Templates/templates/blazorweb-csharp-10/.template.config/localize/templatestrings.zh-Hans.json
@@ -39,6 +39,8 @@
   "symbols/NoHttps/description": "是否关闭 HTTPS。仅当 Individual 不用于 --auth 时，此选项才适用。",
   "symbols/UseProgramMain/displayName": "不使用顶级语句(_T)",
   "symbols/UseProgramMain/description": "是否生成显式程序类和主方法，而不是顶级语句。",
+  "symbols/LocalhostTld/displayName": "在应用程序 URL 中使用 .dev.localhost TLD",
+  "symbols/LocalhostTld/description": "是否在应用程序 URL 中将项目名称与 .dev.localhost TLD 合并以用于本地开发，例如 https://myapp.dev.localhost:12345。",
   "postActions/restore/description": "还原此项目所需的 NuGet 包。",
   "postActions/restore/manualInstructions/default/text": "运行 \"dotnet restore\""
 }

--- a/src/Templates/templates/blazorweb-csharp-10/.template.config/localize/templatestrings.zh-Hant.json
+++ b/src/Templates/templates/blazorweb-csharp-10/.template.config/localize/templatestrings.zh-Hant.json
@@ -39,6 +39,8 @@
   "symbols/NoHttps/description": "是否要關閉 HTTPS。此選項僅適用於個人未用於 --auth 時。",
   "symbols/UseProgramMain/displayName": "不要使用最上層陳述式(_T)",
   "symbols/UseProgramMain/description": "是否要產生明確的 Program 類別和 Main 方法，而非最上層語句。",
+  "symbols/LocalhostTld/displayName": "在應用程式 URL 中使用 .dev.localhost TLD",
+  "symbols/LocalhostTld/description": "是否要在本機開發的應用程式 URL 中將專案名稱與 .dev.localhost TLD 合併，例如 https://myapp.dev.localhost:12345。",
   "postActions/restore/description": "還原此專案所需的 NuGet 套件。",
   "postActions/restore/manualInstructions/default/text": "執行 'dotnet restore'"
 }

--- a/src/Templates/templates/blazorweb-csharp-10/.template.config/template.json
+++ b/src/Templates/templates/blazorweb-csharp-10/.template.config/template.json
@@ -331,6 +331,19 @@
       },
       "replaces": "44300"
     },
+    "StyleBundleName":{
+      "type": "generated",
+      "generator": "regex",
+      "replaces": "StyleBundleName",
+      "parameters": {
+      "source": "name",
+      "steps": [
+        {
+          "regex": " ",
+          "replacement": "_"
+        }]
+      }
+    },
     "InteractivityPlatform": {
       "type": "parameter",
       "datatype": "choice",
@@ -475,6 +488,13 @@
       "defaultValue": "false",
       "displayName": "Do not use _top-level statements",
       "description": "Whether to generate an explicit Program class and Main method instead of top-level statements."
+    },
+    "LocalhostTld": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "displayName": "Use the .dev.localhost TLD in the application URL",
+      "description": "Whether to combine the project name with the .dev.localhost TLD in the application URL for local development, e.g. https://myapp.dev.localhost:12345."
     }
   },
   "tags": {

--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Components/Account/IdentityComponentsEndpointRouteBuilderExtensions.cs
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Components/Account/IdentityComponentsEndpointRouteBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using System.Text.Json;
+using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Http.Extensions;
@@ -54,8 +55,11 @@ internal static class IdentityComponentsEndpointRouteBuilderExtensions
         accountGroup.MapPost("/PasskeyCreationOptions", async (
             HttpContext context,
             [FromServices] UserManager<ApplicationUser> userManager,
-            [FromServices] SignInManager<ApplicationUser> signInManager) =>
+            [FromServices] SignInManager<ApplicationUser> signInManager,
+            [FromServices] IAntiforgery antiforgery) =>
         {
+            await antiforgery.ValidateRequestAsync(context);
+
             var user = await userManager.GetUserAsync(context.User);
             if (user is null)
             {
@@ -64,24 +68,27 @@ internal static class IdentityComponentsEndpointRouteBuilderExtensions
 
             var userId = await userManager.GetUserIdAsync(user);
             var userName = await userManager.GetUserNameAsync(user) ?? "User";
-            var userEntity = new PasskeyUserEntity(userId, userName, displayName: userName);
-            var passkeyCreationArgs = new PasskeyCreationArgs(userEntity);
-            var options = await signInManager.ConfigurePasskeyCreationOptionsAsync(passkeyCreationArgs);
-            return TypedResults.Content(options.AsJson(), contentType: "application/json");
+            var optionsJson = await signInManager.MakePasskeyCreationOptionsAsync(new()
+            {
+                Id = userId,
+                Name = userName,
+                DisplayName = userName
+            });
+            return TypedResults.Content(optionsJson, contentType: "application/json");
         });
 
         accountGroup.MapPost("/PasskeyRequestOptions", async (
+            HttpContext context,
             [FromServices] UserManager<ApplicationUser> userManager,
             [FromServices] SignInManager<ApplicationUser> signInManager,
+            [FromServices] IAntiforgery antiforgery,
             [FromQuery] string? username) =>
         {
+            await antiforgery.ValidateRequestAsync(context);
+
             var user = string.IsNullOrEmpty(username) ? null : await userManager.FindByNameAsync(username);
-            var passkeyRequestArgs = new PasskeyRequestArgs<ApplicationUser>
-            {
-                User = user,
-            };
-            var options = await signInManager.ConfigurePasskeyRequestOptionsAsync(passkeyRequestArgs);
-            return TypedResults.Content(options.AsJson(), contentType: "application/json");
+            var optionsJson = await signInManager.MakePasskeyRequestOptionsAsync(user);
+            return TypedResults.Content(optionsJson, contentType: "application/json");
         });
 
         var manageGroup = accountGroup.MapGroup("/Manage").RequireAuthorization();

--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Components/Account/Pages/Login.razor
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Components/Account/Pages/Login.razor
@@ -88,14 +88,7 @@
         if (!string.IsNullOrEmpty(Input.Passkey?.CredentialJson))
         {
             // When performing passkey sign-in, don't perform form validation.
-            var options = await SignInManager.RetrievePasskeyRequestOptionsAsync();
-            if (options is null)
-            {
-                errorMessage = "Error: Could not complete passkey login. Please try again.";
-                return;
-            }
-
-            result = await SignInManager.PasskeySignInAsync(Input.Passkey.CredentialJson, options);
+            result = await SignInManager.PasskeySignInAsync(Input.Passkey.CredentialJson);
         }
         else
         {

--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Components/Account/Pages/Manage/ChangePassword.razor
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Components/Account/Pages/Manage/ChangePassword.razor
@@ -2,11 +2,10 @@
 
 @using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Identity
-@using TemplateWithPasskey.Data
+@using BlazorWeb_CSharp.Data
 
 @inject UserManager<ApplicationUser> UserManager
 @inject SignInManager<ApplicationUser> SignInManager
-@inject RedirectManager RedirectManager
 @inject IdentityRedirectManager RedirectManager
 @inject ILogger<ChangePassword> Logger
 

--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Components/Account/Pages/Manage/DeletePersonalData.razor
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Components/Account/Pages/Manage/DeletePersonalData.razor
@@ -2,7 +2,7 @@
 
 @using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Identity
-@using TemplateWithPasskey.Data
+@using BlazorWeb_CSharp.Data
 
 @inject UserManager<ApplicationUser> UserManager
 @inject SignInManager<ApplicationUser> SignInManager

--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Components/Account/Pages/Manage/Email.razor
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Components/Account/Pages/Manage/Email.razor
@@ -5,7 +5,7 @@
 @using System.Text.Encodings.Web
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.WebUtilities
-@using TemplateWithPasskey.Data
+@using BlazorWeb_CSharp.Data
 
 @inject UserManager<ApplicationUser> UserManager
 @inject IEmailSender<ApplicationUser> EmailSender

--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Components/Account/Pages/Manage/Index.razor
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Components/Account/Pages/Manage/Index.razor
@@ -2,7 +2,7 @@
 
 @using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Identity
-@using TemplateWithPasskey.Data
+@using BlazorWeb_CSharp.Data
 
 @inject UserManager<ApplicationUser> UserManager
 @inject SignInManager<ApplicationUser> SignInManager

--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Components/Account/Pages/Manage/Passkeys.razor
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Components/Account/Pages/Manage/Passkeys.razor
@@ -1,6 +1,6 @@
 ﻿@page "/Account/Manage/Passkeys"
 
-@using TemplateWithPasskey.Data
+@using BlazorWeb_CSharp.Data
 @using Microsoft.AspNetCore.Identity
 @using System.ComponentModel.DataAnnotations
 @using System.Buffers.Text
@@ -60,16 +60,24 @@
         {
             <p>No passkeys are registered.</p>
         }
-            <form @formname="add-passkey" @onsubmit="AddPasskey" method="post">
+    <form @formname="add-passkey" @onsubmit="AddPasskey" method="post">
                 <AntiforgeryToken />
-        <p style="margin-top: 10px; text-align: end;">
-                <PasskeySubmit Operation="PasskeyOperation.Create" Name="Input" class="btn btn-primary">Add a new passkey</PasskeySubmit>
-        </p>
-            </form>
+    @if (currentPasskeys is { Count: >= MaxPasskeyCount })
+    {
+        <p class="text-danger">You have reached the maximum number of allowed passkeys. Please delete one before adding a new one.</p>
+    }
+    else
+    {
+        <PasskeySubmit Operation="PasskeyOperation.Create" Name="Input" class="btn btn-primary">Add a new passkey</PasskeySubmit>
+    }
+
+        </form>
     </FluentGridItem>
 </FluentGrid>
 
 @code {
+    private const int MaxPasskeyCount = 100;
+
     private ApplicationUser? user;
     private IList<UserPasskeyInfo>? currentPasskeys;
 
@@ -118,22 +126,21 @@
             return;
         }
 
-        var options = await SignInManager.RetrievePasskeyCreationOptionsAsync();
-        if (options is null)
+        if (currentPasskeys!.Count >= MaxPasskeyCount)
         {
-            RedirectManager.RedirectToCurrentPageWithStatus("Error: Could not retrieve passkey creation options.", HttpContext);
+            RedirectManager.RedirectToCurrentPageWithStatus($"Error: You have reached the maximum number of allowed passkeys.", HttpContext);
             return;
         }
 
-        var attestationResult = await SignInManager.PerformPasskeyAttestationAsync(Input.CredentialJson, options);
+        var attestationResult = await SignInManager.PerformPasskeyAttestationAsync(Input.CredentialJson);
         if (!attestationResult.Succeeded)
         {
             RedirectManager.RedirectToCurrentPageWithStatus($"Error: Could not add the passkey: {attestationResult.Failure.Message}", HttpContext);
             return;
         }
 
-        var setPasskeyResult = await UserManager.SetPasskeyAsync(user, attestationResult.Passkey);
-        if (!setPasskeyResult.Succeeded)
+        var addPasskeyResult = await UserManager.AddOrUpdatePasskeyAsync(user, attestationResult.Passkey);
+        if (!addPasskeyResult.Succeeded)
         {
             RedirectManager.RedirectToCurrentPageWithStatus("Error: The passkey could not be added to your account.", HttpContext);
             return;

--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Components/Account/Pages/Manage/PersonalData.razor
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Components/Account/Pages/Manage/PersonalData.razor
@@ -1,7 +1,7 @@
 ﻿@page "/Account/Manage/PersonalData"
 
 @using Microsoft.AspNetCore.Identity
-@using TemplateWithPasskey.Data
+@using BlazorWeb_CSharp.Data
 
 @inject UserManager<ApplicationUser> UserManager
 @inject IdentityRedirectManager RedirectManager

--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Components/Account/Pages/Manage/RenamePasskey.razor
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Components/Account/Pages/Manage/RenamePasskey.razor
@@ -1,6 +1,6 @@
 ﻿@page "/Account/Manage/RenamePasskey/{Id}"
 
-@using TemplateWithPasskey.Data
+@using BlazorWeb_CSharp.Data
 @using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Identity
 @using System.Buffers.Text
@@ -79,7 +79,7 @@
     private async Task Rename()
     {
         passkey!.Name = Input.Name;
-        var result = await UserManager.SetPasskeyAsync(user!, passkey);
+        var result = await UserManager.AddOrUpdatePasskeyAsync(user!, passkey);
         if (!result.Succeeded)
         {
             RedirectManager.RedirectToWithStatus("Account/Manage/Passkeys", "Error: The passkey could not be updated.", HttpContext);
@@ -92,6 +92,7 @@
     private sealed class InputModel
     {
         [Required]
+        [StringLength(200, ErrorMessage = "Passkey names must be no longer than {1} characters.")]
         public string Name { get; set; } = "";
     }
 }

--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Components/Account/Pages/Manage/SetPassword.razor
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Components/Account/Pages/Manage/SetPassword.razor
@@ -2,7 +2,7 @@
 
 @using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Identity
-@using TemplateWithPasskey.Data
+@using BlazorWeb_CSharp.Data
 
 @inject UserManager<ApplicationUser> UserManager
 @inject SignInManager<ApplicationUser> SignInManager

--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Components/Account/Pages/Manage/TwoFactorAuthentication.razor
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Components/Account/Pages/Manage/TwoFactorAuthentication.razor
@@ -2,7 +2,7 @@
 
 @using Microsoft.AspNetCore.Http.Features
 @using Microsoft.AspNetCore.Identity
-@using TemplateWithPasskey.Data
+@using BlazorWeb_CSharp.Data
 
 @inject UserManager<ApplicationUser> UserManager
 @inject SignInManager<ApplicationUser> SignInManager

--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Components/Account/Shared/PasskeySubmit.razor
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Components/Account/Shared/PasskeySubmit.razor
@@ -1,7 +1,20 @@
-﻿<FluentButton Type="ButtonType.Submit" Name="__passkeySubmit" Appearance="Appearance.Accent" @attributes="AdditionalAttributes">@ChildContent</FluentButton>
-<passkey-submit operation="@Operation" name="@Name" email-name="@EmailName"></passkey-submit>
+﻿@using Microsoft.AspNetCore.Antiforgery
+@inject IServiceProvider Services
+<FluentButton Type="ButtonType.Submit" Name="__passkeySubmit" Appearance="Appearance.Accent" @attributes="AdditionalAttributes">@ChildContent</FluentButton>
+<passkey-submit
+    operation="@Operation"
+    name="@Name"
+    email-name="@EmailName"
+    request-token-name="@tokens?.HeaderName"
+    request-token-value="@tokens?.RequestToken">
+</passkey-submit>
 
 @code {
+    private AntiforgeryTokenSet? tokens;
+
+    [CascadingParameter]
+    private HttpContext HttpContext { get; set; } = default!;
+
     [Parameter]
     [EditorRequired]
     public PasskeyOperation Operation { get; set; }
@@ -18,4 +31,9 @@
 
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    protected override void OnInitialized()
+    {
+        tokens = Services.GetService<IAntiforgery>()?.GetTokens(HttpContext);
+    }
 }

--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Components/Layout/ReconnectModal.razor.js
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Components/Layout/ReconnectModal.razor.js
@@ -32,7 +32,7 @@ async function retry() {
         if (!successful) {
             // We have been able to reach the server, but the circuit is no longer available.
             // We'll reload the page so the user can continue using the app as quickly as possible.
-            const resumeSuccessful = await Blazor.resume();
+            const resumeSuccessful = await Blazor.resumeCircuit();
             if (!resumeSuccessful) {
                 location.reload();
             } else {
@@ -47,7 +47,7 @@ async function retry() {
 
 async function resume() {
     try {
-        const successful = await Blazor.resume();
+        const successful = await Blazor.resumeCircuit();
         if (!successful) {
             location.reload();
         }

--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Data/SqlLite/00000000000000_CreateIdentitySchema.Designer.cs
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Data/SqlLite/00000000000000_CreateIdentitySchema.Designer.cs
@@ -187,40 +187,6 @@ namespace BlazorWeb_CSharp.Migrations
                         .HasMaxLength(1024)
                         .HasColumnType("BLOB");
 
-                    b.Property<byte[]>("AttestationObject")
-                        .IsRequired()
-                        .HasColumnType("BLOB");
-
-                    b.Property<byte[]>("ClientDataJson")
-                        .IsRequired()
-                        .HasColumnType("BLOB");
-
-                    b.Property<DateTimeOffset>("CreatedAt")
-                        .HasColumnType("TEXT");
-
-                    b.Property<bool>("IsBackedUp")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<bool>("IsBackupEligible")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<bool>("IsUserVerified")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<string>("Name")
-                        .HasColumnType("TEXT");
-
-                    b.Property<byte[]>("PublicKey")
-                        .IsRequired()
-                        .HasMaxLength(1024)
-                        .HasColumnType("BLOB");
-
-                    b.Property<uint>("SignCount")
-                        .HasColumnType("INTEGER");
-
-                    b.PrimitiveCollection<string>("Transports")
-                        .HasColumnType("TEXT");
-
                     b.Property<string>("UserId")
                         .IsRequired()
                         .HasColumnType("TEXT");
@@ -301,6 +267,57 @@ namespace BlazorWeb_CSharp.Migrations
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.OwnsOne("Microsoft.AspNetCore.Identity.IdentityPasskeyData", "Data", b1 =>
+                        {
+                            b1.Property<byte[]>("IdentityUserPasskeyCredentialId")
+                                .HasColumnType("BLOB");
+
+                            b1.Property<byte[]>("AttestationObject")
+                                .IsRequired()
+                                .HasColumnType("BLOB");
+
+                            b1.Property<byte[]>("ClientDataJson")
+                                .IsRequired()
+                                .HasColumnType("BLOB");
+
+                            b1.Property<DateTimeOffset>("CreatedAt")
+                                .HasColumnType("TEXT");
+
+                            b1.Property<bool>("IsBackedUp")
+                                .HasColumnType("INTEGER");
+
+                            b1.Property<bool>("IsBackupEligible")
+                                .HasColumnType("INTEGER");
+
+                            b1.Property<bool>("IsUserVerified")
+                                .HasColumnType("INTEGER");
+
+                            b1.Property<string>("Name")
+                                .HasColumnType("TEXT");
+
+                            b1.Property<byte[]>("PublicKey")
+                                .IsRequired()
+                                .HasColumnType("BLOB");
+
+                            b1.Property<uint>("SignCount")
+                                .HasColumnType("INTEGER");
+
+                            b1.PrimitiveCollection<string>("Transports")
+                                .HasColumnType("TEXT");
+
+                            b1.HasKey("IdentityUserPasskeyCredentialId");
+
+                            b1.ToTable("AspNetUserPasskeys");
+
+                            b1.ToJson("Data");
+
+                            b1.WithOwner()
+                                .HasForeignKey("IdentityUserPasskeyCredentialId");
+                        });
+
+                    b.Navigation("Data")
                         .IsRequired();
                 });
 

--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Data/SqlLite/00000000000000_CreateIdentitySchema.cs
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Data/SqlLite/00000000000000_CreateIdentitySchema.cs
@@ -118,16 +118,7 @@ namespace BlazorWeb_CSharp.Migrations
                 {
                     CredentialId = table.Column<byte[]>(type: "BLOB", maxLength: 1024, nullable: false),
                     UserId = table.Column<string>(type: "TEXT", nullable: false),
-                    PublicKey = table.Column<byte[]>(type: "BLOB", maxLength: 1024, nullable: false),
-                    Name = table.Column<string>(type: "TEXT", nullable: true),
-                    CreatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
-                    SignCount = table.Column<uint>(type: "INTEGER", nullable: false),
-                    Transports = table.Column<string>(type: "TEXT", nullable: true),
-                    IsUserVerified = table.Column<bool>(type: "INTEGER", nullable: false),
-                    IsBackupEligible = table.Column<bool>(type: "INTEGER", nullable: false),
-                    IsBackedUp = table.Column<bool>(type: "INTEGER", nullable: false),
-                    AttestationObject = table.Column<byte[]>(type: "BLOB", nullable: false),
-                    ClientDataJson = table.Column<byte[]>(type: "BLOB", nullable: false)
+                    Data = table.Column<string>(type: "TEXT", nullable: false)
                 },
                 constraints: table =>
                 {

--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Data/SqlLite/ApplicationDbContextModelSnapshot.cs
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Data/SqlLite/ApplicationDbContextModelSnapshot.cs
@@ -184,40 +184,6 @@ namespace BlazorWeb_CSharp.Migrations
                         .HasMaxLength(1024)
                         .HasColumnType("BLOB");
 
-                    b.Property<byte[]>("AttestationObject")
-                        .IsRequired()
-                        .HasColumnType("BLOB");
-
-                    b.Property<byte[]>("ClientDataJson")
-                        .IsRequired()
-                        .HasColumnType("BLOB");
-
-                    b.Property<DateTimeOffset>("CreatedAt")
-                        .HasColumnType("TEXT");
-
-                    b.Property<bool>("IsBackedUp")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<bool>("IsBackupEligible")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<bool>("IsUserVerified")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<string>("Name")
-                        .HasColumnType("TEXT");
-
-                    b.Property<byte[]>("PublicKey")
-                        .IsRequired()
-                        .HasMaxLength(1024)
-                        .HasColumnType("BLOB");
-
-                    b.Property<uint>("SignCount")
-                        .HasColumnType("INTEGER");
-
-                    b.PrimitiveCollection<string>("Transports")
-                        .HasColumnType("TEXT");
-
                     b.Property<string>("UserId")
                         .IsRequired()
                         .HasColumnType("TEXT");
@@ -298,6 +264,57 @@ namespace BlazorWeb_CSharp.Migrations
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.OwnsOne("Microsoft.AspNetCore.Identity.IdentityPasskeyData", "Data", b1 =>
+                        {
+                            b1.Property<byte[]>("IdentityUserPasskeyCredentialId")
+                                .HasColumnType("BLOB");
+
+                            b1.Property<byte[]>("AttestationObject")
+                                .IsRequired()
+                                .HasColumnType("BLOB");
+
+                            b1.Property<byte[]>("ClientDataJson")
+                                .IsRequired()
+                                .HasColumnType("BLOB");
+
+                            b1.Property<DateTimeOffset>("CreatedAt")
+                                .HasColumnType("TEXT");
+
+                            b1.Property<bool>("IsBackedUp")
+                                .HasColumnType("INTEGER");
+
+                            b1.Property<bool>("IsBackupEligible")
+                                .HasColumnType("INTEGER");
+
+                            b1.Property<bool>("IsUserVerified")
+                                .HasColumnType("INTEGER");
+
+                            b1.Property<string>("Name")
+                                .HasColumnType("TEXT");
+
+                            b1.Property<byte[]>("PublicKey")
+                                .IsRequired()
+                                .HasColumnType("BLOB");
+
+                            b1.Property<uint>("SignCount")
+                                .HasColumnType("INTEGER");
+
+                            b1.PrimitiveCollection<string>("Transports")
+                                .HasColumnType("TEXT");
+
+                            b1.HasKey("IdentityUserPasskeyCredentialId");
+
+                            b1.ToTable("AspNetUserPasskeys");
+
+                            b1.ToJson("Data");
+
+                            b1.WithOwner()
+                                .HasForeignKey("IdentityUserPasskeyCredentialId");
+                        });
+
+                    b.Navigation("Data")
                         .IsRequired();
                 });
 

--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Data/SqlServer/00000000000000_CreateIdentitySchema.Designer.cs
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Data/SqlServer/00000000000000_CreateIdentitySchema.Designer.cs
@@ -198,40 +198,6 @@ namespace BlazorWeb_CSharp.Migrations
                         .HasMaxLength(1024)
                         .HasColumnType("varbinary(1024)");
 
-                    b.Property<byte[]>("AttestationObject")
-                        .IsRequired()
-                        .HasColumnType("varbinary(max)");
-
-                    b.Property<byte[]>("ClientDataJson")
-                        .IsRequired()
-                        .HasColumnType("varbinary(max)");
-
-                    b.Property<DateTimeOffset>("CreatedAt")
-                        .HasColumnType("datetimeoffset");
-
-                    b.Property<bool>("IsBackedUp")
-                        .HasColumnType("bit");
-
-                    b.Property<bool>("IsBackupEligible")
-                        .HasColumnType("bit");
-
-                    b.Property<bool>("IsUserVerified")
-                        .HasColumnType("bit");
-
-                    b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<byte[]>("PublicKey")
-                        .IsRequired()
-                        .HasMaxLength(1024)
-                        .HasColumnType("varbinary(1024)");
-
-                    b.Property<long>("SignCount")
-                        .HasColumnType("bigint");
-
-                    b.PrimitiveCollection<string>("Transports")
-                        .HasColumnType("nvarchar(max)");
-
                     b.Property<string>("UserId")
                         .IsRequired()
                         .HasColumnType("nvarchar(450)");
@@ -312,6 +278,57 @@ namespace BlazorWeb_CSharp.Migrations
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.OwnsOne("Microsoft.AspNetCore.Identity.IdentityPasskeyData", "Data", b1 =>
+                        {
+                            b1.Property<byte[]>("IdentityUserPasskeyCredentialId")
+                                .HasColumnType("varbinary(1024)");
+
+                            b1.Property<byte[]>("AttestationObject")
+                                .IsRequired()
+                                .HasColumnType("varbinary(max)");
+
+                            b1.Property<byte[]>("ClientDataJson")
+                                .IsRequired()
+                                .HasColumnType("varbinary(max)");
+
+                            b1.Property<DateTimeOffset>("CreatedAt")
+                                .HasColumnType("datetimeoffset");
+
+                            b1.Property<bool>("IsBackedUp")
+                                .HasColumnType("bit");
+
+                            b1.Property<bool>("IsBackupEligible")
+                                .HasColumnType("bit");
+
+                            b1.Property<bool>("IsUserVerified")
+                                .HasColumnType("bit");
+
+                            b1.Property<string>("Name")
+                                .HasColumnType("nvarchar(max)");
+
+                            b1.Property<byte[]>("PublicKey")
+                                .IsRequired()
+                                .HasColumnType("varbinary(max)");
+
+                            b1.Property<long>("SignCount")
+                                .HasColumnType("bigint");
+
+                            b1.PrimitiveCollection<string>("Transports")
+                                .HasColumnType("nvarchar(max)");
+
+                            b1.HasKey("IdentityUserPasskeyCredentialId");
+
+                            b1.ToTable("AspNetUserPasskeys");
+
+                            b1.ToJson("Data");
+
+                            b1.WithOwner()
+                                .HasForeignKey("IdentityUserPasskeyCredentialId");
+                        });
+
+                    b.Navigation("Data")
                         .IsRequired();
                 });
 

--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Data/SqlServer/00000000000000_CreateIdentitySchema.cs
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Data/SqlServer/00000000000000_CreateIdentitySchema.cs
@@ -118,16 +118,7 @@ namespace BlazorWeb_CSharp.Migrations
                 {
                     CredentialId = table.Column<byte[]>(type: "varbinary(1024)", maxLength: 1024, nullable: false),
                     UserId = table.Column<string>(type: "nvarchar(450)", nullable: false),
-                    PublicKey = table.Column<byte[]>(type: "varbinary(1024)", maxLength: 1024, nullable: false),
-                    Name = table.Column<string>(type: "nvarchar(max)", nullable: true),
-                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
-                    SignCount = table.Column<long>(type: "bigint", nullable: false),
-                    Transports = table.Column<string>(type: "nvarchar(max)", nullable: true),
-                    IsUserVerified = table.Column<bool>(type: "bit", nullable: false),
-                    IsBackupEligible = table.Column<bool>(type: "bit", nullable: false),
-                    IsBackedUp = table.Column<bool>(type: "bit", nullable: false),
-                    AttestationObject = table.Column<byte[]>(type: "varbinary(max)", nullable: false),
-                    ClientDataJson = table.Column<byte[]>(type: "varbinary(max)", nullable: false)
+                    Data = table.Column<string>(type: "nvarchar(max)", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -240,6 +231,9 @@ namespace BlazorWeb_CSharp.Migrations
 
             migrationBuilder.DropTable(
                 name: "AspNetUserLogins");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserPasskeys");
 
             migrationBuilder.DropTable(
                 name: "AspNetUserRoles");

--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Data/SqlServer/ApplicationDbContextModelSnapshot.cs
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Data/SqlServer/ApplicationDbContextModelSnapshot.cs
@@ -195,40 +195,6 @@ namespace BlazorWeb_CSharp.Migrations
                         .HasMaxLength(1024)
                         .HasColumnType("varbinary(1024)");
 
-                    b.Property<byte[]>("AttestationObject")
-                        .IsRequired()
-                        .HasColumnType("varbinary(max)");
-
-                    b.Property<byte[]>("ClientDataJson")
-                        .IsRequired()
-                        .HasColumnType("varbinary(max)");
-
-                    b.Property<DateTimeOffset>("CreatedAt")
-                        .HasColumnType("datetimeoffset");
-
-                    b.Property<bool>("IsBackedUp")
-                        .HasColumnType("bit");
-
-                    b.Property<bool>("IsBackupEligible")
-                        .HasColumnType("bit");
-
-                    b.Property<bool>("IsUserVerified")
-                        .HasColumnType("bit");
-
-                    b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<byte[]>("PublicKey")
-                        .IsRequired()
-                        .HasMaxLength(1024)
-                        .HasColumnType("varbinary(1024)");
-
-                    b.Property<long>("SignCount")
-                        .HasColumnType("bigint");
-
-                    b.PrimitiveCollection<string>("Transports")
-                        .HasColumnType("nvarchar(max)");
-
                     b.Property<string>("UserId")
                         .IsRequired()
                         .HasColumnType("nvarchar(450)");
@@ -309,6 +275,57 @@ namespace BlazorWeb_CSharp.Migrations
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.OwnsOne("Microsoft.AspNetCore.Identity.IdentityPasskeyData", "Data", b1 =>
+                        {
+                            b1.Property<byte[]>("IdentityUserPasskeyCredentialId")
+                                .HasColumnType("varbinary(1024)");
+
+                            b1.Property<byte[]>("AttestationObject")
+                                .IsRequired()
+                                .HasColumnType("varbinary(max)");
+
+                            b1.Property<byte[]>("ClientDataJson")
+                                .IsRequired()
+                                .HasColumnType("varbinary(max)");
+
+                            b1.Property<DateTimeOffset>("CreatedAt")
+                                .HasColumnType("datetimeoffset");
+
+                            b1.Property<bool>("IsBackedUp")
+                                .HasColumnType("bit");
+
+                            b1.Property<bool>("IsBackupEligible")
+                                .HasColumnType("bit");
+
+                            b1.Property<bool>("IsUserVerified")
+                                .HasColumnType("bit");
+
+                            b1.Property<string>("Name")
+                                .HasColumnType("nvarchar(max)");
+
+                            b1.Property<byte[]>("PublicKey")
+                                .IsRequired()
+                                .HasColumnType("varbinary(max)");
+
+                            b1.Property<long>("SignCount")
+                                .HasColumnType("bigint");
+
+                            b1.PrimitiveCollection<string>("Transports")
+                                .HasColumnType("nvarchar(max)");
+
+                            b1.HasKey("IdentityUserPasskeyCredentialId");
+
+                            b1.ToTable("AspNetUserPasskeys");
+
+                            b1.ToJson("Data");
+
+                            b1.WithOwner()
+                                .HasForeignKey("IdentityUserPasskeyCredentialId");
+                        });
+
+                    b.Navigation("Data")
                         .IsRequired();
                 });
 

--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Program.Main.cs
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Program.Main.cs
@@ -109,8 +109,7 @@ public class Program
         #endif
         }
 
-        app.UseStatusCodePagesWithReExecute("/not-found", createScopeForErrors: true);
-
+        app.UseStatusCodePagesWithReExecute("/not-found", createScopeForStatusCodePages: true);
         #if (HasHttpsProfile)
         app.UseHttpsRedirection();
 

--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Program.cs
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Program.cs
@@ -102,8 +102,7 @@ if (!app.Environment.IsDevelopment())
     app.UseHsts();
 #endif
 }
-app.UseStatusCodePagesWithReExecute("/not-found", createScopeForErrors: true);
-
+app.UseStatusCodePagesWithReExecute("/not-found", createScopeForStatusCodePages: true);
 #if (HasHttpsProfile)
 app.UseHttpsRedirection();
 

--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Properties/launchSettings.json
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/Properties/launchSettings.json
@@ -6,14 +6,18 @@
         "commandName": "Project",
         "dotnetRunMessages": true,
         "launchBrowser": true,
-      //#if (UseWebAssembly)
+        //#if (UseWebAssembly)
         "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
-      //#endif
+        //#endif
+        //#if (LocalhostTld)
+        "applicationUrl": "http://blazorweb_csharp.dev.localhost:5500",
+        //#else
         "applicationUrl": "http://localhost:5500",
+        //#endif
         "environmentVariables": {
           "ASPNETCORE_ENVIRONMENT": "Development"
         }
-      //#if (HasHttpsProfile)
+        //#if (HasHttpsProfile)
       },
       //#else
       }
@@ -27,7 +31,11 @@
         //#if (UseWebAssembly)
         "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
         //#endif
+        //#if (LocalhostTld)
+        "applicationUrl": "https://blazorweb_csharp.dev.localhost:5501;http://blazorweb_csharp.dev.localhost:5500",
+        //#else
         "applicationUrl": "https://localhost:5501;http://localhost:5500",
+        //#endif
         "environmentVariables": {
           "ASPNETCORE_ENVIRONMENT": "Development"
         }

--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/appsettings.json
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWeb-CSharp/appsettings.json
@@ -4,7 +4,7 @@
 //#if (UseLocalDB)
 //    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnet-BlazorWeb_CSharp-53bc9b9d-9d6a-45d4-8429-2a2761773502;Trusted_Connection=True;MultipleActiveResultSets=true"
 //#else
-//    "DefaultConnection": "DataSource=Data\\app.db;Cache=Shared"
+//    "DefaultConnection": "DataSource=Data/app.db;Cache=Shared"
 //#endif
 //  },
 ////#endif

--- a/tests/Core/Microsoft.FluentUI.AspNetCore.Components.Tests.csproj
+++ b/tests/Core/Microsoft.FluentUI.AspNetCore.Components.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/tests/Core/_StartCodeCoverage.cmd
+++ b/tests/Core/_StartCodeCoverage.cmd
@@ -19,5 +19,5 @@ echo on
 cls
 
 dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura
-reportgenerator "-reports:coverage.net9.0.cobertura.xml" "-targetdir:C:\Temp\FluentUI\Coverage" -reporttypes:HtmlInline_AzurePipelines -classfilters:"-Microsoft.FluentUI.AspNetCore.Components.DesignTokens.*"
+reportgenerator "-reports:coverage.net10.0.cobertura.xml" "-targetdir:C:\Temp\FluentUI\Coverage" -reporttypes:HtmlInline_AzurePipelines -classfilters:"-Microsoft.FluentUI.AspNetCore.Components.DesignTokens.*"
 start "" "C:\Temp\FluentUI\Coverage\index.htm"


### PR DESCRIPTION
With earlier versions we had the issue that the esproj file contents would get served instead of the generated javascript (resulting in a non-functional site). This has now been fixed in the SDKs for both NET 9 and NET 10.
So, I've re-added the net10.0 TFM to the project files and configured the solution (and GH workflows/ADO pipelines) to use the latest available SDKs and NuGet packages.

Also updates the NET 10.0 Web App template source
