### PR TITLE
[dev-v5][Card] Add `CardShadow.None`

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Card/Examples/CardShadowExample.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Card/Examples/CardShadowExample.razor
@@ -16,6 +16,10 @@
         Large shadow
     </FluentCard>
 
+    <FluentCard Shadow="CardShadow.None" Width="150px" OnClick="@CardClick">
+        No shadow
+    </FluentCard>
+
 </FluentStack>
 
 @code

--- a/src/Core/Components/Card/FluentCard.razor.css
+++ b/src/Core/Components/Card/FluentCard.razor.css
@@ -30,6 +30,10 @@
   }
 
   /* Shadow */
+  .fluent-card[shadow="none"] {
+    box-shadow: none;
+  }
+
   .fluent-card[shadow="small"] {
     box-shadow: var(--shadow2);
   }

--- a/src/Core/Enums/CardShadow.cs
+++ b/src/Core/Enums/CardShadow.cs
@@ -34,4 +34,10 @@ public enum CardShadow
     /// </summary>
     [Description("large")]
     Large,
+
+    /// <summary>
+    /// There is no shadow below the card.
+    /// </summary>
+    [Description("none")]
+    None,
 }

--- a/tests/Core/Components/Card/FluentCardTests.razor
+++ b/tests/Core/Components/Card/FluentCardTests.razor
@@ -38,6 +38,7 @@
     [InlineData(CardShadow.Small, "shadow='small'")]
     [InlineData(CardShadow.Medium, "shadow='medium'")]
     [InlineData(CardShadow.Large, "shadow='large'")]
+    [InlineData(CardShadow.None, "shadow='none'")]
     [InlineData((CardShadow)999, "")]
     public void FluentCard_Shadow(CardShadow shadow, string expectedAttribute)
     {


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR adds the new enum variant `CardShadow.None`. This allows the developer to render a `FluentCard` without a background-shadow.

<img width="878" height="256" alt="grafik" src="https://github.com/user-attachments/assets/ab88242d-7e27-44d9-8f78-a4722e365241" />

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
