### PR TITLE
[MCP] Improve [Parameter] XML doc comments — Group C: Data Display

### DIFF
--- a/src/Core/Components/DataGrid/Columns/ColumnBase.razor.cs
+++ b/src/Core/Components/DataGrid/Columns/ColumnBase.razor.cs
@@ -74,8 +74,8 @@ public abstract partial class ColumnBase<TGridItem>
     public int Index { get; set; }
 
     /// <summary>
-    /// Gets or sets the an optional CSS class name.
-    /// If specified, this is included in the class attribute of header and grid cells
+    /// Gets or sets an optional CSS class name.
+    /// If specified, this is included in the <c>class</c> attribute of header and grid cells
     /// for this column.
     /// </summary>
     [Parameter]
@@ -90,13 +90,15 @@ public abstract partial class ColumnBase<TGridItem>
     public string? Style { get; set; }
 
     /// <summary>
-    /// If specified, controls the justification of header and grid cells for this column.
+    /// Gets or sets the cell alignment for header and grid cells in this column
+    /// (e.g., <c>Align="DataGridCellAlignment.Center"</c>).
     /// </summary>
     [Parameter]
     public DataGridCellAlignment Align { get; set; }
 
     /// <summary>
-    /// If true, generates a title and aria-label attribute for the cell contents
+    /// Gets or sets whether each cell in this column renders a <c>title</c> and <c>aria-label</c> attribute
+    /// derived from the cell's content. Use <see cref="TooltipText"/> to supply a custom tooltip value.
     /// </summary>
     [Parameter]
     public bool Tooltip { get; set; } = false;
@@ -168,8 +170,7 @@ public abstract partial class ColumnBase<TGridItem>
     public abstract IGridSort<TGridItem>? SortBy { get; set; }
 
     /// <summary>
-    /// Gets or sets the initial sort direction.
-    /// if <see cref="IsDefaultSortColumn"/> is true.
+    /// Gets or sets the initial sort direction, applied when <see cref="IsDefaultSortColumn"/> is <c>true</c>.
     /// </summary>
     [Parameter]
     public DataGridSortDirection InitialSortDirection { get; set; } = default;
@@ -181,7 +182,8 @@ public abstract partial class ColumnBase<TGridItem>
     public bool IsDefaultSortColumn { get; set; } = false;
 
     /// <summary>
-    /// If specified, virtualized grids will use this template to render cells whose data has not yet been loaded.
+    /// Gets or sets the template used to render placeholder cells whose data has not yet loaded
+    /// (applicable when <see cref="FluentDataGrid{TGridItem}.Virtualize"/> is enabled).
     /// </summary>
     [Parameter]
     public RenderFragment<PlaceholderContext>? PlaceholderTemplate { get; set; }
@@ -228,14 +230,14 @@ public abstract partial class ColumnBase<TGridItem>
     public string MinWidth { get; set; } = "100px";
 
     /// <summary>
-    /// If true, the column will include an expand/collapse toggle for hierarchical data.
-    /// This only applies if <typeparamref name="TGridItem"/> implements <see cref="IHierarchicalGridItem"/>.
+    /// Gets or sets whether this column renders an expand/collapse toggle for hierarchical data.
+    /// Requires <typeparamref name="TGridItem"/> to implement <see cref="IHierarchicalGridItem"/>.
     /// </summary>
     [Parameter]
     public bool HierarchicalToggle { get; set; }
 
     /// <summary>
-    /// Disables the ability for cells to receive focus.
+    /// Gets or sets whether keyboard focus is disabled for cells in this column.
     /// </summary>
     [Parameter]
     public bool DisableCellFocus { get; set; }

--- a/src/Core/Components/DataGrid/Columns/ColumnBase.razor.cs
+++ b/src/Core/Components/DataGrid/Columns/ColumnBase.razor.cs
@@ -97,7 +97,7 @@ public abstract partial class ColumnBase<TGridItem>
     public DataGridCellAlignment Align { get; set; }
 
     /// <summary>
