### PR TITLE
[dev-v5] Hide 'Microsoft' label in small viewports

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/wwwroot/app.css
+++ b/examples/Demo/FluentUI.Demo.Client/wwwroot/app.css
@@ -14,7 +14,7 @@
 }
 
 /* Hide the label "Microsoft" when the page is too small */
-body[data-media="xs"] svg g[data-name="MS-symbol"] path:first-of-type {
+body[data-media="xs"] svg g[data-name="MS-symbol"] {
   display: none;
 }
 

--- a/examples/Demo/FluentUI.Demo.Client/wwwroot/app.css
+++ b/examples/Demo/FluentUI.Demo.Client/wwwroot/app.css
@@ -13,6 +13,11 @@
   display: none;
 }
 
+/* Hide the label "Microsoft" when the page is too small */
+body[data-media="xs"] svg g[data-name="MS-symbol"] path:first-of-type {
+  display: none;
+}
+
 /* Blazor Styles */
 
 #blazor-error-ui {


### PR DESCRIPTION
# [dev-v5] Hide 'Microsoft' label in small viewports

Remove the "Microsoft" label from view when the viewport is too small to improve visual clarity and user experience.

## Before

<img width="584" height="75" alt="image" src="https://github.com/user-attachments/assets/ff063475-ace7-46e2-b173-a6af8a31a38d" />

## After

<img width="585" height="78" alt="image" src="https://github.com/user-attachments/assets/25584588-1f82-4e66-9faf-fe177971cc82" />


## Desktop

<img width="1291" height="97" alt="image" src="https://github.com/user-attachments/assets/1ffc5653-bb46-4ee1-8842-44526e6cb2fc" />
