### PR TITLE
[MCP] Improve [Parameter] XML doc comments in FluentDialog for AI accuracy

### DIFF
--- a/src/Core/Components/Dialog/FluentDialog.razor.cs
+++ b/src/Core/Components/Dialog/FluentDialog.razor.cs
@@ -49,7 +49,8 @@ public partial class FluentDialog : FluentComponentBase
     public IDialogInstance? Instance { get; set; }
 
     /// <summary>
-    /// Used when not calling the <see cref="DialogService" /> to show a dialog.
+    /// Gets or sets the child content rendered inside the dialog when not using the <see cref="DialogService"/>.
+    /// When using the <see cref="DialogService"/>, use <see cref="Instance"/> instead.
     /// </summary>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
@@ -72,7 +73,7 @@ public partial class FluentDialog : FluentComponentBase
     public bool Modal { get; set; } = true;
 
     /// <summary>
-    /// Command executed when the user clicks on the button.
+    /// Gets or sets the callback that is invoked when the dialog state changes (e.g., opening or closing).
     /// </summary>
     [Parameter]
     public EventCallback<DialogEventArgs> OnStateChange { get; set; }

--- a/src/Core/Components/Dialog/FluentDialogBody.razor.cs
+++ b/src/Core/Components/Dialog/FluentDialogBody.razor.cs
@@ -35,18 +35,22 @@ public partial class FluentDialogBody : FluentComponentBase
 
     /// <summary>
     /// Gets or sets the content for the title element.
+    /// For an action button in the title area, use <see cref="TitleActionTemplate"/> instead.
     /// </summary>
     [Parameter]
     public RenderFragment? TitleTemplate { get; set; }
 
     /// <summary>
-    /// Gets or sets the content for the action element in the title.
+    /// Gets or sets the content for the action button rendered inside the title area.
+    /// For the primary title content, use <see cref="TitleTemplate"/>.
+    /// For footer-level actions, use <see cref="ActionTemplate"/>.
     /// </summary>
     [Parameter]
     public RenderFragment? TitleActionTemplate { get; set; }
 
     /// <summary>
-    /// Gets or sets the content for the action element.
+    /// Gets or sets the content for the footer action area (e.g., confirm/cancel buttons).
+    /// For an action button inside the title bar, use <see cref="TitleActionTemplate"/> instead.
     /// </summary>
     [Parameter]
     public RenderFragment? ActionTemplate { get; set; }


### PR DESCRIPTION
## Summary

Improves XML doc comments on `[Parameter]` properties in `FluentDialog` and `FluentDialogBody` to ensure the MCP server serves accurate, unambiguous descriptions to AI models.

## Changes

- `FluentDialog.ChildContent`: Added proper "Gets or sets" prefix and cross-reference to `Instance`/`DialogService` to distinguish the two authoring modes.
- `FluentDialog.OnStateChange`: Fixed name/description mismatch — was incorrectly described as "Command executed when the user clicks on the button"; now correctly describes it as the state-change callback.
- `FluentDialogBody.TitleTemplate`: Added cross-reference to `TitleActionTemplate` to disambiguate.
- `FluentDialogBody.TitleActionTemplate`: Clarified that this renders an action button inside the title bar; added cross-references to `TitleTemplate` and `ActionTemplate`.
- `FluentDialogBody.ActionTemplate`: Clarified that this renders footer-level actions; added cross-reference to `TitleActionTemplate`.

## Part of

Part of #4777