### PR TITLE
[MCP] Improve [Parameter] XML doc comments — Group A: Input Controls

### DIFF
--- a/src/Core/Components/Button/FluentAnchorButton.razor.cs
+++ b/src/Core/Components/Button/FluentAnchorButton.razor.cs
@@ -106,6 +106,7 @@ public partial class FluentAnchorButton : FluentComponentBase, ITooltipComponent
     /// <summary>
     /// Gets or sets a value indicating whether the button renders icon-only (no visible text label).
     /// Typically used when <see cref="IconStart"/> or <see cref="IconEnd"/> is set and no text label is needed.
+    /// When using icon-only mode, provide an accessible name via <see cref="Title"/> or an <c>aria-label</c> attribute to ensure screen reader accessibility.
     /// </summary>
     [Parameter]
     public bool IconOnly { get; set; }
@@ -131,6 +132,7 @@ public partial class FluentAnchorButton : FluentComponentBase, ITooltipComponent
 
     /// <summary>
     /// Gets or sets the plain-text label rendered inside the button (e.g., <c>Label="Go"</c>).
+    /// If both <see cref="Label"/> and <see cref="ChildContent"/> are set, both are rendered together.
     /// For rich content such as icons or custom markup, use <see cref="ChildContent"/> instead.
     /// </summary>
     [Parameter]

--- a/src/Core/Components/Button/FluentAnchorButton.razor.cs
+++ b/src/Core/Components/Button/FluentAnchorButton.razor.cs
@@ -104,8 +104,8 @@ public partial class FluentAnchorButton : FluentComponentBase, ITooltipComponent
     public string? Color { get; set; }
 
     /// <summary>
-    /// Gets or sets if the button only shows an icon
-    /// Can be used when using <see cref="ChildContent"/> that renders as an icon
+    /// Gets or sets a value indicating whether the button renders icon-only (no visible text label).
+    /// Typically used when <see cref="IconStart"/> or <see cref="IconEnd"/> is set and no text label is needed.
     /// </summary>
     [Parameter]
     public bool IconOnly { get; set; }
@@ -130,10 +130,9 @@ public partial class FluentAnchorButton : FluentComponentBase, ITooltipComponent
     public string? Title { get; set; }
 
     /// <summary>
-    ///  Gets or sets the content to be rendered inside the button.
-    ///  This can be used as an alternative to specifying the content as a child component of the button.
-    ///  If both are specified, both will be rendered.
-    ///  </summary>
+    /// Gets or sets the plain-text label rendered inside the button (e.g., <c>Label="Go"</c>).
+    /// For rich content such as icons or custom markup, use <see cref="ChildContent"/> instead.
+    /// </summary>
     [Parameter]
     public string? Label { get; set; }
 

--- a/src/Core/Components/Button/FluentButton.razor.cs
+++ b/src/Core/Components/Button/FluentButton.razor.cs
@@ -68,8 +68,8 @@ public partial class FluentButton : FluentComponentBase, ITooltipComponent
     public string? FormMethod { get; set; }
 
     /// <summary>
-    /// Gets or sets if the form need to be validated when it is submitted
-    /// (if the button is a submit button).
+    /// Gets or sets a value indicating whether form validation is bypassed when this button submits the form
+    /// (if the button is a submit button). When <c>true</c>, the form's validation constraints are not checked on submission.
     /// </summary>
     [Parameter]
     public bool? FormNoValidate { get; set; }
@@ -116,7 +116,8 @@ public partial class FluentButton : FluentComponentBase, ITooltipComponent
     public bool Disabled { get; set; } = false;
 
     /// <summary>
-    /// Gets or sets the value indicating the button is focusable.
+    /// Gets or sets a value indicating whether the button is disabled yet still reachable via keyboard focus.
+    /// Unlike <see cref="Disabled"/>, a focusable-disabled button participates in the tab order and can expose tooltips.
     /// </summary>
     [Parameter]
     public bool DisabledFocusable { get; set; } = false;
@@ -161,8 +162,8 @@ public partial class FluentButton : FluentComponentBase, ITooltipComponent
     public bool Loading { get; set; } = false;
 
     /// <summary>
