### PR TITLE
[dev-v5][Popover] Remove touchstart event listener

### DIFF
--- a/src/Core.Scripts/src/Components/Popover/FluentPopover.ts
+++ b/src/Core.Scripts/src/Components/Popover/FluentPopover.ts
@@ -229,13 +229,11 @@ export namespace Microsoft.FluentUI.Blazor.Components.Popover {
 
     private addEventsAfterOpening() {
       document.addEventListener('mousedown', this.handleOutsideClick);
-      document.addEventListener('touchstart', this.handleOutsideClick);
       document.addEventListener('keydown', this.handleCloseKeydown);
     }
 
     private removeEventsAfterClosing() {
       document.removeEventListener('mousedown', this.handleOutsideClick);
-      document.removeEventListener('touchstart', this.handleOutsideClick);
       document.removeEventListener('keydown', this.handleCloseKeydown);
     }
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR removes the `touchstart` event from `FluentPopover`. This improves the component on mobile scenarios because the popover won't close itself when you start scrolling on touch devices. It will close itself though when the user clicks on the touch. This significantly improves the `FluentAutocomplete` component.

Before:

https://github.com/user-attachments/assets/be035590-ddbc-48d7-8118-cf4d18221fc6

After:

https://github.com/user-attachments/assets/b8ded524-28f2-4a4f-b528-449f4d416f73


### 🎫 Issues

This fixes #4877

## 👩‍💻 Reviewer Notes


## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
