### PR TITLE
[MCP] Improve [Parameter] XML doc comments in DateTime components for AI accuracy

### DIFF
--- a/src/Core/Components/DateTime/FluentCalendar.razor.cs
+++ b/src/Core/Components/DateTime/FluentCalendar.razor.cs
@@ -133,14 +133,15 @@ public partial class FluentCalendar<TValue> : FluentCalendarBase<TValue>
     public bool DisplayToday { get; set; } = true;
 
     /// <summary>
-    /// Gets ot sets if the calendar items are animated during a period change.
+    /// Gets or sets a value indicating whether calendar items are animated during a period change.
     /// By default, the animation is enabled for Months views, but disabled for Days and Years view.
     /// </summary>
     [Parameter]
     public bool? AnimatePeriodChanges { get; set; }
 
     /// <summary>
-    /// Gets or sets the way the user can select one or more dates
+    /// Gets or sets the date selection mode (e.g., <c>SelectMode="CalendarSelectMode.Range"</c>).
+    /// Controls whether the user can select a single date, a range, or multiple dates.
     /// </summary>
     [Parameter]
     public CalendarSelectMode SelectMode { get; set; } = CalendarSelectMode.Single;
@@ -158,7 +159,8 @@ public partial class FluentCalendar<TValue> : FluentCalendarBase<TValue>
     public EventCallback<IEnumerable<TValue>> SelectedDatesChanged { get; set; }
 
     /// <summary>
-    /// Fired when the selected mouse over change, to display the future range of dates.
+    /// Gets or sets a function invoked when the user hovers over a date, returning the projected range to highlight.
+    /// Only used when <see cref="SelectMode"/> is <see cref="CalendarSelectMode.Range"/>.
     /// </summary>
     [Parameter]
     public Func<TValue, IEnumerable<TValue>>? SelectDatesHover { get; set; }

--- a/src/Core/Components/DateTime/FluentDatePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor.cs
@@ -52,18 +52,22 @@ public partial class FluentDatePicker<TValue> : FluentCalendarBase<TValue>
         .Build();
 
     /// <summary>
-    /// Gets or sets the visual appearance.
+    /// Gets or sets the icon displayed in the date picker toggle button (e.g., <c>Icon="new CoreIcons.Regular.Size20.Calendar()"</c>).
+    /// Defaults to the calendar icon.
     /// </summary>
     [Parameter]
     public Icon Icon { get; set; } = new CoreIcons.Regular.Size20.Calendar().WithColor("currentColor");
 
     /// <summary>
-    /// Gets or sets the visual appearance.
+    /// Gets or sets the visual appearance of the text input (e.g., <c>Appearance="TextInputAppearance.Outline"</c>).
     /// </summary>
     [Parameter]
     public TextInputAppearance Appearance { get; set; } = TextInputAppearance.Outline;
 
-    /// <summary />
+    /// <summary>
+    /// Gets or sets the render style of the date picker (e.g., <c>RenderStyle="DatePickerRenderStyle.FluentUI"</c>).
+    /// <see cref="DatePickerRenderStyle.FluentUI"/> renders a popup calendar; <see cref="DatePickerRenderStyle.Native"/> uses the browser's built-in date input.
+    /// </summary>
     [Parameter]
     public DatePickerRenderStyle RenderStyle { get; set; } = DatePickerRenderStyle.FluentUI;
 

--- a/src/Core/Components/DateTime/FluentTimePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentTimePicker.razor.cs
@@ -52,7 +52,10 @@ public partial class FluentTimePicker<TValue> : FluentInputBase<TValue>
     [Parameter]
     public ListAppearance Appearance { get; set; } = ListAppearance.Outline;
 
-    /// <summary />
+    /// <summary>
+    /// Gets or sets the render style of the time picker (e.g., <c>RenderStyle="DatePickerRenderStyle.FluentUI"</c>).
+    /// <see cref="DatePickerRenderStyle.FluentUI"/> renders a dropdown list; <see cref="DatePickerRenderStyle.Native"/> uses the browser's built-in time input.
+    /// </summary>
     [Parameter]
     public DatePickerRenderStyle RenderStyle { get; set; } = DatePickerRenderStyle.FluentUI;
 
@@ -76,19 +79,22 @@ public partial class FluentTimePicker<TValue> : FluentInputBase<TValue>
     public string? Placeholder { get; set; }
 
     /// <summary>
-    /// Function to know if a specific time must be disabled.
+    /// Gets or sets a function that determines whether a specific time value should be disabled in the picker.
+    /// Return <see langword="true"/> to disable a time; <see langword="false"/> to allow it.
     /// </summary>
     [Parameter]
     public virtual Func<TValue, bool>? DisabledTimeFunc { get; set; }
 
     /// <summary>
-    /// Gets or sets the hour of the day at which the operation or schedule should start, in 24-hour format.
+    /// Gets or sets the first hour displayed in the time dropdown list, in 24-hour format (e.g., <c>StartHour="9"</c>).
+    /// See also <see cref="EndHour"/>.
     /// </summary>
     [Parameter]
     public int StartHour { get; set; } = 8;
 
     /// <summary>
-    /// Gets or sets the ending hour for the time range, in 24-hour format.
+    /// Gets or sets the last hour displayed in the time dropdown list, in 24-hour format (e.g., <c>EndHour="17"</c>).
+    /// See also <see cref="StartHour"/>.
     /// </summary>
     [Parameter]
     public int EndHour { get; set; } = 18;


### PR DESCRIPTION
## Summary
Improves XML doc comments on `[Parameter]` properties in `FluentCalendar`, `FluentDatePicker`, and `FluentTimePicker` so the MCP server serves accurate descriptions to AI models.

## Changes

### FluentCalendar
- `AnimatePeriodChanges`: fixed typo "Gets ot sets" → "Gets or sets"; changed to standard boolean-style description
- `SelectMode`: added period, added description of selection behavior with usage example
- `SelectDatesHover`: description "Fired when the selected mouse over change" was grammatically wrong and misleading; now "Gets or sets a function invoked when the user hovers over a date"

### FluentDatePicker
- `Icon`: description was "Gets or sets the visual appearance" (copy of `Appearance`) — wrong; now correctly describes the calendar icon with usage example
- `Appearance`: disambiguated from `Icon` with enum type mention and usage example
- `RenderStyle`: was `/// <summary />` (completely undocumented); now documents both render style options with usage example

### FluentTimePicker
- `RenderStyle`: was `/// <summary />` (completely undocumented); now documents both render style options with usage example
- `DisabledTimeFunc`: "Function to know if a specific time must be disabled" → standard "Gets or sets a function that determines..." convention
- `StartHour`: "the operation or schedule should start" → "first hour displayed in the time dropdown list"
- `EndHour`: "ending hour for the time range" → "last hour displayed in the time dropdown list"; added cross-reference to `StartHour`

## Part of
Part of #4777