### PR TITLE
[MCP] Improve [Parameter] XML doc comments in FluentHighlighter for AI accuracy

### DIFF
--- a/src/Core/Components/Highlighter/FluentHighlighter.razor.cs
+++ b/src/Core/Components/Highlighter/FluentHighlighter.razor.cs
@@ -32,7 +32,8 @@ public partial class FluentHighlighter : FluentComponentBase
     public bool CaseSensitive { get; set; } = false;
 
     /// <summary>
-    /// Gets or sets the fragment of text to be highlighted.
+    /// Gets or sets the search term to highlight within <see cref="Text"/> (e.g., <c>HighlightedText="blazor"</c>).
+    /// Use <see cref="CaseSensitive"/> to control case sensitivity and <see cref="Delimiters"/> to split the term.
     /// </summary>
     [Parameter]
     public string HighlightedText { get; set; } = string.Empty;
@@ -50,7 +51,7 @@ public partial class FluentHighlighter : FluentComponentBase
     public string Delimiters { get; set; } = string.Empty;
 
     /// <summary>
-    /// If true, highlights the text until the next regex boundary.
+    /// Gets or sets whether the <see cref="HighlightedText"/> match should extend until the next regex word boundary.
     /// </summary>
     [Parameter]
     public bool UntilNextBoundary { get; set; }


### PR DESCRIPTION
## Summary
Improves XML doc comments on `[Parameter]` properties in `FluentHighlighter` so the MCP server serves accurate descriptions to AI models.

## Changes
- `HighlightedText`: Replaced vague "fragment of text to be highlighted" with precise "search term to highlight within Text"; added cross-references to `Text`, `CaseSensitive`, and `Delimiters`; added usage example
- `UntilNextBoundary`: Added "Gets or sets whether" prefix; added cross-reference to `HighlightedText`

## Part of
Part of #4777