### PR TITLE
[MCP] Improve [Parameter] XML doc comments — Group G: Feedback & Display

### DIFF
--- a/src/Core/Components/DateTime/FluentCalendar.razor.cs
+++ b/src/Core/Components/DateTime/FluentCalendar.razor.cs
@@ -134,7 +134,7 @@ public partial class FluentCalendar<TValue> : FluentCalendarBase<TValue>
 
     /// <summary>
     /// Gets or sets a value indicating whether calendar items are animated during a period change.
-    /// By default, the animation is enabled for Months views, but disabled for Days and Years view.
+    /// By default, the animation is enabled for Months views, but disabled for Days and Years views.
     /// </summary>
     [Parameter]
     public bool? AnimatePeriodChanges { get; set; }

--- a/src/Core/Components/DateTime/FluentCalendar.razor.cs
+++ b/src/Core/Components/DateTime/FluentCalendar.razor.cs
@@ -133,14 +133,15 @@ public partial class FluentCalendar<TValue> : FluentCalendarBase<TValue>
     public bool DisplayToday { get; set; } = true;
 
     /// <summary>
-    /// Gets ot sets if the calendar items are animated during a period change.
+    /// Gets or sets a value indicating whether calendar items are animated during a period change.
     /// By default, the animation is enabled for Months views, but disabled for Days and Years view.
     /// </summary>
     [Parameter]
     public bool? AnimatePeriodChanges { get; set; }
 
     /// <summary>
-    /// Gets or sets the way the user can select one or more dates
+    /// Gets or sets the date selection mode (e.g., <c>SelectMode="CalendarSelectMode.Range"</c>).
+    /// Controls whether the user can select a single date, a range, or multiple dates.
     /// </summary>
     [Parameter]
     public CalendarSelectMode SelectMode { get; set; } = CalendarSelectMode.Single;
@@ -158,7 +159,8 @@ public partial class FluentCalendar<TValue> : FluentCalendarBase<TValue>
     public EventCallback<IEnumerable<TValue>> SelectedDatesChanged { get; set; }
 
     /// <summary>
-    /// Fired when the selected mouse over change, to display the future range of dates.
+    /// Gets or sets a function invoked when the user hovers over a date, returning the projected range to highlight.
+    /// Only used when <see cref="SelectMode"/> is <see cref="CalendarSelectMode.Range"/>.
     /// </summary>
     [Parameter]
     public Func<TValue, IEnumerable<TValue>>? SelectDatesHover { get; set; }

--- a/src/Core/Components/DateTime/FluentDatePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor.cs
@@ -52,18 +52,22 @@ public partial class FluentDatePicker<TValue> : FluentCalendarBase<TValue>
         .Build();
 
     /// <summary>
-    /// Gets or sets the visual appearance.
+    /// Gets or sets the icon displayed in the date picker toggle button (e.g., <c>Icon="new CoreIcons.Regular.Size20.Calendar()"</c>).
+    /// Defaults to the calendar icon.
     /// </summary>
     [Parameter]
     public Icon Icon { get; set; } = new CoreIcons.Regular.Size20.Calendar().WithColor("currentColor");
 
     /// <summary>
-    /// Gets or sets the visual appearance.
+    /// Gets or sets the visual appearance of the text input (e.g., <c>Appearance="TextInputAppearance.Outline"</c>).
     /// </summary>
     [Parameter]
     public TextInputAppearance Appearance { get; set; } = TextInputAppearance.Outline;
 
-    /// <summary />
+    /// <summary>
+    /// Gets or sets the render style of the date picker (e.g., <c>RenderStyle="DatePickerRenderStyle.FluentUI"</c>).
+    /// <see cref="DatePickerRenderStyle.FluentUI"/> renders a popup calendar; <see cref="DatePickerRenderStyle.Native"/> uses the browser's built-in date input.
+    /// </summary>
     [Parameter]
     public DatePickerRenderStyle RenderStyle { get; set; } = DatePickerRenderStyle.FluentUI;
 

--- a/src/Core/Components/DateTime/FluentDatePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor.cs
@@ -52,8 +52,8 @@ public partial class FluentDatePicker<TValue> : FluentCalendarBase<TValue>
         .Build();
 
     /// <summary>
-    /// Gets or sets the icon displayed in the date picker toggle button (e.g., <c>Icon="new CoreIcons.Regular.Size20.Calendar()"</c>).
-    /// Defaults to the calendar icon.
+    /// Gets or sets the icon displayed in the date picker toggle button.
+    /// Defaults to the calendar icon. Provide any <see cref="Icon"/> instance from the public <c>Icons.*</c> types to customize.
     /// </summary>
     [Parameter]
     public Icon Icon { get; set; } = new CoreIcons.Regular.Size20.Calendar().WithColor("currentColor");

