### PR TITLE
[dev-v5] Enhance code `<c>` styling in MarkdownViewer

### DIFF
--- a/examples/Tools/FluentUI.Demo.DocViewer/Components/MarkdownViewer.razor.css
+++ b/examples/Tools/FluentUI.Demo.DocViewer/Components/MarkdownViewer.razor.css
@@ -55,11 +55,13 @@
     height: 20px;
   }
   /* Code */
-  .doc-viewer ::deep code {
+  .doc-viewer ::deep code,
+  .doc-viewer ::deep c {
     font-weight: 500;
     background-color: var(--colorNeutralBackground3);
     padding: 0px 4px;
-    overflow-wrap: anywhere
+    overflow-wrap: anywhere;
+    font-family: monospace;
   }
 
   .doc-viewer ::deep pre {

--- a/examples/Tools/FluentUI.Demo.DocViewer/Components/MarkdownViewer.razor.css
+++ b/examples/Tools/FluentUI.Demo.DocViewer/Components/MarkdownViewer.razor.css
@@ -61,7 +61,7 @@
     background-color: var(--colorNeutralBackground3);
     padding: 0px 4px;
     overflow-wrap: anywhere;
-    font-family: monospace;
+    font-family: var(--fontFamilyMonospace);
   }
 
   .doc-viewer ::deep pre {


### PR DESCRIPTION
# [dev-v5] Enhance code `<c>` styling in MarkdownViewer

Small change to display the tag `<c>` like `<code>`, used in `///` documentation.

<img width="953" height="183" alt="image" src="https://github.com/user-attachments/assets/7c8b1895-687f-4982-b049-f1caea6fe69c" />
