### PR TITLE
[MCP] Improve [Parameter] XML doc comments — Group H: Utility & Media

### DIFF
--- a/src/Core/Components/Field/FluentField.razor.cs
+++ b/src/Core/Components/Field/FluentField.razor.cs
@@ -111,7 +111,7 @@ public partial class FluentField : FluentComponentBase, IFluentField
     [Parameter]
     public Func<IFluentField, bool>? MessageCondition { get; set; }
 
-    /// <inheritdoc cref="IFluentField.MessageIcon"/>
+    /// <inheritdoc cref="IFluentField.MessageState"/>
     [Parameter]
     public MessageState? MessageState { get; set; }
 

--- a/src/Core/Components/Highlighter/FluentHighlighter.razor.cs
+++ b/src/Core/Components/Highlighter/FluentHighlighter.razor.cs
@@ -32,7 +32,8 @@ public partial class FluentHighlighter : FluentComponentBase
     public bool CaseSensitive { get; set; } = false;
 
     /// <summary>
-    /// Gets or sets the fragment of text to be highlighted.
+    /// Gets or sets the search term to highlight within <see cref="Text"/> (e.g., <c>HighlightedText="blazor"</c>).
+    /// Use <see cref="CaseSensitive"/> to control case sensitivity and <see cref="Delimiters"/> to split the term.
     /// </summary>
     [Parameter]
     public string HighlightedText { get; set; } = string.Empty;
@@ -50,7 +51,7 @@ public partial class FluentHighlighter : FluentComponentBase
     public string Delimiters { get; set; } = string.Empty;
 
     /// <summary>
-    /// If true, highlights the text until the next regex boundary.
+    /// Gets or sets whether the <see cref="HighlightedText"/> match should extend until the next regex word boundary.
     /// </summary>
     [Parameter]
     public bool UntilNextBoundary { get; set; }

--- a/src/Core/Components/Image/FluentImage.razor.cs
+++ b/src/Core/Components/Image/FluentImage.razor.cs
@@ -34,19 +34,19 @@ public partial class FluentImage : FluentComponentBase
         .Build();
 
     /// <summary>
-    /// Gets or sets the height of the image, applies only to the parameter.
+    /// Gets or sets the height of the image (e.g., <c>Height="200px"</c>).
     /// </summary>
     [Parameter]
     public string? Height { get; set; }
 
     /// <summary>
-    /// Gets or sets the width of the image, applies only to the parameter.
+    /// Gets or sets the width of the image (e.g., <c>Width="300px"</c>).
     /// </summary>
     [Parameter]
     public string? Width { get; set; }
 
     /// <summary>
-    /// Gets or sets the source link for the image, applies only to the parameter.
+    /// Gets or sets the URL source of the image (e.g., <c>Source="/images/photo.jpg"</c>).
     /// </summary>
     [Parameter]
     public string? Source { get; set; }
@@ -58,19 +58,19 @@ public partial class FluentImage : FluentComponentBase
     public string? AlternateText { get; set; }
 
     /// <summary>
-    /// Gets or sets the image html component.
+    /// Gets or sets the child content rendered inside the image container.
     /// </summary>
     [Parameter]
     public RenderFragment ChildContent { get; set; } = null!;
 
     /// <summary>
-    /// Gets or sets the border surrounding image.
+    /// Gets or sets a value indicating whether a border is rendered around the image.
     /// </summary>
     [Parameter]
     public bool Bordered { get; set; }
 
     /// <summary>
-    /// Gets or sets the argument ‘block’ so that the image's width will expand to fill the available container space.
+    /// Gets or sets whether the image is displayed as a block element, expanding its width to fill the available container space.
     /// </summary>
     [Parameter]
     public bool Block { get; set; }

--- a/src/Core/Components/InputFile/FluentInputFile.razor.cs
+++ b/src/Core/Components/InputFile/FluentInputFile.razor.cs
@@ -54,21 +54,21 @@ public partial class FluentInputFile : FluentComponentBase, IAsyncDisposable, II
     public string? Width { get; set; }
 
     /// <summary>
-    /// Gets or sets the component width.
+    /// Gets or sets the component height.
     /// </summary>
     [Parameter]
     public string? Height { get; set; }
 
     /// <summary>
-    /// To enable multiple file selection and upload, set the Multiple property to true.
-    /// Set <see cref="MaximumFileCount"/> to change the number of allowed files.
+    /// Gets or sets a value indicating whether multiple file selection is enabled.
+    /// Set <see cref="MaximumFileCount"/> to change the maximum number of allowed files.
     /// </summary>
     [Parameter]
     public bool Multiple { get; set; } = false;
 
     /// <summary>
-    /// To select multiple files, set the maximum number of files allowed to be uploaded.
-    /// Default value is 10.
+    /// Gets or sets the maximum number of files allowed to be uploaded (e.g., <c>MaximumFileCount="5"</c>).
+    /// Default value is 10. Requires <see cref="Multiple"/> to be true.
     /// </summary>
     [Parameter]
     public int MaximumFileCount { get; set; } = 10;