--- a/src/Core/Components/DateTime/FluentTimePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentTimePicker.razor.cs
@@ -52,7 +52,10 @@ public partial class FluentTimePicker<TValue> : FluentInputBase<TValue>
     [Parameter]
     public ListAppearance Appearance { get; set; } = ListAppearance.Outline;
 
-    /// <summary />
+    /// <summary>
+    /// Gets or sets the render style of the time picker (e.g., <c>RenderStyle="DatePickerRenderStyle.FluentUI"</c>).
+    /// <see cref="DatePickerRenderStyle.FluentUI"/> renders a dropdown list; <see cref="DatePickerRenderStyle.Native"/> uses the browser's built-in time input.
+    /// </summary>
     [Parameter]
     public DatePickerRenderStyle RenderStyle { get; set; } = DatePickerRenderStyle.FluentUI;
 
@@ -76,19 +79,22 @@ public partial class FluentTimePicker<TValue> : FluentInputBase<TValue>
     public string? Placeholder { get; set; }
 
     /// <summary>
-    /// Function to know if a specific time must be disabled.
+    /// Gets or sets a function that determines whether a specific time value should be disabled in the picker.
+    /// Return <see langword="true"/> to disable a time; <see langword="false"/> to allow it.
     /// </summary>
     [Parameter]
     public virtual Func<TValue, bool>? DisabledTimeFunc { get; set; }
 
     /// <summary>
-    /// Gets or sets the hour of the day at which the operation or schedule should start, in 24-hour format.
+    /// Gets or sets the first hour displayed in the time dropdown list, in 24-hour format (e.g., <c>StartHour="9"</c>).
+    /// See also <see cref="EndHour"/>.
     /// </summary>
     [Parameter]
     public int StartHour { get; set; } = 8;
 
     /// <summary>
-    /// Gets or sets the ending hour for the time range, in 24-hour format.
+    /// Gets or sets the last hour displayed in the time dropdown list, in 24-hour format (e.g., <c>EndHour="17"</c>).
+    /// See also <see cref="StartHour"/>.
     /// </summary>
     [Parameter]
     public int EndHour { get; set; } = 18;

--- a/src/Core/Components/Progress/FluentProgressBar.razor.cs
+++ b/src/Core/Components/Progress/FluentProgressBar.razor.cs
@@ -30,14 +30,16 @@ public partial class FluentProgressBar : FluentComponentBase, ITooltipComponent
         .Build();
 
     /// <summary>
-    /// Gets or sets the minimum value.
+    /// Gets or sets the minimum value (e.g., <c>Min="0"</c>).
+    /// See also <see cref="Max"/>.
     /// </summary>
     [Parameter]
     public int? Min { get; set; }
 
     /// <summary>
-    /// Gets or sets the maximum value.
-    /// The FluentProgressBar bar will be full when value equals <see cref="Max"/>.
+    /// Gets or sets the maximum value (e.g., <c>Max="100"</c>).
+    /// The progress bar will be full when <see cref="Value"/> equals this.
+    /// See also <see cref="Min"/>.
     /// </summary>
     [Parameter]
     public int? Max { get; set; }
@@ -49,8 +51,9 @@ public partial class FluentProgressBar : FluentComponentBase, ITooltipComponent
     public ProgressShape? Shape { get; set; }
 
     /// <summary>
-    /// Gets or sets the current value.
-    /// If `null` (default), the FluentProgressBar will display an indeterminate state.
+    /// Gets or sets the current progress value (e.g., <c>Value="75"</c>).
+    /// If <see langword="null"/> (default), the bar displays an indeterminate state.
+    /// Must be between <see cref="Min"/> and <see cref="Max"/>.
     /// </summary>
     [Parameter]
     public int? Value { get; set; }
@@ -83,8 +86,8 @@ public partial class FluentProgressBar : FluentComponentBase, ITooltipComponent
     public string? BackgroundColor { get; set; }
 
     /// <summary>
-    /// Gets or sets the color of the progress bar.
-    /// This property is not used when the <see cref="State"/> property is set.
+    /// Gets or sets the color of the progress bar indicator (e.g., <c>Color="#0078d4"</c>).
+    /// Ignored when <see cref="State"/> is set.
     /// </summary>
     [Parameter]
     public string? Color { get; set; }
@@ -98,7 +101,8 @@ public partial class FluentProgressBar : FluentComponentBase, ITooltipComponent
     public ProgressStroke? Stroke { get; set; }
 
     /// <summary>
