### PR TITLE
[MCP] Improve [Parameter] XML doc comments in FluentTooltip for AI accuracy

### DIFF
--- a/src/Core/Components/Tooltip/FluentTooltip.razor.cs
+++ b/src/Core/Components/Tooltip/FluentTooltip.razor.cs
@@ -57,8 +57,8 @@ public partial class FluentTooltip : FluentComponentBase
     private ITooltipService? TooltipService => GetCachedServiceOrNull<ITooltipService>();
 
     /// <summary>
-    /// Use ITooltipService to create the tooltip, if this service was injected.
-    /// If the <see cref="ChildContent"/> is dynamic, set this to false. Default, true.
+    /// Gets or sets a value indicating whether the <see cref="ITooltipService"/> is used to render the tooltip.
+    /// Set this to <see langword="false"/> when <see cref="ChildContent"/> is dynamic (e.g., <c>UseTooltipService="false"</c>). Default is <see langword="true"/>.
     /// </summary>
     [Parameter]
     public bool UseTooltipService { get; set; } = true;
@@ -89,13 +89,13 @@ public partial class FluentTooltip : FluentComponentBase
     public string? MaxWidth { get; set; }
 
     /// <summary>
-    /// Gets or sets the tooltip's horizontal spacing. Default is 4px;
+    /// Gets or sets the tooltip's horizontal spacing. Default is 4px.
     /// </summary>
     [Parameter]
     public string? SpacingHorizontal { get; set; }
 
     /// <summary>
-    /// Gets or sets the tooltip's horizontal spacing. Default is 4px;
+    /// Gets or sets the tooltip's vertical spacing. Default is 4px.
     /// </summary>
     [Parameter]
     public string? SpacingVertical { get; set; }


### PR DESCRIPTION
## Summary

Improves XML doc comments on `[Parameter]` properties in `FluentTooltip` to ensure the MCP server serves accurate, unambiguous descriptions to AI models.

## Changes

- `UseTooltipService`: Added proper "Gets or sets" prefix; rewrote to declarative form with usage example and cross-reference to `ChildContent`.
- `SpacingHorizontal`: Fixed trailing semicolon to period.
- `SpacingVertical`: Fixed copy-paste error — summary said "horizontal spacing" instead of "vertical spacing".

## Part of

Part of #4777