### PR TITLE
[dev-v5] Add integration test for FluentAutocomplete after event

### DIFF
--- a/tests/Integration/Components/FluentPlaywrightBaseTest.cs
+++ b/tests/Integration/Components/FluentPlaywrightBaseTest.cs
@@ -37,12 +37,13 @@ public abstract class FluentPlaywrightBaseTest : IAsyncDisposable, IDisposable
     /// </summary>
     protected virtual StartServerFixture Server { get; set; }
 
-    public async Task<IPage> WaitOpenPageAsync(string url, bool? openDevTools = null)
+    public async Task<IPage> WaitOpenPageAsync(string url, bool? openDevTools = null, bool? openHeadlessBrowser = null)
     {
         _playwright = await Playwright.Playwright.CreateAsync();
         _browser = await _playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions()
         {
-            Devtools = openDevTools
+            Devtools = openDevTools,
+            Headless = openHeadlessBrowser
         });
 
         var page = await _browser.NewPageAsync();

--- a/tests/Integration/Components/List/Autocomplete/Examples/OnChangeAfterPage.razor
+++ b/tests/Integration/Components/List/Autocomplete/Examples/OnChangeAfterPage.razor
@@ -1,0 +1,33 @@
+﻿@page "/list/autocomplete/onchange-after"
+
+<div>
+    Current count: <span data-testid="current-value">@countAfter</span>
+</div>
+
+<FluentAutocomplete TValue="string"
+                    TOption="string"
+                    Label="Test"
+                    Items="Options"
+                    @bind-SelectedItems="SelectedItems"
+                    @bind-SelectedItems:after="AfterChanged" />
+
+@code
+{
+    string test = string.Empty;
+    int countAfter = 0;
+    IEnumerable<string> SelectedItems { get; set; } = [];
+
+    void AfterChanged()
+    {
+        countAfter++;
+    }
+
+    List<string> Options = new List<string>
+    {
+        "Option 1",
+        "Option 2",
+        "Option 3",
+        "Option 4",
+        "Option 5"
+    };
+}

--- a/tests/Integration/Components/List/Autocomplete/FluentAutocompleteTests.cs
+++ b/tests/Integration/Components/List/Autocomplete/FluentAutocompleteTests.cs
@@ -1,0 +1,41 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using Microsoft.FluentUI.AspNetCore.Components.IntegrationTests.WebServer;
+using Microsoft.Playwright;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.IntegrationTests.Components.List;
+
+[Collection(StartServerCollection.Name)]
+public class FluentAutocompleteTests : FluentPlaywrightBaseTest
+{
+    public FluentAutocompleteTests(ITestOutputHelper output, StartServerFixture server)
+        : base(output, server)
+    {
+    }
+
+    [Fact(Skip = "Playwright is optional for the moment. This test will fail.")]
+    public async Task FluentAutocomplete_OnChangeAfter()
+    {
+        // Arrange
+        var page = await WaitOpenPageAsync($"/list/autocomplete/onchange-after", openDevTools: false);
+
+        // Act
+        await page.ClickAsync("fluent-text-input");
+        await page.ClickAsync("fluent-option");
+        await Task.Delay(100); // Wait for the onChange event to propagate
+
+        // Assert
+        await page.ScreenshotAsync(new()
+        {
+            Path = $"{Server.ScreenshotsFolder}FluentAutocomplete_OnChangeAfter.png"
+        });
+
+        await Assertions.Expect(page.GetByTestId("current-value"))
+                        .ToContainTextAsync("1");
+    }
+}
+


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR adds an additional integration test for the `FluentAutocomplete` component. I tried the same test case in the normal unit tests but here the count will always be one. When rendered on a real page the count is always two.

In addition this PR adds an optional parameter `openHeadlessBrowser` to `WaitOpenPageAsync` to control if the browser should be shown or not. This makes it easier during debug to see what's going on. 

The test is still disabled as this one will always fail right now. There is an bug in the `FluentAutocomplete` which will trigger the `:after` event to be executed twice.
## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [ ] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