-    /// Gets or sets the stroke width of the progress bar.
+    /// Gets or sets the visual thickness of the progress bar track (e.g., <c>Thickness="ProgressThickness.Large"</c>).
+    /// If not set, the default theme thickness is used.
     /// </summary>
     [Parameter]
     public ProgressThickness? Thickness { get; set; }

--- a/src/Core/Components/Progress/FluentSpinner.razor.cs
+++ b/src/Core/Components/Progress/FluentSpinner.razor.cs
@@ -33,7 +33,8 @@ public partial class FluentSpinner : FluentComponentBase, ITooltipComponent
     public bool? Visible { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets whether the spinner should be shown in an inverted color scheme (i.e. light spinner on dark background)
+    /// Gets or sets a value indicating whether the spinner should be shown in an inverted color scheme
+    /// (e.g., <c>AppearanceInverted="true"</c> for a light spinner on a dark background).
     /// </summary>
     [Parameter]
     public bool AppearanceInverted { get; set; }

--- a/src/Core/Components/RatingDisplay/FluentRatingDisplay.razor.cs
+++ b/src/Core/Components/RatingDisplay/FluentRatingDisplay.razor.cs
@@ -56,8 +56,8 @@ public partial class FluentRatingDisplay : FluentComponentBase, ITooltipComponen
     public RatingSize? Size { get; set; }
 
     /// <summary>
-    /// Gets or sets the icon used for each rating item (e.g., <c>Shape="new MyIcons.Star()"</c>).
-    /// Defaults to a star icon.
+    /// Gets or sets the icon used for each rating item.
+    /// Defaults to a star icon. Provide any <see cref="Icon"/> instance to customize the shape.
     /// </summary>
     [Parameter]
     public Icon? Shape { get; set; }

--- a/src/Core/Components/RatingDisplay/FluentRatingDisplay.razor.cs
+++ b/src/Core/Components/RatingDisplay/FluentRatingDisplay.razor.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Components;
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 /// <summary>
-/// Visual representation of content being loaded or processed.
+/// Displays a read-only star rating, such as an average product score or user review summary.
 /// </summary>
 public partial class FluentRatingDisplay : FluentComponentBase, ITooltipComponent
 {
@@ -29,8 +29,8 @@ public partial class FluentRatingDisplay : FluentComponentBase, ITooltipComponen
     public RatingDisplayColor? Color { get; set; }
 
     /// <summary>
-    /// Gets or sets the compact mode.
-    /// Renders a single filled star, with the value written next to it.
+    /// Gets or sets a value indicating whether compact mode is enabled.
+    /// When <see langword="true"/>, renders a single filled star with the numeric value next to it.
     /// </summary>
     [Parameter]
     public bool? Compact { get; set; }
@@ -43,26 +43,28 @@ public partial class FluentRatingDisplay : FluentComponentBase, ITooltipComponen
     public double? Count { get; set; }
 
     /// <summary>
-    /// Gets or sets the max value of the rating.
-    /// This controls the number of rating items displayed. Must be a whole number greater than 1
+    /// Gets or sets the maximum number of rating items displayed (e.g., <c>Max="5"</c>).
+    /// Must be a whole number greater than 1. See also <see cref="Value"/>.
     /// </summary>
     [Parameter]
     public byte? Max { get; set; }
 
     /// <summary>
-    /// Gets or sets the size of the rating items
+    /// Gets or sets the size of the rating items (e.g., <c>Size="RatingSize.Small"</c>).
     /// </summary>
     [Parameter]
     public RatingSize? Size { get; set; }
 
     /// <summary>
-    /// Gets or sets the shape
+    /// Gets or sets the icon used for each rating item (e.g., <c>Shape="new MyIcons.Star()"</c>).
+    /// Defaults to a star icon.
     /// </summary>
     [Parameter]
     public Icon? Shape { get; set; }
 
     /// <summary>
-    /// Gets or sets the value of the rating
+    /// Gets or sets the current rating value (e.g., <c>Value="3.5"</c>).
+    /// Must be between 0 and <see cref="Max"/>.
     /// </summary>
     [Parameter]
     public double? Value { get; set; }

--- a/src/Core/Components/Skeleton/FluentSkeleton.razor.cs
+++ b/src/Core/Components/Skeleton/FluentSkeleton.razor.cs
@@ -50,13 +50,15 @@ public partial class FluentSkeleton : FluentComponentBase
     public bool Visible { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets a value indicating whether the loading effect is visible.
+    /// Gets or sets a value indicating whether the shimmer animation (loading wave effect) is shown.
+    /// Distinct from <see cref="Visible"/>, which controls component visibility entirely.
     /// </summary>
     [Parameter]
     public bool Shimmer { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets a value indicating whether the skeleton in a circular mode.
+    /// Gets or sets a value indicating whether the skeleton is displayed as a circle.
+    /// When <see langword="true"/>, both <see cref="Width"/> and <see cref="Height"/> are set to the same value to form a circle.
     /// </summary>
     [Parameter]
     public bool Circular { get; set; }
@@ -74,8 +76,9 @@ public partial class FluentSkeleton : FluentComponentBase
     public string? Height { get; set; } = "48px";
 
     /// <summary>
-    /// Gets or sets the predefined skeleton pattern used to define the structure or layout of the component.
-    /// You can customize the skeleton's appearance by using <see cref="ChildContent" />
+    /// Gets or sets the predefined skeleton pattern used to define the structure or layout of the component
+    /// (e.g., <c>Pattern="SkeletonPattern.Article"</c>).
+    /// For custom layouts, use <see cref="ChildContent"/> instead.
     /// </summary>
     [Parameter]
     public SkeletonPattern? Pattern { get; set; }

--- a/src/Core/Components/Skeleton/FluentSkeleton.razor.cs
+++ b/src/Core/Components/Skeleton/FluentSkeleton.razor.cs
@@ -58,7 +58,7 @@ public partial class FluentSkeleton : FluentComponentBase
 
     /// <summary>
     /// Gets or sets a value indicating whether the skeleton is displayed as a circle.
-    /// When <see langword="true"/>, both <see cref="Width"/> and <see cref="Height"/> are set to the same value to form a circle.
+    /// When <see langword="true"/>, the component renders with equal width and height styles to form a circle (the parameter values themselves are not mutated).
     /// </summary>
     [Parameter]
     public bool Circular { get; set; }
@@ -76,7 +76,7 @@ public partial class FluentSkeleton : FluentComponentBase
     public string? Height { get; set; } = "48px";
 
     /// <summary>
-    /// Gets or sets the predefined skeleton pattern used to define the structure or layout of the component
+    /// Gets or sets the predefined skeleton pattern used to define the structure or layout of the component.
     /// (e.g., <c>Pattern="SkeletonPattern.Article"</c>).
     /// For custom layouts, use <see cref="ChildContent"/> instead.
     /// </summary>

--- a/src/Core/Components/Slider/FluentSlider.razor.cs
+++ b/src/Core/Components/Slider/FluentSlider.razor.cs
@@ -48,13 +48,15 @@ public partial class FluentSlider<TValue> : FluentInputBase<TValue>, ITooltipCom
     public SliderSize? Size { get; set; }
 
     /// <summary>
-    /// Gets or sets the slider's minimal value. Default is 0.
+    /// Gets or sets the slider's minimum value (e.g., <c>Min="0"</c>). Default is 0.
+    /// See also <see cref="Max"/>.
     /// </summary>
     [Parameter]
     public TValue? Min { get; set; }
 
     /// <summary>
-    /// Gets or sets the slider's maximum value. Default is 100.
+    /// Gets or sets the slider's maximum value (e.g., <c>Max="100"</c>). Default is 100.
+    /// See also <see cref="Min"/>.
     /// </summary>
     [Parameter]
     public TValue? Max { get; set; }
@@ -84,7 +86,7 @@ public partial class FluentSlider<TValue> : FluentInputBase<TValue>, ITooltipCom
     public string? Tooltip { get; set; }
 
     /// <summary>
-    /// Gets or sets the delay, in milliseconds, before to raise the change event.
+    /// Gets or sets the delay, in milliseconds, before raising the change event (e.g., <c>ImmediateDelay="100"</c>).
     /// </summary>
     [Parameter]
     public ushort ImmediateDelay { get; set; } = 60;


### PR DESCRIPTION
## Summary
Improves XML doc comments on `[Parameter]` properties in feedback and display components so the MCP server serves accurate descriptions to AI models.

## Components
| Component | Key Fixes |
|-----------|-----------|
| **FluentProgressBar / FluentSpinner** | `Thickness` name/description mismatch, swapped CSS cross-refs |
| **FluentSkeleton** | `Shimmer` ambiguous with `Visible`, grammar issues |
| **FluentRatingDisplay** | **Critical:** class summary was copy-pasted verbatim from `FluentProgressBar` |
| **FluentSlider** | `Min` said "minimal" (not a valid description), `ImmediateDelay` grammar |
| **FluentDatePicker / FluentTimePicker / FluentCalendar** | `Icon` same description as `Appearance`, empty summaries on several props |

## Part of
Part of #4777