### PR TITLE
[MCP] Improve [Parameter] XML doc comments in Button components for AI accuracy

### DIFF
--- a/src/Core/Components/Button/FluentAnchorButton.razor.cs
+++ b/src/Core/Components/Button/FluentAnchorButton.razor.cs
@@ -104,8 +104,8 @@ public partial class FluentAnchorButton : FluentComponentBase, ITooltipComponent
     public string? Color { get; set; }
 
     /// <summary>
-    /// Gets or sets if the button only shows an icon
-    /// Can be used when using <see cref="ChildContent"/> that renders as an icon
+    /// Gets or sets a value indicating whether the button renders icon-only (no visible text label).
+    /// Typically used when <see cref="IconStart"/> or <see cref="IconEnd"/> is set and no text label is needed.
     /// </summary>
     [Parameter]
     public bool IconOnly { get; set; }
@@ -130,10 +130,9 @@ public partial class FluentAnchorButton : FluentComponentBase, ITooltipComponent
     public string? Title { get; set; }
 
     /// <summary>
-    ///  Gets or sets the content to be rendered inside the button.
-    ///  This can be used as an alternative to specifying the content as a child component of the button.
-    ///  If both are specified, both will be rendered.
-    ///  </summary>
+    /// Gets or sets the plain-text label rendered inside the button (e.g., <c>Label="Go"</c>).
+    /// For rich content such as icons or custom markup, use <see cref="ChildContent"/> instead.
+    /// </summary>
     [Parameter]
     public string? Label { get; set; }
 

--- a/src/Core/Components/Button/FluentButton.razor.cs
+++ b/src/Core/Components/Button/FluentButton.razor.cs
@@ -68,8 +68,8 @@ public partial class FluentButton : FluentComponentBase, ITooltipComponent
     public string? FormMethod { get; set; }
 
     /// <summary>
-    /// Gets or sets if the form need to be validated when it is submitted
-    /// (if the button is a submit button).
+    /// Gets or sets a value indicating whether form validation is bypassed when this button submits the form
+    /// (if the button is a submit button). When <c>true</c>, the form's validation constraints are not checked on submission.
     /// </summary>
     [Parameter]
     public bool? FormNoValidate { get; set; }
@@ -116,7 +116,8 @@ public partial class FluentButton : FluentComponentBase, ITooltipComponent
     public bool Disabled { get; set; } = false;
 
     /// <summary>
-    /// Gets or sets the value indicating the button is focusable.
+    /// Gets or sets a value indicating whether the button is disabled yet still reachable via keyboard focus.
+    /// Unlike <see cref="Disabled"/>, a focusable-disabled button participates in the tab order and can expose tooltips.
     /// </summary>
     [Parameter]
     public bool DisabledFocusable { get; set; } = false;
@@ -161,8 +162,8 @@ public partial class FluentButton : FluentComponentBase, ITooltipComponent
     public bool Loading { get; set; } = false;
 
     /// <summary>
-    /// Gets or sets if the button only shows an icon
-    /// Can be used when using <see cref="ChildContent"/> that renders as an icon
+    /// Gets or sets a value indicating whether the button renders icon-only (no visible text label).
+    /// Typically used when <see cref="IconStart"/> or <see cref="IconEnd"/> is set and no text label is needed.
     /// </summary>
     [Parameter]
     public bool IconOnly { get; set; }
@@ -187,10 +188,9 @@ public partial class FluentButton : FluentComponentBase, ITooltipComponent
     public string? Title { get; set; }
 
     /// <summary>
-    ///  Gets or sets the content to be rendered inside the button.
-    ///  This can be used as an alternative to specifying the content as a child component of the button.
-    ///  If both are specified, both will be rendered.
-    ///  </summary>
+    /// Gets or sets the plain-text label rendered inside the button (e.g., <c>Label="Submit"</c>).
+    /// For rich content such as icons or custom markup, use <see cref="ChildContent"/> instead.
+    /// </summary>
     [Parameter]
     public string? Label { get; set; }
 

--- a/src/Core/Components/Button/FluentCompoundButton.razor.cs
+++ b/src/Core/Components/Button/FluentCompoundButton.razor.cs
@@ -110,22 +110,22 @@ public partial class FluentCompoundButton : FluentComponentBase, ITooltipCompone
     public bool StopPropagation { get; set; } = false;
 
     /// <summary>
