### PR TITLE
[MCP] Improve [Parameter] XML doc comments — Group E: Navigation & Identity

### DIFF
--- a/src/Core/Components/Avatar/FluentAvatar.razor.cs
+++ b/src/Core/Components/Avatar/FluentAvatar.razor.cs
@@ -24,7 +24,8 @@ public partial class FluentAvatar : FluentComponentBase, ITooltipComponent
         .Build();
 
     /// <summary>
-    /// Gets or sets activity indicator
+    /// Gets or sets whether the avatar displays an active state indicator ring (e.g., <c>Active="true"</c>).
+    /// Use <see cref="ActiveAppearance"/> to control the visual style of the active indicator.
     /// </summary>
     [Parameter]
     public bool? Active { get; set; }
@@ -48,20 +49,22 @@ public partial class FluentAvatar : FluentComponentBase, ITooltipComponent
     public Icon? Icon { get; set; }
 
     /// <summary>
-    /// Gets or sets an avatar can display an image.
+    /// Gets or sets the URL of the image displayed in the avatar (e.g., <c>Image="/images/profile.jpg"</c>).
+    /// The image takes precedence over <see cref="Initials"/> and <see cref="Name"/>-generated initials.
     /// </summary>
     [Parameter]
     public string? Image { get; set; }
 
     /// <summary>
-    /// Gets or sets custom initials rather than one generated via the name
+    /// Gets or sets custom initials to display in the avatar (e.g., <c>Initials="JD"</c>),
+    /// overriding the initials automatically generated from <see cref="Name"/>.
     /// </summary>
     [Parameter]
     public string? Initials { get; set; }
 
     /// <summary>
-    /// The name of the person or entity represented by this Avatar. This should always be provided if it is available.
-    /// The name is used to determine the initials displayed when there is no image.It is also provided to accessibility tools.
+    /// Gets or sets the name of the person or entity represented by this avatar (e.g., <c>Name="Jane Doe"</c>).
+    /// The name is used to generate initials when no <see cref="Image"/> is set, and is also provided to accessibility tools.
     /// </summary>
     [Parameter]
     public string? Name { get; set; }
@@ -73,7 +76,7 @@ public partial class FluentAvatar : FluentComponentBase, ITooltipComponent
     public AvatarShape? Shape { get; set; }
 
     /// <summary>
-    /// Gets or sets size of the avatar.
+    /// Gets or sets the size of the avatar (e.g., <c>Size="AvatarSize.Size48"</c>).
     /// </summary>
     [Parameter]
     public AvatarSize? Size { get; set; }

--- a/src/Core/Components/Badge/FluentBadge.razor.cs
+++ b/src/Core/Components/Badge/FluentBadge.razor.cs
@@ -37,13 +37,15 @@ public partial class FluentBadge : FluentComponentBase
         .Build();
 
     /// <summary>
-    /// Gets or sets the content to be rendered inside the component.
+    /// Gets or sets the text content displayed inside the badge (e.g., <c>Content="New"</c>).
+    /// For structured content, use <see cref="ChildContent"/> instead.
     /// </summary>
     [Parameter]
     public string? Content { get; set; }
 
     /// <summary>
-    /// Gets or sets the color.
+    /// Gets or sets the color of the badge (e.g., <c>Color="BadgeColor.Brand"</c>).
+    /// When using <see cref="BackgroundColor"/>, set this to <c>null</c>.
     /// </summary>
     [Parameter]
     public BadgeColor? Color { get; set; }
@@ -95,7 +97,8 @@ public partial class FluentBadge : FluentComponentBase
     public Icon? IconStart { get; set; }
 
     /// <summary>
-    /// Gets or sets the aria-label of the <see cref="Icon"/>.
+    /// Gets or sets the <c>aria-label</c> attribute applied to the icon(s) rendered in the badge
+    /// (e.g., <c>IconLabel="New notifications"</c>).
     /// </summary>
     [Parameter]
     public string? IconLabel { get; set; }

