### PR TITLE
[dev-v5][Docs] Add search and filter for localization strings

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/General/Examples/LocalizationDefaultTranslations.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/General/Examples/LocalizationDefaultTranslations.razor
@@ -1,29 +1,54 @@
 ﻿@using System.Resources
 @using System.Globalization
 @using System.Collections
+<FluentStack Orientation="Orientation.Vertical">
+    <FluentStack VerticalAlignment="@VerticalAlignment.Center" Height="70px">
+        <FluentMenu>
+            <FluentMenuButton Appearance="ButtonAppearance.Transparent"
+                              IconStart="@(new Icons.Regular.Size20.Filter())">
+                Filter&nbsp;
+            </FluentMenuButton>
+            <FluentMenuList>
+                @foreach (var filter in Filters)
+                {
+                    <FluentMenuItem OnClick="@FilterClickHander">@filter</FluentMenuItem>
+                }
+            </FluentMenuList>
+        </FluentMenu>
 
-<table>
-    <thead>
-        <tr>
-            <th>Key</th>
-            <th>Default translation</th>
-        </tr>
-    </thead>
-    <tbody>
-        @foreach (var entry in _localizedStrings)
-        {
+        <FluentTextInput @bind-Value="Search" placeholder="Search..." Immediate="true" />
+
+    </FluentStack>
+    <table>
+        <thead>
             <tr>
-                <td>@entry.Key</td>
-                <td>@entry.Value</td>
+                <th>Key</th>
+                <th>Default translation</th>
             </tr>
-        }
-    </tbody>
-</table>
+        </thead>
+        <tbody>
+            @foreach (var entry in _localizedStrings)
+            {
+                if (string.IsNullOrEmpty(Search) ||
+                    entry.Key.Contains(Search, StringComparison.OrdinalIgnoreCase))
+                {
+                    <tr>
+                        <td>@entry.Key</td>
+                        <td>@entry.Value</td>
+                    </tr>
+                }
+            }
+        </tbody>
+    </table>
+</FluentStack>
 
 
 
 @code {
+    [SupplyParameterFromQuery(Name = "search")]
+    private string Search { get; set; } = "";
 
+    private string[] Filters { get; set; } = [];
     private Dictionary<string, string> _localizedStrings = [];
 
     protected override Task OnInitializedAsync()
@@ -34,18 +59,39 @@
 
         if (resourceSet is not null)
         {
-            _localizedStrings = resourceSet
+            var entries = resourceSet
                 .Cast<DictionaryEntry>()
-                .Where(e => e.Value is string)
-                .OrderBy(x => x.Key)
-                .ToDictionary(
-                    e => (string)e.Key,
-                    e => e.Value as string ?? string.Empty
-                );
+                .Where(e => e.Value is string && e.Key is string)
+                .Select(e => new
+                {
+                    Key = (string)e.Key,
+                    Value = (string)e.Value!
+                })
+                .OrderBy(e => e.Key)
+                .ToArray();
 
+            _localizedStrings = entries.ToDictionary(
+                e => e.Key,
+                e => e.Value!
+            );
+
+            Filters = entries
+                .Select(e =>
+                {
+                    var index = e.Key.IndexOf('_');
+                    return index >= 0
+                        ? e.Key[..index]
+                        : e.Key;
+                })
+                .Distinct()
+                .ToArray();
         }
 
         return base.OnInitializedAsync();
     }
 
+    private void FilterClickHander(MenuItemEventArgs item)
+    {
+        Search = item.Text ?? "";
+    }
 }

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/General/Examples/LocalizationDefaultTranslations.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/General/Examples/LocalizationDefaultTranslations.razor
@@ -3,7 +3,7 @@
 @using System.Collections
 <FluentStack Orientation="Orientation.Vertical">
     <FluentStack VerticalAlignment="@VerticalAlignment.Center" Height="70px">
-        <FluentMenu>
+        <FluentMenu Height="300px">
             <FluentMenuButton Appearance="ButtonAppearance.Transparent"
                               IconStart="@(new Icons.Regular.Size20.Filter())">
                 Filter&nbsp;
@@ -16,7 +16,14 @@
             </FluentMenuList>
         </FluentMenu>
 
-        <FluentTextInput @bind-Value="Search" placeholder="Search..." Immediate="true" />
+        <FluentTextInput @bind-Value="Search"
+                         placeholder="Search..."
+                         Spellcheck="false"
+                         ChangeAfterKeyPress="@([KeyPress.For(KeyCode.Enter)])">
+            <StartTemplate>
+                <FluentIcon Value="@(new Icons.Regular.Size16.Search())" Color="Color.Primary" />
+            </StartTemplate>
+        </FluentTextInput>
 
     </FluentStack>
     <table>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/General/Localization.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/General/Localization.md
@@ -131,4 +131,4 @@ You can use an embedded resource to store your translations.
 
 ## Default translations
 
-   {{ LocalizationDefaultTranslations SourceCode=false }}
+{{ LocalizationDefaultTranslations SourceCode=false }}


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR adds filter and search options for localization strings. This makes it possible to link from other documentations directly to all available translations for one component.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [ ] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