-    /// Gets or sets whether each cell in this column renders a <c>title</c> and <c>aria-label</c> attribute
+    /// Gets or sets whether each cell in this column renders a <c>title</c> and <c>aria-label</c> attributes
     /// derived from the cell's content. Use <see cref="TooltipText"/> to supply a custom tooltip value.
     /// </summary>
     [Parameter]

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -129,7 +129,7 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     public Func<GridItemsProviderRequest<TGridItem>, Task>? RefreshItems { get; set; }
 
     /// <summary>
-    /// Gets or sets a callback that supplies data for the rid.
+    /// Gets or sets a callback that supplies data for the grid.
     /// You should supply either <see cref="Items"/> or <see cref="ItemsProvider"/>, but not both.
     /// </summary>
     [Parameter]

--- a/src/Core/Components/List/FluentAutocomplete.razor.cs
+++ b/src/Core/Components/List/FluentAutocomplete.razor.cs
@@ -146,7 +146,8 @@ public partial class FluentAutocomplete<TOption, TValue> : FluentListBase<TOptio
     public string? MaxSelectedWidth { get; set; }
 
     /// <summary>
-    /// Gets or sets whether the Search icon or Clear button is displayed.
+    /// Gets or sets whether the dismiss (clear) button is visible. When <c>true</c> (default), the
+    /// dismiss button is shown; when <c>false</c>, the search icon is shown instead.
     /// </summary>
     [Parameter]
     public bool ShowDismiss { get; set; } = true;

--- a/src/Core/Components/List/FluentListBase.razor.cs
+++ b/src/Core/Components/List/FluentListBase.razor.cs
@@ -105,7 +105,7 @@ public abstract partial class FluentListBase<TOption, TValue> : FluentInputBase<
     public virtual RenderFragment<TOption>? OptionTemplate { get; set; }
 
     /// <summary>
-    /// Gets or sets the function used to determine which value to apply to the binded value.
+    /// Gets or sets the function used to determine which value to apply to the bound value.
     /// </summary>
     [Parameter]
     public virtual Func<TOption?, TValue?>? OptionValue { get; set; }

--- a/src/Core/Components/Overflow/FluentOverflow.razor.cs
+++ b/src/Core/Components/Overflow/FluentOverflow.razor.cs
@@ -43,7 +43,9 @@ public partial class FluentOverflow : FluentComponentBase
     public RenderFragment<FluentOverflow>? OverflowTemplate { get; set; }
 
     /// <summary>
-    /// To prevent a flickering effect, set this property to False to hide the overflow items until the component is fully loaded.
+    /// Gets or sets whether overflow items are visible immediately on load.
+    /// Set to <c>false</c> to hide items until the component is fully loaded,
+    /// preventing a flickering effect. Defaults to <c>true</c>.
     /// </summary>
     [Parameter]
     public bool VisibleOnLoad { get; set; } = true;
