### PR TITLE
[dev-v5] Enhance dialog component with customizable header actions

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/Examples/Dialog/SimpleDialog.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/Examples/Dialog/SimpleDialog.razor
@@ -29,7 +29,7 @@
             await DialogInstance.CloseAsync("Yes");
         }
         else
-        {            
+        {
             await DialogInstance.CancelAsync();
         }
     }

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/Examples/DialogServiceCustomized.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/Examples/DialogServiceCustomized.razor
@@ -16,6 +16,7 @@
         var result = await DialogService.ShowDialogAsync<Dialog.CustomizedDialog>(options =>
         {
             options.Header.Title = "Dialog Title";
+            options.Header.CloseAction.Visible = true;
 
             options.Parameters.Add(nameof(Dialog.CustomizedDialog.Name), "John");  // Simple type
             options.Parameters.Add(nameof(Dialog.CustomizedDialog.Person), John);  // Updatable object

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/Examples/DialogServiceHeaderAction.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/Examples/DialogServiceHeaderAction.razor
@@ -1,0 +1,43 @@
+﻿@inject IDialogService DialogService
+
+<FluentButton OnClick="@OpenDialogAsync"
+              Appearance="ButtonAppearance.Primary">
+    Open Dialog
+</FluentButton>
+
+<hr />
+<div>
+    John: @John
+</div>
+
+@code
+{
+    private Dialog.PersonDetails John = new() { Age = "20" };
+
+    private async Task OpenDialogAsync()
+    {
+        var result = await DialogService.ShowDialogAsync<Dialog.SimpleDialog>(options =>
+        {
+            options.Modal = true;
+            options.Alignment = DialogAlignment.End;
+
+            options.Header.Title = "Dialog with Header Action";
+            options.Header.CloseAction.Visible = true;
+            options.Header.InfoAction.Visible = true;
+            options.Header.InfoAction.Label = "Info";
+            options.Header.InfoAction.OnClickAsync = async (e) => { await Task.CompletedTask; Console.WriteLine("Info action clicked"); };
+
+            options.Parameters.Add(nameof(Dialog.SimpleDialog.Name), "John"); // Simple type
+            options.Parameters.Add(nameof(Dialog.SimpleDialog.Person), John); // Updatable object
+        });
+
+        if (result.Cancelled)
+        {
+            Console.WriteLine($"Dialog Canceled: {result.Value}");
+        }
+        else
+        {
+            Console.WriteLine($"Dialog Saved: {result.Value}");
+        }
+    }
+}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/Examples/DialogServiceHeaderAction.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/Examples/DialogServiceHeaderAction.razor
@@ -23,9 +23,16 @@
 
             options.Header.Title = "Dialog with Header Action";
             options.Header.CloseAction.Visible = true;
+
             options.Header.InfoAction.Visible = true;
-            options.Header.InfoAction.Label = "Info";
-            options.Header.InfoAction.OnClickAsync = async (e) => { await Task.CompletedTask; Console.WriteLine("Info action clicked"); };
+            options.Header.InfoAction.OnClickAsync = async (dialog) => { await Task.CompletedTask; Console.WriteLine("Info action clicked"); };
+            
+            options.Header.AddAction(action =>
+            {
+                action.Icon = new Icons.Regular.Size20.Settings();
+                action.Label = "Settings";
+                action.OnClickAsync = async (dialog) => { await Task.CompletedTask; Console.WriteLine("Settings action clicked"); };
+            });
 
             options.Parameters.Add(nameof(Dialog.SimpleDialog.Name), "John"); // Simple type
             options.Parameters.Add(nameof(Dialog.SimpleDialog.Person), John); // Updatable object

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/Examples/DialogServiceHeaderAction.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/Examples/DialogServiceHeaderAction.razor
@@ -21,7 +21,6 @@
             options.Modal = true;
             options.Alignment = DialogAlignment.End;
 
-            options.Header.Title = "Dialog with Header Action";
             options.Header.CloseAction.Visible = true;
 
             options.Header.InfoAction.Visible = true;

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/FluentDialog.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/FluentDialog.md
@@ -103,7 +103,21 @@ var result = await DialogService.ShowDialogAsync<SimpleDialog>(options =>
 {
     options.Modal = true;
 });
-```` 
+```
+
+## Actions in the header
+
+{{ DialogServiceHeaderAction }}
+
+By default, the title and actions are aligned to the top of the header. When the title fits on a single line, 
+this can leave a small visible gap between the two. To vertically center the title and the actions 
+within the header, apply the following global style:
+
+```css
+fluent-dialog-body::part(title) {
+  align-items: center;
+}
+```
 
 ## Customized
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/FluentDialog.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/FluentDialog.md
@@ -107,6 +107,25 @@ var result = await DialogService.ShowDialogAsync<SimpleDialog>(options =>
 
 ## Actions in the header
 
+You can display action buttons (such as **Close** and **Info**) in the header of the dialog box.
+By default, these actions are **not displayed**. To enable them, set the `Visible` property to `true`
+on the corresponding action via `options.Header.CloseAction` or `options.Header.InfoAction`.
+
+```csharp
+options.Header.CloseAction.Visible = true;
+options.Header.InfoAction.Visible = true;
+```
+
+When the user clicks the **Close** button, the `FluentDialogInstance.OnActionClickedAsync(false)` method
+is called by default (which cancels the dialog). If you need a different behavior, you can override
+`OnActionClickedAsync` in your dialog component, or assign a custom handler directly to the action using
+the `OnClickAsync` property:
+
+```csharp
+options.Header.CloseAction.OnClickAsync = async (e) => { /* custom close logic */ };
+options.Header.InfoAction.OnClickAsync = async (e) => { /* custom info logic */ };
+```
+
 {{ DialogServiceHeaderAction }}
 
 By default, the title and actions are aligned to the top of the header. When the title fits on a single line, 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/FluentDialog.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/FluentDialog.md
@@ -138,6 +138,22 @@ fluent-dialog-body::part(title) {
 }
 ```
 
+In addition to the built-in **Close** and **Info** actions, you can add your own extra action buttons
+to the header by calling `options.Header.AddAction(...)`. Each call registers a new
+`DialogOptionsHeaderAction` which is rendered before the **Info** and **Close** buttons.
+
+```csharp
+options.Header.AddAction(action =>
+{
+    action.Icon = new Icons.Regular.Size20.Settings();
+    action.Tooltip = "Settings";
+    action.OnClickAsync = async (dialog) => { /* custom logic */ };
+});
+```
+
+> **Note:** Unlike `CloseAction` and `InfoAction`, extra actions have no default icon, so you must
+> assign an `Icon` (or a `Label`) for them to be displayed.
+
 ## Customized
 
 The previous `FluentDialogInstance` object is optional. You can create your own custom dialog box in two different ways.

--- a/src/Core/Components/Dialog/FluentDialogBody.razor
+++ b/src/Core/Components/Dialog/FluentDialogBody.razor
@@ -21,9 +21,38 @@
     }
 
     @* Header Action *@
-    @if (TitleActionTemplate is not null)
+    @if (TitleActionTemplate is not null || Instance?.Options.Header.HasActions == true)
     {
-        <div slot="@(IsDrawer() ? FluentSlot.DialogClose : FluentSlot.DialogTitleAction)">@TitleActionTemplate</div>
+        <div slot="@(IsDrawer() ? FluentSlot.DialogClose : FluentSlot.DialogTitleAction)" style="white-space: nowrap;">
+            @TitleActionTemplate
+
+            @if(Instance is not null)
+            {
+                foreach (var action in Instance.Options.Header.GetActions())
+                {
+                    if (action.ToDisplay)
+                    {
+                        if (string.IsNullOrEmpty(action.Label))
+                        {
+                            <FluentButton OnClick="@(async e => await ActionClickHandlerAsync(action))"
+                                          IconStart="@action.Icon"
+                                          IconOnly="true"
+                                          Tooltip="@action.Tooltip"
+                                          Appearance="ButtonAppearance.Transparent" />
+                        }
+                        else
+                        {
+                            <FluentButton OnClick="@(async e => await ActionClickHandlerAsync(action))"
+                                          IconStart="@action.Icon"
+                                          Tooltip="@action.Tooltip"
+                                          Appearance="ButtonAppearance.Transparent">
+                                @action.Label
+                            </FluentButton>
+                        }
+                    }
+                }
+            }
+        </div>
     }
 
     @* Content *@

--- a/src/Core/Components/Dialog/FluentDialogBody.razor
+++ b/src/Core/Components/Dialog/FluentDialogBody.razor
@@ -23,7 +23,7 @@
     @* Header Action *@
     @if (TitleActionTemplate is not null || Instance?.Options.Header.HasActions == true)
     {
-        <div slot="@(IsDrawer() ? FluentSlot.DialogClose : FluentSlot.DialogTitleAction)" style="white-space: nowrap;">
+        <div slot="@(IsDrawer() ? FluentSlot.DialogClose : FluentSlot.DialogTitleAction)">
             @TitleActionTemplate
 
             @if(Instance is not null)

--- a/src/Core/Components/Dialog/FluentDialogBody.razor
+++ b/src/Core/Components/Dialog/FluentDialogBody.razor
@@ -36,6 +36,7 @@
                                       IconStart="@action.Icon"
                                       IconOnly="@(action.Icon != null && string.IsNullOrEmpty(action.Label))"
                                       Tooltip="@action.Tooltip"
+                                      Title="@action.Title"
                                       Label="@action.Label"
                                       Appearance="ButtonAppearance.Transparent" />
                     }

--- a/src/Core/Components/Dialog/FluentDialogBody.razor
+++ b/src/Core/Components/Dialog/FluentDialogBody.razor
@@ -32,23 +32,12 @@
                 {
                     if (action.ToDisplay)
                     {
-                        if (string.IsNullOrEmpty(action.Label))
-                        {
-                            <FluentButton OnClick="@(async e => await ActionClickHandlerAsync(action))"
-                                          IconStart="@action.Icon"
-                                          IconOnly="true"
-                                          Tooltip="@action.Tooltip"
-                                          Appearance="ButtonAppearance.Transparent" />
-                        }
-                        else
-                        {
-                            <FluentButton OnClick="@(async e => await ActionClickHandlerAsync(action))"
-                                          IconStart="@action.Icon"
-                                          Tooltip="@action.Tooltip"
-                                          Appearance="ButtonAppearance.Transparent">
-                                @action.Label
-                            </FluentButton>
-                        }
+                        <FluentButton OnClick="@(async e => await ActionClickHandlerAsync(action))"
+                                      IconStart="@action.Icon"
+                                      IconOnly="@(action.Icon != null && string.IsNullOrEmpty(action.Label))"
+                                      Tooltip="@action.Tooltip"
+                                      ChildContent="@(builder => builder.AddContent(0, action.Label))"
+                                      Appearance="ButtonAppearance.Transparent" />
                     }
                 }
             }

