### PR TITLE
[dev-v5][Docs] Fix api-table on mobile

### DIFF
--- a/examples/Tools/FluentUI.Demo.DocViewer/Components/MarkdownViewer.razor.css
+++ b/examples/Tools/FluentUI.Demo.DocViewer/Components/MarkdownViewer.razor.css
@@ -116,31 +116,28 @@
     }
   /* API table */
 
-  .doc-viewer ::deep .api-table {
-    width: 100%;
-    border-collapse: collapse;
+  .doc-viewer ::deep .api-table th {
+    text-align: start;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    font-weight: 600;
   }
 
-    .doc-viewer ::deep .api-table th {
-      text-align: start;
-      text-overflow: ellipsis;
-      overflow: hidden;
-      white-space: nowrap;
-      font-weight: 600;
-    }
+  .doc-viewer ::deep .api-table tr {
+    border-bottom: var(--strokeWidthThin) solid var(--colorNeutralStroke1);
+    vertical-align: top;
+  }
 
-    .doc-viewer ::deep .api-table tr {
-      border-bottom: var(--strokeWidthThin) solid var(--colorNeutralStroke1);
-      vertical-align: top;
-    }
-
-    .doc-viewer ::deep .api-table td {
-      padding: 8px 12px 8px 0px;
-    }
+  .doc-viewer ::deep .api-table td {
+    padding: 8px 12px 8px 0px;
+  }
 
   .doc-viewer ::deep .api-table {
     width: 100%;
-    max-width: calc(100vw - 32px);
+    max-width: calc(100dvw - 32px);
+    overflow: auto;
+    display: block;
     border-collapse: collapse;
   }
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR fixes the `api-table` CSS class for mobile devices. Previously this could result in exceeding containers on mobile which resulted to global horizontal scroll as can be seen on the `Autocomplete` demo page on mobile.

This PR fixes this by setting `display: block;` in combination with `overflow: auto;` for `api-table`.


### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [ ] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