@@ -67,7 +69,7 @@ public partial class FluentOverflow : FluentComponentBase
     public string? Selectors { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets if the tooltip should be displayed by using the TooltipService
+    /// Gets or sets whether the tooltip is displayed using the TooltipService.
     /// </summary>
     [Parameter]
     public bool UseTooltipService { get; set; } = false;

--- a/src/Core/Components/Pagination/FluentPaginator.razor.cs
+++ b/src/Core/Components/Pagination/FluentPaginator.razor.cs
@@ -41,7 +41,7 @@ public partial class FluentPaginator : FluentComponentBase
     public EventCallback<int> CurrentPageIndexChanged { get; set; }
 
     /// <summary>
-    /// Disables the pagination buttons
+    /// Gets or sets whether the pagination buttons are disabled.
     /// </summary>
     [Parameter]
     public bool Disabled { get; set; }

--- a/src/Core/Components/TreeView/FluentTreeView.razor.cs
+++ b/src/Core/Components/TreeView/FluentTreeView.razor.cs
@@ -84,7 +84,7 @@ public partial class FluentTreeView : FluentComponentBase
 
     /// <summary>
     /// Gets or sets the id of the currently selected tree item.
-    /// See also <see cref="SelectedItem"/> (returns the <see cref="ITreeViewItem"/> data model)
+    /// See also <see cref="SelectedItem"/> (returns the <see cref="ITreeViewItem"/> data model),
     /// and <see cref="CurrentSelected"/> (returns the <see cref="FluentTreeItem"/> component instance).
     /// </summary>
     [Parameter]
@@ -98,7 +98,7 @@ public partial class FluentTreeView : FluentComponentBase
 
     /// <summary>
     /// Gets or sets the selected <see cref="FluentTreeItem"/> component instance.
-    /// See also <see cref="SelectedId"/> (returns the item id string)
+    /// See also <see cref="SelectedId"/> (returns the item id string),
     /// and <see cref="SelectedItem"/> (returns the <see cref="ITreeViewItem"/> data model).
     /// </summary>
     [Parameter]
@@ -112,7 +112,7 @@ public partial class FluentTreeView : FluentComponentBase
 
     /// <summary>
     /// Gets or sets the selected <see cref="ITreeViewItem"/> data model item.
-    /// See also <see cref="SelectedId"/> (returns the item id string)
+    /// See also <see cref="SelectedId"/> (returns the item id string),
     /// and <see cref="CurrentSelected"/> (returns the <see cref="FluentTreeItem"/> component instance).
     /// </summary>
     [Parameter]

--- a/src/Core/Components/TreeView/FluentTreeView.razor.cs
+++ b/src/Core/Components/TreeView/FluentTreeView.razor.cs
@@ -50,7 +50,8 @@ public partial class FluentTreeView : FluentComponentBase
     public TreeAppearance? Appearance { get; set; } = TreeAppearance.Subtle;
 
     /// <summary>
-    /// Gets or sets whether the tree view element is not highlighted to indicate that it is selected.
+    /// Gets or sets whether the selection highlight is hidden.
+    /// When <c>true</c>, the selected tree item is not visually highlighted.
     /// </summary>
     [Parameter]
     public bool HideSelection { get; set; }
@@ -82,7 +83,9 @@ public partial class FluentTreeView : FluentComponentBase
     public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
-    /// Gets or sets the selected item id.
+    /// Gets or sets the id of the currently selected tree item.
+    /// See also <see cref="SelectedItem"/> (returns the <see cref="ITreeViewItem"/> data model)
+    /// and <see cref="CurrentSelected"/> (returns the <see cref="FluentTreeItem"/> component instance).
     /// </summary>
     [Parameter]
     public string? SelectedId { get; set; }
@@ -94,7 +97,9 @@ public partial class FluentTreeView : FluentComponentBase
     public EventCallback<string?> SelectedIdChanged { get; set; }
 
     /// <summary>
-    /// Gets or sets the selected <see cref="FluentTreeItem" /> item.
+    /// Gets or sets the selected <see cref="FluentTreeItem"/> component instance.
+    /// See also <see cref="SelectedId"/> (returns the item id string)
+    /// and <see cref="SelectedItem"/> (returns the <see cref="ITreeViewItem"/> data model).
     /// </summary>
     [Parameter]
     public FluentTreeItem? CurrentSelected { get; set; }
@@ -106,7 +111,9 @@ public partial class FluentTreeView : FluentComponentBase
     public EventCallback<FluentTreeItem?> CurrentSelectedChanged { get; set; }
 
     /// <summary>
-    /// Gets or sets the selected <see cref="ITreeViewItem" /> item.
+    /// Gets or sets the selected <see cref="ITreeViewItem"/> data model item.
+    /// See also <see cref="SelectedId"/> (returns the item id string)
+    /// and <see cref="CurrentSelected"/> (returns the <see cref="FluentTreeItem"/> component instance).
     /// </summary>
     [Parameter]
     public ITreeViewItem? SelectedItem { get; set; }


### PR DESCRIPTION
## Summary
Improves XML doc comments on `[Parameter]` properties in data display components so the MCP server serves accurate descriptions to AI models.

## Components
| Component | Key Fixes |
|-----------|-----------|
| **FluentDataGrid** | 8 fixes: typos, missing "Gets or sets" prefixes, missing cross-refs |
| **FluentList / FluentAutocomplete** | "binded" → "bound", `ShowDismiss` ambiguous |
| **FluentTreeView** | `HideSelection` double-negative, selection props missing cross-refs |
| **FluentPaginator** | `Disabled` imperative style → declarative |
| **FluentOverflow** | `VisibleOnLoad` imperative style, `UseTooltipService` grammar |

## Part of
Part of #4777