### PR TITLE
[dev-v5] Add global overlay support with IDialogService integration

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/Examples/Dialog/SimpleDialog.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/Examples/Dialog/SimpleDialog.razor
@@ -1,4 +1,5 @@
 ﻿@inherits FluentDialogInstance
+@inject IDialogService DialogService
 
 <FluentDialogBody>
     <FluentTextInput Label="Name:" @bind-Value="@Name" Disabled="true" Style="max-width: 100%;" />
@@ -26,11 +27,14 @@
     {
         if (primary)
         {
-            await DialogInstance.CloseAsync("Yes");
+            await DialogService.ShowOverlayAsync(options =>
+            {
+                options.Text = "Saving...";
+            });            
         }
         else
         {
-            await DialogInstance.CancelAsync();
+            await DialogService.HideOverlayAsync();
         }
     }
 }

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/Examples/Dialog/SimpleDialog.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/Examples/Dialog/SimpleDialog.razor
@@ -1,5 +1,4 @@
 ﻿@inherits FluentDialogInstance
-@inject IDialogService DialogService
 
 <FluentDialogBody>
     <FluentTextInput Label="Name:" @bind-Value="@Name" Disabled="true" Style="max-width: 100%;" />
@@ -27,14 +26,11 @@
     {
         if (primary)
         {
-            await DialogService.ShowOverlayAsync(options =>
-            {
-                options.Text = "Saving...";
-            });            
+            await DialogInstance.CloseAsync("Yes");
         }
         else
         {
-            await DialogService.HideOverlayAsync();
+            await DialogInstance.CancelAsync();
         }
     }
 }

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Overlay/Examples/OverlayService.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Overlay/Examples/OverlayService.razor
@@ -1,4 +1,4 @@
-﻿@inject IDialogService DialogService
+@inject IDialogService DialogService
 
 <FluentStack Wrap="true" HorizontalGap="24px">
     <FluentTextInput Label="Overlay Text"
@@ -27,9 +27,14 @@
             options.CardAppearance = appearance;
         });
 
-        // Simulate a long-running operation
-        await Task.Delay(5000);
-
-        await DialogService.HideOverlayAsync();
+        try
+        {
+            // Simulate a long-running operation
+            await Task.Delay(5000);
+        }
+        finally
+        {
+            await DialogService.HideOverlayAsync();
+        }
     }
 }

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Overlay/Examples/OverlayService.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Overlay/Examples/OverlayService.razor
@@ -4,9 +4,13 @@
     <FluentTextInput Label="Overlay Text"
                      @bind-Value="overlayText" />
 
-    <FluentSelect Items="@GetEnumValues()"
+    <FluentSelect Items="@GetAppearanceValues()"
                   Label="Appearance"
                   @bind-Value="appearance" />
+
+    <FluentSelect Items="@GetSpinnerSizes()"
+                  Label="Spinner Size"
+                  @bind-Value="spinnerSize" />
 </FluentStack>
 
 <FluentButton OnClick="@DisplayOverlay">
