### PR TITLE
[DragContrainer][DropZone] Switch to `EventCallback`

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -3936,6 +3936,7 @@
             left (full height), right (full height)
             or screen middle (using Width and Height properties).
             HorizontalAlignment.Stretch is not supported for this property.
+            NOTE: Left/Right only works for Panels, not Dialogs, which are always centered.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.DialogParameters.Title">
@@ -4736,22 +4737,22 @@
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentDropZone`1.IsOver">
             <summary />
         </member>
-        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDropZone`1.OnDragStartHandler(Microsoft.AspNetCore.Components.Web.DragEventArgs)">
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDropZone`1.OnDragStartHandlerAsync(Microsoft.AspNetCore.Components.Web.DragEventArgs)">
             <summary />
         </member>
-        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDropZone`1.OnDragEndHandler(Microsoft.AspNetCore.Components.Web.DragEventArgs)">
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDropZone`1.OnDragEndHandlerAsync(Microsoft.AspNetCore.Components.Web.DragEventArgs)">
             <summary />
         </member>
-        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDropZone`1.OnDragEnterHandler(Microsoft.AspNetCore.Components.Web.DragEventArgs)">
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDropZone`1.OnDragEnterHandlerAsync(Microsoft.AspNetCore.Components.Web.DragEventArgs)">
             <summary />
         </member>
-        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDropZone`1.OnDragOverHandler(Microsoft.AspNetCore.Components.Web.DragEventArgs)">
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDropZone`1.OnDragOverHandlerAsync(Microsoft.AspNetCore.Components.Web.DragEventArgs)">
             <summary />
         </member>
-        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDropZone`1.OnDragLeaveHandler(Microsoft.AspNetCore.Components.Web.DragEventArgs)">
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDropZone`1.OnDragLeaveHandlerAsync(Microsoft.AspNetCore.Components.Web.DragEventArgs)">
             <summary />
         </member>
-        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDropZone`1.OnDropHandler(Microsoft.AspNetCore.Components.Web.DragEventArgs)">
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentDropZone`1.OnDropHandlerAsync(Microsoft.AspNetCore.Components.Web.DragEventArgs)">
             <summary />
         </member>
         <member name="T:Microsoft.FluentUI.AspNetCore.Components.CustomEmoji">
@@ -8532,6 +8533,12 @@
             <param name="force">If true, the total item count will be updated even if it is the same as the current value.</param>
             <returns></returns>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.LibraryConfiguration">
+            <summary />
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.JSRuntime">
+            <summary />
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.AnchorId">
             <summary>
             Gets or sets the id of the component the popover is positioned relative to.
@@ -8610,19 +8617,26 @@
             By default, Escape
             </summary>
         </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.CloseAndTabKeys">
-            <summary />
-        </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.OnInitialized">
             <summary />
         </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.OnParametersSet">
             <summary />
         </member>
-        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.CloseAsync">
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.OnAfterRenderAsync(System.Boolean)">
             <summary />
         </member>
-        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.CloseOnKeyAsync(Microsoft.FluentUI.AspNetCore.Components.FluentKeyCodeEventArgs)">
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.CloseAsync">
+            <summary>
+            Closes the popover. Called from JavaScript keyboard navigation.
+            </summary>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.CloseOverlayAsync">
+            <summary>
+            Closes the popover and returns focus to the original element (used by the overlay on outside-click).
+            </summary>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.DisposeAsync">
             <summary />
         </member>
         <member name="T:Microsoft.FluentUI.AspNetCore.Components.FluentPresenceBadge">

--- a/src/Core/Components/Drag/FluentDragContainer.razor.cs
+++ b/src/Core/Components/Drag/FluentDragContainer.razor.cs
@@ -26,37 +26,37 @@ public partial class FluentDragContainer<TItem> : FluentComponentBase
     /// This event is fired when the user starts dragging an element.
     /// </summary>
     [Parameter]
-    public Action<FluentDragEventArgs<TItem>>? OnDragStart { get; set; }
+    public EventCallback<FluentDragEventArgs<TItem>> OnDragStart { get; set; }
 
     /// <summary>
     /// This event is fired when the drag operation ends (such as releasing a mouse button or hitting the Esc key).
     /// </summary>
     [Parameter]
-    public Action<FluentDragEventArgs<TItem>>? OnDragEnd { get; set; }
+    public EventCallback<FluentDragEventArgs<TItem>> OnDragEnd { get; set; }
 
     /// <summary>
     /// This event is fired when a dragged element enters a valid drop target.
     /// </summary>
     [Parameter]
-    public Action<FluentDragEventArgs<TItem>>? OnDragEnter { get; set; }
+    public EventCallback<FluentDragEventArgs<TItem>> OnDragEnter { get; set; }
 
     /// <summary>
     /// This event is fired when an element is being dragged over a valid drop target.
     /// </summary>
     [Parameter]
-    public Action<FluentDragEventArgs<TItem>>? OnDragOver { get; set; }
+    public EventCallback<FluentDragEventArgs<TItem>> OnDragOver { get; set; }
 
     /// <summary>
     /// This event is fired when a dragged element leaves a valid drop target.
     /// </summary>
     [Parameter]
-    public Action<FluentDragEventArgs<TItem>>? OnDragLeave { get; set; }
+    public EventCallback<FluentDragEventArgs<TItem>> OnDragLeave { get; set; }
 
     /// <summary>
     /// This event is fired when an element is dropped on a valid drop target.
     /// </summary>
     [Parameter]
-    public Action<FluentDragEventArgs<TItem>>? OnDropEnd { get; set; }
+    public EventCallback<FluentDragEventArgs<TItem>> OnDropEnd { get; set; }
 
     /// <summary>
     /// property to keep the zone currently dragged.

--- a/src/Core/Components/Drag/FluentDropZone.razor
+++ b/src/Core/Components/Drag/FluentDropZone.razor
@@ -13,14 +13,15 @@
      @ondragover:stopPropagation="@StopPropagation"
      @ondragleave:stopPropagation="@StopPropagation"
      @ondragstart:stopPropagation="@StopPropagation"
-     @ondragstart=@OnDragStartHandler
-     @ondragover=@OnDragOverHandler
+     @ondragstart="@OnDragStartHandlerAsync"
+     @ondragover="@OnDragOverHandlerAsync"
      @ondragover:preventDefault="@Droppable"
-     @ondragenter=@OnDragEnterHandler
+     @ondragenter="@OnDragEnterHandlerAsync"
      @ondragenter:preventDefault="@Droppable"
-     @ondragleave=@OnDragLeaveHandler
+     @ondragleave="@OnDragLeaveHandlerAsync"
      @ondragleave:preventDefault="@Droppable"
-     @ondragend=@OnDragEndHandler
-     @ondrop=@OnDropHandler @ondrop:preventDefault>
+     @ondragend="@OnDragEndHandlerAsync"
+     @ondrop="@OnDropHandlerAsync"
+     @ondrop:preventDefault>
     @ChildContent
 </div>

--- a/src/Core/Components/Drag/FluentDropZone.razor.cs
+++ b/src/Core/Components/Drag/FluentDropZone.razor.cs
@@ -50,37 +50,37 @@ public partial class FluentDropZone<TItem> : FluentComponentBase
     /// This event is fired when the user starts dragging an element.
     /// </summary>
     [Parameter]
-    public Action<FluentDragEventArgs<TItem>>? OnDragStart { get; set; }
+    public EventCallback<FluentDragEventArgs<TItem>> OnDragStart { get; set; }
 
     /// <summary>
     /// This event is fired when the drag operation ends (such as releasing a mouse button or hitting the Esc key).
     /// </summary>
     [Parameter]
-    public Action<FluentDragEventArgs<TItem>>? OnDragEnd { get; set; }
+    public EventCallback<FluentDragEventArgs<TItem>> OnDragEnd { get; set; }
 
     /// <summary>
     /// This event is fired when a dragged element enters a valid drop target.
     /// </summary>
     [Parameter]
-    public Action<FluentDragEventArgs<TItem>>? OnDragEnter { get; set; }
+    public EventCallback<FluentDragEventArgs<TItem>> OnDragEnter { get; set; }
 
     /// <summary>
     /// This event is fired when an element is being dragged over a valid drop target.
     /// </summary>
     [Parameter]
-    public Action<FluentDragEventArgs<TItem>>? OnDragOver { get; set; }
+    public EventCallback<FluentDragEventArgs<TItem>> OnDragOver { get; set; }
 
     /// <summary>
     /// This event is fired when a dragged element leaves a valid drop target.
     /// </summary>
     [Parameter]
-    public Action<FluentDragEventArgs<TItem>>? OnDragLeave { get; set; }
+    public EventCallback<FluentDragEventArgs<TItem>> OnDragLeave { get; set; }
 
     /// <summary>
     /// This event is fired when an element is dropped on a valid drop target.
     /// </summary>
     [Parameter]
-    public Action<FluentDragEventArgs<TItem>>? OnDropEnd { get; set; }
+    public EventCallback<FluentDragEventArgs<TItem>> OnDropEnd { get; set; }
 
     /// <summary>
     /// Gets or sets a way to prevent further propagation of the current event in the capturing and bubbling phases.
@@ -92,7 +92,7 @@ public partial class FluentDropZone<TItem> : FluentComponentBase
     private bool IsOver { get; set; } = false;
 
     /// <summary />
-    private void OnDragStartHandler(DragEventArgs e)
+    private async Task OnDragStartHandlerAsync(DragEventArgs e)
     {
         if (!Draggable)
         {
@@ -101,38 +101,38 @@ public partial class FluentDropZone<TItem> : FluentComponentBase
 
         Container.SetStartedZone(this);
 
-        if (OnDragStart != null)
+        if (OnDragStart.HasDelegate)
         {
-            OnDragStart(new FluentDragEventArgs<TItem>(this, this));
+            await OnDragStart.InvokeAsync(new FluentDragEventArgs<TItem>(source: this, target: this));
         }
 
-        if (Container.OnDragStart != null)
+        if (Container.OnDragStart.HasDelegate)
         {
-            Container.OnDragStart(new FluentDragEventArgs<TItem>(this, this));
+            await Container.OnDragStart.InvokeAsync(new FluentDragEventArgs<TItem>(source: this, target: this));
         }
     }
 
     /// <summary />
-    private void OnDragEndHandler(DragEventArgs e)
+    private async Task OnDragEndHandlerAsync(DragEventArgs e)
     {
         if (!Draggable)
         {
             return;
         }
 
-        if (OnDragEnd != null)
+        if (OnDragEnd.HasDelegate)
         {
-            OnDragEnd(new FluentDragEventArgs<TItem>(this, this));
+            await OnDragEnd.InvokeAsync(new FluentDragEventArgs<TItem>(source: this, target: this));
         }
 
-        if (Container.OnDragEnd != null)
+        if (Container.OnDragEnd.HasDelegate)
         {
-            Container.OnDragEnd(new FluentDragEventArgs<TItem>(this, this));
+            await Container.OnDragEnd.InvokeAsync(new FluentDragEventArgs<TItem>(source: this, target: this));
         }
     }
 
     /// <summary />
-    private void OnDragEnterHandler(DragEventArgs e)
+    private async Task OnDragEnterHandlerAsync(DragEventArgs e)
     {
         if (!Droppable)
         {
@@ -146,19 +146,19 @@ public partial class FluentDropZone<TItem> : FluentComponentBase
             return;
         }
 
-        if (OnDragEnter != null)
+        if (OnDragEnter.HasDelegate)
         {
-            OnDragEnter(new FluentDragEventArgs<TItem>(Container.StartedZone, this));
+            await OnDragEnter.InvokeAsync(new FluentDragEventArgs<TItem>(source: Container.StartedZone, target: this));
         }
 
-        if (Container.OnDragEnter != null)
+        if (Container.OnDragEnter.HasDelegate)
         {
-            Container.OnDragEnter(new FluentDragEventArgs<TItem>(Container.StartedZone, this));
+            await Container.OnDragEnter.InvokeAsync(new FluentDragEventArgs<TItem>(source: Container.StartedZone, target: this));
         }
     }
 
     /// <summary />
-    private void OnDragOverHandler(DragEventArgs e)
+    private async Task OnDragOverHandlerAsync(DragEventArgs e)
     {
         if (!Droppable)
         {
@@ -172,19 +172,19 @@ public partial class FluentDropZone<TItem> : FluentComponentBase
 
         IsOver = true;
 
-        if (OnDragOver != null)
+        if (OnDragOver.HasDelegate)
         {
-            OnDragOver(new FluentDragEventArgs<TItem>(Container.StartedZone, this));
+            await OnDragOver.InvokeAsync(new FluentDragEventArgs<TItem>(source: Container.StartedZone, target: this));
         }
 
-        if (Container.OnDragOver != null)
+        if (Container.OnDragOver.HasDelegate)
         {
-            Container.OnDragOver(new FluentDragEventArgs<TItem>(Container.StartedZone, this));
+            await Container.OnDragOver.InvokeAsync(new FluentDragEventArgs<TItem>(source: Container.StartedZone, target: this));
         }
     }
 
     /// <summary />
-    private void OnDragLeaveHandler(DragEventArgs e)
+    private async Task OnDragLeaveHandlerAsync(DragEventArgs e)
     {
         if (!Droppable)
         {
@@ -198,19 +198,19 @@ public partial class FluentDropZone<TItem> : FluentComponentBase
             return;
         }
 
-        if (OnDragLeave != null)
+        if (OnDragLeave.HasDelegate)
         {
-            OnDragLeave(new FluentDragEventArgs<TItem>(Container.StartedZone, this));
+            await OnDragLeave.InvokeAsync(new FluentDragEventArgs<TItem>(source: Container.StartedZone, target: this));
         }
 
-        if (Container.OnDragLeave != null)
+        if (Container.OnDragLeave.HasDelegate)
         {
-            Container.OnDragLeave(new FluentDragEventArgs<TItem>(Container.StartedZone, this));
+            await Container.OnDragLeave.InvokeAsync(new FluentDragEventArgs<TItem>(source: Container.StartedZone, target: this));
         }
     }
 
     /// <summary />
-    private void OnDropHandler(DragEventArgs e)
+    private async Task OnDropHandlerAsync(DragEventArgs e)
     {
         if (!Droppable)
         {
@@ -224,14 +224,14 @@ public partial class FluentDropZone<TItem> : FluentComponentBase
             return;
         }
 
-        if (OnDropEnd != null)
+        if (OnDropEnd.HasDelegate)
         {
-            OnDropEnd(new FluentDragEventArgs<TItem>(Container.StartedZone, this));
+            await OnDropEnd.InvokeAsync(new FluentDragEventArgs<TItem>(source: Container.StartedZone, target: this));
         }
 
-        if (Container.OnDropEnd != null)
+        if (Container.OnDropEnd.HasDelegate)
         {
-            Container.OnDropEnd(new FluentDragEventArgs<TItem>(Container.StartedZone, this));
+            await Container.OnDropEnd.InvokeAsync(new FluentDragEventArgs<TItem>(source: Container.StartedZone, target: this));
         }
 
         Container.SetStartedZone(null);


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR updates the `FluentDragContainer` and `FluentDropZone` components and exchanges all `Action<FluentDragEventArgs<TItem>>` with `EventCallback<FluentDragEventArgs<TItem>>`. This makes it possible to provide both `Task` and `void` methods as callback.

This three methods are now possible:
```cs
private void OnRowDropEnd(FluentDragEventArgs<FormRow> e) ...

private Task OnRowDropEnd(FluentDragEventArgs<FormRow> e) ...

private async Task OnRowDropEnd(FluentDragEventArgs<FormRow> e) ...
```

This should not introduce any breaking change.

These changes are the same as we have already done in v5. See: #4590

### 🎫 Issues

Fix: #4598 

## 👩‍💻 Reviewer Notes


## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