--- a/src/Core/Components/Dialog/FluentDialogBody.razor
+++ b/src/Core/Components/Dialog/FluentDialogBody.razor
@@ -36,7 +36,7 @@
                                       IconStart="@action.Icon"
                                       IconOnly="@(action.Icon != null && string.IsNullOrEmpty(action.Label))"
                                       Tooltip="@action.Tooltip"
-                                      ChildContent="@(builder => builder.AddContent(0, action.Label))"
+                                      Label="@action.Label"
                                       Appearance="ButtonAppearance.Transparent" />
                     }
                 }

--- a/src/Core/Components/Dialog/FluentDialogBody.razor.cs
+++ b/src/Core/Components/Dialog/FluentDialogBody.razor.cs
@@ -79,6 +79,24 @@ public partial class FluentDialogBody : FluentComponentBase
     }
 
     /// <summary />
+    internal async Task ActionClickHandlerAsync(DialogOptionsHeaderAction item)
+    {
+        if (!item.Visible || Instance is null)
+        {
+            return;
+        }
+
+        if (item.OnClickAsync is not null)
+        {
+            await item.OnClickAsync(Instance);
+        }
+        else if (item.IsClosedAction)
+        {
+            await Instance.CloseAsync(DialogResult.Cancel());
+        }
+    }
+
+    /// <summary />
     private bool IsDrawer() => FluentDialog.IsDrawer(Instance);
 
 }