-    /// Gets or sets if the button only shows an icon
-    /// Can be used when using <see cref="ChildContent"/> that renders as an icon
+    /// Gets or sets a value indicating whether the button renders icon-only (no visible text label).
+    /// Typically used when <see cref="IconStart"/> or <see cref="IconEnd"/> is set and no text label is needed.
     /// </summary>
     [Parameter]
     public bool IconOnly { get; set; }
 
     /// <summary>
-    ///  Gets or sets the content to be rendered inside the button.
-    ///  This can be used as an alternative to specifying the content as a child component of the button.
-    ///  If both are specified, both will be rendered.
-    ///  </summary>
+    /// Gets or sets the plain-text label rendered as the primary button text (e.g., <c>Label="Open"</c>).
+    /// For rich content, use <see cref="ChildContent"/> instead. See also <see cref="Description"/> for secondary text.
+    /// </summary>
     [Parameter]
     public string? Label { get; set; }
 
     /// <summary>
-    /// Gets or sets the content to be rendered inside description area of the button.
+    /// Gets or sets the secondary description content rendered below the primary label (e.g., a subtitle or hint).
+    /// See also <see cref="Label"/> for the primary button text.
     /// </summary>
     [Parameter]
     public RenderFragment? Description { get; set; }

--- a/src/Core/Components/Button/FluentSplitButton.razor.cs
+++ b/src/Core/Components/Button/FluentSplitButton.razor.cs
@@ -70,8 +70,8 @@ public partial class FluentSplitButton : FluentComponentBase
     public string? Color { get; set; }
 
     /// <summary>
-    /// Gets or sets if the button only shows an icon
-    /// Can be used when using <see cref="ChildContent"/> that renders as an icon
+    /// Gets or sets a value indicating whether the button renders icon-only (no visible text label).
+    /// Typically used when <see cref="IconStart"/> is set and no text label is needed.
     /// </summary>
     [Parameter]
     public bool IconOnly { get; set; }
@@ -97,10 +97,9 @@ public partial class FluentSplitButton : FluentComponentBase
     public string? Title { get; set; }
 
     /// <summary>
-    ///  Gets or sets the content to be rendered inside the button.
-    ///  This can be used as an alternative to specifying the content as a child component of the button.
-    ///  If both are specified, both will be rendered.
-    ///  </summary>
+    /// Gets or sets the plain-text label rendered inside the primary button area (e.g., <c>Label="Save"</c>).
+    /// For rich content such as icons or custom markup, use <see cref="ChildContent"/> instead.
+    /// </summary>
     [Parameter]
     public string? Label { get; set; }
 


### PR DESCRIPTION
## Summary

Improves XML doc comments on `[Parameter]` properties in `FluentButton`, `FluentSplitButton`, `FluentAnchorButton`, and `FluentCompoundButton` to ensure the MCP server serves accurate, unambiguous descriptions to AI models.

## Changes

- **`Label` (all four Button types)** — Description was a copy of the `ChildContent` description ("content to be rendered inside the button… as an alternative to specifying the content as a child component"). Fixed to clarify `Label` is a plain-text `string` and cross-referenced `ChildContent` for rich content.
- **`IconOnly` (FluentButton, FluentSplitButton, FluentAnchorButton, FluentCompoundButton)** — "Gets or sets if the button only shows an icon" reworded to standard "Gets or sets a value indicating whether…" form, with cross-references to `IconStart`/`IconEnd`.
- **`DisabledFocusable` (FluentButton, FluentCompoundButton)** — "Gets or sets the value indicating the button is focusable" was misleading. Fixed to explain the disabled-but-keyboard-focusable concept and cross-referenced `Disabled`.
- **`FormNoValidate` (FluentButton)** — "Gets or sets if the form need to be validated" had a grammar error and was confusing given the double-negative property name. Rewritten to clearly state it bypasses validation.
- **`Description` (FluentCompoundButton)** — Added cross-reference to `Label` so AI models understand the primary vs. secondary text relationship.

## Part of

Part of #4777