### PR TITLE
[dev-v5][Docs] Add migration guide for `@onclick`

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentMenu.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentMenu.md
@@ -29,6 +29,7 @@ displaying the menu (using `popover` when available).
 - You need to change the type of the `Trigger` parameter from `MouseButton` to `string`. The value should be the `id` of the element the menu is attached to. If you want to attach opening the menu to the context menu action, you can use the `OpenOnContext` parameter. Opening the menu omn oter mouse button actions is no longer supported.
 - You need to change the type argument of the `OnCheckedChanged` event from `FluentMenuItem` to `MenuItemEventArgs`. the item concerned is available in the `Item` property of the event args.
 - You need to check the `MenuItemRole` values usage when migrating to v5. See below for the mapping of the values. The changed values have been mapped to the corresponding new values but they are marked obsolete and will be removed in a future release. 
+- If you were using `@onclick` on the `FluentMenuItem`, you need to replace it with the new `OnClick` parameter. Otherwise, your app will crash at runtime when loading the page or component containing the menu.
 
 |v3 & v4|v5|
 |-----|-----|


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR adds a small migration text for `@onclick` to the `FluentMenu` migration. In v4 it was possible to use `@onclick` on the `FluentMenuItem` component. In v5 you can still define `@onclick` but it will result in a runtime exception. Found this one out during my migration progress - coul dbe helpful for others.


## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [ ] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
