### PR TITLE
[MCP] Improve [Parameter] XML doc comments in FluentMenu components for AI accuracy

### DIFF
--- a/src/Core/Components/Menu/FluentMenu.razor.cs
+++ b/src/Core/Components/Menu/FluentMenu.razor.cs
@@ -47,7 +47,7 @@ public partial class FluentMenu : FluentComponentBase, ITooltipComponent
     public bool? OpenOnContext { get; set; }
 
     /// <summary>
-    /// Gets or sets whether the menu when scrolling outside of it.
+    /// Gets or sets whether the menu closes automatically when the user scrolls outside of it.
     /// </summary>
     [Parameter]
     public bool? CloseOnScroll { get; set; }
@@ -59,7 +59,8 @@ public partial class FluentMenu : FluentComponentBase, ITooltipComponent
     public bool? PersistOnItemClick { get; set; }
 
     /// <summary>
-    /// Gets or sets the id of the menu trigger.
+    /// Gets or sets the HTML element ID of the trigger element that opens this menu (e.g., <c>Trigger="my-button-id"</c>).
+    /// When set, clicking the referenced element toggles the menu open or closed.
     /// </summary>
     [Parameter]
     public string? Trigger { get; set; }
@@ -71,7 +72,7 @@ public partial class FluentMenu : FluentComponentBase, ITooltipComponent
     public string? Height { get; set; }
 
     /// <summary>
-    /// Gets or sets the menu's submenus.
+    /// Gets or sets the child content rendered inside the menu, typically <see cref="FluentMenuItem"/> elements.
     /// </summary>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }

--- a/src/Core/Components/Menu/FluentMenuItem.razor.cs
+++ b/src/Core/Components/Menu/FluentMenuItem.razor.cs
@@ -67,13 +67,15 @@ public partial class FluentMenuItem : FluentComponentBase
     public bool? Disabled { get; set; }
 
     /// <summary>
-    /// Gets or sets the <see cref="Icon"/> displayed at the start of menu item content.
+    /// Gets or sets the <see cref="Icon"/> displayed at the start (left side) of the menu item content.
+    /// Use <see cref="IconEnd"/> to add an icon at the end.
     /// </summary>
     [Parameter]
     public Icon? IconStart { get; set; }
 
     /// <summary>
-    /// Gets or sets the <see cref="Icon"/> displayed at the end of menu item content.
+    /// Gets or sets the <see cref="Icon"/> displayed at the end (right side) of the menu item content.
+    /// Use <see cref="IconStart"/> to add an icon at the start.
     /// </summary>
     [Parameter]
     public Icon? IconEnd { get; set; }
@@ -85,16 +87,16 @@ public partial class FluentMenuItem : FluentComponentBase
     public Icon? IconSubmenu { get; set; }
 
     /// <summary>
-    /// Gets or sets the <see cref="Icon"/> displayed as the indicator of being checked .
+    /// Gets or sets the <see cref="Icon"/> displayed as the checked indicator for items with <see cref="Role"/> set to
+    /// <see cref="MenuItemRole.Checkbox"/> or <see cref="MenuItemRole.Radio"/>.
     /// </summary>
     [Parameter]
     public Icon? IconIndicator { get; set; }
 
     /// <summary>
-    ///  Gets or sets the content to be rendered inside the menu item.
-    ///  This can be used as an alternative to specifying the content as a child component of the button.
-    ///  If both are specified, both will be rendered.
-    ///  </summary>
+    /// Gets or sets the text label of the menu item.
+    /// Use as an alternative to <see cref="ChildContent"/> for simple text; if both are set, both are rendered.
+    /// </summary>
     [Parameter]
     public string? Label { get; set; }
 


### PR DESCRIPTION
## Summary
Improves XML doc comments on `[Parameter]` properties in `FluentMenu` and `FluentMenuItem` so the MCP server serves accurate descriptions to AI models.

## Changes
- `FluentMenu.CloseOnScroll`: fixed broken grammar ("Gets or sets whether the menu when scrolling outside of it." → complete sentence with verb)
- `FluentMenu.Trigger`: clarified that this is an HTML element ID, added usage example; previously just "Gets or sets the id of the menu trigger."
- `FluentMenu.ChildContent`: replaced misleading "Gets or sets the menu's submenus." with an accurate description that references `FluentMenuItem`
- `FluentMenuItem.IconStart`: added cross-reference to sibling `IconEnd`
- `FluentMenuItem.IconEnd`: added cross-reference to sibling `IconStart`
- `FluentMenuItem.IconIndicator`: fixed trailing space; clarified that this indicator only applies to `MenuItemRole.Checkbox` and `MenuItemRole.Radio` items
- `FluentMenuItem.Label`: fixed description that said "child component of the button" (this is a menu item); simplified to concise description with cross-reference to `ChildContent`

## Part of
Part of #4777