### PR TITLE
[DatePicker & TimePicker] Fix FocusAsync throwing null exception

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -3050,6 +3050,11 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDatePicker.PopupId">
             <summary />
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDatePicker.TextField">
+            <summary>
+            Holds the reference to the internal <see cref="T:Microsoft.FluentUI.AspNetCore.Components.FluentTextField"/> component.
+            </summary>
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDatePicker.Appearance">
             <summary>
             Gets or sets the design of this input.

--- a/src/Core/Components/Base/FluentInputBase.cs
+++ b/src/Core/Components/Base/FluentInputBase.cs
@@ -352,7 +352,7 @@ public abstract partial class FluentInputBase<TValue> : FluentComponentBase, IDi
     /// Exposes the elements FocusAsync() method.
     /// </summary>
     [SuppressMessage("Style", "VSTHRD200:Use `Async` suffix for async methods", Justification = "#vNext: To update in the next version")]
-    public async void FocusAsync()
+    public virtual async void FocusAsync()
     {
         await Element!.FocusAsync();
     }

--- a/src/Core/Components/DateTime/FluentDatePicker.razor
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor
@@ -2,46 +2,47 @@
 @inherits FluentCalendarBase
 
 <FluentInputLabel ForId="@Id" Label="@Label" AriaLabel="@AriaLabel" ChildContent="@LabelTemplate" Required="@Required" />
-<FluentTextField Id="@Id"
-                 Embedded="true"
-                 Class="@ClassValue"
-                 Style="@StyleValue"
-                 AutoComplete="off"
-                 Autofocus="@Autofocus"
-                 Appearance="@Appearance"
-                 @bind-Value="@CurrentValueAsString"
-                 @onclick="@OnCalendarOpenHandlerAsync"
-                 @ondblclick="@OnDoubleClickHandlerAsync"
-                 @onkeydown="(e => KeyDown.SimulateClickAsync(e, OnCalendarOpenHandlerAsync))"
-                 ReadOnly="@ReadOnly"
-                 Disabled="@Disabled"
-                 Required="@Required"
-                 Placeholder="@(Placeholder ?? PlaceholderAccordingToView())"
-                 Name="@Name"
-                 @attributes="@AdditionalAttributes">
-    @((MarkupString)CalendarIcon)
+<FluentTextField @ref="TextField"
+				 Id="@Id"
+				 Embedded="true"
+				 Class="@ClassValue"
+				 Style="@StyleValue"
+				 AutoComplete="off"
+				 Autofocus="@Autofocus"
+				 Appearance="@Appearance"
+				 @bind-Value="@CurrentValueAsString"
+				 @onclick="@OnCalendarOpenHandlerAsync"
+				 @ondblclick="@OnDoubleClickHandlerAsync"
+				 @onkeydown="(e => KeyDown.SimulateClickAsync(e, OnCalendarOpenHandlerAsync))"
+				 ReadOnly="@ReadOnly"
+				 Disabled="@Disabled"
+				 Required="@Required"
+				 Placeholder="@(Placeholder ?? PlaceholderAccordingToView())"
+				 Name="@Name"
+				 @attributes="@AdditionalAttributes">
+	@((MarkupString)CalendarIcon)
 </FluentTextField>
 
 @if (Opened)
 {
-    <FluentOverlay @bind-Visible="@Opened" Dismissable="true" FullScreen="true" Interactive="true" InteractiveExceptId="@PopupId" />
-    <FluentAnchoredRegion Anchor="@Id"
-                          Id="@PopupId"
-                          HorizontalDefaultPosition="@(PopupHorizontalPosition ?? (System.Globalization.CultureInfo.CurrentUICulture.TextInfo.IsRightToLeft ? HorizontalPosition.Left : HorizontalPosition.Right))"
-                          HorizontalInset="true"
-                          VerticalDefaultPosition="@VerticalPosition.Unset"
-                          Shadow="ElevationShadow.Flyout"
-                          Class="fluent-datepicker-popup"
-                          Style="@($"z-index: {ZIndex.DatePickerPopup}; border-radius: calc(var(--control-corner-radius) * 1px); padding: 12px;")">
-        <FluentCalendar Culture="@Culture"
-                        View="@View"
-                        DayFormat="@DayFormat"
-                        DisabledDateFunc="@DisabledDateFunc"
-                        DisabledCheckAllDaysOfMonthYear="@DisabledCheckAllDaysOfMonthYear"
-                        DisabledSelectable="@DisabledSelectable"
-                        Value="@Value"
-                        ValueChanged="@OnSelectedDateAsync"
-                        DaysTemplate="@DaysTemplate"
-                        PickerMonthChanged="@PickerMonthChanged" />
-    </FluentAnchoredRegion>
+	<FluentOverlay @bind-Visible="@Opened" Dismissable="true" FullScreen="true" Interactive="true" InteractiveExceptId="@PopupId" />
+	<FluentAnchoredRegion Anchor="@Id"
+						  Id="@PopupId"
+						  HorizontalDefaultPosition="@(PopupHorizontalPosition ?? (System.Globalization.CultureInfo.CurrentUICulture.TextInfo.IsRightToLeft ? HorizontalPosition.Left : HorizontalPosition.Right))"
+						  HorizontalInset="true"
+						  VerticalDefaultPosition="@VerticalPosition.Unset"
+						  Shadow="ElevationShadow.Flyout"
+						  Class="fluent-datepicker-popup"
+						  Style="@($"z-index: {ZIndex.DatePickerPopup}; border-radius: calc(var(--control-corner-radius) * 1px); padding: 12px;")">
+		<FluentCalendar Culture="@Culture"
+						View="@View"
+						DayFormat="@DayFormat"
+						DisabledDateFunc="@DisabledDateFunc"
+						DisabledCheckAllDaysOfMonthYear="@DisabledCheckAllDaysOfMonthYear"
+						DisabledSelectable="@DisabledSelectable"
+						Value="@Value"
+						ValueChanged="@OnSelectedDateAsync"
+						DaysTemplate="@DaysTemplate"
+						PickerMonthChanged="@PickerMonthChanged" />
+	</FluentAnchoredRegion>
 }

