### PR TITLE
[MCP] Improve [Parameter] XML doc comments in FluentSpacer for AI accuracy

### DIFF
--- a/src/Core/Components/Spacer/FluentSpacer.razor.cs
+++ b/src/Core/Components/Spacer/FluentSpacer.razor.cs
@@ -27,19 +27,22 @@ public partial class FluentSpacer : FluentComponentBase
         .Build();
 
     /// <summary>
-    /// Gets or sets the height of the spacer when the orientation is vertical.
+    /// Gets or sets the height of the spacer when the <see cref="Orientation"/> is <see cref="Orientation.Vertical"/> (e.g., <c>Height="16px"</c>).
+    /// Use <see cref="Width"/> to set the size for a horizontal spacer.
     /// </summary>
     [Parameter]
     public string? Height { get; set; }
 
     /// <summary>
-    /// Gets or sets the size of the spacer when the orientation is horizontal.
+    /// Gets or sets the width of the spacer when the <see cref="Orientation"/> is <see cref="Orientation.Horizontal"/> (e.g., <c>Width="16px"</c>).
+    /// Use <see cref="Height"/> to set the size for a vertical spacer.
     /// </summary>
     [Parameter]
     public string? Width { get; set; }
 
     /// <summary>
-    /// Specify the orientation of the parent container, which can be either horizontal or vertical.
+    /// Gets or sets the orientation of the parent container.
+    /// Use <see cref="Orientation.Horizontal"/> (default) for a horizontal spacer, or <see cref="Orientation.Vertical"/> for a vertical one.
     /// </summary>
     [Parameter]
     public Orientation Orientation { get; set; } = Orientation.Horizontal;


### PR DESCRIPTION
## Summary
Improves XML doc comments on `[Parameter]` properties in `FluentSpacer` so the MCP server serves accurate descriptions to AI models.

## Changes
- `Height`: Added cross-reference to `Width`; clarified it applies when `Orientation` is `Vertical`; added usage example
- `Width`: Fixed description — was "size of the spacer" (wrong term); now correctly says "width of the spacer"; added `<see cref="Orientation"/>` and `<see cref="Height"/>` cross-references; added usage example
- `Orientation`: Added "Gets or sets" prefix; replaced imperative "Specify" wording; clarified horizontal/vertical behavior with `<see cref>` references

## Part of
Part of #4777