@@ -81,7 +81,7 @@ public partial class FluentInputFile : FluentComponentBase, IAsyncDisposable, II
     public long MaximumFileSize { get; set; } = 10 * 1024 * 1024;
 
     /// <summary>
-    /// Gets or sets the sze of buffer to read bytes from uploaded file (in bytes).
+    /// Gets or sets the size of the buffer used to read bytes from an uploaded file (in bytes).
     /// Default value is 10 KiB.
     /// </summary>
     [Parameter]
@@ -97,7 +97,7 @@ public partial class FluentInputFile : FluentComponentBase, IAsyncDisposable, II
     public string Accept { get; set; } = string.Empty;
 
     /// <summary>
-    /// Disables the form control, ensuring it doesn't participate in form submission.
+    /// Gets or sets a value indicating whether the form control is disabled and doesn't participate in form submission.
     /// </summary>
     [Parameter]
     public bool Disabled { get; set; }

--- a/src/Core/Components/KeyCode/FluentKeyCode.razor.cs
+++ b/src/Core/Components/KeyCode/FluentKeyCode.razor.cs
@@ -48,7 +48,7 @@ public partial class FluentKeyCode : FluentComponentBase, IFluentComponentElemen
     /// <summary>
     /// Gets or sets the control identifier associated with the KeyCode engine.
     /// If not set, the KeyCode will be applied to the FluentKeyCode content: see <see cref="ChildContent"/>.
-    /// This attribute is ignored when the <see cref="ChildContent" /> is used..
+    /// This parameter is ignored when <see cref="ChildContent"/> is used.
     /// </summary>
     [Parameter]
     public string Anchor { get; set; } = string.Empty;
@@ -72,7 +72,7 @@ public partial class FluentKeyCode : FluentComponentBase, IFluentComponentElemen
     public EventCallback<FluentKeyCodeEventArgs> OnKeyUp { get; set; }
 
     /// <summary>
-    /// Ignore modifier keys (Shift, Alt, Ctrl, Meta) when evaluating the key code.
+    /// Gets or sets whether modifier keys (Shift, Alt, Ctrl, Meta) should be ignored when evaluating the key code.
     /// </summary>
     [Parameter]
     public bool IgnoreModifier { get; set; } = true;
@@ -96,14 +96,15 @@ public partial class FluentKeyCode : FluentComponentBase, IFluentComponentElemen
     public bool StopPropagation { get; set; } = false;
 
     /// <summary>
-    /// Gets or sets a way to tells the user agent that if the event does not get explicitly handled, its default action should not be taken as it normally would be.
+    /// Gets or sets whether the default browser action should be prevented for all key events.
+    /// Use <see cref="PreventDefaultOnly"/> to restrict prevention to specific keys.
     /// </summary>
     [Parameter]
     public bool PreventDefault { get; set; } = false;
 
     /// <summary>
-    /// Gets or sets the list of <see cref="KeyCode"/> to tells the user agent that if the event does not get explicitly handled,
-    /// its default action should not be taken as it normally would be.
+    /// Gets or sets the list of <see cref="KeyCode"/> values for which the default browser action should be prevented.
+    /// Use <see cref="PreventDefault"/> to prevent the default action for all key events.
     /// </summary>
     [Parameter]
     public KeyCode[] PreventDefaultOnly { get; set; } = [];
@@ -115,7 +116,7 @@ public partial class FluentKeyCode : FluentComponentBase, IFluentComponentElemen
     public bool StopRepeat { get; set; }
 
     /// <summary>
-    /// Prevent multiple KeyDown events.
+    /// Gets or sets whether multiple consecutive KeyDown events (key held down) should be suppressed.
     /// </summary>
     [Parameter]
     public bool PreventMultipleKeyDown { get; set; }

--- a/src/Core/Components/PullToRefresh/FluentPullToRefresh.razor.cs
+++ b/src/Core/Components/PullToRefresh/FluentPullToRefresh.razor.cs
@@ -47,34 +47,35 @@ public partial class FluentPullToRefresh : FluentComponentBase
     public PullDirection Direction { get; set; } = PullDirection.Down;
 
     /// <summary>
-    /// Gets or sets if the pull action is disabled.
+    /// Gets or sets whether the pull action is disabled.
     /// Defaults to false.
     /// </summary>
     [Parameter]
     public bool Disabled { get; set; }
 
     /// <summary>
