### PR TITLE
[MCP] Improve [Parameter] XML doc comments in FluentDivider for AI accuracy

### DIFF
--- a/src/Core/Components/Divider/FluentDivider.razor.cs
+++ b/src/Core/Components/Divider/FluentDivider.razor.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Components;
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 /// <summary>
-/// FluentDivider component
+/// A horizontal or vertical rule used to visually separate content.
 /// </summary>
 public partial class FluentDivider : FluentComponentBase, ITooltipComponent
 {
@@ -23,25 +23,27 @@ public partial class FluentDivider : FluentComponentBase, ITooltipComponent
         .Build();
 
     /// <summary>
-    /// Gets or sets the alignment of the content.
+    /// Gets or sets the alignment of any child content within the divider (e.g., <c>AlignContent="DividerAlignContent.Center"</c>).
+    /// See <see cref="DividerAlignContent"/> for available values.
     /// </summary>
     [Parameter]
     public DividerAlignContent? AlignContent { get; set; }
 
     /// <summary>
-    /// Gets or sets the appearance of the content.
+    /// Gets or sets the visual appearance of the divider (e.g., <c>Appearance="DividerAppearance.Strong"</c>).
+    /// See <see cref="DividerAppearance"/> for available values.
     /// </summary>
     [Parameter]
     public DividerAppearance? Appearance { get; set; }
 
     /// <summary>
-    /// Adds padding to the beginning and end of the divider.
+    /// Gets or sets whether padding is added to the beginning and end of the divider (e.g., <c>Inset="true"</c>).
     /// </summary>
     [Parameter]
     public bool? Inset { get; set; }
 
     /// <summary>
-    /// A divider can be horizontal (default) or vertical.
+    /// Gets or sets whether the divider is vertical (<c>true</c>) or horizontal (<c>false</c>, default).
     /// </summary>
     [Parameter]
     public bool? Vertical { get; set; }


### PR DESCRIPTION
## Summary
Improves XML doc comments on `[Parameter]` properties in `FluentDivider` so the MCP server serves accurate descriptions to AI models.

## Changes
- Class summary: replaced unhelpful "FluentDivider component" with a descriptive sentence
- `AlignContent`: Added `<see cref="DividerAlignContent"/>` cross-reference and usage example
- `Appearance`: Fixed description — was "appearance of the content" (wrong); now "visual appearance of the divider"; added `<see cref="DividerAppearance"/>` reference and usage example
- `Inset`: Added "Gets or sets" prefix; added usage example
- `Vertical`: Added "Gets or sets" prefix; clarified `true`/`false` semantics

## Part of
Part of #4777