### PR TITLE
[MCP] Improve [Parameter] XML doc comments — Group B: Overlays & Notifications

### DIFF
--- a/src/Core/Components/Dialog/FluentDialog.razor.cs
+++ b/src/Core/Components/Dialog/FluentDialog.razor.cs
@@ -49,7 +49,8 @@ public partial class FluentDialog : FluentComponentBase
     public IDialogInstance? Instance { get; set; }
 
     /// <summary>
-    /// Used when not calling the <see cref="DialogService" /> to show a dialog.
+    /// Gets or sets the child content rendered inside the dialog when not using the <see cref="DialogService"/>.
+    /// When using the <see cref="DialogService"/>, use <see cref="Instance"/> instead.
     /// </summary>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
@@ -80,7 +81,7 @@ public partial class FluentDialog : FluentComponentBase
     public bool PreventDismissOnEscape { get; set; }
 
     /// <summary>
-    /// Command executed when the user clicks on the button.
+    /// Gets or sets the callback that is invoked when the dialog state changes (e.g., opening or closing).
     /// </summary>
     [Parameter]
     public EventCallback<DialogEventArgs> OnStateChange { get; set; }

--- a/src/Core/Components/Dialog/FluentDialog.razor.cs
+++ b/src/Core/Components/Dialog/FluentDialog.razor.cs
@@ -49,8 +49,9 @@ public partial class FluentDialog : FluentComponentBase
     public IDialogInstance? Instance { get; set; }
 
     /// <summary>
-    /// Gets or sets the child content rendered inside the dialog when not using the <see cref="DialogService"/>.
-    /// When using the <see cref="DialogService"/>, use <see cref="Instance"/> instead.
+    /// Gets or sets the child content rendered directly inside the dialog.
+    /// Use this when displaying the dialog declaratively in Razor without the <see cref="DialogService"/>.
+    /// When using <see cref="DialogService"/> to show dialogs, content is provided through the dialog component class, not via this parameter.
     /// </summary>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }

--- a/src/Core/Components/Dialog/FluentDialogBody.razor.cs
+++ b/src/Core/Components/Dialog/FluentDialogBody.razor.cs
@@ -35,18 +35,22 @@ public partial class FluentDialogBody : FluentComponentBase
 
     /// <summary>
     /// Gets or sets the content for the title element.
+    /// For an action button in the title area, use <see cref="TitleActionTemplate"/> instead.
     /// </summary>
     [Parameter]
     public RenderFragment? TitleTemplate { get; set; }
 
     /// <summary>
-    /// Gets or sets the content for the action element in the title.
+    /// Gets or sets the content for the action button rendered inside the title area.
+    /// For the primary title content, use <see cref="TitleTemplate"/>.
+    /// For footer-level actions, use <see cref="ActionTemplate"/>.
     /// </summary>
     [Parameter]
     public RenderFragment? TitleActionTemplate { get; set; }
 
     /// <summary>
-    /// Gets or sets the content for the action element.
+    /// Gets or sets the content for the footer action area (e.g., confirm/cancel buttons).
+    /// For an action button inside the title bar, use <see cref="TitleActionTemplate"/> instead.
     /// </summary>
     [Parameter]
     public RenderFragment? ActionTemplate { get; set; }

--- a/src/Core/Components/MessageBar/FluentMessageBar.razor.cs
+++ b/src/Core/Components/MessageBar/FluentMessageBar.razor.cs
@@ -63,15 +63,16 @@ public partial class FluentMessageBar : FluentComponentBase
     public AriaLive? AriaLive { get; set; }
 
     /// <summary>
-    /// Gets or sets the icon to show in the message bar based on the intent of the message.
+    /// Gets or sets the icon to show in the message bar.
+    /// When set, overrides the default icon determined by <see cref="Intent"/>.
     /// </summary>
     [Parameter]
     public Icon? Icon { get; set; }
 
     /// <summary>
