### PR TITLE
[dev-v5] fix(mcp): Add missing ListCategories and ListEnums MCP tools

### DIFF
--- a/src/Tools/McpServer/README.md
+++ b/src/Tools/McpServer/README.md
@@ -185,11 +185,13 @@ Tools are invoked automatically by the LLM for dynamic queries.
 | Tool | Description | Parameters |
 |------|-------------|------------|
 | `ListComponents` | Lists all available components | `category` (optional) |
+| `ListCategories` | Lists all available component categories | - |
 | `GetComponentDetails` | Gets detailed documentation for a component | `componentName` |
 | `SearchComponents` | Searches components by name or description | `searchTerm` |
 | `GetEnumValues` | Gets enum type values | `enumName`, `filter` (optional) |
 | `GetComponentEnums` | Lists enums used by a component | `componentName` |
-| `ListDocumentationTopics` | Lists all documentation topics | - |
+| `ListEnums` | Lists all available enum types | - |
+| `ListDocumentation` | Lists all documentation topics | - |
 | `GetDocumentationTopic` | Gets detailed documentation for a documentation topic | `topicName` |
 | `SearchDocumentation` | Searches documentation by keyword | `searchTerm` |
 | `GetMigrationGuide` | Gets migration guide for upgrading to v5 | - |

--- a/src/Tools/McpServer/Tools/ComponentListTools.cs
+++ b/src/Tools/McpServer/Tools/ComponentListTools.cs
@@ -159,4 +159,37 @@ public class ComponentListTools
         // Sort the combined results by name for stable output
         return [.. components.Concat(additionalComponents).OrderBy(c => c.Name, StringComparer.OrdinalIgnoreCase)];
     }
+
+    /// <summary>
+    /// Lists all available component categories in the Fluent UI Blazor library.
+    /// Use this to discover valid category names for filtering <see cref="ListComponents"/>.
+    /// </summary>
+    /// <returns>
+    /// A formatted string listing all component categories with the number of components in each.
+    /// </returns>
+    [McpServerTool]
+    [Description("Lists all available component categories in Fluent UI Blazor. Use this to find valid category names for filtering ListComponents(category: ...).")]
+    public string ListCategories()
+    {
+        var components = _documentationService.GetAllComponents();
+
+        var groups = components
+            .GroupBy(c => c.Category, StringComparer.OrdinalIgnoreCase)
+            .OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var sb = new StringBuilder();
+        sb.AppendLine(CultureInfo.InvariantCulture, $"# Fluent UI Blazor - Component Categories ({groups.Count} categories)");
+        sb.AppendLine();
+
+        foreach (var group in groups)
+        {
+            sb.AppendLine(CultureInfo.InvariantCulture, $"- **{group.Key}** ({group.Count()} components)");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("Use `ListComponents(category: \"<CategoryName>\")` to list components in a specific category.");
+
+        return sb.ToString();
+    }
 }

--- a/src/Tools/McpServer/Tools/ComponentListTools.cs
+++ b/src/Tools/McpServer/Tools/ComponentListTools.cs
@@ -178,6 +178,10 @@ public class ComponentListTools
             .OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
+        if (groups.Count == 0)
+        {
+            return "No component categories found.";
+        }
         var sb = new StringBuilder();
         sb.AppendLine(CultureInfo.InvariantCulture, $"# Fluent UI Blazor - Component Categories ({groups.Count} categories)");
         sb.AppendLine();

--- a/src/Tools/McpServer/Tools/ComponentListTools.cs
+++ b/src/Tools/McpServer/Tools/ComponentListTools.cs
@@ -182,6 +182,7 @@ public class ComponentListTools
         {
             return "No component categories found.";
         }
+        
         var sb = new StringBuilder();
         sb.AppendLine(CultureInfo.InvariantCulture, $"# Fluent UI Blazor - Component Categories ({groups.Count} categories)");
         sb.AppendLine();

--- a/src/Tools/McpServer/Tools/EnumTools.cs
+++ b/src/Tools/McpServer/Tools/EnumTools.cs
@@ -157,4 +157,33 @@ public class EnumTools
 
         return sb.ToString();
     }
+
+    /// <summary>
+    /// Lists all enum types available in the Fluent UI Blazor library.
+    /// Use this to discover valid enum names for <see cref="GetEnumValues"/>.
+    /// </summary>
+    /// <returns>
+    /// A formatted string listing all enum types with their descriptions.
+    /// </returns>
+    [McpServerTool]
+    [Description("Lists all enum types available in the Fluent UI Blazor library. Use this to discover valid enum names for GetEnumValues(enumName: ...).")]
+    public string ListEnums()
+    {
+        var enums = _documentationService.GetAllEnums();
+
+        var sb = new StringBuilder();
+        sb.AppendLine(CultureInfo.InvariantCulture, $"# Fluent UI Blazor - Enum Types ({enums.Count} enums)");
+        sb.AppendLine();
+
+        foreach (var enumInfo in enums)
+        {
+            var description = string.IsNullOrEmpty(enumInfo.Description) ? string.Empty : $" — {enumInfo.Description}";
+            sb.AppendLine(CultureInfo.InvariantCulture, $"- **{enumInfo.Name}**{description}");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("Use `GetEnumValues(enumName: \"EnumName\")` to see all values for a specific enum.");
+
+        return sb.ToString();
+    }
 }

