### PR TITLE
[dev-v5] Implement nullable parameter validation in FluentInput components

### DIFF
--- a/src/Core/Components/Base/FluentInputBase.cs
+++ b/src/Core/Components/Base/FluentInputBase.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.FluentUI.AspNetCore.Components.Extensions;
 using Microsoft.FluentUI.AspNetCore.Components.Utilities;
 using Microsoft.JSInterop;
 
@@ -271,4 +272,27 @@ public abstract partial class FluentInputBase<TValue> : InputBase<TValue>, IFlue
     protected Task RenderTooltipAsync(string? label) => (_cachedServices ??= new CachedServices(ServiceProvider)).RenderTooltipAsync(this, label);
 
     #endregion
+
+    /// <summary>
+    /// Sets parameters supplied by the component's parent in the render tree.
+    /// </summary>
+    /// <param name="parameters">The parameters.</param>
+    /// <returns>A <see cref="Task"/> that completes when the component has finished updating and rendering itself.</returns>
+    /// <remarks>
+    /// <para>
+    /// Parameters are passed when <see cref="SetParametersAsync(ParameterView)"/> is called. It is not required that
+    /// the caller supply a parameter value for all of the parameters that are logically understood by the component.
+    /// </para>
+    /// <para>
+    /// The default implementation of <see cref="SetParametersAsync(ParameterView)"/> will set the value of each property
+    /// decorated with <see cref="ParameterAttribute" /> or <see cref="CascadingParameterAttribute" /> that has
+    /// a corresponding value in the <see cref="ParameterView" />. Parameters that do not have a corresponding value
+    /// will be unchanged.
+    /// </para>
+    /// </remarks>
+    public override Task SetParametersAsync(ParameterView parameters)
+    {
+        parameters.ThrowNullableParameters(component: this, parameterNames: nameof(Id));
+        return base.SetParametersAsync(parameters);
+    }
 }

--- a/src/Core/Extensions/FluentInputExtensions.cs
+++ b/src/Core/Extensions/FluentInputExtensions.cs
@@ -58,7 +58,7 @@ internal static class FluentInputExtensions
         {
             if (parameters.TryGetValue(parameterName, out object? value) && value is null)
             {
-                throw new InvalidOperationException($"The '{parameterName}' parameter of '{component.GetType().Name}' cannot be null.");
+                throw new InvalidOperationException($"The '{parameterName}' parameter of '{component.GetType().Name}' cannot be null. Omit the parameter to use the component default value, or provide a non-null value.");
             }
         }
     }

--- a/src/Core/Extensions/FluentInputExtensions.cs
+++ b/src/Core/Extensions/FluentInputExtensions.cs
@@ -52,6 +52,18 @@ internal static class FluentInputExtensions
     }
 
     /// <summary />
+    internal static void ThrowNullableParameters(this ParameterView parameters, ComponentBase component, params string[] parameterNames)
+    {
+        foreach (var parameterName in parameterNames)
+        {
+            if (parameters.TryGetValue(parameterName, out object? value) && value is null)
+            {
+                throw new InvalidOperationException($"The '{parameterName}' parameter of '{component.GetType().Name}' cannot be null.");
+            }
+        }
+    }
+
+    /// <summary />
     private static bool TryConvertToBool<TValue>(string? value, out TValue result)
     {
         if (bool.TryParse(value, out var @bool))

--- a/tests/Core/Extensions/FluentInputExtensionsTests.cs
+++ b/tests/Core/Extensions/FluentInputExtensionsTests.cs
@@ -99,7 +99,7 @@ public class FluentInputExtensionsTests
             () => parameters.ThrowNullableParameters(component, attributeName));
 
         // Assert
-        Assert.Equal("The 'Id' parameter of 'FluentSelect`2' cannot be null.", ex.Message);
+        Assert.Equal("The 'Id' parameter of 'FluentSelect`2' cannot be null. Omit the parameter to use the component default value, or provide a non-null value.", ex.Message);
     }
 
     [Fact]

--- a/tests/Core/Extensions/FluentInputExtensionsTests.cs
+++ b/tests/Core/Extensions/FluentInputExtensionsTests.cs
@@ -2,6 +2,7 @@
 // This file is licensed to you under the MIT License.
 // ------------------------------------------------------------------------
 
+using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components.Extensions;
 using Xunit;
 
@@ -79,5 +80,39 @@ public class FluentInputExtensionsTests
         Assert.True(ok == expectedValid);
         Assert.Equal(expectedResult, result);
         Assert.Equal(expectedValidationMessage, validationErrorMessage);
+    }
+
+    private const string attributeName = "Id";
+
+    [Fact]
+    public void FluentInputExtensions_ThrowNullableParameters_NullId_Throws()
+    {
+        // Arrange
+        var component = new FluentSelect<string, string>(LibraryConfiguration.Empty);
+        var parameters = ParameterView.FromDictionary(new Dictionary<string, object?>
+        {
+            { attributeName, null },
+        });
+
+        // Act
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => parameters.ThrowNullableParameters(component, attributeName));
+
+        // Assert
+        Assert.Equal("The 'Id' parameter of 'FluentSelect`2' cannot be null.", ex.Message);
+    }
+
+    [Fact]
+    public void FluentInputExtensions_ThrowNullableParameters_NonNullId_DoesNotThrow()
+    {
+        // Arrange
+        var component = new FluentSelect<string, string>(LibraryConfiguration.Empty);
+        var parameters = ParameterView.FromDictionary(new Dictionary<string, object?>
+        {
+            { attributeName, "my-id" },
+        });
+
+        // Act & Assert
+        parameters.ThrowNullableParameters(component, attributeName);
     }
 }


### PR DESCRIPTION
# [dev-v5] Implement nullable parameter validation in FluentInput components

Introduce validation for nullable parameters in **FluentInput** components to prevent `null` values from being assigned to critical parameters. 

This change enhances the robustness of the component by ensuring that required parameters are not null during rendering.

See #4846

For example, this code

```razor
<FluentDatePicker Label="Days view"
                  Id="@null"
                  @bind-Value="@SelectedValue" />
```

will generate this exception `System.InvalidOperationException: The 'Id' parameter of 'FluentDatePicker`1' cannot be null.`

## Unit Tests

Added