### PR TITLE
[MCP] Improve [Parameter] XML doc comments in FluentSkeleton for AI accuracy

### DIFF
--- a/src/Core/Components/Skeleton/FluentSkeleton.razor.cs
+++ b/src/Core/Components/Skeleton/FluentSkeleton.razor.cs
@@ -50,13 +50,15 @@ public partial class FluentSkeleton : FluentComponentBase
     public bool Visible { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets a value indicating whether the loading effect is visible.
+    /// Gets or sets a value indicating whether the shimmer animation (loading wave effect) is shown.
+    /// Distinct from <see cref="Visible"/>, which controls component visibility entirely.
     /// </summary>
     [Parameter]
     public bool Shimmer { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets a value indicating whether the skeleton in a circular mode.
+    /// Gets or sets a value indicating whether the skeleton is displayed as a circle.
+    /// When <see langword="true"/>, both <see cref="Width"/> and <see cref="Height"/> are set to the same value to form a circle.
     /// </summary>
     [Parameter]
     public bool Circular { get; set; }
@@ -74,8 +76,9 @@ public partial class FluentSkeleton : FluentComponentBase
     public string? Height { get; set; } = "48px";
 
     /// <summary>
-    /// Gets or sets the predefined skeleton pattern used to define the structure or layout of the component.
-    /// You can customize the skeleton's appearance by using <see cref="ChildContent" />
+    /// Gets or sets the predefined skeleton pattern used to define the structure or layout of the component
+    /// (e.g., <c>Pattern="SkeletonPattern.Article"</c>).
+    /// For custom layouts, use <see cref="ChildContent"/> instead.
     /// </summary>
     [Parameter]
     public SkeletonPattern? Pattern { get; set; }


### PR DESCRIPTION
## Summary
Improves XML doc comments on `[Parameter]` properties in `FluentSkeleton` so the MCP server serves accurate descriptions to AI models.

## Changes
- `Shimmer`: description "loading effect is visible" was ambiguous with `Visible`; now explicitly named "shimmer animation (loading wave effect)" and cross-referenced with `Visible`
- `Circular`: fixed grammar ("skeleton in a circular mode" → "skeleton is displayed as a circle"); added note on Width/Height behavior
- `Pattern`: added `<see cref="ChildContent"/>` cross-reference for the alternative customization approach; added usage example

## Part of
Part of #4777