### PR TITLE
[MCP] Improve [Parameter] XML doc comments in FluentRatingDisplay for AI accuracy

### DIFF
--- a/src/Core/Components/RatingDisplay/FluentRatingDisplay.razor.cs
+++ b/src/Core/Components/RatingDisplay/FluentRatingDisplay.razor.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Components;
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 /// <summary>
-/// Visual representation of content being loaded or processed.
+/// Displays a read-only star rating, such as an average product score or user review summary.
 /// </summary>
 public partial class FluentRatingDisplay : FluentComponentBase, ITooltipComponent
 {
@@ -29,8 +29,8 @@ public partial class FluentRatingDisplay : FluentComponentBase, ITooltipComponen
     public RatingDisplayColor? Color { get; set; }
 
     /// <summary>
-    /// Gets or sets the compact mode.
-    /// Renders a single filled star, with the value written next to it.
+    /// Gets or sets a value indicating whether compact mode is enabled.
+    /// When <see langword="true"/>, renders a single filled star with the numeric value next to it.
     /// </summary>
     [Parameter]
     public bool? Compact { get; set; }
@@ -43,26 +43,28 @@ public partial class FluentRatingDisplay : FluentComponentBase, ITooltipComponen
     public double? Count { get; set; }
 
     /// <summary>
-    /// Gets or sets the max value of the rating.
-    /// This controls the number of rating items displayed. Must be a whole number greater than 1
+    /// Gets or sets the maximum number of rating items displayed (e.g., <c>Max="5"</c>).
+    /// Must be a whole number greater than 1. See also <see cref="Value"/>.
     /// </summary>
     [Parameter]
     public byte? Max { get; set; }
 
     /// <summary>
-    /// Gets or sets the size of the rating items
+    /// Gets or sets the size of the rating items (e.g., <c>Size="RatingSize.Small"</c>).
     /// </summary>
     [Parameter]
     public RatingSize? Size { get; set; }
 
     /// <summary>
-    /// Gets or sets the shape
+    /// Gets or sets the icon used for each rating item (e.g., <c>Shape="new MyIcons.Star()"</c>).
+    /// Defaults to a star icon.
     /// </summary>
     [Parameter]
     public Icon? Shape { get; set; }
 
     /// <summary>
-    /// Gets or sets the value of the rating
+    /// Gets or sets the current rating value (e.g., <c>Value="3.5"</c>).
+    /// Must be between 0 and <see cref="Max"/>.
     /// </summary>
     [Parameter]
     public double? Value { get; set; }


### PR DESCRIPTION
## Summary
Improves XML doc comments on `[Parameter]` properties in `FluentRatingDisplay` so the MCP server serves accurate descriptions to AI models.

## Changes
- **Class summary**: was copy-pasted from `FluentProgressBar` ("Visual representation of content being loaded or processed") — now correctly describes a read-only star rating display
- `Compact`: changed from "Gets or sets the compact mode" to proper boolean-style "Gets or sets a value indicating whether compact mode is enabled"; added description of rendering behavior
- `Max`: fixed missing period; renamed from "max value" to "maximum number of rating items"; added cross-reference to `Value`
- `Size`: added missing period; added usage example
- `Shape`: "Gets or sets the shape" → descriptive doc explaining it is the icon for each rating item with example
- `Value`: added missing period; added cross-reference to `Max`

## Part of
Part of #4777