### PR TITLE
[MCP] Improve [Parameter] XML doc comments in FluentRadioGroup for AI accuracy

### DIFF
--- a/src/Core/Components/Radio/FluentRadioGroup.razor.cs
+++ b/src/Core/Components/Radio/FluentRadioGroup.razor.cs
@@ -47,7 +47,8 @@ public partial class FluentRadioGroup<TValue> : FluentInputBase<TValue>, IFluent
     public bool Wrap { get; set; }
 
     /// <summary>
-    ///     
+    /// Gets or sets the collection of items from which radio buttons are generated.
+    /// Use with <see cref="RadioLabel"/> and <see cref="RadioValue"/> to control display text and submitted value.
     /// </summary>
     [Parameter]
     public IEnumerable<TValue?>? Items { get; set; }
@@ -59,13 +60,13 @@ public partial class FluentRadioGroup<TValue> : FluentInputBase<TValue>, IFluent
     public virtual Func<TValue?, string?>? RadioValue { get; set; }
 
     /// <summary>
-    /// Gets or sets the function used to determine which text to display for each radio checkedItem.
+    /// Gets or sets the function used to determine the display label for each radio button item.
     /// </summary>
     [Parameter]
     public virtual Func<TValue?, string?>? RadioLabel { get; set; }
 
     /// <summary>
-    /// Gets or sets the function used to determine if an radio is disabled.
+    /// Gets or sets the function used to determine whether a radio button item is disabled.
     /// </summary>
     [Parameter]
     public virtual Func<TValue?, bool>? RadioDisabled { get; set; }


### PR DESCRIPTION
## Summary

Improves XML doc comments on `[Parameter]` properties in `FluentRadioGroup` to ensure the MCP server serves accurate, unambiguous descriptions to AI models.

## Changes

- **`Items`** — Had a completely empty `<summary>` block. Added a clear description explaining it is the collection from which radio buttons are generated, with cross-references to `RadioLabel` and `RadioValue`.
- **`RadioLabel`** — "which text to display for each radio **checkedItem**" used the confusing internal term "checkedItem". Rewritten to "display label for each radio button item".
- **`RadioDisabled`** — "determine if **an** radio is disabled" had a grammar error ("an radio" → "a radio button item" with clearer phrasing).

## Part of

Part of #4777