### PR TITLE
[DataGrid] Fix invalid optimization when using Virtualize icw ItemsProvider

### DIFF
--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -752,9 +752,6 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
             // (2) We won't know what slice of data to query for
             await _virtualizeComponent.RefreshDataAsync();
             _pendingDataLoadCancellationTokenSource = null;
-
-            StateHasChanged();
-            return;
         }
 
         // If we're not using Virtualize, we build and execute a request against the items provider directly


### PR DESCRIPTION
Remove an invalid optimization. In case of Virtualize icw ItemsProvider, the rest of the code still needs to be executed otherwise InternalGridContext.Items will not get updated.

Fix #4148 