@@ -17,7 +21,9 @@
 {
     string overlayText = "Processing...";
     CardAppearance? appearance = null;
-    IEnumerable<CardAppearance?> GetEnumValues() => (new CardAppearance?[] { null }).Union(Enum.GetValues(typeof(CardAppearance)).Cast<CardAppearance?>());
+    SpinnerSize? spinnerSize = null;
+    IEnumerable<CardAppearance?> GetAppearanceValues() => (new CardAppearance?[] { null }).Union(Enum.GetValues(typeof(CardAppearance)).Cast<CardAppearance?>());
+    IEnumerable<SpinnerSize?> GetSpinnerSizes() => (new SpinnerSize?[] { null }).Union(Enum.GetValues(typeof(SpinnerSize)).Cast<SpinnerSize?>());
 
     async Task DisplayOverlay()
     {
@@ -25,6 +31,7 @@
         {
             options.Text = overlayText;
             options.CardAppearance = appearance;
+            options.SpinnerSize = spinnerSize;
         });
 
         try

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Overlay/Examples/OverlayService.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Overlay/Examples/OverlayService.razor
@@ -1,0 +1,35 @@
+﻿@inject IDialogService DialogService
+
+<FluentStack Wrap="true" HorizontalGap="24px">
+    <FluentTextInput Label="Overlay Text"
+                     @bind-Value="overlayText" />
+
+    <FluentSelect Items="@GetEnumValues()"
+                  Label="Appearance"
+                  @bind-Value="appearance" />
+</FluentStack>
+
+<FluentButton OnClick="@DisplayOverlay">
+    Show Overlay during 5 seconds
+</FluentButton>
+
+@code
+{
+    string overlayText = "Processing...";
+    CardAppearance? appearance = null;
+    IEnumerable<CardAppearance?> GetEnumValues() => (new CardAppearance?[] { null }).Union(Enum.GetValues(typeof(CardAppearance)).Cast<CardAppearance?>());
+
+    async Task DisplayOverlay()
+    {
+        await DialogService.ShowOverlayAsync(options =>
+        {
+            options.Text = overlayText;
+            options.CardAppearance = appearance;
+        });
+
+        // Simulate a long-running operation
+        await Task.Delay(5000);
+
+        await DialogService.HideOverlayAsync();
+    }
+}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Overlay/FluentOverlay.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Overlay/FluentOverlay.md
@@ -16,6 +16,18 @@ Full screen overlay with a default background color (`var(--colorBackgroundOverl
 
 {{ OverlayDefault }}
 
+## Service
+
+In addition to the `FluentOverlay` component, you can use the `IDialogService` to display a global overlay from anywhere in your application,
+without having to declare a `FluentOverlay` in your markup.
+
+Only **one global overlay** can be displayed at a time. The overlay shows a centered spinner, with an optional text message displayed below it.
+You can also choose a `CardAppearance` style to customize how the overlay content is rendered.
+
+Use `DialogService.ShowOverlayAsync(...)` to display the overlay and `DialogService.HideOverlayAsync()` to close it.
+
+{{ OverlayService }}
+
 ## Detailed Usage
 
 The overlay can be customized to suit various use cases, including:

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Overlay/FluentOverlay.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Overlay/FluentOverlay.md
@@ -28,6 +28,14 @@ Use `DialogService.ShowOverlayAsync(...)` to display the overlay and `DialogServ
 
 {{ OverlayService }}
 
+The global overlay is enabled by default. If you don't need this feature,
+you can disable it when registering the Fluent UI services to avoid rendering
+the underlying `FluentOverlay` element in the `FluentDialogProvider`:
+
+```csharp
+Services.AddFluentUIComponents(options => options.UseGlobalOverlay = false);
+```
+
 ## Detailed Usage
 
 The overlay can be customized to suit various use cases, including:

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Overlay/FluentOverlay.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Overlay/FluentOverlay.md
@@ -22,7 +22,8 @@ In addition to the `FluentOverlay` component, you can use the `IDialogService` t
 without having to declare a `FluentOverlay` in your markup.
 
 Only **one global overlay** can be displayed at a time. The overlay shows a centered spinner, with an optional text message displayed below it.
-You can also choose a `CardAppearance` style to customize how the overlay content is rendered.
+You can also choose a `CardAppearance` style to customize how the overlay content is rendered. 
+And a `SpinnerSize` to set the size of the spinner.
 
 Use `DialogService.ShowOverlayAsync(...)` to display the overlay and `DialogService.HideOverlayAsync()` to close it.
 

--- a/src/Core.Scripts/src/Components/Overlay/FluentOverlay.ts
+++ b/src/Core.Scripts/src/Components/Overlay/FluentOverlay.ts
@@ -61,11 +61,9 @@ export namespace Microsoft.FluentUI.Blazor.Components.Overlay {
         sheet
       ];
 
-      // Slot for user content
+      // Slot for user content. Children stay in the light DOM and are
+      // projected through the slot, so document-level CSS can style them.
       const contentSlot = document.createElement('slot');
-      while (this.firstChild) {
-        contentSlot.appendChild(this.firstChild);
-      }
       this.dialog.appendChild(contentSlot);
       shadow.appendChild(this.dialog);
     }

--- a/src/Core/Components/Dialog/FluentDialogProvider.razor
+++ b/src/Core/Components/Dialog/FluentDialogProvider.razor
@@ -1,4 +1,5 @@
 ﻿@namespace Microsoft.FluentUI.AspNetCore.Components
+@using Microsoft.FluentUI.AspNetCore.Components.Extensions
 @inherits FluentComponentBase
 
 <div id="@Id" class="@ClassValue" style="@StyleValue" @attributes="AdditionalAttributes">
@@ -34,6 +35,27 @@
                 }
             }
 
+            @* FluentOverlay (global overlay) *@
+            else if (dialog.ComponentType == typeof(FluentOverlay))
+            {
+                var overlayOptions = dialog.Options?.Parameters[Components.DialogService.GlobalOverlayOptionsKey] as OverlayOptions 
+                                  ?? new OverlayOptions();
+
+                <FluentOverlay Id="@Components.DialogService.GlobalOverlayId"
+                               FullScreen="true"
+                               CloseMode="OverlayCloseMode.Manual">
+                    @if (!string.IsNullOrEmpty(overlayOptions.Text))
+                    {
+                        <div class="@overlayOptions.ClassValue"
+                             style="@overlayOptions.StyleValue"
+                             appearance="@overlayOptions.CardAppearance.ToAttributeValue()">
+                            <FluentSpinner />
+                            <FluentText>@overlayOptions.Text</FluentText>
+                        </div>
+                    }
+                </FluentOverlay>
+            }
+
             @* FluentDialog *@
             else
             {
@@ -46,5 +68,6 @@
                               @attributes="@AdditionalAttributes" />
             }
         }
