### PR TITLE
[List] Add an `OptionTitle` attribute

### DIFF
--- a/.github/workflows/build-core-lib.yml
+++ b/.github/workflows/build-core-lib.yml
@@ -134,7 +134,7 @@ jobs:
      - name: Report Generator
        uses: danielpalme/ReportGenerator-GitHub-Action@5.2.4
        with:
-         reports: '**/coverage.cobertura.xml;**/coverage.net8.0.cobertura.xml;**/coverage.net9.0.cobertura.xml;**/coverage.net10.0.cobertura.xml'
+         reports: '**/coverage.cobertura.xml;**/coverage.*.cobertura.xml'
          targetdir: 'CoverageReports'
          title: 'Unit Tests Code Coverage'
          classfilters: '-Microsoft.FluentUI.AspNetCore.Components.DesignTokens.*'

--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -6298,6 +6298,11 @@
             Called whenever the selection changed.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentOption`1.Title">
+            <summary>
+            Gets or sets the title tooltip of this option.
+            </summary>
+        </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentOption`1.OnClickHandlerAsync">
             <summary />
         </member>

--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -6486,6 +6486,12 @@
             Gets or sets the function used to determine if an option is initially selected.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.ListComponentBase`1.OptionTitle">
+            <summary>
+            Gets or sets the function used to determine the option tooltip (title).
+            If null is returned, then no title is displayed.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.ListComponentBase`1.OptionComparer">
             <summary>
             Gets or sets the <see cref="T:System.Collections.Generic.IEqualityComparer`1"/> used to determine if an option is already added to the internal list.
@@ -6567,6 +6573,9 @@
             <summary />
         </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.ListComponentBase`1.GetOptionValue(`0)">
+            <summary />
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.ListComponentBase`1.GetOptionTitle(`0)">
             <summary />
         </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.ListComponentBase`1.GetOptionText(`0)">

--- a/examples/Demo/Shared/Pages/List/Listbox/Examples/ListboxManual.razor
+++ b/examples/Demo/Shared/Pages/List/Listbox/Examples/ListboxManual.razor
@@ -1,5 +1,5 @@
 ﻿<FluentListbox TOption="string" ValueChanged="@(e => listboxValue = e)">
-    <FluentOption>This option has no value</FluentOption>
+    <FluentOption Title="With a tooltip">This option has no value</FluentOption>
     <FluentOption Value="Item 1" Disabled="true">This option is disabled</FluentOption>
     <FluentOption Value="Item 2">This option has a value</FluentOption>
     <FluentOption Value="Item 3">

--- a/examples/Demo/Shared/Pages/List/Select/Examples/SelectDefault.razor
+++ b/examples/Demo/Shared/Pages/List/Select/Examples/SelectDefault.razor
@@ -8,6 +8,7 @@
               Placeholder="Make a selection..."
               OptionValue="@(p => p.PersonId.ToString())"
               OptionText="@(p => p.LastName + ", " + p.FirstName)"
+              OptionTitle="@(p => p.LastName.Length + p.FirstName.Length > 20 ? p.LastName : null)"
               @bind-Value="@SelectedValue"
               @bind-SelectedOption="@SelectedPerson" />
 

--- a/src/Core/Components/List/FluentOption.razor
+++ b/src/Core/Components/List/FluentOption.razor
@@ -7,6 +7,7 @@
                style="@Style"
                disabled="@Disabled"
                value="@Value"
+               title="@Title"
                selected="@Selected"
                aria-selected="@(Selected ? "true" : "false")"
                @onclick="@OnClickHandlerAsync"

--- a/src/Core/Components/List/FluentOption.razor.cs
+++ b/src/Core/Components/List/FluentOption.razor.cs
@@ -48,6 +48,12 @@ public partial class FluentOption<TOption> : FluentComponentBase, IDisposable wh
     [Parameter]
     public EventCallback<string> OnSelect { get; set; }
 
+    /// <summary>
+    /// Gets or sets the title tooltip of this option.
+    /// </summary>
+    [Parameter]
+    public string? Title { get; set; }
+
     protected override Task OnInitializedAsync()
     {
         InternalListContext.Register(this);

--- a/src/Core/Components/List/ListComponentBase.razor
+++ b/src/Core/Components/List/ListComponentBase.razor
@@ -28,6 +28,7 @@
             {
                 <FluentOption TOption="TOption"
                               Value="@GetOptionValue(item)"
+                              Title="@GetOptionTitle(item)"
                               Selected="@GetOptionSelected(item)"
                               Disabled="@(GetOptionDisabled(item) ?? false)"
                               OnSelect="@OnSelectCallback(item)"

--- a/src/Core/Components/List/ListComponentBase.razor.cs
+++ b/src/Core/Components/List/ListComponentBase.razor.cs
@@ -130,6 +130,13 @@ public abstract partial class ListComponentBase<TOption> : FluentInputBase<strin
     public virtual Func<TOption, bool>? OptionSelected { get; set; }
 
     /// <summary>
+    /// Gets or sets the function used to determine the option tooltip (title).
+    /// If null is returned, then no title is displayed.
+    /// </summary>
+    [Parameter]
+    public virtual Func<TOption, string?>? OptionTitle { get; set; }
+
+    /// <summary>
     /// Gets or sets the <see cref="IEqualityComparer{T}"/> used to determine if an option is already added to the internal list.
     /// ⚠️ Only available when Multiple = true.
     /// </summary>
@@ -498,6 +505,19 @@ public abstract partial class ListComponentBase<TOption> : FluentInputBase<strin
         if (item != null)
         {
             return OptionValue?.Invoke(item) ?? OptionText?.Invoke(item) ?? item?.ToString();
+        }
+        else
+        {
+            return null;
+        }
+    }
+
+    /// <summary />
+    protected virtual string? GetOptionTitle(TOption? item)
+    {
+        if (item != null && OptionTitle != null)
+        {
+            return OptionTitle.Invoke(item);
         }
         else
         {


### PR DESCRIPTION
# [List] Add an `OptionTitle` attribute

**FluentSelect** has an issue where it is hard to see long item content.
This becomes a problem when there are multiple long values that start the same. 
It's impossible to tell them apart.

See #4136

We added this new attribute to defined when and what to display in the `FluentOption.Title` attribute

## Example:

```xml
<FluentSelect OptionValue="@(p => p.PersonId.ToString())"
              OptionText="@(p => p.LastName + ", " + p.FirstName)"
              OptionTitle="@(p => p.LastName.Length + p.FirstName.Length > 20 ? p.LastName : null)" />
´´´

## `OptionTitle` attribute

```csharp
/// <summary>
/// Gets or sets the function used to determine the option tooltip (title).
/// If null is returned, then no title is displayed.
/// </summary>
[Parameter]
public virtual Func<TOption, string?>? OptionTitle { get; set; }
```

## Unit Tests

No changes