### PR TITLE
[Select] Fix selected items color

### DIFF
--- a/src/Core/Components/List/FluentSelect.razor.cs
+++ b/src/Core/Components/List/FluentSelect.razor.cs
@@ -24,7 +24,7 @@ public partial class FluentSelect<TOption> : ListComponentBase<TOption> where TO
         .AddStyle($"#{Id}::part(selected-value)", "white-space", "nowrap")
         .AddStyle($"#{Id}::part(selected-value)", "overflow", "hidden")
         .AddStyle($"#{Id}::part(selected-value)", "text-overflow", "ellipsis")
-        .AddStyle($"#{Id}::part(selected-value)", "color", "var(--input-placeholder-rest)", when: !string.IsNullOrEmpty(Placeholder) && SelectedOption is null)
+        .AddStyle($"#{Id}::part(selected-value)", "color", "var(--input-placeholder-rest)", when: !string.IsNullOrEmpty(Placeholder) && SelectedOption is null && string.IsNullOrEmpty(Value) && SelectedOptions is null)
         .BuildMarkupString();
 
     protected override string? StyleValue => new StyleBuilder(base.StyleValue)


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR fixes an issue with the selected value being colored as a placeholder in `FluentSelect` when the developer is using a binding other than `SelectedOption`.

Before:

<img width="219" height="126" alt="before" src="https://github.com/user-attachments/assets/3188140d-da61-42e9-aac1-2885a53011e6" />

After:

<img width="182" height="114" alt="after" src="https://github.com/user-attachments/assets/7da07000-10a3-4b18-b1bd-6e9988a5dede" />


## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
