### PR TITLE
[MCP] Improve [Parameter] XML doc comments — Group D: Layout Containers

### DIFF
--- a/src/Core/Components/Accordion/FluentAccordion.razor.cs
+++ b/src/Core/Components/Accordion/FluentAccordion.razor.cs
@@ -60,7 +60,7 @@ public partial class FluentAccordion : FluentComponentBase
     public AccordionItemMarkerPosition? MarkerPosition { get; set; }
 
     /// <summary>
-    /// Gets or sets the width of the focus state
+    /// Gets or sets whether accordion items expand to fill the full available width (block-level display).
     /// </summary>
     [Parameter]
     public bool? Block { get; set; }

--- a/src/Core/Components/Accordion/FluentAccordion.razor.cs
+++ b/src/Core/Components/Accordion/FluentAccordion.razor.cs
@@ -61,6 +61,7 @@ public partial class FluentAccordion : FluentComponentBase
 
     /// <summary>
     /// Gets or sets whether accordion items expand to fill the full available width (block-level display).
+    /// When <see langword="null"/>, the default component behavior applies (items do not expand to fill width).
     /// </summary>
     [Parameter]
     public bool? Block { get; set; }

--- a/src/Core/Components/Accordion/FluentAccordionItem.razor.cs
+++ b/src/Core/Components/Accordion/FluentAccordionItem.razor.cs
@@ -21,15 +21,15 @@ public partial class FluentAccordionItem : FluentComponentBase, IDisposable
     protected string? StyleValue => DefaultStyleBuilder.Build();
 
     /// <summary>
-    /// Gets or sets the owning FluentTreeView.
+    /// Gets or sets the parent <see cref="FluentAccordion"/> that owns this item.
     /// </summary>
     [CascadingParameter]
     public FluentAccordion? Owner { get; set; } = default!;
 
     /// <summary>
-    /// Gets or sets the heading of the accordion item.
-    /// Use either this or the <see cref="HeaderTemplate"/> parameter."/>
-    /// If both are set, this parameter will be used.
+    /// Gets or sets the plain-text heading of the accordion item (e.g., <c>Header="Section Title"</c>).
+    /// Use either this or the <see cref="HeaderTemplate"/> parameter.
+    /// If both are set, this parameter takes precedence.
     /// </summary>
     [Parameter]
     public string? Header { get; set; }
@@ -86,7 +86,7 @@ public partial class FluentAccordionItem : FluentComponentBase, IDisposable
     public AccordionItemMarkerPosition? MarkerPosition { get; set; }
 
     /// <summary>
-    /// Gets or sets the width of the focus state
+    /// Gets or sets whether this accordion item expands to fill the full available width (block-level display).
     /// </summary>
     [Parameter]
     public bool? Block { get; set; }

--- a/src/Core/Components/Accordion/FluentAccordionItem.razor.cs
+++ b/src/Core/Components/Accordion/FluentAccordionItem.razor.cs
@@ -21,7 +21,7 @@ public partial class FluentAccordionItem : FluentComponentBase, IDisposable
     protected string? StyleValue => DefaultStyleBuilder.Build();
 
     /// <summary>
-    /// Gets or sets the parent <see cref="FluentAccordion"/> that owns this item.
+    /// Gets the parent <see cref="FluentAccordion"/> that owns this item, provided via cascading parameter.
     /// </summary>
     [CascadingParameter]
     public FluentAccordion? Owner { get; set; } = default!;
@@ -87,6 +87,7 @@ public partial class FluentAccordionItem : FluentComponentBase, IDisposable
 
     /// <summary>
     /// Gets or sets whether this accordion item expands to fill the full available width (block-level display).
+    /// When <see langword="null"/>, the value is inherited from the parent <see cref="FluentAccordion.Block"/> setting.
     /// </summary>
     [Parameter]
     public bool? Block { get; set; }

--- a/src/Core/Components/Splitter/FluentMultiSplitterPane.razor.cs
+++ b/src/Core/Components/Splitter/FluentMultiSplitterPane.razor.cs
@@ -55,12 +55,14 @@ public partial class FluentMultiSplitterPane : FluentComponentBase
 
     /// <summary>
     /// Gets or sets the maximum size of the pane as a CSS value (e.g., <c>Max="80%"</c>).
