### PR TITLE
[MCP] Improve [Parameter] XML doc comments in FluentBadge components for AI accuracy

### DIFF
--- a/src/Core/Components/Badge/FluentBadge.razor.cs
+++ b/src/Core/Components/Badge/FluentBadge.razor.cs
@@ -37,13 +37,15 @@ public partial class FluentBadge : FluentComponentBase
         .Build();
 
     /// <summary>
-    /// Gets or sets the content to be rendered inside the component.
+    /// Gets or sets the text content displayed inside the badge (e.g., <c>Content="New"</c>).
+    /// For structured content, use <see cref="ChildContent"/> instead.
     /// </summary>
     [Parameter]
     public string? Content { get; set; }
 
     /// <summary>
-    /// Gets or sets the color.
+    /// Gets or sets the color of the badge (e.g., <c>Color="BadgeColor.Brand"</c>).
+    /// When using <see cref="BackgroundColor"/>, set this to <c>null</c>.
     /// </summary>
     [Parameter]
     public BadgeColor? Color { get; set; }
@@ -87,7 +89,8 @@ public partial class FluentBadge : FluentComponentBase
     public Icon? IconStart { get; set; }
 
     /// <summary>
-    /// Gets or sets the aria-label of the <see cref="Icon"/>.
+    /// Gets or sets the <c>aria-label</c> attribute applied to the icon(s) rendered in the badge
+    /// (e.g., <c>IconLabel="New notifications"</c>).
     /// </summary>
     [Parameter]
     public string? IconLabel { get; set; }

--- a/src/Core/Components/Badge/FluentCounterBadge.razor.cs
+++ b/src/Core/Components/Badge/FluentCounterBadge.razor.cs
@@ -21,13 +21,13 @@ public partial class FluentCounterBadge : FluentBadge
     private int? GetCount() => ShowWhen?.Invoke(Count) == true ? Count : null;
 
     /// <summary>
-    ///  Gets or sets the badge's dot state.
+    /// Gets or sets whether the badge renders as a small dot without any text content (e.g., <c>Dot="true"</c>).
     /// </summary>
     [Parameter]
     public bool Dot { get; set; }
 
     /// <summary>
-    /// Gets or sets the badge's show-zero state.
+    /// Gets or sets whether the badge is visible when <see cref="Count"/> is zero (e.g., <c>ShowZero="true"</c>).
     /// </summary>
     [Parameter]
     public bool? ShowZero { get; set; }
@@ -56,8 +56,9 @@ public partial class FluentCounterBadge : FluentBadge
     public int? Count { get; set; }
 
     /// <summary>
-    /// Gets or sets the badge's overflow count.
-    /// The default value is `null`. Internally the component uses 99 as its default value.
+    /// Gets or sets the maximum count value displayed before showing an overflow indicator (e.g., <c>OverflowCount="99"</c>).
+    /// When <see cref="Count"/> exceeds this value, the badge displays the overflow count followed by a "+" sign.
+    /// The default value is <c>null</c>; the component uses <c>99</c> as its internal default.
     /// </summary>
     [Parameter]
     public int? OverflowCount { get; set; }

--- a/src/Core/Components/Badge/FluentPresenceBadge.razor.cs
+++ b/src/Core/Components/Badge/FluentPresenceBadge.razor.cs
@@ -7,8 +7,8 @@ using Microsoft.AspNetCore.Components;
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 /// <summary>
-/// The FluentCounterBadge component is a visual indicator that communicates a value about an associated component.
-/// It uses short positive numbers, color, and icons for quick recognition and is placed near the relevant content.
+/// The FluentPresenceBadge component is a visual indicator that communicates a user's presence status.
+/// It displays a colored icon overlay typically attached to an avatar or similar element.
 /// </summary>
 public partial class FluentPresenceBadge : FluentComponentBase
 {
@@ -41,7 +41,8 @@ public partial class FluentPresenceBadge : FluentComponentBase
     public PresenceStatus? Status { get; set; } = PresenceStatus.Available;
 
     /// <summary>
-    ///  Gets or sets the out of office state.
+    /// Gets or sets whether the presence badge indicates an out-of-office state.
+    /// When <c>true</c>, adjusts the displayed icon to reflect the out-of-office variant of the current <see cref="Status"/>.
     /// </summary>
     [Parameter]
     public bool OutOfOffice { get; set; }
@@ -53,7 +54,8 @@ public partial class FluentPresenceBadge : FluentComponentBase
     public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
-    /// Gets or sets the <see cref="Icon"/> displayed at the start of badge content.
+    /// Gets or sets an icon override for the badge.
+    /// By default the icon is automatically chosen based on <see cref="Status"/> and <see cref="OutOfOffice"/>.
     /// </summary>
     [Parameter]
     public Icon? Icon { get; set; }


### PR DESCRIPTION
## Summary
Improves XML doc comments on `[Parameter]` properties in `FluentBadge`, `FluentCounterBadge`, and `FluentPresenceBadge` so the MCP server serves accurate descriptions to AI models.

## Changes
- `FluentBadge.Content`: fixed duplicate description (identical to `ChildContent`); clarified that `Content` is string text content; added cross-reference to `ChildContent` and usage example
- `FluentBadge.Color`: improved terse "Gets or sets the color." to include type name and cross-reference to `BackgroundColor` with usage example
- `FluentBadge.IconLabel`: clarified ambiguous "aria-label of the Icon" (there are two icons); updated to describe it as the aria-label for all badge icons; added usage example
- `FluentCounterBadge.Dot`: fixed leading space; improved from vague "dot state" to descriptive explanation with usage example
- `FluentCounterBadge.ShowZero`: improved from vague "show-zero state" to explicit description referencing `Count`; added usage example
- `FluentCounterBadge.OverflowCount`: improved to describe the overflow display behavior (shows `{n}+`) with usage example
- `FluentPresenceBadge` class summary: fixed copy-paste bug — summary still said "FluentCounterBadge"; corrected to describe the presence badge accurately
- `FluentPresenceBadge.OutOfOffice`: fixed leading space; improved from vague "out of office state" to description referencing `Status`; added behavior explanation
- `FluentPresenceBadge.Icon`: fixed misleading "displayed at the start of badge content"; the presence icon is determined automatically from `Status`/`OutOfOffice`; clarified as an override

## Part of
Part of #4777