### PR TITLE
[dev-v5][Theme] Fix `data-theme` for `light` and `system` values

### DIFF
--- a/src/Core.Scripts/src/Utilities/Theme.ts
+++ b/src/Core.Scripts/src/Utilities/Theme.ts
@@ -491,8 +491,12 @@ export namespace Microsoft.FluentUI.Blazor.Utilities.Theme {
     return mode === 'dark' ? true : mode === 'light' ? false : isSystemDark();
   }
 
-  function tryGetThemeModeFromBody(): 'dark' | null {
-    return document.body.getAttribute('data-theme') === 'dark' ? 'dark' : null;
+  function tryGetThemeModeFromBody(): 'dark' | 'light' | 'system' | null {
+    const value = document.body.getAttribute('data-theme') as ThemeMode;
+
+    const validModes: ThemeMode[] = ['dark', 'light', 'system'];
+
+    return validModes.includes(value as ThemeMode) ? (value as ThemeMode) : null;
   }
 
   function tryGetRampInputs(

--- a/src/Core.Scripts/src/Utilities/Theme.ts
+++ b/src/Core.Scripts/src/Utilities/Theme.ts
@@ -491,8 +491,8 @@ export namespace Microsoft.FluentUI.Blazor.Utilities.Theme {
     return mode === 'dark' ? true : mode === 'light' ? false : isSystemDark();
   }
 
-  function tryGetThemeModeFromBody(): 'dark' | 'light' | 'system' | null {
-    const value = document.body.getAttribute('data-theme') as ThemeMode;
+  function tryGetThemeModeFromBody(): ThemeMode | null {
+    const value = document.body.getAttribute('data-theme');
 
     const validModes: ThemeMode[] = ['dark', 'light', 'system'];
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR fixes an issue within the theme detection. The cases where the user has set `data-theme="light"` or `data-theme="system"` on the body were previously ignored by the initialization process.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [ ] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