+
     }
 </div>

--- a/src/Core/Components/Dialog/FluentDialogProvider.razor
+++ b/src/Core/Components/Dialog/FluentDialogProvider.razor
@@ -44,17 +44,17 @@
                                     ?? new OverlayOptions();
 
                     <FluentOverlay Id="@Components.DialogService.GlobalOverlayId"
-                                FullScreen="true"
-                                CloseMode="OverlayCloseMode.Manual">
-                        @if (!string.IsNullOrEmpty(overlayOptions.Text))
-                        {
-                            <div class="@overlayOptions.ClassValue"
-                                style="@overlayOptions.StyleValue"
-                                appearance="@overlayOptions.CardAppearance.ToAttributeValue()">
-                                <FluentSpinner />
+                                   FullScreen="true"
+                                   CloseMode="OverlayCloseMode.Manual">
+                        <div class="@overlayOptions.ClassValue"
+                             style="@overlayOptions.StyleValue"
+                             appearance="@overlayOptions.CardAppearance.ToAttributeValue()">
+                            <FluentSpinner Size="@overlayOptions.SpinnerSize" />
+                            @if (!string.IsNullOrEmpty(overlayOptions.Text))
+                            {
                                 <FluentText>@overlayOptions.Text</FluentText>
-                            </div>
-                        }
+                            }
+                        </div>
                     </FluentOverlay>
                 }
             }

--- a/src/Core/Components/Dialog/FluentDialogProvider.razor
+++ b/src/Core/Components/Dialog/FluentDialogProvider.razor
@@ -38,22 +38,25 @@
             @* FluentOverlay (global overlay) *@
             else if (dialog.ComponentType == typeof(FluentOverlay))
             {
-                var overlayOptions = dialog.Options?.Parameters[Components.DialogService.GlobalOverlayOptionsKey] as OverlayOptions 
-                                  ?? new OverlayOptions();
+                if (LibraryConfiguration?.UseGlobalOverlay == true)
+                {
+                    var overlayOptions = dialog.Options?.Parameters[Components.DialogService.GlobalOverlayOptionsKey] as OverlayOptions 
+                                    ?? new OverlayOptions();
 
-                <FluentOverlay Id="@Components.DialogService.GlobalOverlayId"
-                               FullScreen="true"
-                               CloseMode="OverlayCloseMode.Manual">
-                    @if (!string.IsNullOrEmpty(overlayOptions.Text))
-                    {
-                        <div class="@overlayOptions.ClassValue"
-                             style="@overlayOptions.StyleValue"
-                             appearance="@overlayOptions.CardAppearance.ToAttributeValue()">
-                            <FluentSpinner />
-                            <FluentText>@overlayOptions.Text</FluentText>
-                        </div>
-                    }
-                </FluentOverlay>
+                    <FluentOverlay Id="@Components.DialogService.GlobalOverlayId"
+                                FullScreen="true"
+                                CloseMode="OverlayCloseMode.Manual">
+                        @if (!string.IsNullOrEmpty(overlayOptions.Text))
+                        {
+                            <div class="@overlayOptions.ClassValue"
+                                style="@overlayOptions.StyleValue"
+                                appearance="@overlayOptions.CardAppearance.ToAttributeValue()">
+                                <FluentSpinner />
+                                <FluentText>@overlayOptions.Text</FluentText>
+                            </div>
+                        }
+                    </FluentOverlay>
+                }
             }
 
             @* FluentDialog *@

