### PR TITLE
[dev-v5] Keep a predefined dark/light theme

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Theme/Dark/ThemeDark.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Theme/Dark/ThemeDark.md
@@ -23,12 +23,15 @@ public async Task SwitchThemeAsync()
 {
     DarkTheme = !DarkTheme;
     await JSRuntime.InvokeVoidAsync(DarkTheme ? "Blazor.theme.setDarkTheme" : "Blazor.theme.setLightTheme");
+
+    // Or simply toggle the theme
+    // await JSRuntime.InvokeVoidAsync("Blazor.theme.switchTheme");
 }
 ```
 
 > [!NOTE] Soon you will be able to use the Blazor `FluentDesignTheme` component to manage themes in a more declarative way.
 
-#  body data-theme
+## body data-theme
 
 The `<body data-theme>` attribute is used to specify the current theme of the application.  
 When the dark theme is applied, this attribute will be set to `data-theme="dark"`.  
@@ -36,6 +39,12 @@ When the light theme is applied, this attribute will be missing.
 
 For example, open the browser DevTools and switch between light and dark themes using the top-right button.
 You will see the `data-theme` attribute change accordingly.
+
+**Force a theme**
+
+The theme is automatically managed by Fluent UI Blazor when the application is first loaded (Startup).  
+You can force a specific theme by directly adding the attribute `data-theme="dark"` or `data-theme="light"`
+in the `<body>` tag of your `index.html` or `_Host.cshtml` file.
 
 **Style**
 
@@ -53,7 +62,7 @@ body[data-theme="dark"] {
 }
 ```
 
-**Client side**
+## themeChanged event
 
 A JavaScript `themeChanged` event is triggered each time the `data-theme` attribute changes.
 
