### PR TITLE
[DatePicker] Allow to prevent scrolling on focus

### DIFF
--- a/src/Core/Components/Base/FluentInputBase.cs
+++ b/src/Core/Components/Base/FluentInputBase.cs
@@ -366,7 +366,7 @@ public abstract partial class FluentInputBase<TValue> : FluentComponentBase, IDi
     /// means that the browser will scroll the element into view after focusing it.
     /// If preventScroll is set to true, no scrolling will occur.</param>
     [SuppressMessage("Style", "VSTHRD200:Use `Async` suffix for async methods", Justification = "#vNext: To update in the next version")]
-    public async void FocusAsync(bool preventScroll)
+    public virtual async void FocusAsync(bool preventScroll)
     {
         await Element!.FocusAsync(preventScroll);
     }

--- a/src/Core/Components/DateTime/FluentDatePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor.cs
@@ -163,4 +163,9 @@ public partial class FluentDatePicker : FluentCalendarBase
     {
         TextField?.FocusAsync();
     }
+
+    public override void FocusAsync(bool preventScroll)
+    {
+        TextField?.FocusAsync(preventScroll);
+    }
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

I haven't seen that there is a second method to focus an element in PR #4167. This PR marks the second FocusAsync as `virtual` as well and it gets overwritten in the `FluentDatePicker`

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
