### PR TITLE
[dev-v5] Update .gitignore to include lscache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.userosscache
 *.sln.docstates
 .claude/*.local.json
+*.lscache
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs


### PR DESCRIPTION
# Update .gitignore to include lscache files

Add lscache files to the .gitignore to prevent them from being tracked in the repository. This change helps maintain a cleaner project by ignoring unnecessary cache files.

`.lscache` files are lightweight caches that store project metadata next to your .csproj files. They contain project structure information like references, target frameworks, and output paths -- no source code or secrets. They allow C# Dev Kit and potentially other clients to skip expensive processing on startup, providing near-instant project loading.

See https://github.com/microsoft/vscode-dotnettools/issues/2961