### PR TITLE
[dev-v5] Fix FluentTimePicker item generation logic and add unit tests

### DIFF
--- a/src/Core/Components/DateTime/FluentTimePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentTimePicker.razor.cs
@@ -117,8 +117,8 @@ public partial class FluentTimePicker<TValue> : FluentInputBase<TValue>
     {
         get
         {
-            var hourSpan = EndHour - StartHour < 1 ? 1 : EndHour - StartHour;
-            var count = hourSpan * (60 / Increment) + 1;
+            var totalMinutes = Math.Max(0, (EndHour - StartHour) * 60);
+            var count = totalMinutes / Increment + 1;
 
             return Enumerable.Range(0, count)
                              .Select(i => (DateTime?)DefaultTime.AddHours(StartHour).AddMinutes(i * Increment));

--- a/src/Core/Components/DateTime/FluentTimePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentTimePicker.razor.cs
@@ -117,9 +117,10 @@ public partial class FluentTimePicker<TValue> : FluentInputBase<TValue>
     {
         get
         {
-            var count = EndHour - StartHour < 1 ? 1 : EndHour - StartHour + 1;
+            var hourSpan = EndHour - StartHour < 1 ? 1 : EndHour - StartHour;
+            var count = hourSpan * (60 / Increment) + 1;
 
-            return Enumerable.Range(0, count * (60 / Increment) - 1)
+            return Enumerable.Range(0, count)
                              .Select(i => (DateTime?)DefaultTime.AddHours(StartHour).AddMinutes(i * Increment));
         }
     }

--- a/tests/Core/Components/DateTimes/FluentTimePickerTests.razor
+++ b/tests/Core/Components/DateTimes/FluentTimePickerTests.razor
@@ -139,7 +139,7 @@
     [InlineData(8, 12, 30, 9, "08:00", "12:00")]
     [InlineData(8, 18, 15, 41, "08:00", "18:00")]
     [InlineData(7, 18, 5, 133, "07:00", "18:00")]
-    [InlineData(9, 17, 7, 65, "09:00", "16:28")]
+    [InlineData(9, 17, 7, 69, "09:00", "16:56")]
     public void FluentTimePicker_Items_GeneratesExpectedTimes(int startHour, int endHour, int increment, int expectedCount, string expectedFirst, string expectedLast)
     {
         // Arrange & Act

--- a/tests/Core/Components/DateTimes/FluentTimePickerTests.razor
+++ b/tests/Core/Components/DateTimes/FluentTimePickerTests.razor
@@ -135,6 +135,28 @@
         Assert.Equal(increment, timePickerInstance.Increment);
     }
 
+    [Theory]
+    [InlineData(8, 12, 30, 9, "08:00", "12:00")]
+    [InlineData(8, 18, 15, 41, "08:00", "18:00")]
+    [InlineData(7, 18, 5, 133, "07:00", "18:00")]
+    [InlineData(9, 17, 7, 65, "09:00", "16:28")]
+    public void FluentTimePicker_Items_GeneratesExpectedTimes(int startHour, int endHour, int increment, int expectedCount, string expectedFirst, string expectedLast)
+    {
+        // Arrange & Act
+        var timePicker = Render(@<FluentTimePicker TValue="DateTime"
+                                                   Culture="@InvariantCulture"
+                                                   RenderStyle="DatePickerRenderStyle.FluentUI"
+                                                   StartHour="@startHour"
+                                                   EndHour="@endHour"
+                                                   Increment="@increment" />);
+
+        // Assert
+        var options = timePicker.FindAll("fluent-option");
+        Assert.Equal(expectedCount, options.Count);
+        Assert.Equal(expectedFirst, options.First().GetAttribute("text"));
+        Assert.Equal(expectedLast, options.Last().GetAttribute("text"));
+    }
+
     [Fact]
     public void FluentTimePicker_DisabledTimeFunc_DisablesSpecificTimes()
     {


### PR DESCRIPTION
# Fix FluentTimePicker item generation logic and add unit tests

Correct the logic for generating time items in the **FluentTimePicker** component to ensure accurate outputs based on the specified **start** and **end** hours and increment. 
Add unit tests to verify that the generated times match expected values. 

Fix #4889