--- a/src/Tools/McpServer/Tools/EnumTools.cs
+++ b/src/Tools/McpServer/Tools/EnumTools.cs
@@ -171,6 +171,10 @@ public class EnumTools
     {
         var enums = _documentationService.GetAllEnums();
 
+        if (enums.Count == 0)
+        {
+            return "No enums found.";
+        }
         var sb = new StringBuilder();
         sb.AppendLine(CultureInfo.InvariantCulture, $"# Fluent UI Blazor - Enum Types ({enums.Count} enums)");
         sb.AppendLine();

--- a/src/Tools/McpServer/Tools/EnumTools.cs
+++ b/src/Tools/McpServer/Tools/EnumTools.cs
@@ -175,6 +175,7 @@ public class EnumTools
         {
             return "No enums found.";
         }
+        
         var sb = new StringBuilder();
         sb.AppendLine(CultureInfo.InvariantCulture, $"# Fluent UI Blazor - Enum Types ({enums.Count} enums)");
         sb.AppendLine();

--- a/tests/Tools/McpServer.Tests/Tools/ComponentListToolsTests.cs
+++ b/tests/Tools/McpServer.Tests/Tools/ComponentListToolsTests.cs
@@ -287,4 +287,69 @@ public class ComponentListToolsTests
     }
 
     #endregion
+
+    #region ListCategories Tests
+
+    [Fact]
+    public void ListCategories_ShouldReturnCategories()
+    {
+        Skip.IfNot(_jsonFileExists, "JSON documentation file not found");
+
+        // Arrange
+        var tools = CreateTools();
+
+        // Act
+        var result = tools.ListCategories();
+
+        // Assert
+        Assert.False(string.IsNullOrEmpty(result));
+        Assert.Contains("# Fluent UI Blazor - Component Categories", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ListCategories_ShouldIncludeComponentCounts()
+    {
+        Skip.IfNot(_jsonFileExists, "JSON documentation file not found");
+
+        // Arrange
+        var tools = CreateTools();
+
+        // Act
+        var result = tools.ListCategories();
+
+        // Assert
+        Assert.Contains("components)", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ListCategories_ShouldIncludeUsageHint()
+    {
+        Skip.IfNot(_jsonFileExists, "JSON documentation file not found");
+
+        // Arrange
+        var tools = CreateTools();
+
+        // Act
+        var result = tools.ListCategories();
+
+        // Assert
+        Assert.Contains("ListComponents", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ListCategories_ShouldContainKnownCategory()
+    {
+        Skip.IfNot(_jsonFileExists, "JSON documentation file not found");
+
+        // Arrange
+        var tools = CreateTools();
+
+        // Act
+        var result = tools.ListCategories();
+
+        // Assert
+        Assert.Contains("Button", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    #endregion
 }

--- a/tests/Tools/McpServer.Tests/Tools/EnumToolsTests.cs
+++ b/tests/Tools/McpServer.Tests/Tools/EnumToolsTests.cs
@@ -332,4 +332,69 @@ public class EnumToolsTests
     }
 
     #endregion
+
+    #region ListEnums Tests
+
+    [Fact]
+    public void ListEnums_ShouldReturnEnumNames()
+    {
+        Skip.IfNot(_jsonFileExists, "JSON documentation file not found");
+
+        // Arrange
+        var tools = CreateTools();
+
+        // Act
+        var result = tools.ListEnums();
+
+        // Assert
+        Assert.False(string.IsNullOrEmpty(result));
+        Assert.Contains("Appearance", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ListEnums_ShouldReturnHeader()
+    {
+        Skip.IfNot(_jsonFileExists, "JSON documentation file not found");
+
+        // Arrange
+        var tools = CreateTools();
+
+        // Act
+        var result = tools.ListEnums();
+
+        // Assert
+        Assert.Contains("# Fluent UI Blazor - Enum Types", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ListEnums_ShouldIncludeUsageHint()
+    {
+        Skip.IfNot(_jsonFileExists, "JSON documentation file not found");
+
+        // Arrange
+        var tools = CreateTools();
+
+        // Act
+        var result = tools.ListEnums();
+
+        // Assert
+        Assert.Contains("GetEnumValues", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ListEnums_ShouldIncludeCount()
+    {
+        Skip.IfNot(_jsonFileExists, "JSON documentation file not found");
+
+        // Arrange
+        var tools = CreateTools();
+
+        // Act
+        var result = tools.ListEnums();
+
+        // Assert
+        Assert.Contains("enums)", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Problem

When MCP tool methods returned empty or not-found results, the error messages suggested calling tools that did not exist:

- `ComponentListTools.cs` → `"No components found in category '...'. Use ListCategories() to see available categories."` — **tool did not exist**
- `EnumTools.cs` → `"Enum '...' not found. Use ListEnums() to see all available enums."` — **tool did not exist**

An AI agent receiving these suggestions could not act on them, making the guidance misleading and unhelpful.

Additionally, the README Tools table referenced `ListDocumentationTopics` instead of the actual C# method name `ListDocumentation`.

## Changes

### New MCP tools

| Tool | Class | Description |
|------|-------|-------------|
| `ListCategories()` | `ComponentListTools` | Lists all component categories with component counts. Enables the AI to discover valid category names for `ListComponents(category: ...)`. |
| `ListEnums()` | `EnumTools` | Lists all enum types with their descriptions. Enables the AI to discover valid enum names for `GetEnumValues(enumName: ...)`. |

### Documentation fix

- `README.md` Tools table: corrected `ListDocumentationTopics` → `ListDocumentation`, added `ListCategories` and `ListEnums` entries.

### Tests

- 4 new tests for `ListCategories()` in `ComponentListToolsTests.cs`
- 4 new tests for `ListEnums()` in `EnumToolsTests.cs`
- All 35 tests in the affected test files pass

## Files changed

- `src/Tools/McpServer/Tools/ComponentListTools.cs`
- `src/Tools/McpServer/Tools/EnumTools.cs`
- `src/Tools/McpServer/README.md`
- `tests/Tools/McpServer.Tests/Tools/ComponentListToolsTests.cs`
- `tests/Tools/McpServer.Tests/Tools/EnumToolsTests.cs`