--- a/src/Core/Components/Badge/FluentCounterBadge.razor.cs
+++ b/src/Core/Components/Badge/FluentCounterBadge.razor.cs
@@ -21,13 +21,13 @@ public partial class FluentCounterBadge : FluentBadge
     private int? GetCount() => ShowWhen?.Invoke(Count) == true ? Count : null;
 
     /// <summary>
-    ///  Gets or sets the badge's dot state.
+    /// Gets or sets whether the badge renders as a small dot without any text content (e.g., <c>Dot="true"</c>).
     /// </summary>
     [Parameter]
     public bool Dot { get; set; }
 
     /// <summary>
-    /// Gets or sets the badge's show-zero state.
+    /// Gets or sets whether the badge is visible when <see cref="Count"/> is zero (e.g., <c>ShowZero="true"</c>).
     /// </summary>
     [Parameter]
     public bool? ShowZero { get; set; }
@@ -56,8 +56,9 @@ public partial class FluentCounterBadge : FluentBadge
     public int? Count { get; set; }
 
     /// <summary>
-    /// Gets or sets the badge's overflow count.
-    /// The default value is `null`. Internally the component uses 99 as its default value.
+    /// Gets or sets the maximum count value displayed before showing an overflow indicator (e.g., <c>OverflowCount="99"</c>).
+    /// When <see cref="Count"/> exceeds this value, the badge displays the overflow count followed by a "+" sign.
+    /// The default value is <c>null</c>; the component uses <c>99</c> as its internal default.
     /// </summary>
     [Parameter]
     public int? OverflowCount { get; set; }