-    /// Gets or sets if the button only shows an icon
-    /// Can be used when using <see cref="ChildContent"/> that renders as an icon
+    /// Gets or sets a value indicating whether the button renders icon-only (no visible text label).
+    /// Typically used when <see cref="IconStart"/> or <see cref="IconEnd"/> is set and no text label is needed.
     /// </summary>
     [Parameter]
     public bool IconOnly { get; set; }
@@ -187,10 +188,9 @@ public partial class FluentButton : FluentComponentBase, ITooltipComponent
     public string? Title { get; set; }
 
     /// <summary>
-    ///  Gets or sets the content to be rendered inside the button.
-    ///  This can be used as an alternative to specifying the content as a child component of the button.
-    ///  If both are specified, both will be rendered.
-    ///  </summary>
+    /// Gets or sets the plain-text label rendered inside the button (e.g., <c>Label="Submit"</c>).
+    /// For rich content such as icons or custom markup, use <see cref="ChildContent"/> instead.
+    /// </summary>
     [Parameter]
     public string? Label { get; set; }
 

--- a/src/Core/Components/Button/FluentButton.razor.cs
+++ b/src/Core/Components/Button/FluentButton.razor.cs
@@ -164,6 +164,7 @@ public partial class FluentButton : FluentComponentBase, ITooltipComponent
     /// <summary>
     /// Gets or sets a value indicating whether the button renders icon-only (no visible text label).
     /// Typically used when <see cref="IconStart"/> or <see cref="IconEnd"/> is set and no text label is needed.
+    /// When using icon-only mode, provide an accessible name via <see cref="Title"/> or an <c>aria-label</c> attribute to ensure screen reader accessibility.
     /// </summary>
     [Parameter]
     public bool IconOnly { get; set; }
@@ -189,6 +190,7 @@ public partial class FluentButton : FluentComponentBase, ITooltipComponent
 
     /// <summary>
     /// Gets or sets the plain-text label rendered inside the button (e.g., <c>Label="Submit"</c>).
+    /// If both <see cref="Label"/> and <see cref="ChildContent"/> are set, both are rendered together.
     /// For rich content such as icons or custom markup, use <see cref="ChildContent"/> instead.
     /// </summary>
     [Parameter]

--- a/src/Core/Components/Button/FluentCompoundButton.razor.cs
+++ b/src/Core/Components/Button/FluentCompoundButton.razor.cs
@@ -112,12 +112,14 @@ public partial class FluentCompoundButton : FluentComponentBase, ITooltipCompone
     /// <summary>
     /// Gets or sets a value indicating whether the button renders icon-only (no visible text label).
     /// Typically used when <see cref="IconStart"/> or <see cref="IconEnd"/> is set and no text label is needed.
+    /// When using icon-only mode, provide an accessible name via <see cref="Title"/> or an <c>aria-label</c> attribute to ensure screen reader accessibility.
     /// </summary>
     [Parameter]
     public bool IconOnly { get; set; }
 
     /// <summary>
     /// Gets or sets the plain-text label rendered as the primary button text (e.g., <c>Label="Open"</c>).
+    /// If both <see cref="Label"/> and <see cref="ChildContent"/> are set, both are rendered together.
     /// For rich content, use <see cref="ChildContent"/> instead. See also <see cref="Description"/> for secondary text.
     /// </summary>
     [Parameter]

--- a/src/Core/Components/Button/FluentCompoundButton.razor.cs
+++ b/src/Core/Components/Button/FluentCompoundButton.razor.cs
@@ -110,22 +110,22 @@ public partial class FluentCompoundButton : FluentComponentBase, ITooltipCompone
     public bool StopPropagation { get; set; } = false;
 
     /// <summary>
-    /// Gets or sets if the button only shows an icon
-    /// Can be used when using <see cref="ChildContent"/> that renders as an icon
+    /// Gets or sets a value indicating whether the button renders icon-only (no visible text label).
+    /// Typically used when <see cref="IconStart"/> or <see cref="IconEnd"/> is set and no text label is needed.
     /// </summary>
     [Parameter]
     public bool IconOnly { get; set; }
 
     /// <summary>
