### PR TITLE
[dev-v5][Toast] Fix toast sizing in Safari on macOS and iOS

### DIFF
--- a/src/Core.Scripts/src/Components/Toast/FluentToast.ts
+++ b/src/Core.Scripts/src/Components/Toast/FluentToast.ts
@@ -119,6 +119,7 @@ export namespace Microsoft.FluentUI.Blazor.Components.Toast {
                 box-sizing: border-box;
                 min-width: 292px;
                 max-width: 292px;
+                height: auto;
                 padding: 12px;
                 transition:
                   top 240ms cubic-bezier(0.22, 1, 0.36, 1),


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR fixes sizing issues on iOS and macOS for `FluentToast` by setting `height: auto`.

Before desktop:
<img width="1280" height="827" alt="grafik" src="https://github.com/user-attachments/assets/c46fa47b-2cb9-4af8-a6d8-70b8e291d991" />

After desktop:

<img width="1280" height="827" alt="grafik" src="https://github.com/user-attachments/assets/d0ebd69b-41ca-41fe-b86e-23565d0663b5" />

Before mobile:

<img width="943" height="2048" alt="grafik" src="https://github.com/user-attachments/assets/11710c83-c63e-4604-85e8-22aaa76a0f65" />

After mobile:

<img width="943" height="2048" alt="grafik" src="https://github.com/user-attachments/assets/0e4a2a94-7b41-4162-bd19-6b45ecad373f" />



## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

I have tested this changes on Safari on macOS and iOS and on Chrome, Edge and Firefox. I also tested the positioning. You still need to test for Android.
