### PR TITLE
[Docs] Update keycode docs to reflect latest interface

### DIFF
--- a/examples/Demo/Shared/Pages/KeyCode/KeyCodePage.razor
+++ b/examples/Demo/Shared/Pages/KeyCode/KeyCodePage.razor
@@ -39,7 +39,10 @@ protected override void OnInitialized()
     KeyCodeService.RegisterListener(OnKeyDownAsync);
 }
 
-public async Task OnKeyDownAsync(FluentKeyCodeEventArgs args) => { // ... }
+public async Task OnKeyDownAsync(FluentKeyCodeEventArgs args)
+{
+    // ...
+}
 
 public ValueTask DisposeAsync()
 {
@@ -49,7 +52,7 @@ public ValueTask DisposeAsync()
         </li>
         <li>
             Implement the interface <b>IKeyCodeListener</b>, retrieve the service and register the method that will capture the keys:<br />
-            <CodeSnippet Language="CSharp">public partial MyPage : IKeyCodeListener, IDisposableAsync
+            <CodeSnippet Language="CSharp">public partial MyPage : IKeyCodeListener, IAsyncDisposable
 {
     [Inject]
     private IKeyCodeService KeyCodeService { get; set; }
@@ -59,7 +62,15 @@ public ValueTask DisposeAsync()
         KeyCodeService.RegisterListener(this);
     }
 
-    public async Task OnKeyDownAsync(FluentKeyCodeEventArgs args) => { // ... }
+    public async Task OnKeyDownAsync(FluentKeyCodeEventArgs args)
+    {
+        // ...
+    }
+
+    public async Task OnKeyUpAsync(FluentKeyCodeEventArgs args)
+    {
+        // ...
+    }
 
     public ValueTask DisposeAsync()
     {


### PR DESCRIPTION
Some small updates to the `FluentKeyCode` docs.

- `IDisposableAsync` has been changed to `IAsyncDisposable`
- `OnKeyUpAsync` has been added from the `IKeyCodeListener` interface
- `=>` has been removed to make the code copyable

