### PR TITLE
[dev-v5] DocViewer - Enhance support for multiple JSON comment files

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Infrastructure/ServiceCollectionExtensions.cs
+++ b/examples/Demo/FluentUI.Demo.Client/Infrastructure/ServiceCollectionExtensions.cs
@@ -64,7 +64,7 @@ public static class ServiceCollectionExtensions
             options.PageTitle = "{0} - FluentUI Blazor Components";
             options.ComponentsAssembly = typeof(Client._Imports).Assembly;
             options.ResourcesAssembly = typeof(Client._Imports).Assembly;
-            options.ApiAssembly = typeof(Microsoft.FluentUI.AspNetCore.Components._Imports).Assembly;
+            options.ApiAssemblies = [typeof(Microsoft.FluentUI.AspNetCore.Components._Imports).Assembly];
             options.ApiCommentSummary = (data, component, member) =>
             {
                 if (member is null && (data is null || data?.Items?.Count <= 1))

--- a/examples/Demo/FluentUI.Demo.Client/Infrastructure/ServiceCollectionExtensions.cs
+++ b/examples/Demo/FluentUI.Demo.Client/Infrastructure/ServiceCollectionExtensions.cs
@@ -69,7 +69,7 @@ public static class ServiceCollectionExtensions
             {
                 if (member is null && (data is null || data?.Items?.Count <= 1))
                 {
-                    return "⚠️ The file `api-comments.json` was not found. " +
+                    return "⚠️ The file `api-comments.json` or `chart-comments.json` was not found. " +
                            "Run the project `FluentUI.Demo.DocApiGen` to generate the file. ";
                 }
 

--- a/examples/Tools/FluentUI.Demo.DocViewer/Components/MarkdownViewer.razor.cs
+++ b/examples/Tools/FluentUI.Demo.DocViewer/Components/MarkdownViewer.razor.cs
@@ -69,11 +69,11 @@ public partial class MarkdownViewer
 
         Sections = await page.ExtractSectionsAsync();
 
-        // Read api-comments.json
+        // Read api-comments.json and chart-comments.json
         if (ApiDocSummary.Cached is null)
         {
             HttpClient.BaseAddress ??= new Uri(NavigationManager.BaseUri);
-            ApiDocSummary.Cached = await HttpClient.LoadSummariesAsync("/api-comments.json");
+            ApiDocSummary.Cached = await HttpClient.LoadSummariesAsync("/api-comments.json", "/chart-comments.json");
         }
 
         // Load MCP documentation if any MCP or McpSummary section is present

--- a/examples/Tools/FluentUI.Demo.DocViewer/Components/MarkdownViewer.razor.cs
+++ b/examples/Tools/FluentUI.Demo.DocViewer/Components/MarkdownViewer.razor.cs
@@ -138,9 +138,9 @@ public partial class MarkdownViewer
             componentType = match.Groups[3].Value;
         }
 
-        // Get the component type
-        var type = DocViewerService.ApiAssembly
-                                  ?.GetTypes()
+        // Get the component type from the first assembly that contains it
+        var type = DocViewerService.ApiAssemblies
+                                  ?.SelectMany(a => a.GetTypes())
                                   ?.FirstOrDefault(i => i.Name == componentName
                                                      || i.Name.StartsWith($"{componentName}`1")
                                                      || i.Name.StartsWith($"{componentName}`2"));

--- a/examples/Tools/FluentUI.Demo.DocViewer/Extensions/ServicesExtensions.cs
+++ b/examples/Tools/FluentUI.Demo.DocViewer/Extensions/ServicesExtensions.cs
@@ -43,31 +43,65 @@ public static class ServicesExtensions
     }
 
     /// <summary>
-    /// Load the summaries from the api-comments.json file.
+    /// Load the summaries from one or more api-comments.json files.
+    /// When multiple files are provided, their contents are merged into a single <see cref="ApiDocSummary.Items"/> dictionary.
+    /// If the same key exists in several files, entries from later files are merged into the earlier ones
+    /// (inner keys from later files override the previous ones).
     /// </summary>
     /// <param name="httpClient"></param>
-    /// <param name="jsonFile"></param>
+    /// <param name="jsonFiles">One or more json files to load.</param>
     /// <returns></returns>
-    public static async Task<ApiDocSummary> LoadSummariesAsync(this HttpClient httpClient, string jsonFile)
+    public static async Task<ApiDocSummary> LoadSummariesAsync(this HttpClient httpClient, params string[] jsonFiles)
     {
-        // Read api-comments.json
-        try
+        var summary = new ApiDocSummary()
         {
-            var json = await httpClient.GetStringAsync(jsonFile);
-            return new ApiDocSummary()
-            {
-                Items = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, Dictionary<string, string>>>(json)
-            };
+            Items = new Dictionary<string, Dictionary<string, string>>(),
+        };
+
+        if (jsonFiles is null || jsonFiles.Length == 0)
+        {
+            return summary;
         }
-        catch (Exception ex)
+
+        foreach (var jsonFile in jsonFiles)
         {
-            return new ApiDocSummary()
+            try
             {
-                Items = new Dictionary<string, Dictionary<string, string>>
+                var json = await httpClient.GetStringAsync(jsonFile);
+                var items = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, Dictionary<string, string>>>(json);
+
+                if (items is null)
                 {
-                    ["ERROR"] = new Dictionary<string, string> { [$"{jsonFile} cannot be loaded"] = ex.Message },
+                    continue;
                 }
-            };
+
+                foreach (var (key, value) in items)
+                {
+                    if (summary.Items.TryGetValue(key, out var existing))
+                    {
+                        foreach (var (innerKey, innerValue) in value)
+                        {
+                            existing[innerKey] = innerValue;
+                        }
+                    }
+                    else
+                    {
+                        summary.Items[key] = new Dictionary<string, string>(value);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                if (!summary.Items.TryGetValue("ERROR", out var errors))
+                {
+                    errors = new Dictionary<string, string>();
+                    summary.Items["ERROR"] = errors;
+                }
+
+                errors[$"{jsonFile} cannot be loaded"] = ex.Message;
+            }
         }
+
+        return summary;
     }
 }

