### PR TITLE
[dev-v5][Popover] Consider viewport for mobile devices

### DIFF
--- a/src/Core.Scripts/src/Components/Popover/FluentPopover.ts
+++ b/src/Core.Scripts/src/Components/Popover/FluentPopover.ts
@@ -24,7 +24,7 @@ export namespace Microsoft.FluentUI.Blazor.Components.Popover {
       this.dialog.setAttribute('fuib', '');
       this.dialog.setAttribute('popover', '');
       this.dialog.setAttribute('part', 'dialog');    // To allow styling using `fluent-popover-b::part(dialog)`
-      
+
       // Dispatch the toggle event when the popover is opened or closed
       // For nested popovers, the event is dispatched during showPopover/closePopover methods
       this.dialog.addEventListener('toggle', (e) => {
@@ -169,7 +169,7 @@ export namespace Microsoft.FluentUI.Blazor.Components.Popover {
 
       // Reflect opened property and attribute
       this.opened = true;
-      
+
       // Dispatch event when shown.
       // For non-nested popovers, the event is dispatched by the Popover component itself.
       if (this.nested) {
@@ -185,7 +185,7 @@ export namespace Microsoft.FluentUI.Blazor.Components.Popover {
 
         // Reflect opened property and attribute
         this.opened = false;
-        
+
         // Dispatch event when closed
         // For non-nested popovers, the event is dispatched by the Popover component itself.
         if (this.nested) {
@@ -280,34 +280,41 @@ export namespace Microsoft.FluentUI.Blazor.Components.Popover {
       if (this.anchorEl === null || this.dialog === null) return;
 
       const rect = this.anchorEl.getBoundingClientRect();
+
+      const visualViewport = window.visualViewport;
+      const viewportHeight = visualViewport?.height ?? window.innerHeight;
+      const viewportWidth = visualViewport?.width ?? window.innerWidth;
+      const viewportTop = visualViewport?.offsetTop ?? 0;
+      const viewportLeft = visualViewport?.offsetLeft ?? 0;
+
       const dialogHeight = this.dialog.offsetHeight + this.offsetVertical;
       const dialogWidth = this.dialog.offsetWidth + this.offsetHorizontal;
+
       const spaceAbove = rect.top;
-      const spaceBelow = window.innerHeight - rect.bottom;
-      const spaceLeft = rect.left + dialogWidth;
-      const spaceRight = window.innerWidth - rect.left;
+      const spaceBelow = viewportHeight - rect.bottom;
+      const spaceLeft = rect.right;
+      const spaceRight = viewportWidth - rect.left;
 
       // Position dialog above the target
       const positionDialogAbove = () => {
-        this.dialog.style.top = `${rect.top - dialogHeight}px`;
+        this.dialog.style.top = `${rect.top - dialogHeight + viewportTop}px`;
       }
 
       // Position dialog below the target
       const positionDialogBelow = () => {
-        this.dialog.style.top = `${rect.bottom + this.offsetVertical}px`;
+        this.dialog.style.top = `${rect.bottom + this.offsetVertical + viewportTop}px`;
       }
 
-      // Position dialog left of the target
+      // Position dialog aligned left with the target
       const positionDialogLeft = () => {
-        this.dialog.style.left = `${rect.left + this.offsetHorizontal}px`;
+        this.dialog.style.left = `${rect.left + this.offsetHorizontal + viewportLeft}px`;
       }
 
-      // Position dialog right of the target
+      // Position dialog aligned right with the target
       const positionDialogRight = () => {
-        this.dialog.style.left = `${rect.left + rect.width - dialogWidth - this.offsetHorizontal}px`;
+        this.dialog.style.left = `${rect.left + rect.width - dialogWidth - this.offsetHorizontal + viewportLeft}px`;
       }
 
-      // Set the position above or below the anchor element
       if (spaceBelow >= dialogHeight) {
         positionDialogBelow();
       }
@@ -315,10 +322,9 @@ export namespace Microsoft.FluentUI.Blazor.Components.Popover {
         positionDialogAbove();
       }
       else {
-        positionDialogBelow();  // Default
+        positionDialogBelow();
       }
 
-      // Set the position left or right of the anchor element
       if (spaceRight >= dialogWidth) {
         positionDialogLeft();
       }
@@ -326,7 +332,7 @@ export namespace Microsoft.FluentUI.Blazor.Components.Popover {
         positionDialogRight();
       }
       else {
-        positionDialogLeft();  // Default
+        positionDialogLeft();
       }
     };
   }


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR adds the viewport into calculation for `FluentPopover` positioning. This is required for mobile devices to calculate the position correctly. This could be seen in components like `FluentAutocomplete`

Before iOS:

<img width="943" height="2048" alt="grafik" src="https://github.com/user-attachments/assets/7d4e4b91-2e73-4e40-94f3-1bcee2ec7089" />


After iOS:

<img width="943" height="2048" alt="grafik" src="https://github.com/user-attachments/assets/9c5af70b-8b86-4ba5-b358-858a577cf3c7" />


## 👩‍💻 Reviewer Notes

I tested this on Edge, Firefox, Chrome on PC and Safari on macOS and iOS. Please test this changes on Android and take a closer look on the changes. This could break something if I missed anything.


## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps


