### PR TITLE
[MCP] Improve [Parameter] XML doc comments in FluentCheckbox for AI accuracy

### DIFF
--- a/src/Core/Components/Checkbox/FluentCheckbox.razor.cs
+++ b/src/Core/Components/Checkbox/FluentCheckbox.razor.cs
@@ -15,9 +15,7 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// </summary>
 public partial class FluentCheckbox : FluentInputBase<bool>, IFluentComponentElementBase, ITooltipComponent
 {
-    /// <summary>
-    ///
-    /// </summary>
+    /// <summary />
     public FluentCheckbox(LibraryConfiguration configuration) : base(configuration)
     {
         LabelPosition = Components.LabelPosition.After;
@@ -28,8 +26,8 @@ public partial class FluentCheckbox : FluentInputBase<bool>, IFluentComponentEle
     public ElementReference Element { get; set; }
 
     /// <summary>
-    /// Gets or sets the state of the CheckBox: true, false or null.
-    /// Useful when the mode ThreeState is enable
+    /// Gets or sets the three-state value of the checkbox: <c>true</c> (checked), <c>false</c> (unchecked), or <c>null</c> (indeterminate).
+    /// Used when <see cref="ThreeState"/> is enabled.
     /// </summary>
     [Parameter]
     public bool? CheckState { get; set; }


### PR DESCRIPTION
## Summary

Improves XML doc comments on `[Parameter]` properties in `FluentCheckbox` to ensure the MCP server serves accurate, unambiguous descriptions to AI models.

## Changes

- **Constructor `<summary>`** — Was an empty `<summary>` block with only whitespace. Replaced with the standard `/// <summary />` single-line form.
- **`CheckState`** — "Useful when the mode ThreeState is enable" had a grammar error ("is enable" → "is enabled") and used informal phrasing. Rewritten to clearly list the three possible values (`true`/`false`/`null`) and cross-referenced `ThreeState`.

## Part of

Part of #4777