--- a/src/Core/Components/Dialog/Overlay/DialogService.cs
+++ b/src/Core/Components/Dialog/Overlay/DialogService.cs
@@ -8,6 +8,8 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 
 public partial class DialogService : IDialogService
 {
+    private bool _isGlobalOverlayRegistered;
+
     /// <summary>
     /// Identifier of the global overlay rendered by the <see cref="FluentDialogProvider"/>.
     /// </summary>
@@ -19,11 +21,16 @@ public partial class DialogService : IDialogService
     internal const string GlobalOverlayOptionsKey = "Options";
 
     /// <see cref="IDialogService.ShowOverlayAsync(Action{OverlayOptions})"/>
-    public virtual async Task ShowOverlayAsync(Action<OverlayOptions>? options)
+    public virtual async Task ShowOverlayAsync(Action<OverlayOptions>? options = null)
     {
         if (this.ProviderNotAvailable())
         {
             throw new FluentServiceProviderException<FluentDialogProvider>();
+        }
+
+        if (!_isGlobalOverlayRegistered)
+        {
+            throw new InvalidOperationException("The global overlay is disabled in the library configuration. To enable it, set the UseGlobalOverlay property to true in the LibraryConfiguration.");
         }
 
         // Get the current options for the global overlay.
@@ -43,6 +50,16 @@ public partial class DialogService : IDialogService
     /// <see cref="IDialogService.HideOverlayAsync()"/>
     public virtual async Task HideOverlayAsync()
     {
+        if (this.ProviderNotAvailable())
+        {
+            throw new FluentServiceProviderException<FluentDialogProvider>();
+        }
+
+        if (!_isGlobalOverlayRegistered)
+        {
+            throw new InvalidOperationException("The global overlay is disabled in the library configuration. To enable it, set the UseGlobalOverlay property to true in the LibraryConfiguration.");
+        }
+
         // Hide the global overlay using JS interop.
         await _jsRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Components.Overlay.Close", GlobalOverlayId);
     }
@@ -54,6 +71,8 @@ public partial class DialogService : IDialogService
     /// </summary>
     private void RegisterGlobalOverlayComponent()
     {
+        _isGlobalOverlayRegistered = true;
+
         // Register the global overlay as a dialog instance so it is rendered by the FluentDialogProvider.
         var overlayInstance = GetGlobalOverlayInstance(new OverlayOptions());
         ServiceProvider.Items.TryAdd(overlayInstance.Id, overlayInstance);

--- a/src/Core/Components/Dialog/Overlay/DialogService.cs
+++ b/src/Core/Components/Dialog/Overlay/DialogService.cs
@@ -1,0 +1,76 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using Microsoft.JSInterop;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+public partial class DialogService : IDialogService
+{
+    /// <summary>
+    /// Identifier of the global overlay rendered by the <see cref="FluentDialogProvider"/>.
+    /// </summary>
+    internal const string GlobalOverlayId = "global-overlay";
+
+    /// <summary>
+    /// Key used to store the <see cref="OverlayOptions"/> of the global overlay in the Parameters of the dialog instance.
+    /// </summary>
+    internal const string GlobalOverlayOptionsKey = "Options";
+
+    /// <see cref="IDialogService.ShowOverlayAsync(Action{OverlayOptions})"/>
+    public virtual async Task ShowOverlayAsync(Action<OverlayOptions>? options)
+    {
+        if (this.ProviderNotAvailable())
+        {
+            throw new FluentServiceProviderException<FluentDialogProvider>();
+        }
+
+        // Get the current options for the global overlay.
+        var overlayOptions = new OverlayOptions();
+        options?.Invoke(overlayOptions);
+        var overlayInstance = GetGlobalOverlayInstance(overlayOptions);
+
+        // Update the dialog instance for the global overlay in the service provider,
+        // so it is rendered by the FluentDialogProvider with the new options.
+        ServiceProvider.Items.AddOrUpdate(GlobalOverlayId, overlayInstance, (key, oldValue) => overlayInstance);
+        await ServiceProvider.OnUpdatedAsync.Invoke(overlayInstance);
+
+        // Show the global overlay using JS interop.
+        await _jsRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Components.Overlay.Show", GlobalOverlayId);
+    }
+
+    /// <see cref="IDialogService.HideOverlayAsync()"/>
+    public virtual async Task HideOverlayAsync()
+    {
+        // Hide the global overlay using JS interop.
+        await _jsRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Components.Overlay.Close", GlobalOverlayId);
+    }
+
+    /// <summary>
+    /// Registers the global overlay component as a dialog instance in the service provider,
+    /// so it can be rendered by the <see cref="FluentDialogProvider"/>.
+    /// This method is called in the constructor of the DialogService, to ensure the global overlay is available as soon as the service is created.
+    /// </summary>
+    private void RegisterGlobalOverlayComponent()
+    {
+        // Register the global overlay as a dialog instance so it is rendered by the FluentDialogProvider.
+        var overlayInstance = GetGlobalOverlayInstance(new OverlayOptions());
+        ServiceProvider.Items.TryAdd(overlayInstance.Id, overlayInstance);
+    }
+
+    /// <summary>
+    /// Gets the global overlay dialog instance for the given options.
+    /// </summary>
+    private DialogInstance GetGlobalOverlayInstance(OverlayOptions options)
+    {
+        return new DialogInstance(this, typeof(FluentOverlay), new DialogOptions()
+        {
+            Id = GlobalOverlayId,
+            Parameters = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                { GlobalOverlayOptionsKey, options },
+            },
+        });
+    }
+}

--- a/src/Core/Components/Dialog/Overlay/IDialogService.cs
+++ b/src/Core/Components/Dialog/Overlay/IDialogService.cs
@@ -1,0 +1,20 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary />
+public partial interface IDialogService
+{
+    /// <summary>
+    /// Shows the global overlay.
+    /// </summary>
+    /// <param name="options">Options used to configure the overlay.</param>
+    Task ShowOverlayAsync(Action<OverlayOptions>? options);
+
+    /// <summary>
+    /// Hides the global overlay.
+    /// </summary>
+    Task HideOverlayAsync();
+}

--- a/src/Core/Components/Dialog/Overlay/IDialogService.cs
+++ b/src/Core/Components/Dialog/Overlay/IDialogService.cs
@@ -11,7 +11,7 @@ public partial interface IDialogService
     /// Shows the global overlay.
     /// </summary>
     /// <param name="options">Options used to configure the overlay.</param>
-    Task ShowOverlayAsync(Action<OverlayOptions>? options);
+    Task ShowOverlayAsync(Action<OverlayOptions>? options = null);
 
     /// <summary>
     /// Hides the global overlay.

--- a/src/Core/Components/Dialog/Overlay/OverlayGlobalStyle.css
+++ b/src/Core/Components/Dialog/Overlay/OverlayGlobalStyle.css
@@ -1,0 +1,8 @@
+/* global-overlay */
+.fluent-overlay-global {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    row-gap: var(--spacingVerticalS);
+    color: var(--colorNeutralForeground1);
+}

--- a/src/Core/Components/Dialog/Overlay/OverlayOptions.cs
+++ b/src/Core/Components/Dialog/Overlay/OverlayOptions.cs
@@ -22,6 +22,12 @@ public class OverlayOptions
     public CardAppearance? CardAppearance { get; set; }
 
     /// <summary>
+    /// Gets or sets the size of the spinner displayed inside the overlay.
+    /// 
+    /// </summary>
+    public SpinnerSize? SpinnerSize { get; set; }
+
+    /// <summary>
     /// Gets or sets the custom CSS styles applied to the overlay.
     /// </summary>
     public string? Style { get; set; }

--- a/src/Core/Components/Dialog/Overlay/OverlayOptions.cs
+++ b/src/Core/Components/Dialog/Overlay/OverlayOptions.cs
@@ -17,7 +17,7 @@ public class OverlayOptions
     public string? Text { get; set; }
 
     /// <summary>
-    /// Add a card style to the overlay, which includes rounded corners and a shadow.
+    /// Gets or sets the card appearance applied to the overlay content (rounded corners and shadow).
     /// </summary>
     public CardAppearance? CardAppearance { get; set; }
 

--- a/src/Core/Components/Dialog/Overlay/OverlayOptions.cs
+++ b/src/Core/Components/Dialog/Overlay/OverlayOptions.cs
@@ -1,0 +1,42 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using Microsoft.FluentUI.AspNetCore.Components.Utilities;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// Options used to configure the global overlay displayed by the <see cref="FluentDialogProvider"/>.
+/// </summary>
+public class OverlayOptions
+{
+    /// <summary>
+    /// Gets or sets the text displayed inside the overlay.
+    /// </summary>
+    public string? Text { get; set; }
+
+    /// <summary>
+    /// Add a card style to the overlay, which includes rounded corners and a shadow.
+    /// </summary>
+    public CardAppearance? CardAppearance { get; set; }
+
+    /// <summary>
+    /// Gets or sets the custom CSS styles applied to the overlay.
+    /// </summary>
+    public string? Style { get; set; }
+
+    /// <summary>
+    /// Gets or sets the custom CSS class applied to the overlay.
+    /// </summary>
+    public string? Class { get; set; }
+
+    /// <summary />
+    internal string? ClassValue => new CssBuilder(Class)
+                                        .AddClass("fluent-overlay-global")
+                                        .AddClass("fluent-card", when: CardAppearance != null)
+                                        .Build();
+
+    /// <summary />
+    internal string? StyleValue => new CssBuilder(Style).Build();
+}

--- a/src/Core/Components/Dialog/Services/DialogInstance.cs
+++ b/src/Core/Components/Dialog/Services/DialogInstance.cs
@@ -23,6 +23,13 @@ public class DialogInstance : IDialogInstance
         DialogService = dialogService;
         Id = string.IsNullOrEmpty(options.Id) ? Identifier.NewId() : options.Id;
         Index = Interlocked.Increment(ref _counter);
+
+        if (string.Equals(options.Id, Components.DialogService.GlobalOverlayId, StringComparison.Ordinal))
+        {
+            // The global overlay must always have the highest index,
+            // so that it is displayed on top of all other dialog boxes.
+            Index = long.MaxValue;
+        }
     }
 
     /// <summary />

--- a/src/Core/Components/Dialog/Services/DialogService.cs
+++ b/src/Core/Components/Dialog/Services/DialogService.cs
@@ -31,8 +31,13 @@ public partial class DialogService : FluentServiceBase<IDialogInstance>, IDialog
         _jsRuntime = serviceProvider.GetRequiredService<IJSRuntime>();
         Localizer = localizer ?? FluentLocalizerInternal.Default;
 
-        // Register the global overlay component
-        RegisterGlobalOverlayComponent();
+        var configuration = serviceProvider.GetService<LibraryConfiguration>();
+        
+        // Register the global overlay component only when enabled
+        if (configuration?.UseGlobalOverlay != false)
+        {
+            RegisterGlobalOverlayComponent();
+        }
     }
 
     /// <summary />