+    /// An empty string (the default) means no maximum constraint is applied.
     /// </summary>
     [Parameter]
     public string Max { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the minimum size of the pane as a CSS value (e.g., <c>Min="100px"</c>).
+    /// An empty string (the default) means no minimum constraint is applied.
     /// </summary>
     [Parameter]
     public string Min { get; set; } = string.Empty;

--- a/src/Core/Components/Splitter/FluentMultiSplitterPane.razor.cs
+++ b/src/Core/Components/Splitter/FluentMultiSplitterPane.razor.cs
@@ -42,37 +42,38 @@ public partial class FluentMultiSplitterPane : FluentComponentBase
     public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
-    /// Gets or sets a collapsed indicating whether this <see cref="FluentMultiSplitterPane"/> is collapsed.
+    /// Gets or sets whether this pane is currently collapsed.
     /// </summary>
     [Parameter]
     public bool Collapsed { get; set; } = false;
 
     /// <summary>
-    /// Gets or sets a collapsed indicating whether this <see cref="FluentMultiSplitterPane"/> is collapsible.
+    /// Gets or sets whether this pane can be collapsed by the user.
     /// </summary>
     [Parameter]
     public bool Collapsible { get; set; } = false;
 
     /// <summary>
-    /// Determines the maximum collapsed.
+    /// Gets or sets the maximum size of the pane as a CSS value (e.g., <c>Max="80%"</c>).
     /// </summary>
     [Parameter]
     public string Max { get; set; } = string.Empty;
 
     /// <summary>
-    /// Determines the minimum collapsed.
+    /// Gets or sets the minimum size of the pane as a CSS value (e.g., <c>Min="100px"</c>).
     /// </summary>
     [Parameter]
     public string Min { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets a collapsed indicating whether this <see cref="FluentMultiSplitterPane"/> is resizable.
+    /// Gets or sets whether the user can resize this pane by dragging its splitter bar. Default is <c>true</c>.
     /// </summary>
     [Parameter]
     public bool Resizable { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets the size.
+    /// Gets or sets the initial size of the pane as a CSS value (e.g., <c>Size="200px"</c> or <c>Size="30%"</c>).
+    /// When omitted, remaining space is distributed equally among unsized panes.
     /// </summary>
     [Parameter]
     public string? Size { get; set; }

--- a/src/Core/Components/Tabs/FluentTabs.razor.cs
+++ b/src/Core/Components/Tabs/FluentTabs.razor.cs
@@ -36,7 +36,7 @@ public partial class FluentTabs : FluentComponentBase
         .Build();
 
     /// <summary>
-    /// Gets or sets the appearance affects each of the contained tabs.
+    /// Gets or sets the visual appearance applied to each contained tab (e.g., <c>Appearance="TabsAppearance.Subtle"</c>).
     /// </summary>
     [Parameter]
     public TabsAppearance? Appearance { get; set; }
@@ -72,7 +72,8 @@ public partial class FluentTabs : FluentComponentBase
     public string? Width { get; set; }
 
     /// <summary>
-    /// Gets the the active selected tab id.
+    /// Gets or sets the ID of the currently active tab. Use <c>@bind-ActiveTabId</c> for two-way binding.
+    /// See also <see cref="ActiveTab"/> to work with the <see cref="FluentTab"/> instance directly.
     /// </summary>
     [Parameter]
     public string? ActiveTabId { get; set; }
@@ -84,7 +85,8 @@ public partial class FluentTabs : FluentComponentBase
     public EventCallback<string?> ActiveTabIdChanged { get; set; }
 
     /// <summary>
-    /// Gets the the active selected tab.
+    /// Gets or sets the currently active <see cref="FluentTab"/> instance. Use <c>@bind-ActiveTab</c> for two-way binding.
+    /// See also <see cref="ActiveTabId"/> to work with the tab ID string directly.
     /// </summary>
     [Parameter]
     public FluentTab? ActiveTab { get; set; }

--- a/src/Core/Components/Wizard/FluentWizard.razor.cs
+++ b/src/Core/Components/Wizard/FluentWizard.razor.cs
@@ -60,13 +60,14 @@ public partial class FluentWizard : FluentComponentBase
     public string? StepperBulletSpace { get; set; }
 
     /// <summary>
-    /// Display a border of the Wizard.
+    /// Gets or sets whether and how a border is displayed around the wizard (e.g., <c>Border="WizardBorder.Outside"</c>).
     /// </summary>
     [Parameter]
     public WizardBorder Border { get; set; } = WizardBorder.None;
 
     /// <summary>
-    /// Display a number on each step icon. Can be overridden by the step <see cref="FluentWizardStep.DisplayStepNumber"/> property.
+    /// Gets or sets when to display a step number on each step icon.
+    /// Can be overridden per step via <see cref="FluentWizardStep.DisplayStepNumber"/>.
     /// </summary>
     [Parameter]
     public WizardStepStatus DisplayStepNumber { get; set; } = WizardStepStatus.None;

--- a/src/Core/Components/Wizard/FluentWizardStep.razor.cs
+++ b/src/Core/Components/Wizard/FluentWizardStep.razor.cs
@@ -41,13 +41,15 @@ public partial class FluentWizardStep : FluentComponentBase
     public bool Disabled { get; set; }
 
     /// <summary>
-    /// Render the Wizard Step content only when the Step is selected.
+    /// Gets or sets whether to render the step content only when the step is active.
+    /// Content is cleared when the step is deselected, reducing page size for inactive steps.
     /// </summary>
     [Parameter]
     public bool DeferredLoading { get; set; }
 
     /// <summary>
-    /// Gets or sets the label of the step.
+    /// Gets or sets the plain-text label shown in the step indicator (e.g., <c>Label="Step 1"</c>).
+    /// See also <see cref="Summary"/> for a short subtitle displayed below the label.
     /// </summary>
     [Parameter]
     public string Label { get; set; } = string.Empty;
@@ -67,7 +69,7 @@ public partial class FluentWizardStep : FluentComponentBase
     public EventCallback<FluentWizardStepChangeEventArgs> OnChange { get; set; }
 
     /// <summary>
-    /// Gets or sets the summary of the step, to display near the label.
+    /// Gets or sets a short subtitle displayed below the <see cref="Label"/> in the step indicator.
     /// </summary>
     [Parameter]
     public string Summary { get; set; } = string.Empty;


### PR DESCRIPTION
## Summary
Improves XML doc comments on `[Parameter]` properties in layout container components so the MCP server serves accurate descriptions to AI models.

## Components
| Component | Key Fixes |
|-----------|-----------|
| **FluentTabs** | `ActiveTabId`/`ActiveTab` double "the" + missing cross-refs between the two |
| **FluentWizard** | Missing "Gets or sets" x3, `Label`/`Summary` missing usage examples |
| **FluentAccordion** | `Owner` wrong type name, `Header` malformed XML |
| **FluentSplitter** | `Collapsed`/`Collapsible`/`Resizable` broken grammar, `Min`/`Max` nonsensical descriptions |

## Part of
Part of #4777