### PR TITLE
Autocomplete SelectedOption issue #4380

### DIFF
--- a/src/Core/Components/List/FluentAutocomplete.razor.cs
+++ b/src/Core/Components/List/FluentAutocomplete.razor.cs
@@ -27,6 +27,7 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
     private readonly Debounce _debounce = new();
     private bool _shouldRender = true;
     private bool _inProgress;
+    private IEnumerable<TOption> _allItems;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FluentAutocomplete{TOption}"/> class.
@@ -279,6 +280,38 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
     /// <summary />
     protected override bool ShouldRender() => _shouldRender;
 
+    public override async Task SetParametersAsync(ParameterView parameters)
+    {
+        if (!Multiple)
+        {
+            bool isSetSelectedOption = false;
+            TOption? newSelectedOption = default;
+
+            foreach (var parameter in parameters)
+            {
+                if (parameter.Name.Equals(nameof(SelectedOption)))
+                {
+                    isSetSelectedOption = true;
+                    newSelectedOption = (TOption?)parameter.Value;
+                    break;
+                }
+            }
+
+            if (newSelectedOption is not null)
+            {
+                if (isSetSelectedOption && !Equals(_currentSelectedOption, newSelectedOption))
+                {
+                    if (_allItems is not null && Items is not null
+                        && _allItems.Contains(newSelectedOption) && !Items.Contains(newSelectedOption))
+                    {
+                        Items = Items.Append(newSelectedOption)!;
+                    }
+                }
+            }
+        }
+        await base.SetParametersAsync(parameters);
+    }
+
     /// <summary>
     /// Closes the multiselect dropdown.
     /// </summary>
@@ -341,8 +374,17 @@ public partial class FluentAutocomplete<TOption> : ListComponentBase<TOption> wh
         };
 
         await OnOptionsSearch.InvokeAsync(args);
+        _allItems = args.Items;
 
-        Items = args.Items?.Take(MaximumOptionsSearch);
+        var topItems = _allItems.Take(MaximumOptionsSearch);
+        if (!Multiple && SelectedOption is not null && _allItems is not null && Items is not null)
+        {
+            if (_allItems.Contains(SelectedOption) && !topItems.Contains(SelectedOption))
+            {
+                topItems = _allItems.Take(MaximumOptionsSearch - 1).Append(SelectedOption);
+            }
+        }
+        Items = topItems;
 
         SelectableItem = Items != null
             ? Items.FirstOrDefault(i => OptionDisabled is null ? true : OptionDisabled.Invoke(i) == false)


### PR DESCRIPTION

# Pull Request

## 📖 Description
If the user clicks on autocomplete (or any action that invokes InvokeOptionsSearchAsync), then the SelectedOption is set outside of the component, and SelectedOptions does not exist in the top options (default 9 top options), the component clears the SelectedOption


## 📑 Test Plan

I updated an existing example for a test 
You can find it [here](https://github.com/ehsangfl/fluentui-blazor/blob/ehsangfl-patch-1/examples/Demo/Shared/Pages/List/Autocomplete/Examples/AutoCompleteMaxSingleItem.razor)

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [X] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [X] I have modified an existing component
- [ ] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
