### PR TITLE
[MCP] Improve [Parameter] XML doc comments in FluentPopover for AI accuracy

### DIFF
--- a/src/Core/Components/Popover/FluentPopover.razor.cs
+++ b/src/Core/Components/Popover/FluentPopover.razor.cs
@@ -41,7 +41,7 @@ public partial class FluentPopover : FluentComponentBase
     public string? Width { get; set; }
 
     /// <summary>
-    /// Gets or sets the width of the popover component.
+    /// Gets or sets the height of the popover component.
     /// </summary>
     [Parameter]
     public string? Height { get; set; }


### PR DESCRIPTION
## Summary

Improves XML doc comments on `[Parameter]` properties in `FluentPopover` to ensure the MCP server serves accurate, unambiguous descriptions to AI models.

## Changes

- `Height`: Fixed copy-paste error — summary said "Gets or sets the **width** of the popover component" instead of "height".

## Part of

Part of #4777