### PR TITLE
[dev-v5] Update debug page for EditForm

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/DebugPages/EditFormPage.razor
+++ b/examples/Demo/FluentUI.Demo.Client/DebugPages/EditFormPage.razor
@@ -1,12 +1,52 @@
 ﻿@page "/Debug/EditForm"
 
-<h1>Just a simple page to do some experimenting</h1>
+<FluentStack Orientation="Orientation.Vertical" VerticalGap="6px" Style="padding: 1em;">
+	<h1>Just a simple page to do some experimenting</h1>
+	<FluentCard>
+		<h2>Debug flags</h2>
+		<FluentSwitch @bind-Value="useNativeButton" Label="Use native submit button" />
+		<FluentSwitch @bind-Value="useNativeInputs" Label="Use native inputs" />
+	</FluentCard>
 
-<InputText @bind-Value="@MyValue" />
-<FluentTextInput Value="@MyValue" />
+	<FluentCard>
+		<h2>Form</h2>
+		<EditForm Model="Input" OnValidSubmit="OnValidSubmit">
+			<FluentStack Orientation="Orientation.Vertical" VerticalGap="6px">
+				@if (useNativeInputs)
+				{
+					<InputText @bind-Value="Input.MyValue" />
+				}
+				else
+				{
+					<FluentTextInput @bind-Value="@Input.MyValue" /> @* Pressing enter in the input will trigger the OnValidSubmit twice *@
+				}
+		
 
-MyValue: @MyValue
+				@if (useNativeButton)
+				{
+					<button type="submit">Submit</button>
+				}
+				else
+				{
+					<FluentButton Type="ButtonType.Submit" Appearance="ButtonAppearance.Primary">Submit</FluentButton>
+				}
+			</FluentStack>
+		</EditForm>
+	</FluentCard>
+</FluentStack>
 
 @code {
-    public string MyValue { get; set; } = "Test";
+	bool useNativeButton;
+	bool useNativeInputs;
+	MyInput Input { get; set; } = new();
+
+	public void OnValidSubmit()
+	{
+		Console.WriteLine($"Submitted value: {Input.MyValue}");
+	}
+
+	public class MyInput
+	{
+		public string MyValue { get; set; } = "Test";
+	}
 }


### PR DESCRIPTION
This PR is updating the debug page for `EditForm`.

It adds two debug toggles to switch between native rendering for inputs and buttons. In addition it adds a test model which can be expanded with more properties for testing. Right now the debug page is showcasing an issue which we thought has been fixed already #1050 but seems to be broken again.

