### PR TITLE
[MCP] Improve [Parameter] XML doc comments in FluentNav components for AI accuracy

### DIFF
--- a/src/Core/Components/Nav/FluentNav.razor.cs
+++ b/src/Core/Components/Nav/FluentNav.razor.cs
@@ -70,19 +70,21 @@ public partial class FluentNav : FluentComponentBase
     public bool UseIcons { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets whether to allow just one expanded category or multiple
+    /// Gets or sets whether only one <see cref="FluentNavCategory"/> can be expanded at a time.
+    /// When <c>true</c>, expanding one category automatically collapses all others.
     /// </summary>
     [Parameter]
     public bool UseSingleExpanded { get; set; }
 
     /// <summary>
-    /// Gets or sets the density of the nav menu item.
+    /// Gets or sets the density (spacing) of the navigation menu items (e.g., <c>Density="NavDensity.Compact"</c>).
     /// </summary>
     [Parameter]
     public NavDensity? Density { get; set; }
 
     /// <summary>
-    /// Gets or sets the content of the nav menu item.
+    /// Gets or sets the child content rendered inside the navigation menu.
+    /// Accepts <see cref="FluentNavItem"/>, <see cref="FluentNavCategory"/>, <see cref="FluentNavSectionHeader"/>, and <see cref="FluentDivider"/> elements.
     /// </summary>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }

--- a/src/Core/Components/Nav/FluentNavCategory.razor.cs
+++ b/src/Core/Components/Nav/FluentNavCategory.razor.cs
@@ -44,13 +44,15 @@ public partial class FluentNavCategory : FluentNavBase
     public string? Title { get; set; }
 
     /// <summary>
-    /// Gets or sets the icon to use when the item is not hovered/selected/active.
+    /// Gets or sets the icon displayed when the category is in its default (resting) state.
+    /// Use <see cref="IconActive"/> to specify the icon shown when the category is hovered, selected, or active.
     /// </summary>
     [Parameter]
     public Icon? IconRest { get; set; } = new CoreIcons.Regular.Size20.Folder();
 
     /// <summary>
-    /// Gets or sets the icon to use when the item is hovered/selected/active.
+    /// Gets or sets the icon displayed when the category is hovered, selected, or active.
+    /// Use <see cref="IconRest"/> to specify the icon shown in the default (resting) state.
     /// </summary>
     [Parameter]
     public Icon? IconActive { get; set; }
@@ -74,7 +76,8 @@ public partial class FluentNavCategory : FluentNavBase
     public string? Tooltip { get; set; }
 
     /// <summary>
-    /// Gets or sets the content of the nav menu item.
+    /// Gets or sets the child content rendered inside the category.
+    /// Typically contains <see cref="FluentNavItem"/> sub-items.
     /// </summary>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }

--- a/src/Core/Components/Nav/FluentNavItem.razor.cs
+++ b/src/Core/Components/Nav/FluentNavItem.razor.cs
@@ -49,38 +49,41 @@ public partial class FluentNavItem : FluentNavBase
     internal FluentNavCategory? Category { get; set; }
 
     /// <summary>
-    /// Gets or sets the icon to use when the item is not hovered/selected/active.
+    /// Gets or sets the icon displayed when the item is in its default (resting) state.
+    /// Use <see cref="IconActive"/> to specify the icon shown when the item is hovered, selected, or active.
     /// </summary>
     [Parameter]
     public Icon? IconRest { get; set; }
 
     /// <summary>
-    /// Gets or sets the icon to use when the item is hovered/selected/active.
+    /// Gets or sets the icon displayed when the item is hovered, selected, or active.
+    /// Use <see cref="IconRest"/> to specify the icon shown in the default (resting) state.
     /// </summary>
     [Parameter]
     public Icon? IconActive { get; set; }
 
     /// <summary>
-    /// Gets or sets the href of the link.
+    /// Gets or sets the navigation URL for the item (e.g., <c>Href="/dashboard"</c>).
+    /// When set, the item renders as an anchor element.
     /// </summary>
     [Parameter]
     public string? Href { get; set; }
 
     /// <summary>
-    /// The callback to invoke when the item is clicked.
+    /// Gets or sets the callback invoked when the item is clicked.
     /// </summary>
     [Parameter]
     public EventCallback<MouseEventArgs> OnClick { get; set; }
 
     /// <summary>
-    /// If true, the item will be disabled.
+    /// Gets or sets whether the item is disabled.
     /// </summary>
     [Parameter]
     public bool Disabled { get; set; }
 
     /// <summary>
-    /// Gets or sets the target attribute that specifies where to open the group, if Href is specified.
-    /// Possible values: _blank | _self | _parent | _top.
+    /// Gets or sets the target attribute that specifies where to open the link when <see cref="Href"/> is set
+    /// (e.g., <c>Target="LinkTarget.Blank"</c> to open in a new tab).
     /// </summary>
     [Parameter]
     public LinkTarget? Target { get; set; }


### PR DESCRIPTION
## Summary
Improves XML doc comments on `[Parameter]` properties in `FluentNav`, `FluentNavItem`, and `FluentNavCategory` so the MCP server serves accurate descriptions to AI models.

## Changes
- `FluentNav.UseSingleExpanded`: clarified description; now explicitly states that expanding one category collapses others
- `FluentNav.Density`: fixed description that incorrectly said "nav menu item" (the property is on the container); added usage example
- `FluentNav.ChildContent`: fixed description that incorrectly said "nav menu item"; added list of accepted child element types
- `FluentNavItem.IconRest`: added cross-reference to sibling `IconActive`
- `FluentNavItem.IconActive`: added cross-reference to sibling `IconRest`
- `FluentNavItem.Href`: improved from terse "href of the link" to navigation URL description with usage example
- `FluentNavItem.OnClick`: fixed missing "Gets or sets" prefix
- `FluentNavItem.Disabled`: fixed missing "Gets or sets" prefix
- `FluentNavItem.Target`: fixed "group" → "link", replaced hard-coded value list with `<see cref="Href"/>` cross-reference and usage example
- `FluentNavCategory.IconRest`: added cross-reference to sibling `IconActive`
- `FluentNavCategory.IconActive`: added cross-reference to sibling `IconRest`
- `FluentNavCategory.ChildContent`: fixed description that incorrectly said "nav menu item"; added accepted child element type

## Part of
Part of #4777