### PR TITLE
[dev-v5] Add additional allowed frame ancestors for CSP

### DIFF
--- a/examples/Demo/FluentUI.Explorers/Program.cs
+++ b/examples/Demo/FluentUI.Explorers/Program.cs
@@ -43,6 +43,7 @@ app.Use(async (context, next) =>
             "https://www.fluentui-blazor.net",
             "https://preview.fluentui-blazor.net",
             "https://fluentui-explorer-v5.azurewebsites.net",
+            "https://fluentui-blazor-v5.azurewebsites.net",
             "https://fluentui-blazor-v5-preview.azurewebsites.net",
             "https://v5.fluentui-blazor.net",
         ];

--- a/examples/Demo/FluentUI.Explorers/Program.cs
+++ b/examples/Demo/FluentUI.Explorers/Program.cs
@@ -38,10 +38,12 @@ app.Use(async (context, next) =>
             "https://localhost:7026",
             "https://localhost:7062",
             "https://localhost:7197",
+            "https://localhost:5000",
             "https://fluentui-blazor.net",
             "https://www.fluentui-blazor.net",
             "https://preview.fluentui-blazor.net",
             "https://fluentui-explorer-v5.azurewebsites.net",
+            "https://fluentui-blazor-v5-preview.azurewebsites.net",
             "https://v5.fluentui-blazor.net",
         ];
 


### PR DESCRIPTION
# Add additional allowed frame ancestors for CSP

Enhance the Content Security Policy by adding more allowed frame ancestors to improve security and flexibility for the application. This change addresses the need for additional trusted sources.