--- a/examples/Tools/FluentUI.Demo.DocViewer/Extensions/ServicesExtensions.cs
+++ b/examples/Tools/FluentUI.Demo.DocViewer/Extensions/ServicesExtensions.cs
@@ -43,7 +43,7 @@ public static class ServicesExtensions
     }
 
     /// <summary>
-    /// Load the summaries from one or more api-comments.json files.
+    /// Load the summaries from one or more "comments.json" files.
     /// When multiple files are provided, their contents are merged into a single <see cref="ApiDocSummary.Items"/> dictionary.
     /// If the same key exists in several files, entries from later files are merged into the earlier ones
     /// (inner keys from later files override the previous ones).

--- a/examples/Tools/FluentUI.Demo.DocViewer/Models/Api/ApiDocSummary.cs
+++ b/examples/Tools/FluentUI.Demo.DocViewer/Models/Api/ApiDocSummary.cs
@@ -10,7 +10,7 @@ namespace FluentUI.Demo.DocViewer.Models;
 public class ApiDocSummary
 {
     /// <summary>
-    /// Gets or sets the content of the API documentation, read from the api-comments.json file.
+    /// Gets or sets the content of the API documentation, read from a "comments.json" file.
     /// </summary>
     public Dictionary<string, Dictionary<string, string>>? Items { get; set; }
 

--- a/examples/Tools/FluentUI.Demo.DocViewer/Services/DocViewerOptions.cs
+++ b/examples/Tools/FluentUI.Demo.DocViewer/Services/DocViewerOptions.cs
@@ -27,9 +27,9 @@ public class DocViewerOptions
     public Assembly? ResourcesAssembly { get; set; }
 
     /// <summary>
-    /// Assembly containing the API classes to display in API sections.
+    /// Assemblies containing the API classes to display in API sections.
     /// </summary>
-    public Assembly? ApiAssembly { get; set; }
+    public Assembly[]? ApiAssemblies { get; set; }
 
     /// <summary>
     /// Function to get the summary of an API comment.

--- a/examples/Tools/FluentUI.Demo.DocViewer/Services/DocViewerService.cs
+++ b/examples/Tools/FluentUI.Demo.DocViewer/Services/DocViewerService.cs
@@ -30,7 +30,7 @@ public class DocViewerService
         Options = options;
         ComponentsAssembly = options.ComponentsAssembly;
         ResourcesAssembly = options.ResourcesAssembly;
-        ApiAssembly = options.ApiAssembly;
+        ApiAssemblies = options.ApiAssemblies;
         ApiCommentSummary = options.ApiCommentSummary;
     }
 
@@ -50,9 +50,9 @@ public class DocViewerService
     public Assembly? ResourcesAssembly { get; }
 
     /// <summary>
-    /// Gets the assembly containing the classes to display in API sections.
+    /// Gets the assemblies containing the classes to display in API sections.
     /// </summary>
-    public Assembly? ApiAssembly { get; }
+    public Assembly[]? ApiAssemblies { get; }
 
     /// <summary>
     /// Function to get the summary of an API comment.


### PR DESCRIPTION
# [dev-v5] Enhance support for multiple JSON comment files

- Improve the `LoadSummariesAsync` method to handle multiple JSON files and merge their contents. 
- Update the `DocViewer` to accommodate multiple API assemblies and adjust related documentation accordingly. 

This change enhances flexibility in managing API documentation.

## How to use it?

1. Run a command similar to this one to generate the `chart-comments.json`.

    See **examples\Tools\FluentUI.Demo.DocApiGen\ReadMe.md**
    ```bash
    # Note: Update net9.0 paths to match NetVersion in Directory.Build.props (net8.0, net9.0, or net10.0)
    dotnet run --xml "./Microsoft.FluentUI.AspNetCore.Components.Charts.xml" --dll  "../../../src/Core/bin/Debug/net9.0/Microsoft.FluentUI.AspNetCore.Components.Charts.dll" --output "../../../examples/Demo/FluentUI.Demo.Client/wwwroot/chart-comments.json" --format json
   ```

    This command will need to be added to the pipeline once the Charts library has been developed

2. Update the `ServiceCollectionExtensions.cs` to add the new Chart assembly.

   See **examples\Demo\FluentUI.Demo.Client\Infrastructure\ServiceCollectionExtensions.cs**

    ```csharp
    options.ApiAssemblies = [typeof(Microsoft.FluentUI.AspNetCore.Components._Imports).Assembly];
    ```