### PR TITLE
[MCP] Improve [Parameter] XML doc comments in Progress for AI accuracy

### DIFF
--- a/src/Core/Components/Progress/FluentProgressBar.razor.cs
+++ b/src/Core/Components/Progress/FluentProgressBar.razor.cs
@@ -30,14 +30,16 @@ public partial class FluentProgressBar : FluentComponentBase, ITooltipComponent
         .Build();
 
     /// <summary>
-    /// Gets or sets the minimum value.
+    /// Gets or sets the minimum value (e.g., <c>Min="0"</c>).
+    /// See also <see cref="Max"/>.
     /// </summary>
     [Parameter]
     public int? Min { get; set; }
 
     /// <summary>
-    /// Gets or sets the maximum value.
-    /// The FluentProgressBar bar will be full when value equals <see cref="Max"/>.
+    /// Gets or sets the maximum value (e.g., <c>Max="100"</c>).
+    /// The progress bar will be full when <see cref="Value"/> equals this.
+    /// See also <see cref="Min"/>.
     /// </summary>
     [Parameter]
     public int? Max { get; set; }
@@ -49,8 +51,9 @@ public partial class FluentProgressBar : FluentComponentBase, ITooltipComponent
     public ProgressShape? Shape { get; set; }
 
     /// <summary>
-    /// Gets or sets the current value.
-    /// If `null` (default), the FluentProgressBar will display an indeterminate state.
+    /// Gets or sets the current progress value (e.g., <c>Value="75"</c>).
+    /// If <see langword="null"/> (default), the bar displays an indeterminate state.
+    /// Must be between <see cref="Min"/> and <see cref="Max"/>.
     /// </summary>
     [Parameter]
     public int? Value { get; set; }
@@ -83,8 +86,8 @@ public partial class FluentProgressBar : FluentComponentBase, ITooltipComponent
     public string? BackgroundColor { get; set; }
 
     /// <summary>
-    /// Gets or sets the color of the progress bar.
-    /// This property is not used when the <see cref="State"/> property is set.
+    /// Gets or sets the color of the progress bar indicator (e.g., <c>Color="#0078d4"</c>).
+    /// Ignored when <see cref="State"/> is set.
     /// </summary>
     [Parameter]
     public string? Color { get; set; }
@@ -98,7 +101,8 @@ public partial class FluentProgressBar : FluentComponentBase, ITooltipComponent
     public ProgressStroke? Stroke { get; set; }
 
     /// <summary>
-    /// Gets or sets the stroke width of the progress bar.
+    /// Gets or sets the visual thickness of the progress bar track (e.g., <c>Thickness="ProgressThickness.Large"</c>).
+    /// If not set, the default theme thickness is used.
     /// </summary>
     [Parameter]
     public ProgressThickness? Thickness { get; set; }

--- a/src/Core/Components/Progress/FluentSpinner.razor.cs
+++ b/src/Core/Components/Progress/FluentSpinner.razor.cs
@@ -33,7 +33,8 @@ public partial class FluentSpinner : FluentComponentBase, ITooltipComponent
     public bool? Visible { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets whether the spinner should be shown in an inverted color scheme (i.e. light spinner on dark background)
+    /// Gets or sets a value indicating whether the spinner should be shown in an inverted color scheme
+    /// (e.g., <c>AppearanceInverted="true"</c> for a light spinner on a dark background).
     /// </summary>
     [Parameter]
     public bool AppearanceInverted { get; set; }


### PR DESCRIPTION
## Summary
Improves XML doc comments on `[Parameter]` properties in `FluentProgressBar` and `FluentSpinner` so the MCP server serves accurate descriptions to AI models.

## Changes
- `FluentProgressBar.Min`: added cross-reference to `Max`
- `FluentProgressBar.Max`: fixed "FluentProgressBar bar" redundancy; added cross-references to `Min` and `Value`
- `FluentProgressBar.Value`: replaced markdown backtick syntax with `<see langword="null"/>` ; added cross-references to `Min`/`Max`
- `FluentProgressBar.Color`: added note that it is ignored when `State` is set (cross-ref)
- `FluentProgressBar.Thickness`: description said "stroke width" (mismatch with property name); now clearly describes thickness with usage example
- `FluentSpinner.AppearanceInverted`: fixed lowercase "whether", added "a value indicating", added usage example

## Part of
Part of #4777