### PR TITLE
[MCP] Improve [Parameter] XML doc comments in DataGrid for AI accuracy

### DIFF
--- a/src/Core/Components/DataGrid/Columns/ColumnBase.razor.cs
+++ b/src/Core/Components/DataGrid/Columns/ColumnBase.razor.cs
@@ -74,8 +74,8 @@ public abstract partial class ColumnBase<TGridItem>
     public int Index { get; set; }
 
     /// <summary>
-    /// Gets or sets the an optional CSS class name.
-    /// If specified, this is included in the class attribute of header and grid cells
+    /// Gets or sets an optional CSS class name.
+    /// If specified, this is included in the <c>class</c> attribute of header and grid cells
     /// for this column.
     /// </summary>
     [Parameter]
@@ -90,13 +90,15 @@ public abstract partial class ColumnBase<TGridItem>
     public string? Style { get; set; }
 
     /// <summary>
-    /// If specified, controls the justification of header and grid cells for this column.
+    /// Gets or sets the cell alignment for header and grid cells in this column
+    /// (e.g., <c>Align="DataGridCellAlignment.Center"</c>).
     /// </summary>
     [Parameter]
     public DataGridCellAlignment Align { get; set; }
 
     /// <summary>
-    /// If true, generates a title and aria-label attribute for the cell contents
+    /// Gets or sets whether each cell in this column renders a <c>title</c> and <c>aria-label</c> attribute
+    /// derived from the cell's content. Use <see cref="TooltipText"/> to supply a custom tooltip value.
     /// </summary>
     [Parameter]
     public bool Tooltip { get; set; } = false;
@@ -168,8 +170,7 @@ public abstract partial class ColumnBase<TGridItem>
     public abstract IGridSort<TGridItem>? SortBy { get; set; }
 
     /// <summary>
-    /// Gets or sets the initial sort direction.
-    /// if <see cref="IsDefaultSortColumn"/> is true.
+    /// Gets or sets the initial sort direction, applied when <see cref="IsDefaultSortColumn"/> is <c>true</c>.
     /// </summary>
     [Parameter]
     public DataGridSortDirection InitialSortDirection { get; set; } = default;
@@ -181,7 +182,8 @@ public abstract partial class ColumnBase<TGridItem>
     public bool IsDefaultSortColumn { get; set; } = false;
 
     /// <summary>
-    /// If specified, virtualized grids will use this template to render cells whose data has not yet been loaded.
+    /// Gets or sets the template used to render placeholder cells whose data has not yet loaded
+    /// (applicable when <see cref="FluentDataGrid{TGridItem}.Virtualize"/> is enabled).
     /// </summary>
     [Parameter]
     public RenderFragment<PlaceholderContext>? PlaceholderTemplate { get; set; }
@@ -228,14 +230,14 @@ public abstract partial class ColumnBase<TGridItem>
     public string MinWidth { get; set; } = "100px";
 
     /// <summary>
-    /// If true, the column will include an expand/collapse toggle for hierarchical data.
-    /// This only applies if <typeparamref name="TGridItem"/> implements <see cref="IHierarchicalGridItem"/>.
+    /// Gets or sets whether this column renders an expand/collapse toggle for hierarchical data.
+    /// Requires <typeparamref name="TGridItem"/> to implement <see cref="IHierarchicalGridItem"/>.
     /// </summary>
     [Parameter]
     public bool HierarchicalToggle { get; set; }
 
     /// <summary>
-    /// Disables the ability for cells to receive focus.
+    /// Gets or sets whether keyboard focus is disabled for cells in this column.
     /// </summary>
     [Parameter]
     public bool DisableCellFocus { get; set; }

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -129,7 +129,7 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     public Func<GridItemsProviderRequest<TGridItem>, Task>? RefreshItems { get; set; }
 
     /// <summary>
-    /// Gets or sets a callback that supplies data for the rid.
+    /// Gets or sets a callback that supplies data for the grid.
     /// You should supply either <see cref="Items"/> or <see cref="ItemsProvider"/>, but not both.
     /// </summary>
     [Parameter]


### PR DESCRIPTION
## Summary
Improves XML doc comments on `[Parameter]` properties in `FluentDataGrid` / `ColumnBase` so the MCP server serves accurate descriptions to AI models.

## Changes
- `FluentDataGrid.ItemsProvider`: fixed typo "rid" → "grid" in summary
- `ColumnBase.Class`: fixed typo "the an" → "an"
- `ColumnBase.Align`: replaced imperative "If specified, controls the justification…" with "Gets or sets the cell alignment…" + usage example
- `ColumnBase.Tooltip`: replaced "If true, generates a title and aria-label…" with "Gets or sets whether…" + cross-reference to `TooltipText`
- `ColumnBase.InitialSortDirection`: fixed lowercase "if" after a period to "applied when … is `true`"
- `ColumnBase.PlaceholderTemplate`: replaced "If specified, virtualized grids will use…" with "Gets or sets the template…" + cross-reference to `Virtualize`
- `ColumnBase.HierarchicalToggle`: replaced "If true, the column will include…" with "Gets or sets whether…"
- `ColumnBase.DisableCellFocus`: replaced "Disables the ability for cells to receive focus" with "Gets or sets whether keyboard focus is disabled…"

## Part of
Part of #4777