@@ -61,6 +70,24 @@ A JavaScript `themeChanged` event is triggered each time the `data-theme` attrib
 <script>
     document.body.addEventListener('themeChanged', function (e) {
         console.log('Theme changed: isDark=', e.detail.isDark);
+    });
+</script>
+```
+
+The theme does not update by default when the user changes the system or browser theme, and it is not saved across sessions.
+You can listen to the `themeChanged` event to implement your own logic, such as saving the user's preference in local storage or cookies.
+Or to automatically switch themes based on system preferences.
+
+```html
+<script>
+    document.body.addEventListener('themeChanged', function (e) {
+        if (e.detail.isDark) {
+            // Apply dark theme
+            Blazor.theme.setDarkTheme();
+        } else {
+            // Apply light theme
+            Blazor.theme.setLightTheme();
+        }        
     });
 </script>
 ```

--- a/examples/Demo/FluentUI.Demo.Client/Layout/DemoMainLayout.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Layout/DemoMainLayout.razor
@@ -20,9 +20,8 @@
         @* DarkTheme *@
         <FluentButton IconStart="@(new Icons.Regular.Size20.DarkTheme().WithColor("var(--colorNeutralForegroundOnBrand)"))"
                         OnClick="@SwitchThemeAsync"
-                        Appearance="ButtonAppearance.Subtle"
-                        BackgroundColor="@(_darkTheme ? "var(--colorBrandBackground)" : "var(--colorBrandBackgroundHover)")"
-                        Title="Switch to Dark theme (Under development)" />
+                        Appearance="ButtonAppearance.Transparent"
+                        Title="Switch to Light/Dark theme" />
 
         @* Reboot *@
         <FluentButton IconStart="@(new Icons.Regular.Size20.DrawText().WithColor("var(--colorNeutralForegroundOnBrand)"))"

--- a/examples/Demo/FluentUI.Demo.Client/Layout/DemoMainLayout.razor.cs
+++ b/examples/Demo/FluentUI.Demo.Client/Layout/DemoMainLayout.razor.cs
@@ -14,7 +14,6 @@ public partial class DemoMainLayout
     private FluentLayoutHamburger _hamburger = default!;
     private bool _consoleLogOpened;
     private bool _useReboot;
-    private bool _darkTheme;
 
     [Inject]
     public required IJSRuntime JSRuntime { get; set; }
@@ -37,8 +36,7 @@ public partial class DemoMainLayout
 
     private async Task SwitchThemeAsync()
     {
-        _darkTheme = !_darkTheme;
-        await JSRuntime.InvokeVoidAsync(_darkTheme ? "Blazor.theme.setDarkTheme" : "Blazor.theme.setLightTheme");
+        await JSRuntime.InvokeVoidAsync("Blazor.theme.switchTheme");
     }
 
     private void ReloadReboot()

--- a/src/Core.Scripts/src/Startup.ts
+++ b/src/Core.Scripts/src/Startup.ts
@@ -47,12 +47,7 @@ export namespace Microsoft.FluentUI.Blazor.Startup {
     // Initialize Fluent UI theme
     blazor.theme = ThemeFile.FluentUI.Blazor.Utilities.Theme;
     ThemeFile.FluentUI.Blazor.Utilities.Theme.addMediaQueriesListener();
-    if (blazor.theme.isSystemDark()) {
-      blazor.theme.setDarkTheme();
-    }
-    else {
-      blazor.theme.setLightTheme();
-    }
+    ThemeFile.FluentUI.Blazor.Utilities.Theme.setDefaultTheme();
 
     // Initialize all custom components
     FluentPageScript.registerComponent(blazor, mode);

--- a/src/Core.Scripts/src/Utilities/Theme.ts
+++ b/src/Core.Scripts/src/Utilities/Theme.ts
@@ -43,8 +43,8 @@ export namespace Microsoft.FluentUI.Blazor.Utilities.Theme {
    * @returns
    */
   export function isDarkMode(): boolean {
-    const luminance: string = getComputedStyle(document.documentElement).getPropertyValue('--base-layer-luminance');
-    return parseFloat(luminance) < 0.5;
+    const bodyTheme = document.body.getAttribute('data-theme');
+    return bodyTheme === 'dark';
   }
 
   /**
@@ -61,6 +61,41 @@ export namespace Microsoft.FluentUI.Blazor.Utilities.Theme {
   export function setDarkTheme(): void {
     setTheme(webDarkTheme);
     updateBodyTag(true);
+  }
+
+  /**
+   * Switches the FluentUI theme between light and dark mode.
+   * And returns true if the new theme is dark mode, false otherwise.
+   */
+  export function switchTheme(): boolean {
+    if (isDarkMode()) {
+      setLightTheme();
+      return false;
+    } else {
+      setDarkTheme();
+      return true;
+    }
+  }
+
+  /**
+   * Sets the FluentUI theme to the default mode based on the body `data-theme` attribute or the browser preference
+   */
+  export function setDefaultTheme(): void {
+    // If the theme is already set by the dev, use it, otherwise try to check browser-prefers scheme
+    const bodyTheme = document.body.getAttribute('data-theme');
+
+    if (bodyTheme === 'dark') {
+      setDarkTheme();
+    }
+    else if (bodyTheme === 'light') {
+      setLightTheme();
+    }
+    else if (isSystemDark()) {
+      setDarkTheme();
+    }
+    else {
+      setLightTheme();
+    }
   }
 
   /**
@@ -112,14 +147,14 @@ export namespace Microsoft.FluentUI.Blazor.Utilities.Theme {
     // Add event listeners for each media query
     getMediaQueries().forEach((mediaQuery) => {
       window.matchMedia(mediaQuery.query).addEventListener('change', media => {
-          if (media.matches) {
-            const bodyTag: HTMLElement = document?.body;
-            if (bodyTag && bodyTag.getAttribute('data-media') !== mediaQuery.id) {
-              bodyTag.setAttribute('data-media', mediaQuery.id);
-              dispatchMediaChanged(bodyTag);
-            }
+        if (media.matches) {
+          const bodyTag: HTMLElement = document?.body;
+          if (bodyTag && bodyTag.getAttribute('data-media') !== mediaQuery.id) {
+            bodyTag.setAttribute('data-media', mediaQuery.id);
+            dispatchMediaChanged(bodyTag);
           }
-        });
+        }
+      });
     });
   }
 


### PR DESCRIPTION
# [dev-v5] Keep a predefined dark/light theme

The theme is automatically managed by Fluent UI Blazor when the application is first loaded (Startup).  
You can force a specific theme by directly adding the attribute `data-theme="dark"` or `data-theme="light"`
in the `<body>` tag of your `index.html` or `_Host.cshtml` file.

We also added a JavaScript function `Blazor.theme.switchTheme` to simplify the switch from light/dark mode.

The theme does not update by default when the user changes the system or browser theme, and it is not saved across sessions.
You can listen to the `themeChanged` event to implement your own logic, such as saving the user's preference in local storage or cookies.
Or to automatically switch themes based on system preferences.

## Unit Tests

No changes