### PR TITLE
[MCP] Improve [Parameter] XML doc comments in List components for AI accuracy

### DIFF
--- a/src/Core/Components/List/FluentAutocomplete.razor.cs
+++ b/src/Core/Components/List/FluentAutocomplete.razor.cs
@@ -146,7 +146,8 @@ public partial class FluentAutocomplete<TOption, TValue> : FluentListBase<TOptio
     public string? MaxSelectedWidth { get; set; }
 
     /// <summary>
-    /// Gets or sets whether the Search icon or Clear button is displayed.
+    /// Gets or sets whether the dismiss (clear) button is visible. When <c>true</c> (default), the
+    /// dismiss button is shown; when <c>false</c>, the search icon is shown instead.
     /// </summary>
     [Parameter]
     public bool ShowDismiss { get; set; } = true;

--- a/src/Core/Components/List/FluentListBase.razor.cs
+++ b/src/Core/Components/List/FluentListBase.razor.cs
@@ -105,7 +105,7 @@ public abstract partial class FluentListBase<TOption, TValue> : FluentInputBase<
     public virtual RenderFragment<TOption>? OptionTemplate { get; set; }
 
     /// <summary>
-    /// Gets or sets the function used to determine which value to apply to the binded value.
+    /// Gets or sets the function used to determine which value to apply to the bound value.
     /// </summary>
     [Parameter]
     public virtual Func<TOption?, TValue?>? OptionValue { get; set; }


### PR DESCRIPTION
## Summary
Improves XML doc comments on `[Parameter]` properties in `FluentListBase` and `FluentAutocomplete` so the MCP server serves accurate descriptions to AI models.

## Changes
- `FluentListBase.OptionValue`: fixed "binded" → "bound" (grammatically incorrect term)
- `FluentAutocomplete.ShowDismiss`: replaced ambiguous "Search icon or Clear button is displayed" with a precise description clarifying the property toggles the dismiss (clear) button visibility vs. the search icon

## Part of
Part of #4777