-    ///  Gets or sets the content to be rendered inside the button.
-    ///  This can be used as an alternative to specifying the content as a child component of the button.
-    ///  If both are specified, both will be rendered.
-    ///  </summary>
+    /// Gets or sets the plain-text label rendered as the primary button text (e.g., <c>Label="Open"</c>).
+    /// For rich content, use <see cref="ChildContent"/> instead. See also <see cref="Description"/> for secondary text.
+    /// </summary>
     [Parameter]
     public string? Label { get; set; }
 
     /// <summary>
-    /// Gets or sets the content to be rendered inside description area of the button.
+    /// Gets or sets the secondary description content rendered below the primary label (e.g., a subtitle or hint).
+    /// See also <see cref="Label"/> for the primary button text.
     /// </summary>
     [Parameter]
     public RenderFragment? Description { get; set; }

--- a/src/Core/Components/Button/FluentSplitButton.razor.cs
+++ b/src/Core/Components/Button/FluentSplitButton.razor.cs
@@ -70,8 +70,8 @@ public partial class FluentSplitButton : FluentComponentBase
     public string? Color { get; set; }
 
     /// <summary>
-    /// Gets or sets if the button only shows an icon
-    /// Can be used when using <see cref="ChildContent"/> that renders as an icon
+    /// Gets or sets a value indicating whether the button renders icon-only (no visible text label).
+    /// Typically used when <see cref="IconStart"/> is set and no text label is needed.
     /// </summary>
     [Parameter]
     public bool IconOnly { get; set; }
@@ -97,10 +97,9 @@ public partial class FluentSplitButton : FluentComponentBase
     public string? Title { get; set; }
 
     /// <summary>
-    ///  Gets or sets the content to be rendered inside the button.
-    ///  This can be used as an alternative to specifying the content as a child component of the button.
-    ///  If both are specified, both will be rendered.
-    ///  </summary>
+    /// Gets or sets the plain-text label rendered inside the primary button area (e.g., <c>Label="Save"</c>).
+    /// For rich content such as icons or custom markup, use <see cref="ChildContent"/> instead.
+    /// </summary>
     [Parameter]
     public string? Label { get; set; }
 

--- a/src/Core/Components/Button/FluentSplitButton.razor.cs
+++ b/src/Core/Components/Button/FluentSplitButton.razor.cs
@@ -72,6 +72,7 @@ public partial class FluentSplitButton : FluentComponentBase
     /// <summary>
     /// Gets or sets a value indicating whether the button renders icon-only (no visible text label).
     /// Typically used when <see cref="IconStart"/> is set and no text label is needed.
+    /// When using icon-only mode, provide an accessible name via <see cref="Title"/> or an <c>aria-label</c> attribute to ensure screen reader accessibility.
     /// </summary>
     [Parameter]
     public bool IconOnly { get; set; }
@@ -98,6 +99,7 @@ public partial class FluentSplitButton : FluentComponentBase
 
     /// <summary>
     /// Gets or sets the plain-text label rendered inside the primary button area (e.g., <c>Label="Save"</c>).
+    /// If both <see cref="Label"/> and <see cref="ChildContent"/> are set, both are rendered together.
     /// For rich content such as icons or custom markup, use <see cref="ChildContent"/> instead.
     /// </summary>
     [Parameter]

