### PR TITLE
[MCP] Improve [Parameter] XML doc comments in FluentWizard for AI accuracy

### DIFF
--- a/src/Core/Components/Wizard/FluentWizard.razor.cs
+++ b/src/Core/Components/Wizard/FluentWizard.razor.cs
@@ -60,13 +60,14 @@ public partial class FluentWizard : FluentComponentBase
     public string? StepperBulletSpace { get; set; }
 
     /// <summary>
-    /// Display a border of the Wizard.
+    /// Gets or sets whether and how a border is displayed around the wizard (e.g., <c>Border="WizardBorder.Outside"</c>).
     /// </summary>
     [Parameter]
     public WizardBorder Border { get; set; } = WizardBorder.None;
 
     /// <summary>
-    /// Display a number on each step icon. Can be overridden by the step <see cref="FluentWizardStep.DisplayStepNumber"/> property.
+    /// Gets or sets when to display a step number on each step icon.
+    /// Can be overridden per step via <see cref="FluentWizardStep.DisplayStepNumber"/>.
     /// </summary>
     [Parameter]
     public WizardStepStatus DisplayStepNumber { get; set; } = WizardStepStatus.None;

--- a/src/Core/Components/Wizard/FluentWizardStep.razor.cs
+++ b/src/Core/Components/Wizard/FluentWizardStep.razor.cs
@@ -41,13 +41,15 @@ public partial class FluentWizardStep : FluentComponentBase
     public bool Disabled { get; set; }
 
     /// <summary>
-    /// Render the Wizard Step content only when the Step is selected.
+    /// Gets or sets whether to render the step content only when the step is active.
+    /// Content is cleared when the step is deselected, reducing page size for inactive steps.
     /// </summary>
     [Parameter]
     public bool DeferredLoading { get; set; }
 
     /// <summary>
-    /// Gets or sets the label of the step.
+    /// Gets or sets the plain-text label shown in the step indicator (e.g., <c>Label="Step 1"</c>).
+    /// See also <see cref="Summary"/> for a short subtitle displayed below the label.
     /// </summary>
     [Parameter]
     public string Label { get; set; } = string.Empty;
@@ -67,7 +69,7 @@ public partial class FluentWizardStep : FluentComponentBase
     public EventCallback<FluentWizardStepChangeEventArgs> OnChange { get; set; }
 
     /// <summary>
-    /// Gets or sets the summary of the step, to display near the label.
+    /// Gets or sets a short subtitle displayed below the <see cref="Label"/> in the step indicator.
     /// </summary>
     [Parameter]
     public string Summary { get; set; } = string.Empty;


### PR DESCRIPTION
## Summary
Improves XML doc comments on `[Parameter]` properties in `FluentWizard` and `FluentWizardStep` so the MCP server serves accurate descriptions to AI models.

## Changes
- `FluentWizard.Border`: Fixed missing "Gets or sets" prefix; added usage example with `WizardBorder` enum
- `FluentWizard.DisplayStepNumber`: Fixed missing "Gets or sets" prefix; kept cross-reference to `FluentWizardStep.DisplayStepNumber`
- `FluentWizardStep.DeferredLoading`: Fixed missing "Gets or sets" prefix; clarified behavior when step is deselected
- `FluentWizardStep.Label`: Added usage example and cross-reference to `Summary`
- `FluentWizardStep.Summary`: Added cross-reference to `Label`

## Part of
Part of #4777