### PR TITLE
[MCP] Improve [Parameter] XML doc comments in FluentAccordion for AI accuracy

### DIFF
--- a/src/Core/Components/Accordion/FluentAccordion.razor.cs
+++ b/src/Core/Components/Accordion/FluentAccordion.razor.cs
@@ -60,7 +60,7 @@ public partial class FluentAccordion : FluentComponentBase
     public AccordionItemMarkerPosition? MarkerPosition { get; set; }
 
     /// <summary>
-    /// Gets or sets the width of the focus state
+    /// Gets or sets whether accordion items expand to fill the full available width (block-level display).
     /// </summary>
     [Parameter]
     public bool? Block { get; set; }

--- a/src/Core/Components/Accordion/FluentAccordionItem.razor.cs
+++ b/src/Core/Components/Accordion/FluentAccordionItem.razor.cs
@@ -21,15 +21,15 @@ public partial class FluentAccordionItem : FluentComponentBase, IDisposable
     protected string? StyleValue => DefaultStyleBuilder.Build();
 
     /// <summary>
-    /// Gets or sets the owning FluentTreeView.
+    /// Gets or sets the parent <see cref="FluentAccordion"/> that owns this item.
     /// </summary>
     [CascadingParameter]
     public FluentAccordion? Owner { get; set; } = default!;
 
     /// <summary>
-    /// Gets or sets the heading of the accordion item.
-    /// Use either this or the <see cref="HeaderTemplate"/> parameter."/>
-    /// If both are set, this parameter will be used.
+    /// Gets or sets the plain-text heading of the accordion item (e.g., <c>Header="Section Title"</c>).
+    /// Use either this or the <see cref="HeaderTemplate"/> parameter.
+    /// If both are set, this parameter takes precedence.
     /// </summary>
     [Parameter]
     public string? Header { get; set; }
@@ -86,7 +86,7 @@ public partial class FluentAccordionItem : FluentComponentBase, IDisposable
     public AccordionItemMarkerPosition? MarkerPosition { get; set; }
 
     /// <summary>
-    /// Gets or sets the width of the focus state
+    /// Gets or sets whether this accordion item expands to fill the full available width (block-level display).
     /// </summary>
     [Parameter]
     public bool? Block { get; set; }


### PR DESCRIPTION
## Summary
Improves XML doc comments on `[Parameter]` properties in `FluentAccordion` and `FluentAccordionItem` so the MCP server serves accurate descriptions to AI models.

## Changes
- `FluentAccordionItem.Owner` (CascadingParameter): Fixed wrong type name in description — said "owning FluentTreeView" but the type is `FluentAccordion`
- `FluentAccordionItem.Header`: Added usage example `Header="Section Title"`; fixed malformed XML comment (`"/>` → proper closing); clarified precedence over `HeaderTemplate`
- `FluentAccordion.Block`: Fixed misleading description "width of the focus state" → correctly describes block-level full-width display
- `FluentAccordionItem.Block`: Same fix as above (was copy of same incorrect description)

## Part of
Part of #4777