--- a/src/Core/Components/Dialog/Services/DialogService.cs
+++ b/src/Core/Components/Dialog/Services/DialogService.cs
@@ -30,6 +30,9 @@ public partial class DialogService : FluentServiceBase<IDialogInstance>, IDialog
         _serviceProvider = serviceProvider;
         _jsRuntime = serviceProvider.GetRequiredService<IJSRuntime>();
         Localizer = localizer ?? FluentLocalizerInternal.Default;
+
+        // Register the global overlay component
+        RegisterGlobalOverlayComponent();
     }
 
     /// <summary />

--- a/src/Core/Infrastructure/LibraryConfiguration.cs
+++ b/src/Core/Infrastructure/LibraryConfiguration.cs
@@ -60,6 +60,12 @@ public class LibraryConfiguration
     /// </summary>
     public MarkupSanitizedOptions MarkupSanitized { get; } = new MarkupSanitizedOptions();
 
+    /// <summary>
+    /// Gets or sets a value indicating whether to use the global overlay via the <see cref="IDialogService"/>.
+    /// The global overlay is a single instance of the <see cref="FluentOverlay"/> component rendered by the <see cref="FluentDialogProvider"/>,
+    /// </summary>
+    public bool UseGlobalOverlay { get; set; } = true;
+
     /* TODO: Implement these properties
      
     /// <summary>

--- a/src/Core/Infrastructure/LibraryConfiguration.cs
+++ b/src/Core/Infrastructure/LibraryConfiguration.cs
@@ -62,7 +62,7 @@ public class LibraryConfiguration
 
     /// <summary>
     /// Gets or sets a value indicating whether to use the global overlay via the <see cref="IDialogService"/>.
-    /// The global overlay is a single instance of the <see cref="FluentOverlay"/> component rendered by the <see cref="FluentDialogProvider"/>,
+    /// The global overlay is a single instance of the <see cref="FluentOverlay"/> component rendered by the <see cref="FluentDialogProvider"/>.
     /// </summary>
     public bool UseGlobalOverlay { get; set; } = true;
 

--- a/tests/Core/Components/Dialog/FluentDialogTests.razor
+++ b/tests/Core/Components/Dialog/FluentDialogTests.razor
@@ -8,7 +8,7 @@
     public FluentDialogTests()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
-        Services.AddFluentUIComponents();
+        Services.AddFluentUIComponents(options => options.UseGlobalOverlay = false);
 
         DialogService = Services.GetRequiredService<IDialogService>();
         DialogProvider = Render<FluentDialogProvider>();

--- a/tests/Core/Components/Dialog/FluentDrawerTests.razor
+++ b/tests/Core/Components/Dialog/FluentDrawerTests.razor
@@ -8,7 +8,7 @@
     public FluentDrawerTests()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
-        Services.AddFluentUIComponents();
+        Services.AddFluentUIComponents(options => options.UseGlobalOverlay = false);
 
         DialogService = Services.GetRequiredService<IDialogService>();
         DialogProvider = Render<FluentDialogProvider>();

--- a/tests/Core/Components/Dialog/FluentMessageBoxTests.razor
+++ b/tests/Core/Components/Dialog/FluentMessageBoxTests.razor
@@ -8,7 +8,7 @@
     public FluentMessageBoxTests()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
-        Services.AddFluentUIComponents();
+        Services.AddFluentUIComponents(options => options.UseGlobalOverlay = false);
 
         DialogService = Services.GetRequiredService<IDialogService>();
         DialogProvider = Render<FluentDialogProvider>();

--- a/tests/Core/Components/Dialog/Overlay/OverlayServiceTests.razor
+++ b/tests/Core/Components/Dialog/Overlay/OverlayServiceTests.razor
@@ -114,8 +114,7 @@
 
         var overlay = DialogProvider.Find($"#{Microsoft.FluentUI.AspNetCore.Components.DialogService.GlobalOverlayId}");
         Assert.NotNull(overlay);
-        // No inner card / spinner / text should be rendered when Text is null/empty.
-        Assert.DoesNotContain("fluent-card", overlay.InnerHtml);
+        Assert.DoesNotContain("fluent-text", overlay.InnerHtml);
     }
 
     [Fact]
@@ -132,6 +131,41 @@
         Assert.Contains("Second", DialogProvider.Markup);
         Assert.DoesNotContain("First", DialogProvider.Markup);
         JSInterop.VerifyInvoke("Microsoft.FluentUI.Blazor.Components.Overlay.Show", 2);
+    }
+
+    [Fact]
+    public async Task DialogService_ShowOverlayAsync_WithSpinnerSize_RendersSpinnerWithSize()
+    {
+        // Act
+        await DialogService.ShowOverlayAsync(options =>
+        {
+            options.SpinnerSize = SpinnerSize.Large;
+        });
+
+        // Assert
+        JSInterop.VerifyInvoke("Microsoft.FluentUI.Blazor.Components.Overlay.Show");
+
+        var overlay = DialogProvider.Find($"#{Microsoft.FluentUI.AspNetCore.Components.DialogService.GlobalOverlayId}");
+        var spinner = overlay.QuerySelector("fluent-spinner");
+        Assert.NotNull(spinner);
+        Assert.Equal("large", spinner.GetAttribute("size"));
+    }
+
+    [Fact]
+    public async Task DialogService_ShowOverlayAsync_WithoutSpinnerSize_RendersSpinnerWithoutSizeAttribute()
+    {
+        // Act
+        await DialogService.ShowOverlayAsync(options => { });
+
+        // Assert
+        JSInterop.VerifyInvoke("Microsoft.FluentUI.Blazor.Components.Overlay.Show");
+
+        var overlay = DialogProvider.Find($"#{Microsoft.FluentUI.AspNetCore.Components.DialogService.GlobalOverlayId}");
+        var spinner = overlay.QuerySelector("fluent-spinner");
+        Assert.NotNull(spinner);
+        // When SpinnerSize is not specified, the attribute is not emitted and the
+        // web component falls back to its default ("medium") at runtime.
+        Assert.False(spinner.HasAttribute("size"));
     }
 
     [Fact]

--- a/tests/Core/Components/Dialog/Overlay/OverlayServiceTests.razor
+++ b/tests/Core/Components/Dialog/Overlay/OverlayServiceTests.razor
@@ -1,0 +1,167 @@
+@using Xunit
+@inherits FluentUITestContext
+@code
+{
+    public OverlayServiceTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddFluentUIComponents(options => options.UseGlobalOverlay = true);
+
+        DialogService = Services.GetRequiredService<IDialogService>();
+        DialogProvider = Render<FluentDialogProvider>();
+    }
+
+    /// <summary>
+    /// Gets the dialog service.
+    /// </summary>
+    public IDialogService DialogService { get; }
+
+    /// <summary>
+    /// Gets the dialog provider.
+    /// </summary>
+    public IRenderedComponent<FluentDialogProvider> DialogProvider { get; }
+
+    [Fact]
+    public void OverlayOptions_Defaults_ReturnsGlobalOverlayClass()
+    {
+        // Arrange
+        var options = new OverlayOptions();
+
+        // Assert
+        Assert.Null(options.Text);
+        Assert.Null(options.CardAppearance);
+        Assert.Null(options.Style);
+        Assert.Null(options.Class);
+        Assert.Equal("fluent-overlay-global", options.ClassValue);
+        Assert.Null(options.StyleValue);
+    }
+
+    [Fact]
+    public void OverlayOptions_WithCustomClassAndStyle_BuildsValues()
+    {
+        // Arrange
+        var options = new OverlayOptions
+        {
+            Class = "my-class",
+            Style = "my-inline-style",
+        };
+
+        // Assert
+        Assert.Equal("fluent-overlay-global my-class", options.ClassValue);
+        Assert.Equal("my-inline-style", options.StyleValue);
+    }
+
+    [Fact]
+    public void OverlayOptions_WithCardAppearance_AddsFluentCardClass()
+    {
+        // Arrange
+        var options = new OverlayOptions
+        {
+            CardAppearance = CardAppearance.Filled,
+        };
+
+        // Assert
+        Assert.Equal("fluent-overlay-global fluent-card", options.ClassValue);
+    }
+
+    [Fact]
+    public async Task DialogService_ShowOverlayAsync_NullOptions_InvokesJsShow()
+    {
+        // Act
+        await DialogService.ShowOverlayAsync(options: null);
+
+        // Assert
+        var invocation = JSInterop.VerifyInvoke("Microsoft.FluentUI.Blazor.Components.Overlay.Show");
+        Assert.Equal(Microsoft.FluentUI.AspNetCore.Components.DialogService.GlobalOverlayId, invocation.Arguments[0]);
+    }
+
+    [Fact]
+    public async Task DialogService_ShowOverlayAsync_WithText_RendersOverlayContent()
+    {
+        // Act
+        await DialogService.ShowOverlayAsync(options =>
+        {
+            options.Text = "Loading...";
+            options.CardAppearance = CardAppearance.Filled;
+            options.Class = "my-overlay";
+            options.Style = "padding-overlay";
+        });
+
+        // Assert: JS interop was invoked
+        JSInterop.VerifyInvoke("Microsoft.FluentUI.Blazor.Components.Overlay.Show");
+
+        // Assert: rendered markup contains the text and applied options
+        var markup = DialogProvider.Markup;
+        Assert.Contains("Loading...", markup);
+        Assert.Contains("my-overlay", markup);
+        Assert.Contains("fluent-overlay-global", markup);
+        Assert.Contains("fluent-card", markup);
+        Assert.Contains("padding-overlay", markup);
+        Assert.Contains("appearance=\"filled\"", markup);
+    }
+
+    [Fact]
+    public async Task DialogService_ShowOverlayAsync_WithoutText_DoesNotRenderInnerCard()
+    {
+        // Act
+        await DialogService.ShowOverlayAsync(options =>
+        {
+            options.CardAppearance = CardAppearance.Outline;
+        });
+
+        // Assert
+        JSInterop.VerifyInvoke("Microsoft.FluentUI.Blazor.Components.Overlay.Show");
+
+        var overlay = DialogProvider.Find($"#{Microsoft.FluentUI.AspNetCore.Components.DialogService.GlobalOverlayId}");
+        Assert.NotNull(overlay);
+        // No inner card / spinner / text should be rendered when Text is null/empty.
+        Assert.DoesNotContain("fluent-card", overlay.InnerHtml);
+    }
+
+    [Fact]
+    public async Task DialogService_ShowOverlayAsync_CalledTwice_UpdatesOptions()
+    {
+        // Act 1
+        await DialogService.ShowOverlayAsync(options => options.Text = "First");
+        Assert.Contains("First", DialogProvider.Markup);
+
+        // Act 2
+        await DialogService.ShowOverlayAsync(options => options.Text = "Second");
+
+        // Assert
+        Assert.Contains("Second", DialogProvider.Markup);
+        Assert.DoesNotContain("First", DialogProvider.Markup);
+        JSInterop.VerifyInvoke("Microsoft.FluentUI.Blazor.Components.Overlay.Show", 2);
+    }
+
+    [Fact]
+    public async Task DialogService_HideOverlayAsync_InvokesJsClose()
+    {
+        // Act
+        await DialogService.HideOverlayAsync();
+
+        // Assert
+        var invocation = JSInterop.VerifyInvoke("Microsoft.FluentUI.Blazor.Components.Overlay.Close");
+        Assert.Equal(Microsoft.FluentUI.AspNetCore.Components.DialogService.GlobalOverlayId, invocation.Arguments[0]);
+    }
+
+    [Fact]
+    public async Task DialogService_ShowOverlayAsync_WhenProviderNotAvailable_ThrowsFluentServiceProviderException()
+    {
+        // Arrange
+        DialogProvider.Instance.UpdateId(null);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<FluentServiceProviderException<FluentDialogProvider>>(async () =>
+        {
+            await DialogService.ShowOverlayAsync(options => options.Text = "Should fail");
+        });
+    }
+
+    [Fact]
+    public void DialogService_ShowOverlayAsync_GlobalOverlay_IsRegisteredAtConstruction()
+    {
+        // Assert: registered at DialogService construction, so the provider already contains the global overlay.
+        Assert.Contains($"id=\"{Microsoft.FluentUI.AspNetCore.Components.DialogService.GlobalOverlayId}\"", DialogProvider.Markup);
+    }
+}

--- a/tests/Core/Components/InputFile/FluentInputFileDialogServiceTests.razor
+++ b/tests/Core/Components/InputFile/FluentInputFileDialogServiceTests.razor
@@ -5,7 +5,7 @@
     public FluentInputFileDialogServiceTests()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
-        Services.AddFluentUIComponents();
+        Services.AddFluentUIComponents(options => options.UseGlobalOverlay = false);
 
         DialogService = Services.GetRequiredService<IDialogService>();
         DialogProvider = Render<FluentDialogProvider>();


### PR DESCRIPTION
# [dev-v5] Add global overlay support with IDialogService integration

Introduce global overlay functionality integrated with IDialogService, allowing for customizable overlay options. This update includes the ability to disable the global overlay in Fluent UI services and adds unit tests for the OverlayService and OverlayOptions.

## Service

In addition to the `FluentOverlay` component, you can use the `IDialogService` to display a global overlay from anywhere in your application,
without having to declare a `FluentOverlay` in your markup.

Only **one global overlay** can be displayed at a time. The overlay shows a centered spinner, with an optional text message displayed below it.
You can also choose a `CardAppearance` style to customize how the overlay content is rendered.

Use `DialogService.ShowOverlayAsync(...)` to display the overlay and `DialogService.HideOverlayAsync()` to close it.

Example

```csharp
await DialogService.ShowOverlayAsync();

await DialogService.ShowOverlayAsync(options =>
{
    options.Text = "Processing...;
});

await DialogService.HideOverlayAsync();
```

**Notes** The global overlay is enabled by default. If you don't need this feature,
you can disable it when registering the Fluent UI services to avoid rendering
the underlying `FluentOverlay` element in the `FluentDialogProvider`:

```csharp
Services.AddFluentUIComponents(options => options.UseGlobalOverlay = false);
```


## Unit Tests

Updated and added