--- a/src/Core/Components/Checkbox/FluentCheckbox.razor.cs
+++ b/src/Core/Components/Checkbox/FluentCheckbox.razor.cs
@@ -15,9 +15,7 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// </summary>
 public partial class FluentCheckbox : FluentInputBase<bool>, IFluentComponentElementBase, ITooltipComponent
 {
-    /// <summary>
-    ///
-    /// </summary>
+    /// <summary />
     public FluentCheckbox(LibraryConfiguration configuration) : base(configuration)
     {
         LabelPosition = Components.LabelPosition.After;
@@ -28,8 +26,8 @@ public partial class FluentCheckbox : FluentInputBase<bool>, IFluentComponentEle
     public ElementReference Element { get; set; }
 
     /// <summary>
-    /// Gets or sets the state of the CheckBox: true, false or null.
-    /// Useful when the mode ThreeState is enable
+    /// Gets or sets the three-state value of the checkbox: <c>true</c> (checked), <c>false</c> (unchecked), or <c>null</c> (indeterminate).
+    /// Used when <see cref="ThreeState"/> is enabled.
     /// </summary>
     [Parameter]
     public bool? CheckState { get; set; }

--- a/src/Core/Components/Checkbox/FluentCheckbox.razor.cs
+++ b/src/Core/Components/Checkbox/FluentCheckbox.razor.cs
@@ -15,7 +15,9 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// </summary>
 public partial class FluentCheckbox : FluentInputBase<bool>, IFluentComponentElementBase, ITooltipComponent
 {
-    /// <summary />
+    /// <summary>
+    /// Initializes a new instance of <see cref="FluentCheckbox"/>.
+    /// </summary>
     public FluentCheckbox(LibraryConfiguration configuration) : base(configuration)
     {
         LabelPosition = Components.LabelPosition.After;

--- a/src/Core/Components/Radio/FluentRadioGroup.razor.cs
+++ b/src/Core/Components/Radio/FluentRadioGroup.razor.cs
@@ -47,7 +47,8 @@ public partial class FluentRadioGroup<TValue> : FluentInputBase<TValue>, IFluent
     public bool Wrap { get; set; }
 
     /// <summary>
-    ///     
+    /// Gets or sets the collection of items from which radio buttons are generated.
+    /// Use with <see cref="RadioLabel"/> and <see cref="RadioValue"/> to control display text and submitted value.
     /// </summary>
     [Parameter]
     public IEnumerable<TValue?>? Items { get; set; }
@@ -59,13 +60,13 @@ public partial class FluentRadioGroup<TValue> : FluentInputBase<TValue>, IFluent
     public virtual Func<TValue?, string?>? RadioValue { get; set; }
 
     /// <summary>
-    /// Gets or sets the function used to determine which text to display for each radio checkedItem.
+    /// Gets or sets the function used to determine the display label for each radio button item.
     /// </summary>
     [Parameter]
     public virtual Func<TValue?, string?>? RadioLabel { get; set; }
 
     /// <summary>
-    /// Gets or sets the function used to determine if an radio is disabled.
+    /// Gets or sets the function used to determine whether a radio button item is disabled.
     /// </summary>
     [Parameter]
     public virtual Func<TValue?, bool>? RadioDisabled { get; set; }

--- a/src/Core/Components/TextArea/FluentTextArea.razor.cs
+++ b/src/Core/Components/TextArea/FluentTextArea.razor.cs
@@ -11,13 +11,13 @@ using Microsoft.JSInterop;
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 /// <summary>
-/// A textarea component that allows users to enter and edit a single line of text.
+/// A textarea component that allows users to enter and edit multiple lines of text.
 /// </summary>
 public partial class FluentTextArea : FluentInputImmediateBase<string?>, IFluentComponentElementBase, ITooltipComponent, IFluentComponentChangeAfterKeyPress
 {
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="FluentTextInput"/> class.
+    /// Initializes a new instance of the <see cref="FluentTextArea"/> class.
     /// </summary>
     public FluentTextArea(LibraryConfiguration configuration) : base(configuration)
     {
@@ -77,14 +77,14 @@ public partial class FluentTextArea : FluentInputImmediateBase<string?>, IFluent
     public int? MinLength { get; set; }
 
     /// <summary>
-    /// Specifies whether a form or an textarea field should have autocomplete "on" or "off" or another value.
+    /// Gets or sets the autocomplete hint for the textarea (e.g., <c>AutoComplete="on"</c> or <c>AutoComplete="off"</c>).
     /// An Id value must be set to use this property.
     /// </summary>
     [Parameter]
     public string? AutoComplete { get; set; }
 
     /// <summary>
-    /// Whether the element’s height should be automatically changed based on the content.
+    /// Gets or sets a value indicating whether the textarea height adjusts automatically to fit its content.
     /// </summary>
     [Parameter]
     public bool? AutoResize { get; set; }
@@ -96,19 +96,19 @@ public partial class FluentTextArea : FluentInputImmediateBase<string?>, IFluent
     public TextAreaSize? Size { get; set; }
 
     /// <summary>
-    /// Gets or sets the width of the input field.
+    /// Gets or sets the width of the textarea (e.g., <c>Width="300px"</c>).
     /// </summary>
     [Parameter]
     public string? Width { get; set; }
 
     /// <summary>
-    /// Gets or sets the height of the input field.
+    /// Gets or sets the height of the textarea (e.g., <c>Height="150px"</c>). See also <see cref="AutoResize"/>.
     /// </summary>
     [Parameter]
     public string? Height { get; set; }
 
     /// <summary>
-    /// Gets or sets the how resize the element. See <see cref="Components.TextAreaResize"/>
+    /// Gets or sets how the textarea can be resized by the user. See <see cref="Components.TextAreaResize"/>.
     /// </summary>
     [Parameter]
     public TextAreaResize? Resize { get; set; }

--- a/src/Core/Components/TextArea/FluentTextArea.razor.cs
+++ b/src/Core/Components/TextArea/FluentTextArea.razor.cs
@@ -108,7 +108,7 @@ public partial class FluentTextArea : FluentInputImmediateBase<string?>, IFluent
     public string? Height { get; set; }
 
     /// <summary>
-    /// Gets or sets how the textarea can be resized by the user. See <see cref="Components.TextAreaResize"/>.
+    /// Gets or sets how the textarea can be resized by the user. See <see cref="TextAreaResize"/>.
     /// </summary>
     [Parameter]
     public TextAreaResize? Resize { get; set; }

--- a/src/Core/Components/TextInput/FluentTextInput.razor.cs
+++ b/src/Core/Components/TextInput/FluentTextInput.razor.cs
@@ -64,13 +64,15 @@ public partial class FluentTextInput : FluentInputImmediateBase<string?>, IFluen
     public string? Placeholder { get; set; }
 
     /// <summary>
-    /// Gets or sets the content to prefix the input component.
+    /// Gets or sets custom content rendered before the text input (e.g., a prefix icon or label).
+    /// See also <see cref="EndTemplate"/> for content placed after the input.
     /// </summary>
     [Parameter]
     public virtual RenderFragment? StartTemplate { get; set; }
 
     /// <summary>
-    /// Gets or sets the content to suffix the input component.
+    /// Gets or sets custom content rendered after the text input (e.g., a suffix icon or unit label).
+    /// See also <see cref="StartTemplate"/> for content placed before the input.
     /// </summary>
     [Parameter]
     public virtual RenderFragment? EndTemplate { get; set; }
@@ -121,8 +123,8 @@ public partial class FluentTextInput : FluentInputImmediateBase<string?>, IFluen
     public string MaskPlaceholder { get; set; } = "_";
 
     /// <summary>
-    /// Specifies whether a form or an input field should have autocomplete "on" or "off" or another value.
-    /// An Id value must be set to use this property.
+    /// Gets or sets the autocomplete hint for the input (e.g., <c>AutoComplete="email"</c>).
+    /// Specifies whether the browser should offer autocomplete suggestions. An Id value must be set to use this property.
     /// </summary>
     [Parameter]
     public string? AutoComplete { get; set; }


### PR DESCRIPTION
## Summary
Improves XML doc comments on `[Parameter]` properties in input control components so the MCP server serves accurate descriptions to AI models.

## Components
| Component | Key Fixes |
|-----------|-----------|
| **FluentButton** | `Label` wrong description, `IconOnly` grammar, `DisabledFocusable` misleading phrasing |
| **FluentTextInput** | `StartTemplate`/`EndTemplate` vague, `AutoComplete` format |
| **FluentTextArea** | Class summary said "single line", broken `cref`, grammar errors |
| **FluentCheckbox** | `CheckState` grammar + missing `ThreeState` cross-ref |
| **FluentRadio** | `Items` empty summary, `RadioDisabled` grammar |

## Part of
Part of #4777