-    /// Gets or sets if the component should work on non-touch devices (by using an emulation script).
+    /// Gets or sets whether the component should work on non-touch devices (by using an emulation script).
     /// Defaults to true.
     /// </summary>
     [Parameter]
     public bool EmulateTouch { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets if a tip is shown when <see cref="ChildContent"/> is not being pulled.
+    /// Gets or sets whether a static tip is shown when <see cref="ChildContent"/> is not being pulled.
     /// Defaults to true.
     /// </summary>
     [Parameter]
     public bool ShowStaticTip { get; set; } = true;
 
     /// <summary>
-    /// Gets or set the content to show.
+    /// Gets or sets the content to show.
     /// </summary>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
-    /// Returns whether there is more data available.
+    /// Gets or sets the async callback invoked when a refresh is triggered.
+    /// Return <c>true</c> if more data is available, or <c>false</c> to display the <see cref="NoDataTemplate"/>.
     /// </summary>
     [Parameter]
     public Func<Task<bool>>? OnRefreshAsync { get; set; }

--- a/src/Core/Components/SortableList/FluentSortableList.razor.cs
+++ b/src/Core/Components/SortableList/FluentSortableList.razor.cs
@@ -83,7 +83,8 @@ public partial class FluentSortableList<TItem> : FluentComponentBase
     public string? Group { get; set; }
 
     /// <summary>
-    /// Gets or sets whether elements are cloned instead of moved. Set Clone to true to enable this.
+    /// Gets or sets whether elements are cloned instead of moved when dragged to another list (e.g., <c>Clone="true"</c>).
+    /// Requires <see cref="Group"/> to be set to the same value on both lists.
     /// </summary>
     [Parameter]
     public bool Clone { get; set; }
@@ -96,16 +97,15 @@ public partial class FluentSortableList<TItem> : FluentComponentBase
     public bool Drop { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets whether the list is sortable.
-    /// Default is true
-    /// Disable sorting within a list by setting to false.
+    /// Gets or sets whether sorting within this list is enabled. Default is <c>true</c>.
+    /// Set to <c>false</c> to disable reordering within this list while still allowing cross-list drag-and-drop.
     /// </summary>
     [Parameter]
     public bool Sort { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets whether the whole item acts as drag handle.
-    /// Set to true to use an element with classname `.sortable-grab` as the handle.
+    /// Gets or sets whether drag handles are used instead of dragging the whole item.
+    /// When <c>true</c>, only elements with the CSS class <c>sortable-grab</c> can initiate a drag.
     /// </summary>
     [Parameter]
     public bool Handle { get; set; }
@@ -117,7 +117,7 @@ public partial class FluentSortableList<TItem> : FluentComponentBase
     public Func<TItem, bool>? ItemFilter { get; set; }
 
     /// <summary>
-    /// Gets or sets whether to ignore the HTML5 DnD behaviour and force the fallback to kick in
+    /// Gets or sets whether to ignore the HTML5 DnD behaviour and force the fallback to kick in.
     /// </summary>
     [Parameter]
     public bool Fallback { get; set; } = false;

--- a/src/Core/Components/Text/FluentText.razor.cs
+++ b/src/Core/Components/Text/FluentText.razor.cs
@@ -55,37 +55,37 @@ public partial class FluentText : FluentComponentBase, ITooltipComponent
     public TextFont? Font { get; set; }
 
     /// <summary>
-    /// Gets or sets if the texts is set to no-wrap.
+    /// Gets or sets whether the text is set to no-wrap (disables line wrapping).
     /// </summary>
     [Parameter]
     public bool Nowrap { get; set; }
 
     /// <summary>
-    /// Gets or sets if the text should truncate. 
+    /// Gets or sets whether the text should truncate with an ellipsis when it overflows.
     /// </summary>
     [Parameter]
     public bool Truncate { get; set; }
 
     /// <summary>
-    /// Gets or sets if the text is set to block.
+    /// Gets or sets whether the text is displayed as a block element.
     /// </summary>
     [Parameter]
     public bool Block { get; set; }
 
     /// <summary>
-    /// Gets or sets if the text is shown in italic.
+    /// Gets or sets whether the text is shown in italic.
     /// </summary>
     [Parameter]
     public bool Italic { get; set; }
 
     /// <summary>
-    /// Gets or sets is shown underlined .
+    /// Gets or sets whether the text is shown with an underline.
     /// </summary>
     [Parameter]
     public bool Underline { get; set; }
 
     /// <summary>
-    /// Gets or sets if the text is shown as strikethrough.
+    /// Gets or sets whether the text is shown with a strikethrough decoration.
     /// </summary>
     [Parameter]
     public bool Strikethrough { get; set; }


### PR DESCRIPTION
## Summary
Improves XML doc comments on `[Parameter]` properties in utility and media components so the MCP server serves accurate descriptions to AI models.

## Components
| Component | Key Fixes |
|-----------|-----------|
| **FluentInputFile** | `Height` copy-paste said "width", `BufferSize` typo ("sze"), missing "Gets or sets" prefixes |
| **FluentText** | `Underline` completely broken summary ("Gets or sets is shown underlined ."), `Nowrap` typo |
| **FluentPullToRefresh** | `OnRefreshAsync` wrong description, "Gets or set" typo |
| **FluentImage** | Meaningless "applies only to the parameter" phrase on `Height`/`Width`/`Source` |
| **FluentKeyCode** | `PreventDefault` "a way to tells" grammar, `Anchor` double period |
| **FluentSortableList** | `Handle` contradictory description, `Clone` redundant self-reference |
| **FluentHighlighter** | `HighlightedText` vague ("fragment of text"), missing cross-refs to siblings |
| **FluentField** | `MessageState` pointed to wrong `cref` (`MessageIcon` instead of `MessageState`) |

## Part of
Part of #4777