--- a/src/Core/Components/DateTime/FluentDatePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor.cs
@@ -34,6 +34,11 @@ public partial class FluentDatePicker : FluentCalendarBase
     private string PopupId => $"{Id}-popup";
 
     /// <summary>
+    /// Holds the reference to the internal <see cref="FluentTextField"/> component.
+    /// </summary>
+    private FluentTextField TextField { get; set; } = default!;
+
+    /// <summary>
     /// Gets or sets the design of this input.
     /// </summary>
     [Parameter]
@@ -153,4 +158,9 @@ public partial class FluentDatePicker : FluentCalendarBase
             CalendarViews.Months => Culture.DateTimeFormat.YearMonthPattern,
             _ => Culture.DateTimeFormat.ShortDatePattern
         };
+
+    public override void FocusAsync()
+    {
+        TextField?.FocusAsync();
+    }
 }

--- a/src/Core/Components/DateTime/FluentTimePicker.razor
+++ b/src/Core/Components/DateTime/FluentTimePicker.razor
@@ -1,7 +1,8 @@
 ﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 @inherits FluentInputBase<DateTime?>
 <FluentInputLabel ForId="@Id" Label="@Label" AriaLabel="@AriaLabel" ChildContent="@LabelTemplate" Required="@Required" />
-<fluent-text-field class="@($"{ClassValue} fluent-timepicker")"
+<fluent-text-field @ref="Element"
+				   class="@($"{ClassValue} fluent-timepicker")"
                    style="@StyleValue"
                    id="@Id"
                    autofocus="@Autofocus"


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR fixes an issue with the `FocusAsync` method within the `FluentDatePicker` and `FluentTimePicker` components.

Both components inherit from `FluentInputBase<T>` but don't assign any reference to the actual `Element` property. This PR mainly does two things to fix this.

1. Make the `FocusAsync` method from the `FluentInputBase` overwritable by adding `virtual` to the method signature
2. Assign missing `@ref` for both components

Since the `FluentDatePicker` uses the `FluentTextField` component internally it overwrites the `FocusAsync` method and passes it down to the actual component.

### 🎫 Issues

Fixes: #4166

## 👩‍💻 Reviewer Notes

The missing behaviour can be reproduced with this code in the IssueTester

```razor
<FluentDatePicker @ref="_datePicker" @bind-Value="_dateTime" Label="Date picker"></FluentDatePicker>
<FluentTimePicker @ref="_timePicker" @bind-Value="_Time" Label="Time picker"></FluentTimePicker>

<FluentButton OnClick="@(() => _datePicker.FocusAsync())">Focus Date picker</FluentButton>
<FluentButton OnClick="@(() => _timePicker.FocusAsync())">Focus Time picker</FluentButton>

@code {
    FluentDatePicker _datePicker = null!;
    FluentTimePicker _timePicker = null!;
    private DateTime? _dateTime = DateTime.Now;
    private DateTime? _Time = DateTime.Now;
}
```

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
