### PR TITLE
[MCP] Improve [Parameter] XML doc comments in FluentLayout for AI accuracy

### DIFF
--- a/src/Core/Components/Layout/FluentLayout.razor.cs
+++ b/src/Core/Components/Layout/FluentLayout.razor.cs
@@ -61,7 +61,7 @@ public partial class FluentLayout : FluentComponentBase
     public bool GlobalScrollbar { get; set; }
 
     /// <summary>
-    /// Gets ot sets the width of the LayoutContainer.
+    /// Gets or sets the width of the layout container (e.g., <c>Width="100%"</c>).
     /// </summary>
     [Parameter]
     public string? Width { get; set; }

--- a/src/Core/Components/Layout/FluentLayoutHamburger.razor.cs
+++ b/src/Core/Components/Layout/FluentLayoutHamburger.razor.cs
@@ -73,7 +73,7 @@ public partial class FluentLayoutHamburger : FluentComponentBase
 
     /// <summary>
     /// Gets or sets the panel position to display when the hamburger menu is open.
-    /// Only <see cref="DialogAlignment.Start"/> and <see cref="DialogAlignment.End"/> are supported."/>.
+    /// Only <see cref="DialogAlignment.Start"/> and <see cref="DialogAlignment.End"/> are supported.
     /// The default value is <see cref="DialogAlignment.Start"/>.
     /// </summary>
     [Parameter]
@@ -107,7 +107,8 @@ public partial class FluentLayoutHamburger : FluentComponentBase
     public bool? Visible { get; set; }
 
     /// <summary>
-    /// Gets or sets the display mode for the hamburger menu.
+    /// Gets or sets the display mode for the hamburger menu (e.g., <c>Display="HamburgerDisplay.MobileOnly"</c>).
+    /// See <see cref="HamburgerDisplay"/> for available values.
     /// </summary>
     [Parameter]
     public HamburgerDisplay Display { get; set; } = HamburgerDisplay.MobileOnly;

--- a/src/Core/Components/Layout/FluentLayoutItem.razor.cs
+++ b/src/Core/Components/Layout/FluentLayoutItem.razor.cs
@@ -75,7 +75,7 @@ public partial class FluentLayoutItem : FluentComponentBase
     public LayoutArea Area { get; set; } = LayoutArea.Content;
 
     /// <summary>
-    /// Gets ot sets the width of the item.
+    /// Gets or sets the width of the item (e.g., <c>Width="300px"</c>).
     /// </summary>
     [Parameter]
     public string? Width { get; set; }
@@ -93,7 +93,7 @@ public partial class FluentLayoutItem : FluentComponentBase
     public bool Sticky { get; set; }
 
     /// <summary>
-    /// Gets or sets the contentArea to be rendered inside the component.
+    /// Gets or sets the content to be rendered inside the component.
     /// </summary>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }


### PR DESCRIPTION
## Summary
Improves XML doc comments on `[Parameter]` properties in `FluentLayout`, `FluentLayoutItem`, and `FluentLayoutHamburger` so the MCP server serves accurate descriptions to AI models.

## Changes
- `FluentLayout.Width`: Fixed typo "Gets ot sets" → "Gets or sets"; added usage example
- `FluentLayoutItem.Width`: Fixed typo "Gets ot sets" → "Gets or sets"; added usage example
- `FluentLayoutItem.ChildContent`: Fixed incorrect term "contentArea" → "content"
- `FluentLayoutHamburger.PanelPosition`: Removed stray `"/>` XML fragment that broke the doc comment
- `FluentLayoutHamburger.Display`: Added `<see cref="HamburgerDisplay"/>` reference and usage example

## Part of
Part of #4777