### PR TITLE
[dev-v5][Select] Apply `Width` and don't use min-width for dropdown

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DebugPage.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DebugPage.razor
@@ -1,0 +1,78 @@
+﻿@page "/Debug"
+
+<div style="padding: 1rem;">
+
+	<FluentTextInput Width="100%" />
+	<FluentTextInput Width="100%" Label="With label" />
+
+	<FluentTextArea Width="100%" />
+	<FluentTextArea Width="100%" Label="With label" />
+	<FluentTextArea Width="100%" LabelWidth="100%" />
+	<FluentTextArea Width="100%" LabelWidth="100%" Label="With label and LabelWidth" />
+
+	<FluentSelect Width="100%" Items="Colors" @bind-Value="Value" />
+	<FluentSelect Width="100%" Items="Colors" @bind-Value="Value" Label="With label" />
+	<FluentSelect Width="100%" LabelWidth="100%" Items="Colors" @bind-Value="Value" />
+	<FluentSelect Width="100%" LabelWidth="100%" Items="Colors" @bind-Value="Value" Label="With label and LabelWidth" />
+
+
+
+
+	<FluentCombobox Width="100%" OptionText="@(i => i?.Name)" OptionValue="@(i => i?.Code)" Items="@Countries" @bind-SelectedItems="@SelectedCountries">
+		<FreeOption>
+			Search for '<FreeOptionOutput />'
+		</FreeOption>
+	</FluentCombobox>
+
+	<FluentCombobox Width="100%" Label="With Label" OptionText="@(i => i?.Name)" OptionValue="@(i => i?.Code)" Items="@Countries" @bind-SelectedItems="@SelectedCountries">
+		<FreeOption>
+			Search for '<FreeOptionOutput />'
+		</FreeOption>
+	</FluentCombobox>
+
+	<FluentCombobox Width="100%" LabelWidth="100%" OptionText="@(i => i?.Name)" OptionValue="@(i => i?.Code)" Items="@Countries" @bind-SelectedItems="@SelectedCountries">
+		<FreeOption>
+			Search for '<FreeOptionOutput />'
+		</FreeOption>
+	</FluentCombobox>
+
+	<FluentCombobox Width="100%" Label="With Label and LabelWidth" OptionText="@(i => i?.Name)" OptionValue="@(i => i?.Code)" Items="@Countries" @bind-SelectedItems="@SelectedCountries">
+		<FreeOption>
+			Search for '<FreeOptionOutput />'
+		</FreeOption>
+	</FluentCombobox>
+
+	<FluentDatePicker Width="100%"
+					  @bind-Value="@SelectedValue" />
+
+	<FluentDatePicker Label="With label"
+					  Width="100%"
+					  @bind-Value="@SelectedValue" />
+
+	<FluentDatePicker Width="100%"
+					  LabelWidth="100%"
+					  @bind-Value="@SelectedValue" />
+
+	<FluentDatePicker Label="With label and LabelWidth"
+					  LabelWidth="100%"
+					  Width="100%"
+					  @bind-Value="@SelectedValue" />
+
+	<FluentTimePicker @bind-Value="@SelectedTime" Width="100%" />
+	<FluentTimePicker @bind-Value="@SelectedTime" Width="100%" Label="With label" />
+	<FluentTimePicker @bind-Value="@SelectedTime" Width="100%" LabelWidth="100%" />
+	<FluentTimePicker @bind-Value="@SelectedTime" Width="100%" Label="With label and LabelWidth" LabelWidth="100%" />
+
+	<FluentSwitch @bind-Value="@value" LabelWidth="100%" />
+	<FluentSwitch @bind-Value="@value" LabelWidth="100%" Label="With Label and LabelWidth" />
+</div>
+@code {
+	IEnumerable<SampleData.Olympics2024.Country> Countries = SampleData.Olympics2024.Countries;
+	IEnumerable<SampleData.Olympics2024.Country> SelectedCountries = [];
+
+	DateOnly? SelectedValue = null;
+	TimeOnly? SelectedTime = null;
+	static string[] Colors = ["Red", "Green", "Blue"];
+	string? Value;
+	bool value = false;
+}

--- a/src/Core/Components/List/FluentSelect.razor.cs
+++ b/src/Core/Components/List/FluentSelect.razor.cs
@@ -23,13 +23,18 @@ public partial class FluentSelect<TOption, TValue> : FluentListBase<TOption, TVa
     protected virtual string DropdownType => "dropdown";
 
     /// <summary />
+    protected override string? StyleValue => DefaultStyleBuilder
+        .AddStyle("width", Width)
+        .Build();
+
+    /// <summary />
     protected virtual string? DropdownStyle => new StyleBuilder()
         .AddStyle("width", Width, when: !string.IsNullOrEmpty(Width))
         .Build();
 
     /// <summary />
     protected virtual string? ListStyle => new StyleBuilder()
-        .AddStyle("min-width", Width, when: !string.IsNullOrEmpty(Width))
+        //.AddStyle("min-width", Width, when: !string.IsNullOrEmpty(Width))
         .AddStyle("height", Height, when: !string.IsNullOrEmpty(Height))
         .Build();
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR applies the `Width` parameter to `FluentSelect` so it will be applied automatically for `FluentCombobox`, FluentSelect` and `FluentTimePicker`

In addition it removes the `min-width` CSS declartion from `ListStyle` as it will generate overflow on the x-axis.

### 🎫 Issues

Fixes #4545 

## 👩‍💻 Reviewer Notes

This PR is for discussion purposes. It’s still not clear what the purpose of `LabelWidth` is. However this PR aligns the functionality of #4475 for all components.

## 📑 Test Plan

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [ ] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