--- a/src/Core/Components/Badge/FluentPresenceBadge.razor.cs
+++ b/src/Core/Components/Badge/FluentPresenceBadge.razor.cs
@@ -7,8 +7,8 @@ using Microsoft.AspNetCore.Components;
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 /// <summary>
-/// The FluentCounterBadge component is a visual indicator that communicates a value about an associated component.
-/// It uses short positive numbers, color, and icons for quick recognition and is placed near the relevant content.
+/// The FluentPresenceBadge component is a visual indicator that communicates a user's presence status.
+/// It displays a colored icon overlay typically attached to an avatar or similar element.
 /// </summary>
 public partial class FluentPresenceBadge : FluentComponentBase
 {
@@ -41,7 +41,8 @@ public partial class FluentPresenceBadge : FluentComponentBase
     public PresenceStatus? Status { get; set; } = PresenceStatus.Available;
 
     /// <summary>
-    ///  Gets or sets the out of office state.
+    /// Gets or sets whether the presence badge indicates an out-of-office state.
+    /// When <c>true</c>, adjusts the displayed icon to reflect the out-of-office variant of the current <see cref="Status"/>.
     /// </summary>
     [Parameter]
     public bool OutOfOffice { get; set; }
@@ -55,7 +56,8 @@ public partial class FluentPresenceBadge : FluentComponentBase
     public RenderFragment? AnchorContent { get; set; }
 
     /// <summary>
-    /// Gets or sets the <see cref="Icon"/> displayed at the start of badge content.
+    /// Gets or sets an icon override for the badge.
+    /// By default the icon is automatically chosen based on <see cref="Status"/> and <see cref="OutOfOffice"/>.
     /// </summary>
     [Parameter]
     public Icon? Icon { get; set; }

--- a/src/Core/Components/Link/FluentLink.razor.cs
+++ b/src/Core/Components/Link/FluentLink.razor.cs
@@ -31,43 +31,44 @@ public partial class FluentLink : FluentComponentBase, ITooltipComponent
     public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
-    /// Command executed when the user clicks on the button.
+    /// Gets or sets the callback invoked when the user clicks on the link.
     /// </summary>
     [Parameter]
     public EventCallback<MouseEventArgs> OnClick { get; set; }
 
     /// <summary>
-    /// Get or set the href of the anchor.
+    /// Gets or sets the URL of the link (e.g., <c>Href="/page"</c> or <c>Href="https://example.com"</c>).
     /// </summary>
     [Parameter]
     public string? Href { get; set; }
 
     /// <summary>
-    /// Get or set the ISO Code language code that specifies the language of the linked document. It is purely advisory.
+    /// Gets or sets the BCP 47 language code for the language of the linked document (e.g., <c>HrefLang="en"</c>). This is advisory only.
     /// </summary>
     [Parameter]
     public string? HrefLang { get; set; }
 
     /// <summary>
-    /// Get or set a string indicating which referrer to use when fetching the resource.
+    /// Gets or sets the referrer policy controlling how much referrer information is sent when following the link.
     /// </summary>
     [Parameter]
     public LinkReferrerPolicy? ReferrerPolicy { get; set; }
 
     /// <summary>
-    /// Get or set relationship of the linked document to the current document.
+    /// Gets or sets the relationship of the linked document to the current document.
     /// </summary>
     [Parameter]
     public LinkRel? Rel { get; set; }
 
     /// <summary>
-    /// Get or set the type of the content linked to.
+    /// Gets or sets the MIME type of the linked content (e.g., <c>LinkType="application/pdf"</c>).
     /// </summary>
     [Parameter]
     public string? LinkType { get; set; }
 
     /// <summary>
-    /// Get or set the frame or window name that has the defined linking relationship.
+    /// Gets or sets the browsing context in which to open <see cref="Href"/>
+    /// (e.g., <c>Target="LinkTarget.Blank"</c> to open in a new tab).
     /// </summary>
     [Parameter]
     public LinkTarget? Target { get; set; }
@@ -80,7 +81,7 @@ public partial class FluentLink : FluentComponentBase, ITooltipComponent
     public LinkAppearance Appearance { get; set; } = LinkAppearance.Default;
 
     /// <summary>
-    /// Get or set if the link is inline with text.
+    /// Gets or sets whether the link is rendered inline with surrounding text.
     /// </summary>
     [Parameter]
     public bool Inline { get; set; } = false;

--- a/src/Core/Components/Menu/FluentMenu.razor.cs
+++ b/src/Core/Components/Menu/FluentMenu.razor.cs
@@ -45,7 +45,7 @@ public partial class FluentMenu : FluentComponentBase, ITooltipComponent
     public bool? OpenOnContext { get; set; }
 
     /// <summary>
-    /// Gets or sets whether the menu when scrolling outside of it.
+    /// Gets or sets whether the menu closes automatically when the user scrolls outside of it.
     /// </summary>
     [Parameter]
     public bool? CloseOnScroll { get; set; }
@@ -57,7 +57,8 @@ public partial class FluentMenu : FluentComponentBase, ITooltipComponent
     public bool? PersistOnItemClick { get; set; }
 
     /// <summary>
-    /// Gets or sets the id of the menu trigger.
+    /// Gets or sets the HTML element ID of the trigger element that opens this menu (e.g., <c>Trigger="my-button-id"</c>).
+    /// When set, clicking the referenced element toggles the menu open or closed.
     /// </summary>
     [Parameter]
     public string? Trigger { get; set; }
@@ -69,7 +70,7 @@ public partial class FluentMenu : FluentComponentBase, ITooltipComponent
     public string? Height { get; set; }
 
     /// <summary>
-    /// Gets or sets the menu's submenus.
+    /// Gets or sets the child content rendered inside the menu, typically <see cref="FluentMenuItem"/> elements.
     /// </summary>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }

--- a/src/Core/Components/Menu/FluentMenuItem.razor.cs
+++ b/src/Core/Components/Menu/FluentMenuItem.razor.cs
@@ -67,13 +67,15 @@ public partial class FluentMenuItem : FluentComponentBase
     public bool? Disabled { get; set; }
 
     /// <summary>
-    /// Gets or sets the <see cref="Icon"/> displayed at the start of menu item content.
+    /// Gets or sets the <see cref="Icon"/> displayed at the start (left side) of the menu item content.
+    /// Use <see cref="IconEnd"/> to add an icon at the end.
     /// </summary>
     [Parameter]
     public Icon? IconStart { get; set; }
 
     /// <summary>
-    /// Gets or sets the <see cref="Icon"/> displayed at the end of menu item content.
+    /// Gets or sets the <see cref="Icon"/> displayed at the end (right side) of the menu item content.
+    /// Use <see cref="IconStart"/> to add an icon at the start.
     /// </summary>
     [Parameter]
     public Icon? IconEnd { get; set; }
@@ -85,16 +87,16 @@ public partial class FluentMenuItem : FluentComponentBase
     public Icon? IconSubmenu { get; set; }
 
     /// <summary>
-    /// Gets or sets the <see cref="Icon"/> displayed as the indicator of being checked .
+    /// Gets or sets the <see cref="Icon"/> displayed as the checked indicator for items with <see cref="Role"/> set to
+    /// <see cref="MenuItemRole.Checkbox"/> or <see cref="MenuItemRole.Radio"/>.
     /// </summary>
     [Parameter]
     public Icon? IconIndicator { get; set; }
 
     /// <summary>
-    ///  Gets or sets the content to be rendered inside the menu item.
-    ///  This can be used as an alternative to specifying the content as a child component of the button.
-    ///  If both are specified, both will be rendered.
-    ///  </summary>
+    /// Gets or sets the text label of the menu item.
+    /// Use as an alternative to <see cref="ChildContent"/> for simple text; if both are set, both are rendered.
+    /// </summary>
     [Parameter]
     public string? Label { get; set; }
 

--- a/src/Core/Components/Menu/FluentMenuItem.razor.cs
+++ b/src/Core/Components/Menu/FluentMenuItem.razor.cs
@@ -67,14 +67,14 @@ public partial class FluentMenuItem : FluentComponentBase
     public bool? Disabled { get; set; }
 
     /// <summary>
-    /// Gets or sets the <see cref="Icon"/> displayed at the start (left side) of the menu item content.
+    /// Gets or sets the <see cref="Icon"/> displayed at the start (leading side) of the menu item content.
     /// Use <see cref="IconEnd"/> to add an icon at the end.
     /// </summary>
     [Parameter]
     public Icon? IconStart { get; set; }
 
     /// <summary>
-    /// Gets or sets the <see cref="Icon"/> displayed at the end (right side) of the menu item content.
+    /// Gets or sets the <see cref="Icon"/> displayed at the end (trailing side) of the menu item content.
     /// Use <see cref="IconStart"/> to add an icon at the start.
     /// </summary>
     [Parameter]

--- a/src/Core/Components/Nav/FluentNav.razor.cs
+++ b/src/Core/Components/Nav/FluentNav.razor.cs
@@ -70,19 +70,21 @@ public partial class FluentNav : FluentComponentBase
     public bool UseIcons { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets whether to allow just one expanded category or multiple
+    /// Gets or sets whether only one <see cref="FluentNavCategory"/> can be expanded at a time.
+    /// When <c>true</c>, expanding one category automatically collapses all others.
     /// </summary>
     [Parameter]
     public bool UseSingleExpanded { get; set; }
 
     /// <summary>
-    /// Gets or sets the density of the nav menu item.
+    /// Gets or sets the density (spacing) of the navigation menu items (e.g., <c>Density="NavDensity.Compact"</c>).
     /// </summary>
     [Parameter]
     public NavDensity? Density { get; set; }
 
     /// <summary>
-    /// Gets or sets the content of the nav menu item.
+    /// Gets or sets the child content rendered inside the navigation menu.
+    /// Accepts <see cref="FluentNavItem"/>, <see cref="FluentNavCategory"/>, <see cref="FluentNavSectionHeader"/>, and <see cref="FluentDivider"/> elements.
     /// </summary>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }

--- a/src/Core/Components/Nav/FluentNavCategory.razor.cs
+++ b/src/Core/Components/Nav/FluentNavCategory.razor.cs
@@ -44,13 +44,15 @@ public partial class FluentNavCategory : FluentNavBase
     public string? Title { get; set; }
 
     /// <summary>
-    /// Gets or sets the icon to use when the item is not hovered/selected/active.
+    /// Gets or sets the icon displayed when the category is in its default (resting) state.
+    /// Use <see cref="IconActive"/> to specify the icon shown when the category is hovered, selected, or active.
     /// </summary>
     [Parameter]
     public Icon? IconRest { get; set; } = new CoreIcons.Regular.Size20.Folder();
 
     /// <summary>
-    /// Gets or sets the icon to use when the item is hovered/selected/active.
+    /// Gets or sets the icon displayed when the category is hovered, selected, or active.
+    /// Use <see cref="IconRest"/> to specify the icon shown in the default (resting) state.
     /// </summary>
     [Parameter]
     public Icon? IconActive { get; set; }
@@ -74,7 +76,8 @@ public partial class FluentNavCategory : FluentNavBase
     public string? Tooltip { get; set; }
 
     /// <summary>
-    /// Gets or sets the content of the nav menu item.
+    /// Gets or sets the child content rendered inside the category.
+    /// Typically contains <see cref="FluentNavItem"/> sub-items.
     /// </summary>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }

--- a/src/Core/Components/Nav/FluentNavItem.razor.cs
+++ b/src/Core/Components/Nav/FluentNavItem.razor.cs
@@ -49,38 +49,41 @@ public partial class FluentNavItem : FluentNavBase
     internal FluentNavCategory? Category { get; set; }
 
     /// <summary>
-    /// Gets or sets the icon to use when the item is not hovered/selected/active.
+    /// Gets or sets the icon displayed when the item is in its default (resting) state.
+    /// Use <see cref="IconActive"/> to specify the icon shown when the item is hovered, selected, or active.
     /// </summary>
     [Parameter]
     public Icon? IconRest { get; set; }
 
     /// <summary>
-    /// Gets or sets the icon to use when the item is hovered/selected/active.
+    /// Gets or sets the icon displayed when the item is hovered, selected, or active.
+    /// Use <see cref="IconRest"/> to specify the icon shown in the default (resting) state.
     /// </summary>
     [Parameter]
     public Icon? IconActive { get; set; }
 
     /// <summary>
-    /// Gets or sets the href of the link.
+    /// Gets or sets the navigation URL for the item (e.g., <c>Href="/dashboard"</c>).
+    /// When set, the item renders as an anchor element.
     /// </summary>
     [Parameter]
     public string? Href { get; set; }
 
     /// <summary>
-    /// The callback to invoke when the item is clicked.
+    /// Gets or sets the callback invoked when the item is clicked.
     /// </summary>
     [Parameter]
     public EventCallback<MouseEventArgs> OnClick { get; set; }
 
     /// <summary>
-    /// If true, the item will be disabled.
+    /// Gets or sets whether the item is disabled.
     /// </summary>
     [Parameter]
     public bool Disabled { get; set; }
 
     /// <summary>
-    /// Gets or sets the target attribute that specifies where to open the group, if Href is specified.
-    /// Possible values: _blank | _self | _parent | _top.
+    /// Gets or sets the target attribute that specifies where to open the link when <see cref="Href"/> is set
+    /// (e.g., <c>Target="LinkTarget.Blank"</c> to open in a new tab).
     /// </summary>
     [Parameter]
     public LinkTarget? Target { get; set; }


### PR DESCRIPTION
## Summary
Improves XML doc comments on `[Parameter]` properties in navigation and identity components so the MCP server serves accurate descriptions to AI models.

## Components
| Component | Key Fixes |
|-----------|-----------|
| **FluentNav** | `IconRest`/`IconActive` missing cross-refs, wrong component names in descriptions |
| **FluentMenu** | `CloseOnScroll` broken grammar, `Trigger` opaque id description |
| **FluentLink** | 8× "Get or set" → "Gets or sets" |
| **FluentBadge** | Class summary copy-pasted, `Content`/`ChildContent` had identical descriptions |
| **FluentAvatar** | Multiple grammar errors + missing "Gets or sets" prefix |

## Part of
Part of #4777