### PR TITLE
[dev-v5] Fix dialog height for better mobile support

### DIFF
--- a/src/Core/Components/Dialog/FluentDialogBody.razor.css
+++ b/src/Core/Components/Dialog/FluentDialogBody.razor.css
@@ -5,8 +5,10 @@
 
 /* Dialog -> scrollable = false */
 fluent-dialog[fuib] fluent-dialog-body[fuib]:not([scrollable]) {
-  grid-template-rows: auto 1fr auto;
+  grid-template-rows: auto minmax(0, 1fr) auto;
   height: 100%;
+  height: -webkit-fill-available; /* Safari */
+  min-height: 100%;
 }
 
 fluent-dialog[fuib] fluent-dialog-body[fuib]:not([scrollable])>div[slot="action"] {
@@ -21,6 +23,8 @@ fluent-dialog[fuib] fluent-dialog-body[fuib][scrollable] {
   padding: 0;
   overflow: hidden;
   height: 100%;
+  height: -webkit-fill-available; /* Safari */
+  min-height: 100%;
 }
 
 fluent-dialog[fuib] fluent-dialog-body[fuib][scrollable]::part(title) {
@@ -45,12 +49,14 @@ fluent-dialog[fuib] fluent-dialog-body[fuib][scrollable]>div[slot="action"] {
 /* Dialog Alignment*/
 fluent-dialog[fuib][position="end"]::part(dialog) {
   margin-inline: auto 0px;
-  height: 100%;
+  height: 100vh;
+  max-height: 100vh;
 }
 
 fluent-dialog[fuib][position="start"]::part(dialog) {
   margin-inline: 0px auto;
-  height: 100%;
+  height: 100vh;
+  max-height: 100vh;
 }
 
 /* Drawer -> scrollable = false */

--- a/src/Core/Components/Dialog/FluentDialogBody.razor.css
+++ b/src/Core/Components/Dialog/FluentDialogBody.razor.css
@@ -6,9 +6,6 @@
 /* Dialog -> scrollable = false */
 fluent-dialog[fuib] fluent-dialog-body[fuib]:not([scrollable]) {
   grid-template-rows: auto minmax(0, 1fr) auto;
-  height: 100%;
-  height: -webkit-fill-available; /* Safari */
-  min-height: 100%;
 }
 
 fluent-dialog[fuib] fluent-dialog-body[fuib]:not([scrollable])>div[slot="action"] {
@@ -22,9 +19,6 @@ fluent-dialog[fuib] fluent-dialog-body[fuib][scrollable] {
   grid-template-rows: min-content minmax(0, 1fr) min-content;
   padding: 0;
   overflow: hidden;
-  height: 100%;
-  height: -webkit-fill-available; /* Safari */
-  min-height: 100%;
 }
 
 fluent-dialog[fuib] fluent-dialog-body[fuib][scrollable]::part(title) {
@@ -47,16 +41,22 @@ fluent-dialog[fuib] fluent-dialog-body[fuib][scrollable]>div[slot="action"] {
 }
 
 /* Dialog Alignment*/
+fluent-dialog[fuib][position="end"] fluent-dialog-body,
+fluent-dialog[fuib][position="start"] fluent-dialog-body {
+  height: 100dvh;
+  max-height: 100dvh;
+}
+
 fluent-dialog[fuib][position="end"]::part(dialog) {
   margin-inline: auto 0px;
-  height: 100vh;
-  max-height: 100vh;
+  height: 100dvh;
+  max-height: 100dvh;
 }
 
 fluent-dialog[fuib][position="start"]::part(dialog) {
   margin-inline: 0px auto;
-  height: 100vh;
-  max-height: 100vh;
+  height: 100dvh;
+  max-height: 100dvh;
 }
 
 /* Drawer -> scrollable = false */

--- a/src/Core/Components/Dialog/FluentDialogBody.razor.css
+++ b/src/Core/Components/Dialog/FluentDialogBody.razor.css
@@ -5,7 +5,7 @@
 
 /* Dialog -> scrollable = false */
 fluent-dialog[fuib] fluent-dialog-body[fuib]:not([scrollable]) {
-  grid-template-rows: auto minmax(0, 1fr) auto;
+  grid-template-rows: min-content minmax(0, 1fr) min-content;
 }
 
 fluent-dialog[fuib] fluent-dialog-body[fuib]:not([scrollable])>div[slot="action"] {
@@ -43,20 +43,20 @@ fluent-dialog[fuib] fluent-dialog-body[fuib][scrollable]>div[slot="action"] {
 /* Dialog Alignment*/
 fluent-dialog[fuib][position="end"] fluent-dialog-body,
 fluent-dialog[fuib][position="start"] fluent-dialog-body {
-  height: 100dvh;
-  max-height: 100dvh;
+  height: 100%;
+  max-height: 100svh;
 }
 
 fluent-dialog[fuib][position="end"]::part(dialog) {
   margin-inline: auto 0px;
-  height: 100dvh;
-  max-height: 100dvh;
+  height: 100%;
+  max-height: 100vh;
 }
 
 fluent-dialog[fuib][position="start"]::part(dialog) {
   margin-inline: 0px auto;
-  height: 100dvh;
-  max-height: 100dvh;
+  height: 100%;
+  max-height: 100vh;
 }
 
 /* Drawer -> scrollable = false */


### PR DESCRIPTION
# [dev-v5] Fix dialog height for better mobile support

It's not perfect, but the dialog box is “usable” (a scroll is possible). 
Need more investigation

<img height="1000" alt="image" src="https://github.com/user-attachments/assets/a12d7a18-4b23-4dbd-b8f2-eaef1ec9baea" />