-    /// Gets or sets the most important info to be shown in the message bar.
+    /// Gets or sets the plain-text title displayed in the message bar (e.g., <c>Title="Action required"</c>).
     /// For security reasons, the content is sanitized using the configured <see cref="LibraryConfiguration.MarkupSanitized"/> before rendering.
-    /// If you need to format the content, use the <see cref="ChildContent"/> parameter.
+    /// For formatted content with markup, use <see cref="ChildContent"/> instead.
     /// </summary>
     [Parameter]
     public string? Title { get; set; }
@@ -83,13 +84,14 @@ public partial class FluentMessageBar : FluentComponentBase
     public bool Visible { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets the ability to dismiss the message bar. Default is true.
+    /// Gets or sets a value indicating whether the message bar can be dismissed by the user. Default is <see langword="true"/>.
     /// </summary>
     [Parameter]
     public bool AllowDismiss { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets the message to be shown when not using the MessageService methods.
+    /// Gets or sets the rich content of the message bar.
+    /// Use this instead of <see cref="Title"/> when the message requires markup or custom formatting.
     /// </summary>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
@@ -101,8 +103,8 @@ public partial class FluentMessageBar : FluentComponentBase
     public RenderFragment? ActionsTemplate { get; set; }
 
     /// <summary>
-    /// Gets or sets the time on which the message was created.
-    /// Only used when <see cref="ActionsTemplate"/> is not used: `null` (if not, this parameter is ignored).
+    /// Gets or sets the timestamp when the message was created.
+    /// Only displayed when <see cref="ActionsTemplate"/> is <see langword="null"/>.
     /// </summary>
     [Parameter]
     public DateTime? TimeStamp { get; set; }

--- a/src/Core/Components/Popover/FluentPopover.razor.cs
+++ b/src/Core/Components/Popover/FluentPopover.razor.cs
@@ -41,7 +41,7 @@ public partial class FluentPopover : FluentComponentBase
     public string? Width { get; set; }
 
     /// <summary>
-    /// Gets or sets the width of the popover component.
+    /// Gets or sets the height of the popover component.
     /// </summary>
     [Parameter]
     public string? Height { get; set; }

--- a/src/Core/Components/Toast/FluentToast.razor.cs
+++ b/src/Core/Components/Toast/FluentToast.razor.cs
@@ -73,7 +73,8 @@ public partial class FluentToast
     public int HorizontalOffset { get; set; } = 20;
 
     /// <summary>
-    /// Gets or sets the type of toast notification to display.
+    /// Gets or sets the <see cref="ToastType"/> of toast notification to display
+    /// (e.g., <c>Type="ToastType.Communication"</c>).
     /// </summary>
     [Parameter]
     public ToastType Type { get; set; } = ToastType.Communication;
@@ -146,7 +147,8 @@ public partial class FluentToast
     public string? Title { get; set; }
 
     /// <summary>
-    /// Gets or sets the body content displayed in the toast.
+    /// Gets or sets the plain-text body message displayed in the toast.
+    /// For rich content, use <see cref="BodyContent"/> instead.
     /// </summary>
     [Parameter]
     public string? Body { get; set; }
@@ -158,25 +160,29 @@ public partial class FluentToast
     public string? Subtitle { get; set; }
 
     /// <summary>
-    /// Gets or sets the first quick action label.
+    /// Gets or sets the first quick action label (e.g., <c>QuickAction1="Undo"</c>).
+    /// See also <see cref="QuickAction2"/>.
     /// </summary>
     [Parameter]
     public string? QuickAction1 { get; set; }
 
     /// <summary>
-    /// Gets or sets the second quick action label.
+    /// Gets or sets the second quick action label (e.g., <c>QuickAction2="Dismiss"</c>).
+    /// See also <see cref="QuickAction1"/>.
     /// </summary>
     [Parameter]
     public string? QuickAction2 { get; set; }
 
     /// <summary>
-    /// Gets or sets whether the toast is dismissable by the user.
+    /// Gets or sets a value indicating whether the toast can be dismissed by the user.
+    /// When <see langword="true"/>, a dismiss button is rendered; use <see cref="DismissAction"/> to customize its label.
     /// </summary>
     [Parameter]
     public bool IsDismissable { get; set; }
 
     /// <summary>
-    /// Gets or sets the dismiss action label
+    /// Gets or sets the label for the dismiss action button (e.g., <c>DismissAction="Close"</c>).
+    /// Only relevant when <see cref="IsDismissable"/> is <see langword="true"/>.
     /// </summary>
     [Parameter]
     public string? DismissAction { get; set; }
@@ -190,6 +196,7 @@ public partial class FluentToast
     /// <summary>
     /// Gets or sets custom content rendered in the toast body, such as progress content managed through
     /// <see cref="IToastInstance.UpdateAsync(Action{ToastOptions})"/>.
+    /// For plain-text body messages, use <see cref="Body"/> instead.
     /// </summary>
     [Parameter]
     public RenderFragment? BodyContent { get; set; }

--- a/src/Core/Components/Tooltip/FluentTooltip.razor.cs
+++ b/src/Core/Components/Tooltip/FluentTooltip.razor.cs
@@ -57,8 +57,8 @@ public partial class FluentTooltip : FluentComponentBase
     private ITooltipService? TooltipService => GetCachedServiceOrNull<ITooltipService>();
 
     /// <summary>
-    /// Use ITooltipService to create the tooltip, if this service was injected.
-    /// If the <see cref="ChildContent"/> is dynamic, set this to false. Default, true.
+    /// Gets or sets a value indicating whether the <see cref="ITooltipService"/> is used to render the tooltip.
+    /// Set this to <see langword="false"/> when <see cref="ChildContent"/> is dynamic (e.g., <c>UseTooltipService="false"</c>). Default is <see langword="true"/>.
     /// </summary>
     [Parameter]
     public bool UseTooltipService { get; set; } = true;
@@ -89,13 +89,13 @@ public partial class FluentTooltip : FluentComponentBase
     public string? MaxWidth { get; set; }
 
     /// <summary>
-    /// Gets or sets the tooltip's horizontal spacing. Default is 4px;
+    /// Gets or sets the tooltip's horizontal spacing. Default is 4px.
     /// </summary>
     [Parameter]
     public string? SpacingHorizontal { get; set; }
 
     /// <summary>
-    /// Gets or sets the tooltip's horizontal spacing. Default is 4px;
+    /// Gets or sets the tooltip's vertical spacing. Default is 4px.
     /// </summary>
     [Parameter]
     public string? SpacingVertical { get; set; }

--- a/src/Core/Components/Tooltip/FluentTooltip.razor.cs
+++ b/src/Core/Components/Tooltip/FluentTooltip.razor.cs
@@ -58,6 +58,7 @@ public partial class FluentTooltip : FluentComponentBase
 
     /// <summary>
     /// Gets or sets a value indicating whether the <see cref="ITooltipService"/> is used to render the tooltip.
+    /// This parameter only has an effect when <see cref="ITooltipService"/> is registered in the DI container; the service is optional and may not be available.
     /// Set this to <see langword="false"/> when <see cref="ChildContent"/> is dynamic (e.g., <c>UseTooltipService="false"</c>). Default is <see langword="true"/>.
     /// </summary>
     [Parameter]


### PR DESCRIPTION
## Summary
Improves XML doc comments on `[Parameter]` properties in overlay and notification components so the MCP server serves accurate descriptions to AI models.

## Components
| Component | Key Fixes |
|-----------|-----------|
| **FluentPopover** | `Height` copy-paste said "width" |
| **FluentTooltip** | `SpacingVertical`/`SpacingHorizontal` had **swapped** descriptions |
| **FluentDialog** | `OnStateChange` wrong description, ambiguous `ActionTemplate` |
| **FluentToast** | `Body`/`BodyContent` missing cross-refs, `QuickAction1`/`QuickAction2` vague |
| **FluentMessageBar** | `Title` terminology mismatch, `Icon` override not documented |

## Part of
Part of #4777