--- a/src/Core/Components/Dialog/FluentDialogBody.razor.css
+++ b/src/Core/Components/Dialog/FluentDialogBody.razor.css
@@ -101,17 +101,23 @@ fluent-drawer[fuib] fluent-drawer-body[fuib][scrollable]>div[slot="footer"] {
 
 /* Header Action Icon Button */
 fluent-dialog-body[fuib]>div[slot="title-action"],
-fluent-dialog-body[fuib]>div[slot="close"] {
+fluent-dialog-body[fuib]>div[slot="close"],
+fluent-drawer-body[fuib]>div[slot="title-action"],
+fluent-drawer-body[fuib]>div[slot="close"] {
     white-space: nowrap;
 }
 
 fluent-dialog-body[fuib]>div[slot="title-action"] fluent-button[icon-only]>svg,
-fluent-dialog-body[fuib]>div[slot="close"] fluent-button[icon-only]>svg {
+fluent-dialog-body[fuib]>div[slot="close"] fluent-button[icon-only]>svg,
+fluent-drawer-body[fuib]>div[slot="title-action"] fluent-button[icon-only]>svg,
+fluent-drawer-body[fuib]>div[slot="close"] fluent-button[icon-only]>svg  {
   min-width: 20px;
 }
 
 fluent-dialog-body[fuib]>div[slot="title-action"] fluent-button,
-fluent-dialog-body[fuib]>div[slot="close"] fluent-button {
+fluent-dialog-body[fuib]>div[slot="close"] fluent-button,
+fluent-drawer-body[fuib]>div[slot="title-action"] fluent-button,
+fluent-drawer-body[fuib]>div[slot="close"] fluent-button {
     min-width: 32px;
     padding: 0 var(--spacingHorizontalXS);
 }

--- a/src/Core/Components/Dialog/FluentDialogBody.razor.css
+++ b/src/Core/Components/Dialog/FluentDialogBody.razor.css
@@ -105,6 +105,12 @@ fluent-dialog-body[fuib]>div[slot="close"] fluent-button[icon-only]>svg {
   min-width: 20px;
 }
 
+fluent-dialog-body[fuib]>div[slot="title-action"] fluent-button,
+fluent-dialog-body[fuib]>div[slot="close"] fluent-button {
+    min-width: 32px;
+    padding: 0 var(--spacingHorizontalXS);
+}
+
 /* Mobile */
 @container (max-width: 479px) {
   fluent-dialog-body[fuib]>div[slot="action"] {

--- a/src/Core/Components/Dialog/FluentDialogBody.razor.css
+++ b/src/Core/Components/Dialog/FluentDialogBody.razor.css
@@ -100,6 +100,11 @@ fluent-drawer[fuib] fluent-drawer-body[fuib][scrollable]>div[slot="footer"] {
 }
 
 /* Header Action Icon Button */
+fluent-dialog-body[fuib]>div[slot="title-action"],
+fluent-dialog-body[fuib]>div[slot="close"] {
+    white-space: nowrap;
+}
+
 fluent-dialog-body[fuib]>div[slot="title-action"] fluent-button[icon-only]>svg,
 fluent-dialog-body[fuib]>div[slot="close"] fluent-button[icon-only]>svg {
   min-width: 20px;

--- a/src/Core/Components/Dialog/FluentDialogBody.razor.css
+++ b/src/Core/Components/Dialog/FluentDialogBody.razor.css
@@ -99,6 +99,12 @@ fluent-drawer[fuib] fluent-drawer-body[fuib][scrollable]>div[slot="footer"] {
   width: 100%;
 }
 
+/* Header Action Icon Button */
+fluent-dialog-body[fuib]>div[slot="title-action"] fluent-button[icon-only]>svg,
+fluent-dialog-body[fuib]>div[slot="close"] fluent-button[icon-only]>svg {
+  min-width: 20px;
+}
+
 /* Mobile */
 @container (max-width: 479px) {
   fluent-dialog-body[fuib]>div[slot="action"] {

--- a/src/Core/Components/Dialog/FluentDialogInstance.cs
+++ b/src/Core/Components/Dialog/FluentDialogInstance.cs
@@ -43,6 +43,9 @@ public abstract class FluentDialogInstance : ComponentBase
     /// <returns></returns>
     protected override Task OnInitializedAsync()
     {
+        var header = DialogInstance.Options.Header;
+        header.CloseAction.OnClickAsync ??= (e) => OnActionClickedAsync(primary: false);
+
         var footer = DialogInstance.Options.Footer;
         footer.PrimaryAction.Label ??= Localizer[LanguageResource.MessageBox_ButtonOk];
         footer.PrimaryAction.OnClickAsync ??= (e) => OnActionClickedAsync(primary: true);

--- a/src/Core/Components/Dialog/Services/DialogOptionsHeader.cs
+++ b/src/Core/Components/Dialog/Services/DialogOptionsHeader.cs
@@ -19,4 +19,23 @@ public class DialogOptionsHeader
     /// For security reasons, the content is sanitized using the configured <see cref="LibraryConfiguration.MarkupSanitized"/> before rendering.
     /// </summary>
     public string? Title { get; set; }
+
+    /// <summary>
+    /// Gets or sets the close action for the header.
+    /// When the user clicks the close action, the dialog will be closed with the result of <see cref="DialogResult{TContent}.Cancel()"/>.
+    /// </summary>
+    public DialogOptionsHeaderAction CloseAction { get; } = new(isClosedAction: true);
+
+    /// <summary>
+    /// Gets or sets the info action for the header.
+    /// When the user clicks the info action, the dialog will not be closed by default.
+    /// You can set the <see cref="DialogOptionsHeaderAction.OnClickAsync"/> property to handle the click event of the info action.
+    /// </summary>
+    public DialogOptionsHeaderAction InfoAction { get; } = new(isClosedAction: false);
+
+    /// <summary />
+    internal IEnumerable<DialogOptionsHeaderAction> GetActions() => [InfoAction, CloseAction];
+
+    /// <summary />
+    internal bool HasActions => CloseAction.ToDisplay || InfoAction.ToDisplay;
 }

--- a/src/Core/Components/Dialog/Services/DialogOptionsHeader.cs
+++ b/src/Core/Components/Dialog/Services/DialogOptionsHeader.cs
@@ -9,6 +9,8 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// </summary>
 public class DialogOptionsHeader
 {
+    private readonly List<DialogOptionsHeaderAction> _extraActions = [];
+
     /// <summary />
     public DialogOptionsHeader()
     {
@@ -33,9 +35,25 @@ public class DialogOptionsHeader
     /// </summary>
     public DialogOptionsHeaderAction InfoAction { get; } = new(isClosedAction: false);
 
-    /// <summary />
-    internal IEnumerable<DialogOptionsHeaderAction> GetActions() => [InfoAction, CloseAction];
+    /// <summary>
+    /// Adds an extra action button to the dialog header.
+    /// Extra actions are displayed before the <see cref="InfoAction"/> and the <see cref="CloseAction"/>.
+    /// </summary>
+    /// <param name="options">A delegate used to configure the new <see cref="DialogOptionsHeaderAction"/>.</param>
+    /// <returns>The newly created <see cref="DialogOptionsHeaderAction"/>.</returns>
+    public DialogOptionsHeaderAction AddAction(Action<DialogOptionsHeaderAction> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var action = new DialogOptionsHeaderAction() { Visible = true };
+        options(action);
+        _extraActions.Add(action);
+        return action;
+    }
 
     /// <summary />
-    internal bool HasActions => CloseAction.ToDisplay || InfoAction.ToDisplay;
+    internal IEnumerable<DialogOptionsHeaderAction> GetActions() => [.. _extraActions, InfoAction, CloseAction];
+
+    /// <summary />
+    internal bool HasActions => CloseAction.ToDisplay || InfoAction.ToDisplay || _extraActions.Any(a => a.ToDisplay);
 }

--- a/src/Core/Components/Dialog/Services/DialogOptionsHeaderAction.cs
+++ b/src/Core/Components/Dialog/Services/DialogOptionsHeaderAction.cs
@@ -53,6 +53,11 @@ public class DialogOptionsHeaderAction
     public string? Tooltip { get; set; }
 
     /// <summary>
+    /// Gets or sets the title of the action button.
+    /// </summary>
+    public string? Title { get; set; }
+
+    /// <summary>
     /// Gets or sets whether the action button is visible.
     /// </summary>
     public bool Visible { get; set; }

--- a/src/Core/Components/Dialog/Services/DialogOptionsHeaderAction.cs
+++ b/src/Core/Components/Dialog/Services/DialogOptionsHeaderAction.cs
@@ -1,0 +1,67 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// Options for configuring a dialog footer action button.
+/// </summary>
+public class DialogOptionsHeaderAction
+{
+    /// <summary />
+    public DialogOptionsHeaderAction()
+    {
+    }
+
+    /// <summary />
+    internal DialogOptionsHeaderAction(bool isClosedAction)
+    {
+        IsClosedAction = isClosedAction;
+
+        if (isClosedAction)
+        {
+            Icon = new CoreIcons.Regular.Size20.Dismiss();
+        }
+        else
+        {
+            Icon = new CoreIcons.Regular.Size20.Info();
+        }
+    }
+
+    /// <summary />
+    internal bool IsClosedAction { get; init; }
+
+    /// <summary>
+    /// Gets or sets the icon of the action button.
+    /// </summary>
+    public Icon? Icon { get; set; }
+
+    /// <summary>
+    /// Gets or sets the label of the action button.
+    /// By default, this label is not set. So, only the icon will be displayed.
+    /// </summary>
+    public string? Label { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tooltip text of the action button (supports HTML tags).
+    /// This parameter requires the presence of a 'FluentTooltipProvider' in your main/layout page.
+    /// </summary>
+    /// <remarks>
+    /// This parameter cannot be updated after the component has been rendered.
+    /// </remarks>
+    public string? Tooltip { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the action button is visible.
+    /// </summary>
+    public bool Visible { get; set; }
+
+    /// <summary>
+    /// Gets or sets the action to be performed when the action button is clicked.
+    /// </summary>
+    public Func<IDialogInstance, Task>? OnClickAsync { get; set; }
+
+    /// <summary />
+    internal bool ToDisplay => (!string.IsNullOrEmpty(Label) || Icon is not null) && Visible;
+}

--- a/src/Core/Components/Dialog/Services/DialogOptionsHeaderAction.cs
+++ b/src/Core/Components/Dialog/Services/DialogOptionsHeaderAction.cs
@@ -5,7 +5,7 @@
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 /// <summary>
-/// Options for configuring a dialog footer action button.
+/// Options for configuring a dialog header action button.
 /// </summary>
 public class DialogOptionsHeaderAction
 {

--- a/tests/Core/Components/Dialog/DialogOptionsHeaderTests.cs
+++ b/tests/Core/Components/Dialog/DialogOptionsHeaderTests.cs
@@ -80,12 +80,14 @@ public class DialogOptionsHeaderTests
         {
             a.Label = "Help";
             a.Tooltip = "Get some help";
+            a.Title = "Help";
         });
 
         // Assert
         Assert.NotNull(action);
         Assert.Equal("Help", action.Label);
         Assert.Equal("Get some help", action.Tooltip);
+        Assert.Equal("Help", action.Title);
         Assert.True(action.Visible);
         Assert.True(action.ToDisplay);
         Assert.True(header.HasActions);

--- a/tests/Core/Components/Dialog/DialogOptionsHeaderTests.cs
+++ b/tests/Core/Components/Dialog/DialogOptionsHeaderTests.cs
@@ -1,0 +1,157 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using Xunit;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Tests.Components.Dialog;
+
+public class DialogOptionsHeaderTests
+{
+    [Fact]
+    public void DialogOptionsHeader_DefaultValues()
+    {
+        // Arrange & Act
+        var header = new DialogOptionsHeader();
+
+        // Assert
+        Assert.Null(header.Title);
+        Assert.NotNull(header.CloseAction);
+        Assert.NotNull(header.InfoAction);
+        Assert.True(header.CloseAction.IsClosedAction);
+        Assert.False(header.InfoAction.IsClosedAction);
+        Assert.IsType<CoreIcons.Regular.Size20.Dismiss>(header.CloseAction.Icon);
+        Assert.IsType<CoreIcons.Regular.Size20.Info>(header.InfoAction.Icon);
+
+        // No actions are visible by default
+        Assert.False(header.HasActions);
+    }
+
+    [Fact]
+    public void DialogOptionsHeader_CloseAction_Visible()
+    {
+        // Arrange
+        var header = new DialogOptionsHeader();
+
+        // Act
+        header.CloseAction.Visible = true;
+
+        // Assert
+        Assert.True(header.CloseAction.ToDisplay);
+        Assert.True(header.HasActions);
+    }
+
+    [Fact]
+    public void DialogOptionsHeader_InfoAction_Visible()
+    {
+        // Arrange
+        var header = new DialogOptionsHeader();
+
+        // Act
+        header.InfoAction.Visible = true;
+
+        // Assert
+        Assert.True(header.InfoAction.ToDisplay);
+        Assert.True(header.HasActions);
+    }
+
+    [Fact]
+    public void DialogOptionsHeader_InfoAction_NoIconAndNoLabel_NotDisplayed()
+    {
+        // Arrange
+        var header = new DialogOptionsHeader();
+        header.InfoAction.Visible = true;
+        header.InfoAction.Icon = null;
+        header.InfoAction.Label = null;
+
+        // Assert
+        Assert.False(header.InfoAction.ToDisplay);
+        Assert.False(header.HasActions);
+    }
+
+    [Fact]
+    public void DialogOptionsHeader_AddAction_AppendsExtraAction()
+    {
+        // Arrange
+        var header = new DialogOptionsHeader();
+
+        // Act
+        var action = header.AddAction(a =>
+        {
+            a.Label = "Help";
+            a.Tooltip = "Get some help";
+        });
+
+        // Assert
+        Assert.NotNull(action);
+        Assert.Equal("Help", action.Label);
+        Assert.Equal("Get some help", action.Tooltip);
+        Assert.True(action.Visible);
+        Assert.True(action.ToDisplay);
+        Assert.True(header.HasActions);
+    }
+
+    [Fact]
+    public void DialogOptionsHeader_AddAction_NullOptions_Throws()
+    {
+        // Arrange
+        var header = new DialogOptionsHeader();
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => header.AddAction(null!));
+    }
+
+    [Fact]
+    public void DialogOptionsHeader_GetActions_ReturnsExtrasThenInfoThenClose()
+    {
+        // Arrange
+        var header = new DialogOptionsHeader();
+        var first = header.AddAction(a => a.Label = "First");
+        var second = header.AddAction(a => a.Label = "Second");
+
+        // Act
+        var actions = header.GetActions().ToList();
+
+        // Assert
+        Assert.Equal(4, actions.Count);
+        Assert.Same(first, actions[0]);
+        Assert.Same(second, actions[1]);
+        Assert.Same(header.InfoAction, actions[2]);
+        Assert.Same(header.CloseAction, actions[3]);
+    }
+
+    [Fact]
+    public void DialogOptionsHeader_HasActions_TrueWhenExtraActionVisible()
+    {
+        // Arrange
+        var header = new DialogOptionsHeader();
+        header.AddAction(a => a.Label = "Custom");
+
+        // Assert
+        Assert.True(header.HasActions);
+    }
+
+    [Fact]
+    public async Task DialogOptionsHeader_AddAction_OnClickAsync_IsInvoked()
+    {
+        // Arrange
+        var header = new DialogOptionsHeader();
+        var clicked = false;
+
+        var action = header.AddAction(a =>
+        {
+            a.Label = "Run";
+            a.OnClickAsync = _ =>
+            {
+                clicked = true;
+                return Task.CompletedTask;
+            };
+        });
+
+        // Act
+        await action.OnClickAsync!(null!);
+
+        // Assert
+        Assert.True(clicked);
+    }
+}

--- a/tests/Core/Components/Dialog/FluentDialogBodyTests.razor
+++ b/tests/Core/Components/Dialog/FluentDialogBodyTests.razor
@@ -85,6 +85,192 @@
     }
 
     [Fact]
+    public async Task FluentDialogBody_HeaderActions()
+    {
+        // Arrange
+        var infoClicked = false;
+        var extraClicked = false;
+        var closeClicked = false;
+
+        var options = new DialogOptions();
+        var instance = new DialogInstance(DialogService, typeof(Templates.DialogRender), options);
+
+        options.Header.Title = "My title";
+
+        // Close action (visible)
+        options.Header.CloseAction.Visible = true;
+        options.Header.CloseAction.Tooltip = "Close me";
+        options.Header.CloseAction.OnClickAsync = (e) =>
+        {
+            closeClicked = true;
+            return Task.CompletedTask;
+        };
+
+        // Info action (visible, with label)
+        options.Header.InfoAction.Visible = true;
+        options.Header.InfoAction.Label = "Info";
+        options.Header.InfoAction.OnClickAsync = (e) =>
+        {
+            infoClicked = true;
+            return Task.CompletedTask;
+        };
+
+        // Extra action (visible by default when added)
+        var extraAction = options.Header.AddAction(a =>
+        {
+            a.Label = "Help";
+            a.Tooltip = "Get help";
+            a.OnClickAsync = (e) =>
+            {
+                extraClicked = true;
+                return Task.CompletedTask;
+            };
+        });
+
+        // Hidden extra action (should not be rendered)
+        options.Header.AddAction(a =>
+        {
+            a.Label = "Hidden";
+            a.Visible = false;
+        });
+
+        // Act
+        var cut = Render(
+    @<CascadingValue Value="@instance">
+        <FluentDialogBody>My content</FluentDialogBody>
+    </CascadingValue>
+    );
+
+        // Assert - 3 visible header buttons (extra + info + close)
+        var titleActionSlot = cut.Find($"div[slot=\"{FluentSlot.DialogTitleAction}\"]");
+        var buttons = titleActionSlot.QuerySelectorAll("fluent-button");
+        Assert.Equal(3, buttons.Length);
+
+        // Trigger each header action and verify the corresponding handler ran
+        var body = cut.FindComponent<FluentDialogBody>();
+
+        await body.Instance.ActionClickHandlerAsync(extraAction);
+        Assert.True(extraClicked);
+
+        await body.Instance.ActionClickHandlerAsync(options.Header.InfoAction);
+        Assert.True(infoClicked);
+
+        await body.Instance.ActionClickHandlerAsync(options.Header.CloseAction);
+        Assert.True(closeClicked);
+    }
+
+    [Fact]
+    public async Task FluentDialogBody_HeaderAction_NotVisible_DoesNothing()
+    {
+        // Arrange
+        var clicked = false;
+
+        var options = new DialogOptions();
+        var instance = new DialogInstance(DialogService, typeof(Templates.DialogRender), options);
+
+        var action = options.Header.AddAction(a =>
+        {
+            a.Label = "Hidden";
+            a.OnClickAsync = (e) =>
+            {
+                clicked = true;
+                return Task.CompletedTask;
+            };
+        });
+        action.Visible = false;
+
+        var cut = Render(
+    @<CascadingValue Value="@instance">
+        <FluentDialogBody>My content</FluentDialogBody>
+    </CascadingValue>
+    );
+
+        // Act
+        var body = cut.FindComponent<FluentDialogBody>();
+        await body.Instance.ActionClickHandlerAsync(action);
+
+        // Assert - handler not invoked when action is not visible
+        Assert.False(clicked);
+    }
+
+    [Fact]
+    public async Task FluentDialogBody_HeaderAction_NullInstance_DoesNothing()
+    {
+        // Arrange - render the body without any cascading IDialogInstance
+        var clicked = false;
+
+        var action = new DialogOptionsHeaderAction
+        {
+            Visible = true,
+            Label = "Action",
+            OnClickAsync = (e) =>
+            {
+                clicked = true;
+                return Task.CompletedTask;
+            }
+        };
+
+        var cut = Render(@<FluentDialogBody>My content</FluentDialogBody>);
+
+        // Act - should not throw even when Instance is null
+        var body = cut.FindComponent<FluentDialogBody>();
+        await body.Instance.ActionClickHandlerAsync(action);
+
+        // Assert
+        Assert.False(clicked);
+    }
+
+    [Fact]
+    public async Task FluentDialogBody_HeaderAction_CloseAction_NoHandler_ClosesWithCancel()
+    {
+        // Arrange - open a real dialog through the service so CloseAsync is wired up
+        var dialogOptions = new DialogOptions();
+        dialogOptions.Header.CloseAction.Visible = true;
+        // No custom OnClickAsync: default IsClosedAction path should close with Cancel.
+        dialogOptions.Header.CloseAction.OnClickAsync = null;
+        dialogOptions.Parameters.Add(nameof(Templates.DialogRender.Options), new Templates.DialogRenderOptions());
+        dialogOptions.Parameters.Add(nameof(Templates.DialogRender.Name), "John");
+
+        var dialogTask = DialogService.ShowDialogAsync<Templates.DialogRender>(dialogOptions);
+
+        await Task.Yield();
+
+        var body = DialogProvider.FindComponents<FluentDialogBody>().First().Instance;
+
+        // Act
+        await body.ActionClickHandlerAsync(dialogOptions.Header.CloseAction);
+
+        // Assert
+        var result = await dialogTask;
+        Assert.True(result.Cancelled);
+    }
+
+    [Fact]
+    public async Task FluentDialogBody_HeaderAction_NonClosedAction_NoHandler_DoesNothing()
+    {
+        // Arrange - InfoAction is not a closed action: with no handler nothing should happen
+        var options = new DialogOptions();
+        var instance = new DialogInstance(DialogService, typeof(Templates.DialogRender), options);
+
+        options.Header.InfoAction.Visible = true;
+        options.Header.InfoAction.Label = "Info";
+        options.Header.InfoAction.OnClickAsync = null;
+
+        var cut = Render(
+    @<CascadingValue Value="@instance">
+        <FluentDialogBody>My content</FluentDialogBody>
+    </CascadingValue>
+    );
+
+        // Act - should not throw and should not complete the dialog result
+        var body = cut.FindComponent<FluentDialogBody>();
+        await body.Instance.ActionClickHandlerAsync(options.Header.InfoAction);
+
+        // Assert
+        Assert.False(instance.Result.IsCompleted);
+    }
+
+    [Fact]
     public void FluentDialogBody_FixedHeaderFooter_False()
     {
         var cut = Render(@<FluentDialogBody FixedHeaderFooter="false"></FluentDialogBody>);

--- a/tests/Core/Components/Dialog/FluentDialogBodyTests.razor
+++ b/tests/Core/Components/Dialog/FluentDialogBodyTests.razor
@@ -100,6 +100,7 @@
         // Close action (visible)
         options.Header.CloseAction.Visible = true;
         options.Header.CloseAction.Tooltip = "Close me";
+        options.Header.CloseAction.Title = "Close";
         options.Header.CloseAction.OnClickAsync = (e) =>
         {
             closeClicked = true;


### PR DESCRIPTION
# [dev-v5] Enhance dialog component with customizable header actions

Improve the dialog component by adding support for customizable header action buttons, including visibility and click handlers. This update allows for a more flexible and user-friendly dialog experience.

You can display action buttons (such as **Close** and **Info**) in the header of the dialog box.
By default, these actions are **not displayed**. To enable them, set the `Visible` property to `true`
on the corresponding action via `options.Header.CloseAction` or `options.Header.InfoAction`.

```csharp
options.Header.CloseAction.Visible = true;
options.Header.InfoAction.Visible = true;
```

When the user clicks the **Close** button, the `FluentDialogInstance.OnActionClickedAsync(false)` method
is called by default (which cancels the dialog). If you need a different behavior, you can override
`OnActionClickedAsync` in your dialog component, or assign a custom handler directly to the action using
the `OnClickAsync` property:

```csharp
options.Header.CloseAction.OnClickAsync = async (e) => { /* custom close logic */ };
options.Header.InfoAction.OnClickAsync = async (e) => { /* custom info logic */ };
```

<img width="964" height="707" alt="image" src="https://github.com/user-attachments/assets/c92ff73f-5e2b-4fd0-9bdb-a0dd82221184" />

By default, the title and actions are aligned to the top of the header. When the title fits on a single line, 
this can leave a small visible gap between the two. To vertically center the title and the actions 
within the header, apply the following global style:

```css
fluent-dialog-body::part(title) {
  align-items: center;
}
```

In addition to the built-in **Close** and **Info** actions, you can add your own extra action buttons
to the header by calling `options.Header.AddAction(...)`. Each call registers a new
`DialogOptionsHeaderAction` which is rendered before the **Info** and **Close** buttons.

```csharp
options.Header.AddAction(action =>
{
    action.Icon = new Icons.Regular.Size20.Settings();
    action.Tooltip = "Settings";
    action.OnClickAsync = async (dialog) => { /* custom logic */ };
});
```

> **Note:** Unlike `CloseAction` and `InfoAction`, extra actions have no default icon, so you must
> assign an `Icon` (or a `Label`) for them to be displayed.

## Unit Tests

- Existing tests: no changes
- New tests => 100%

#See 4837