### PR TITLE
Use an AssemblyLoadContext to read correct DLL versions

### DIFF
--- a/examples/Tools/FluentUI.Demo.DocApiGen.Tests/AssemblyLoading/PluginAssemblyLoadContextTests.cs
+++ b/examples/Tools/FluentUI.Demo.DocApiGen.Tests/AssemblyLoading/PluginAssemblyLoadContextTests.cs
@@ -1,0 +1,163 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Reflection;
+using FluentUI.Demo.DocApiGen.AssemblyLoading;
+using Xunit;
+
+namespace FluentUI.Demo.DocApiGen.Tests.AssemblyLoading;
+
+/// <summary>
+/// Regression tests for <see cref="PluginAssemblyLoadContext"/> dependency resolution behaviour.
+/// </summary>
+public class PluginAssemblyLoadContextTests
+{
+    // The test project has a project-reference to FluentUI.Demo.DocApiGen, so
+    // FluentUI.Demo.DocApiGen.dll is always co-located with this test assembly.
+    private const string DepAssemblyName = "FluentUI.Demo.DocApiGen";
+
+    private static string TestOutputDirectory =>
+        Path.GetDirectoryName(typeof(PluginAssemblyLoadContextTests).Assembly.Location)!;
+
+    // -----------------------------------------------------------------------
+    // Helper
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Creates a temporary plugin directory containing only the specified DLL files
+    /// (without any .deps.json) so the context falls through to directory probing.
+    /// Returns the temp directory path; the caller is responsible for deleting it.
+    /// </summary>
+    private static string CreateTempPluginDirectory(params string[] dllNames)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"docapigen_plc_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+
+        foreach (var name in dllNames)
+        {
+            File.Copy(
+                Path.Combine(TestOutputDirectory, name),
+                Path.Combine(dir, name));
+        }
+
+        return dir;
+    }
+
+    /// <summary>
+    /// Attempts to delete the temporary plugin directory.  Errors are swallowed because
+    /// DLL files can remain memory-mapped on Windows; cleanup does not affect assertions.
+    /// </summary>
+    private static void CleanupContext(PluginAssemblyLoadContext _, string pluginDir)
+    {
+        try
+        {
+            Directory.Delete(pluginDir, recursive: true);
+        }
+        catch (Exception)
+        {
+            // DLL files may still be memory-mapped on Windows; ignore cleanup errors.
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// When a dependency DLL is present in the plugin folder, <see cref="PluginAssemblyLoadContext"/>
+    /// must load it from that folder — not from wherever the default context already has it.
+    /// </summary>
+    [Fact]
+    public void Load_WhenDependencyExistsInPluginDirectory_ReturnsAssemblyFromPluginDirectory()
+    {
+        // Arrange: plugin dir contains both the anchor DLL and the dependency DLL.
+        // No .deps.json is present, so the context exercises the directory-probing
+        // fallback path in PluginAssemblyLoadContext.Load.
+        var pluginDir = CreateTempPluginDirectory(
+            "FluentUI.Demo.DocApiGen.Tests.dll",  // anchor (only used to root _pluginDirectory)
+            $"{DepAssemblyName}.dll");             // dependency to be resolved from plugin folder
+
+        var anchorPath = Path.Combine(pluginDir, "FluentUI.Demo.DocApiGen.Tests.dll");
+        var context = new PluginAssemblyLoadContext(anchorPath);
+        try
+        {
+            // Act: load the dependency by assembly name through the context.
+            var loaded = context.LoadFromAssemblyName(new AssemblyName(DepAssemblyName));
+
+            // Assert: the assembly came from the plugin folder, not the default output dir.
+            Assert.NotNull(loaded);
+            Assert.StartsWith(pluginDir, loaded.Location, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            CleanupContext(context, pluginDir);
+        }
+    }
+
+    /// <summary>
+    /// When a dependency DLL is absent from the plugin folder, <see cref="PluginAssemblyLoadContext"/>
+    /// must return <see langword="null"/> from <c>Load</c>, allowing the runtime to fall back to the
+    /// default context.  The assembly ultimately returned must come from outside the plugin folder.
+    /// </summary>
+    [Fact]
+    public void Load_WhenDependencyAbsentFromPluginDirectory_DefersToDefaultContext()
+    {
+        // Arrange: plugin dir contains ONLY the anchor DLL — the dependency is absent.
+        var pluginDir = CreateTempPluginDirectory("FluentUI.Demo.DocApiGen.Tests.dll");
+
+        var anchorPath = Path.Combine(pluginDir, "FluentUI.Demo.DocApiGen.Tests.dll");
+        var context = new PluginAssemblyLoadContext(anchorPath);
+        try
+        {
+            // Act: the dependency is missing from the plugin dir, so Load returns null and
+            // the runtime resolves it through the default AssemblyLoadContext.
+            var loaded = context.LoadFromAssemblyName(new AssemblyName(DepAssemblyName));
+
+            // Assert: the resolved assembly is NOT from the (empty) plugin folder.
+            Assert.NotNull(loaded);
+            Assert.False(
+                loaded.Location.StartsWith(pluginDir, StringComparison.OrdinalIgnoreCase),
+                $"Assembly should have been resolved from the default context, not the plugin folder. Location: {loaded.Location}");
+        }
+        finally
+        {
+            CleanupContext(context, pluginDir);
+        }
+    }
+
+    /// <summary>
+    /// Two separate <see cref="PluginAssemblyLoadContext"/> instances must each load their own
+    /// isolated copy of the same assembly, proving context isolation from the default load context.
+    /// </summary>
+    [Fact]
+    public void Load_TwoContextsWithSameDependency_LoadIsolatedInstances()
+    {
+        var pluginDirA = CreateTempPluginDirectory(
+            "FluentUI.Demo.DocApiGen.Tests.dll",
+            $"{DepAssemblyName}.dll");
+        var pluginDirB = CreateTempPluginDirectory(
+            "FluentUI.Demo.DocApiGen.Tests.dll",
+            $"{DepAssemblyName}.dll");
+
+        var contextA = new PluginAssemblyLoadContext(Path.Combine(pluginDirA, "FluentUI.Demo.DocApiGen.Tests.dll"));
+        var contextB = new PluginAssemblyLoadContext(Path.Combine(pluginDirB, "FluentUI.Demo.DocApiGen.Tests.dll"));
+        try
+        {
+            var assemblyA = contextA.LoadFromAssemblyName(new AssemblyName(DepAssemblyName));
+            var assemblyB = contextB.LoadFromAssemblyName(new AssemblyName(DepAssemblyName));
+
+            // Each context must yield a distinct assembly instance.
+            Assert.NotSame(assemblyA, assemblyB);
+
+            // And each must come from its own plugin folder.
+            Assert.StartsWith(pluginDirA, assemblyA.Location, StringComparison.OrdinalIgnoreCase);
+            Assert.StartsWith(pluginDirB, assemblyB.Location, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            CleanupContext(contextA, pluginDirA);
+            CleanupContext(contextB, pluginDirB);
+        }
+    }
+}

--- a/examples/Tools/FluentUI.Demo.DocApiGen/AssemblyLoading/PluginAssemblyLoadContext.cs
+++ b/examples/Tools/FluentUI.Demo.DocApiGen/AssemblyLoading/PluginAssemblyLoadContext.cs
@@ -1,0 +1,67 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Runtime.Versioning;
+
+namespace FluentUI.Demo.DocApiGen.AssemblyLoading;
+
+/// <summary>
+/// A custom <see cref="AssemblyLoadContext"/> that resolves dependency assemblies
+/// from the same directory as the target DLL, preventing version conflicts with
+/// assemblies already loaded in the default context.
+/// </summary>
+[SupportedOSPlatform("windows")]
+[SupportedOSPlatform("linux")]
+[SupportedOSPlatform("macos")]
+public sealed class PluginAssemblyLoadContext : AssemblyLoadContext
+{
+    private readonly string _pluginDirectory;
+    private readonly AssemblyDependencyResolver _resolver;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PluginAssemblyLoadContext"/> class.
+    /// </summary>
+    /// <param name="dllPath">The full path to the target assembly DLL.</param>
+    public PluginAssemblyLoadContext(string dllPath)
+        : base(name: Path.GetFileNameWithoutExtension(dllPath), isCollectible: true)
+    {
+        _pluginDirectory = Path.GetDirectoryName(dllPath)!;
+        _resolver = new AssemblyDependencyResolver(dllPath);
+    }
+
+    /// <inheritdoc/>
+    protected override Assembly? Load(AssemblyName assemblyName)
+    {
+        // First try the dependency resolver (uses the .deps.json next to the DLL)
+        var resolvedPath = _resolver.ResolveAssemblyToPath(assemblyName);
+        if (resolvedPath != null)
+        {
+            return LoadFromAssemblyPath(resolvedPath);
+        }
+
+        // Fall back to probing the plugin directory directly
+        var candidatePath = Path.Combine(_pluginDirectory, assemblyName.Name + ".dll");
+        if (File.Exists(candidatePath))
+        {
+            return LoadFromAssemblyPath(candidatePath);
+        }
+
+        // Let the default context handle anything else (BCL, hosting infrastructure, etc.)
+        return null;
+    }
+
+    /// <inheritdoc/>
+    protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
+    {
+        var resolvedPath = _resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
+        if (resolvedPath != null)
+        {
+            return LoadUnmanagedDllFromPath(resolvedPath);
+        }
+
+        return IntPtr.Zero;
+    }
+}

--- a/examples/Tools/FluentUI.Demo.DocApiGen/AssemblyLoading/PluginAssemblyLoadContext.cs
+++ b/examples/Tools/FluentUI.Demo.DocApiGen/AssemblyLoading/PluginAssemblyLoadContext.cs
@@ -13,9 +13,7 @@ namespace FluentUI.Demo.DocApiGen.AssemblyLoading;
 /// from the same directory as the target DLL, preventing version conflicts with
 /// assemblies already loaded in the default context.
 /// </summary>
-[SupportedOSPlatform("windows")]
-[SupportedOSPlatform("linux")]
-[SupportedOSPlatform("macos")]
+[UnsupportedOSPlatform("browser")]
 public sealed class PluginAssemblyLoadContext : AssemblyLoadContext
 {
     private readonly string _pluginDirectory;
@@ -26,7 +24,7 @@ public sealed class PluginAssemblyLoadContext : AssemblyLoadContext
     /// </summary>
     /// <param name="dllPath">The full path to the target assembly DLL.</param>
     public PluginAssemblyLoadContext(string dllPath)
-        : base(name: Path.GetFileNameWithoutExtension(dllPath), isCollectible: true)
+        : base(name: Path.GetFileNameWithoutExtension(dllPath), isCollectible: false)
     {
         _pluginDirectory = Path.GetDirectoryName(dllPath)!;
         _resolver = new AssemblyDependencyResolver(dllPath);

--- a/examples/Tools/FluentUI.Demo.DocApiGen/Program.cs
+++ b/examples/Tools/FluentUI.Demo.DocApiGen/Program.cs
@@ -2,11 +2,12 @@
 // This file is licensed to you under the MIT License.
 // ------------------------------------------------------------------------
 
+using System.Reflection;
 using FluentUI.Demo.DocApiGen.Abstractions;
+using FluentUI.Demo.DocApiGen.AssemblyLoading;
 using FluentUI.Demo.DocApiGen.Formatters;
 using FluentUI.Demo.DocApiGen.Generators;
 using Microsoft.Extensions.Configuration;
-using System.Reflection;
 
 namespace FluentUI.Demo.DocApiGen;
 
@@ -58,7 +59,15 @@ public class Program
             ValidateFormatCompatibility(mode, format);
 
             // Load assembly and XML documentation
-            var assembly = Assembly.LoadFile(dllFile);
+            // Use a custom AssemblyLoadContext so that dependencies (e.g. the core
+            // components DLL referenced by the charts DLL) are resolved from the
+            // same directory as the target DLL rather than from what is already
+            // loaded in the default context.
+#pragma warning disable CA1416
+            var loadContext = new PluginAssemblyLoadContext(dllFile);
+            var assembly = loadContext.LoadFromAssemblyPath(dllFile);
+#pragma warning restore CA1416
+
             var docXml = new FileInfo(xmlFile);
 
             Console.WriteLine("Generating documentation...");

--- a/examples/Tools/FluentUI.Demo.DocApiGen/Program.cs
+++ b/examples/Tools/FluentUI.Demo.DocApiGen/Program.cs
@@ -3,6 +3,7 @@
 // ------------------------------------------------------------------------
 
 using System.Reflection;
+using System.Runtime.Versioning;
 using FluentUI.Demo.DocApiGen.Abstractions;
 using FluentUI.Demo.DocApiGen.AssemblyLoading;
 using FluentUI.Demo.DocApiGen.Formatters;
@@ -14,6 +15,7 @@ namespace FluentUI.Demo.DocApiGen;
 /// <summary>
 /// Main entry point for the DocApiGen tool.
 /// </summary>
+[UnsupportedOSPlatform("browser")]
 public class Program
 {
     private static readonly System.Diagnostics.Stopwatch _watcher = new();
@@ -63,10 +65,8 @@ public class Program
             // components DLL referenced by the charts DLL) are resolved from the
             // same directory as the target DLL rather than from what is already
             // loaded in the default context.
-#pragma warning disable CA1416
             var loadContext = new PluginAssemblyLoadContext(dllFile);
             var assembly = loadContext.LoadFromAssemblyPath(dllFile);
-#pragma warning restore CA1416
 
             var docXml = new FileInfo(xmlFile);
 


### PR DESCRIPTION
This pull request introduces a custom assembly loading mechanism to the `FluentUI.Demo.DocApiGen` tool, ensuring that plugin assemblies and their dependencies are loaded from the correct directory and avoiding version conflicts. The main change is the addition of a new `PluginAssemblyLoadContext` class and its integration into the program's assembly loading logic.

**Assembly loading improvements:**

* Added a new `PluginAssemblyLoadContext` class in `PluginAssemblyLoadContext.cs` that inherits from `AssemblyLoadContext`. This class resolves managed and unmanaged dependencies from the same directory as the target DLL, preventing version conflicts with assemblies already loaded in the default context.
* Updated `Program.cs` to use `PluginAssemblyLoadContext` for loading the target assembly, replacing the previous use of `Assembly.LoadFile`. This ensures dependencies are resolved correctly for plugin scenarios.
* Added the appropriate `using` statement for the new assembly loading namespace in `Program.cs`.