### PR TITLE
[MCP] Improve [Parameter] XML doc comments — Group F: Layout & Structure

### DIFF
--- a/src/Core/Components/AppBar/FluentAppBar.razor.cs
+++ b/src/Core/Components/AppBar/FluentAppBar.razor.cs
@@ -37,7 +37,7 @@ public partial class FluentAppBar : FluentComponentBase
     }
 
     /// <summary>
-    /// Gets or sets if the popover shows the search box.
+    /// Gets or sets whether the popover shows a search box to filter overflowed items.
     /// </summary>
     [Parameter]
     public bool PopoverShowSearch { get; set; } = true;

--- a/src/Core/Components/AppBar/FluentAppBarItem.razor.cs
+++ b/src/Core/Components/AppBar/FluentAppBarItem.razor.cs
@@ -66,7 +66,7 @@ public partial class FluentAppBarItem : FluentComponentBase, IAppBarItem
     public int? Count { get; set; }
 
     /// <summary>
-    ///  Gets or sets the content to be shown.
+    /// Gets or sets the content to be shown.
     /// </summary>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }

--- a/src/Core/Components/Divider/FluentDivider.razor.cs
+++ b/src/Core/Components/Divider/FluentDivider.razor.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Components;
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 /// <summary>
-/// FluentDivider component
+/// A horizontal or vertical rule used to visually separate content.
 /// </summary>
 public partial class FluentDivider : FluentComponentBase, ITooltipComponent
 {
@@ -23,25 +23,27 @@ public partial class FluentDivider : FluentComponentBase, ITooltipComponent
         .Build();
 
     /// <summary>
-    /// Gets or sets the alignment of the content.
+    /// Gets or sets the alignment of any child content within the divider (e.g., <c>AlignContent="DividerAlignContent.Center"</c>).
+    /// See <see cref="DividerAlignContent"/> for available values.
     /// </summary>
     [Parameter]
     public DividerAlignContent? AlignContent { get; set; }
 
     /// <summary>
-    /// Gets or sets the appearance of the content.
+    /// Gets or sets the visual appearance of the divider (e.g., <c>Appearance="DividerAppearance.Strong"</c>).
+    /// See <see cref="DividerAppearance"/> for available values.
     /// </summary>
     [Parameter]
     public DividerAppearance? Appearance { get; set; }
 
     /// <summary>
-    /// Adds padding to the beginning and end of the divider.
+    /// Gets or sets whether padding is added to the beginning and end of the divider (e.g., <c>Inset="true"</c>).
     /// </summary>
     [Parameter]
     public bool? Inset { get; set; }
 
     /// <summary>
-    /// A divider can be horizontal (default) or vertical.
+    /// Gets or sets whether the divider is vertical (<c>true</c>) or horizontal (<c>false</c>, default).
     /// </summary>
     [Parameter]
     public bool? Vertical { get; set; }

--- a/src/Core/Components/Grid/FluentGrid.razor.cs
+++ b/src/Core/Components/Grid/FluentGrid.razor.cs
@@ -48,7 +48,7 @@ public partial class FluentGrid : FluentComponentBase
     public int Spacing { get; set; }
 
     /// <summary>
-    /// Defines how the browser distributes space between and around content items.
+    /// Gets or sets how the browser distributes space between and around content items.
     /// </summary>
     [Parameter]
     public JustifyContent Justify { get; set; } = JustifyContent.FlexStart;

--- a/src/Core/Components/Grid/FluentGridItem.razor.cs
+++ b/src/Core/Components/Grid/FluentGridItem.razor.cs
@@ -32,69 +32,70 @@ public partial class FluentGridItem : FluentComponentBase
     protected FluentGrid? Grid { get; set; }
 
     /// <summary>
-    /// The number of columns the item should span in the 12-column grid system.
-    /// Extra Small (xs) devices (portrait phones, less than 600px wide)
+    /// Gets or sets the number of columns (1–12) the item spans on Extra Small devices (portrait phones, less than 600px wide).
+    /// Use with <see cref="Sm"/>, <see cref="Md"/>, <see cref="Lg"/>, <see cref="Xl"/>, <see cref="Xxl"/> for responsive layouts.
     /// </summary>
     [Parameter]
     public int? Xs { get; set; }
 
     /// <summary>
-    /// The number of columns the item should span in the 12-column grid system.
-    /// Small (sm) devices (landscape phones, less than 960px wide)
+    /// Gets or sets the number of columns (1–12) the item spans on Small devices (landscape phones, less than 960px wide).
+    /// Use with <see cref="Xs"/>, <see cref="Md"/>, <see cref="Lg"/>, <see cref="Xl"/>, <see cref="Xxl"/> for responsive layouts.
     /// </summary>
     [Parameter]
     public int? Sm { get; set; }
 
     /// <summary>
-    /// The number of columns the item should span in the 12-column grid system.
-    /// Medium (md) devices (tablets, less than 1280px wide)
+    /// Gets or sets the number of columns (1–12) the item spans on Medium devices (tablets, less than 1280px wide).
+    /// Use with <see cref="Xs"/>, <see cref="Sm"/>, <see cref="Lg"/>, <see cref="Xl"/>, <see cref="Xxl"/> for responsive layouts.
     /// </summary>
     [Parameter]
     public int? Md { get; set; }
 
     /// <summary>
-    /// The number of columns the item should span in the 12-column grid system.
-    /// Large (lg) devices (desktops, less than 1920px wide)
-    /// </summary> 
+    /// Gets or sets the number of columns (1–12) the item spans on Large devices (desktops, less than 1920px wide).
+    /// Use with <see cref="Xs"/>, <see cref="Sm"/>, <see cref="Md"/>, <see cref="Xl"/>, <see cref="Xxl"/> for responsive layouts.
+    /// </summary>
     [Parameter]
     public int? Lg { get; set; }
 
     /// <summary>
-    /// The number of columns the item should span in the 12-column grid system.
-    /// Extra large (xl) devices (large desktops, less than 2560px wide)
+    /// Gets or sets the number of columns (1–12) the item spans on Extra Large devices (large desktops, less than 2560px wide).
+    /// Use with <see cref="Xs"/>, <see cref="Sm"/>, <see cref="Md"/>, <see cref="Lg"/>, <see cref="Xxl"/> for responsive layouts.
     /// </summary>
     [Parameter]
     public int? Xl { get; set; }
 
     /// <summary>
-    /// The number of columns the item should span in the 12-column grid system.
-    /// Extra extra large (xxl) devices (larger desktops, more than 2560px wide)
+    /// Gets or sets the number of columns (1–12) the item spans on Extra Extra Large devices (larger desktops, more than 2560px wide).
+    /// Use with <see cref="Xs"/>, <see cref="Sm"/>, <see cref="Md"/>, <see cref="Lg"/>, <see cref="Xl"/> for responsive layouts.
     /// </summary>
     [Parameter]
     public int? Xxl { get; set; }
 
     /// <summary>
-    /// Defines how the browser distributes space between and around content items.
+    /// Gets or sets how the browser distributes space between and around content items within this grid item.
     /// </summary>
     [Parameter]
     public JustifyContent? Justify { get; set; }
 
     /// <summary>
-    /// Gets or sets the gaps (gutters) between rows and columns.
-    /// See https://developer.mozilla.org/en-US/docs/Web/CSS/gap
+    /// Gets or sets the gaps (gutters) between rows and columns (e.g., <c>Gap="8px"</c>).
+    /// See <see href="https://developer.mozilla.org/en-US/docs/Web/CSS/gap">CSS gap</see>.
     /// </summary>
     [Parameter]
     public string? Gap { get; set; }
 
     /// <summary>
-    /// Gets or sets the adaptive rendering, which not render the HTML code when the item is hidden (true) or only hide the item by CSS (false).
-    /// Default is false.
+    /// Gets or sets the adaptive rendering behavior: when <c>true</c>, the HTML is not rendered when the item is hidden;
+    /// when <c>false</c>, the item is hidden via CSS only. Default is <c>false</c>.
     /// </summary>
     [Parameter]
     public bool? AdaptiveRendering { get; set; }
 
     /// <summary>
-    /// Hide the item on the specified sizes (you can combine multiple values: GridItemHidden.Sm | GridItemHidden.Xl).
+    /// Gets or sets the breakpoint sizes at which this item is hidden (e.g., <c>HiddenWhen="GridItemHidden.Sm | GridItemHidden.Xl"</c>).
+    /// See <see cref="GridItemHidden"/> for available values.
     /// </summary>
     [Parameter]
     public GridItemHidden? HiddenWhen { get; set; }

--- a/src/Core/Components/Layout/FluentLayout.razor.cs
+++ b/src/Core/Components/Layout/FluentLayout.razor.cs
@@ -61,7 +61,7 @@ public partial class FluentLayout : FluentComponentBase
     public bool GlobalScrollbar { get; set; }
 
     /// <summary>
-    /// Gets ot sets the width of the LayoutContainer.
+    /// Gets or sets the width of the layout container (e.g., <c>Width="100%"</c>).
     /// </summary>
     [Parameter]
     public string? Width { get; set; }

--- a/src/Core/Components/Layout/FluentLayoutHamburger.razor.cs
+++ b/src/Core/Components/Layout/FluentLayoutHamburger.razor.cs
@@ -73,7 +73,7 @@ public partial class FluentLayoutHamburger : FluentComponentBase
 
     /// <summary>
     /// Gets or sets the panel position to display when the hamburger menu is open.
-    /// Only <see cref="DialogAlignment.Start"/> and <see cref="DialogAlignment.End"/> are supported."/>.
+    /// Only <see cref="DialogAlignment.Start"/> and <see cref="DialogAlignment.End"/> are supported.
     /// The default value is <see cref="DialogAlignment.Start"/>.
     /// </summary>
     [Parameter]
@@ -107,7 +107,8 @@ public partial class FluentLayoutHamburger : FluentComponentBase
     public bool? Visible { get; set; }
 
     /// <summary>
-    /// Gets or sets the display mode for the hamburger menu.
+    /// Gets or sets the display mode for the hamburger menu (e.g., <c>Display="HamburgerDisplay.MobileOnly"</c>).
+    /// See <see cref="HamburgerDisplay"/> for available values.
     /// </summary>
     [Parameter]
     public HamburgerDisplay Display { get; set; } = HamburgerDisplay.MobileOnly;

--- a/src/Core/Components/Layout/FluentLayoutItem.razor.cs
+++ b/src/Core/Components/Layout/FluentLayoutItem.razor.cs
@@ -75,7 +75,7 @@ public partial class FluentLayoutItem : FluentComponentBase
     public LayoutArea Area { get; set; } = LayoutArea.Content;
 
     /// <summary>
-    /// Gets ot sets the width of the item.
+    /// Gets or sets the width of the item (e.g., <c>Width="300px"</c>).
     /// </summary>
     [Parameter]
     public string? Width { get; set; }
@@ -93,7 +93,7 @@ public partial class FluentLayoutItem : FluentComponentBase
     public bool Sticky { get; set; }
 
     /// <summary>
-    /// Gets or sets the contentArea to be rendered inside the component.
+    /// Gets or sets the content to be rendered inside the component.
     /// </summary>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }

--- a/src/Core/Components/Spacer/FluentSpacer.razor.cs
+++ b/src/Core/Components/Spacer/FluentSpacer.razor.cs
@@ -27,19 +27,22 @@ public partial class FluentSpacer : FluentComponentBase
         .Build();
 
     /// <summary>
-    /// Gets or sets the height of the spacer when the orientation is vertical.
+    /// Gets or sets the height of the spacer when the <see cref="Orientation"/> is <see cref="Orientation.Vertical"/> (e.g., <c>Height="16px"</c>).
+    /// Use <see cref="Width"/> to set the size for a horizontal spacer.
     /// </summary>
     [Parameter]
     public string? Height { get; set; }
 
     /// <summary>
-    /// Gets or sets the size of the spacer when the orientation is horizontal.
+    /// Gets or sets the width of the spacer when the <see cref="Orientation"/> is <see cref="Orientation.Horizontal"/> (e.g., <c>Width="16px"</c>).
+    /// Use <see cref="Height"/> to set the size for a vertical spacer.
     /// </summary>
     [Parameter]
     public string? Width { get; set; }
 
     /// <summary>
-    /// Specify the orientation of the parent container, which can be either horizontal or vertical.
+    /// Gets or sets the orientation of the parent container.
+    /// Use <see cref="Orientation.Horizontal"/> (default) for a horizontal spacer, or <see cref="Orientation.Vertical"/> for a vertical one.
     /// </summary>
     [Parameter]
     public Orientation Orientation { get; set; } = Orientation.Horizontal;

--- a/src/Core/Components/Spacer/FluentSpacer.razor.cs
+++ b/src/Core/Components/Spacer/FluentSpacer.razor.cs
@@ -41,8 +41,8 @@ public partial class FluentSpacer : FluentComponentBase
     public string? Width { get; set; }
 
     /// <summary>
-    /// Gets or sets the orientation of the parent container.
-    /// Use <see cref="Orientation.Horizontal"/> (default) for a horizontal spacer, or <see cref="Orientation.Vertical"/> for a vertical one.
+    /// Gets or sets the orientation of this spacer, which should match the layout direction of the parent container.
+    /// Use <see cref="Orientation.Horizontal"/> (default) for a horizontal spacer (grows along the horizontal axis), or <see cref="Orientation.Vertical"/> for a vertical one.
     /// </summary>
     [Parameter]
     public Orientation Orientation { get; set; } = Orientation.Horizontal;

--- a/src/Core/Components/Stack/FluentStack.razor.cs
+++ b/src/Core/Components/Stack/FluentStack.razor.cs
@@ -79,17 +79,19 @@ public partial class FluentStack : FluentComponentBase
     public bool Wrap { get; set; } = false;
 
     /// <summary>
-    /// Gets or sets the gap between horizontally stacked components.
+    /// Gets or sets the gap between horizontally stacked components (e.g., <c>HorizontalGap="8px"</c>).
     /// Default is undefined. You can define the default value in the <see cref="LibraryConfiguration.DefaultStyles"/>.
-    /// See the CSS <see href="https://developer.mozilla.org/docs/Web/CSS/row-gap">row-gap</see> property.
+    /// Use <see cref="VerticalGap"/> to set the vertical gap.
+    /// See the CSS <see href="https://developer.mozilla.org/docs/Web/CSS/column-gap">column-gap</see> property.
     /// </summary>
     [Parameter]
     public string? HorizontalGap { get; set; }
 
     /// <summary>
-    /// Gets or sets the gap between vertically stacked components.
+    /// Gets or sets the gap between vertically stacked components (e.g., <c>VerticalGap="8px"</c>).
     /// Default is undefined. You can define the default value in the <see cref="LibraryConfiguration.DefaultStyles"/>.
-    /// See the CSS <see href="https://developer.mozilla.org/docs/Web/CSS/column-gap">column-gap</see> property.
+    /// Use <see cref="HorizontalGap"/> to set the horizontal gap.
+    /// See the CSS <see href="https://developer.mozilla.org/docs/Web/CSS/row-gap">row-gap</see> property.
     /// </summary>
     [Parameter]
     public string? VerticalGap { get; set; }


### PR DESCRIPTION
## Summary
Improves XML doc comments on `[Parameter]` properties in layout and structure components so the MCP server serves accurate descriptions to AI models.

## Components
| Component | Key Fixes |
|-----------|-----------|
| **FluentLayout** | "Gets ot sets" typo x2, malformed XML |
| **FluentStack** | **Critical:** `HorizontalGap`/`VerticalGap` CSS property descriptions were swapped |
| **FluentGrid** | Missing "Gets or sets" on all breakpoint params (Xs–Xxl) |
| **FluentSpacer** | `Width` described as "size", missing cross-refs |
| **FluentDivider** | `Appearance` said "of the content" (copied from wrong component) |
| **FluentAppBar** | "Gets or sets if" → "Gets or sets whether" throughout |

## Part of
Part of #4777