### PR TITLE
[MCP] Improve [Parameter] XML doc comments in FluentAppBar for AI accuracy

### DIFF
--- a/src/Core/Components/AppBar/FluentAppBar.razor.cs
+++ b/src/Core/Components/AppBar/FluentAppBar.razor.cs
@@ -37,7 +37,7 @@ public partial class FluentAppBar : FluentComponentBase
     }
 
     /// <summary>
-    /// Gets or sets if the popover shows the search box.
+    /// Gets or sets whether the popover shows a search box to filter overflowed items.
     /// </summary>
     [Parameter]
     public bool PopoverShowSearch { get; set; } = true;

--- a/src/Core/Components/AppBar/FluentAppBarItem.razor.cs
+++ b/src/Core/Components/AppBar/FluentAppBarItem.razor.cs
@@ -66,7 +66,7 @@ public partial class FluentAppBarItem : FluentComponentBase, IAppBarItem
     public int? Count { get; set; }
 
     /// <summary>
-    ///  Gets or sets the content to be shown.
+    /// Gets or sets the content to be shown.
     /// </summary>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }


### PR DESCRIPTION
## Summary
Improves XML doc comments on `[Parameter]` properties in `FluentAppBar` and `FluentAppBarItem` so the MCP server serves accurate descriptions to AI models.

## Changes
- `FluentAppBar.PopoverShowSearch`: Fixed "Gets or sets if" → "Gets or sets whether"; improved description to clarify it filters overflowed items
- `FluentAppBarItem.ChildContent`: Removed extra leading space in `/// ` doc comment line

## Part of
Part of #4777