### PR TITLE
[dev-v5] Fix default text retrieval for FluentTimePicker and FluentSelect combobox

### DIFF
--- a/src/Core/Components/List/FluentSelect.razor.cs
+++ b/src/Core/Components/List/FluentSelect.razor.cs
@@ -57,7 +57,7 @@ public partial class FluentSelect<TOption, TValue> : FluentListBase<TOption, TVa
             // This method don't change the SelectedItems and Value properties.
             if (string.Equals(DropdownType, "combobox", StringComparison.Ordinal))
             {
-                var defaultText = ""; // GetOptionText(Value);      TODO: implement GetOptionText ????
+                var defaultText = Value is TOption option ? base.GetOptionText(option) : "";
                 await JSModule.ObjectReference.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Select.SetComboBoxValue", Id, defaultText);
             }
         }


### PR DESCRIPTION
# Fix default text retrieval for FluentTimePicker and FluentSelect combobox

Update the default text retrieval logic for the **FluentSelect combobox** to correctly use the selected value. 
This change resolves an issue where the default text was not being set properly.

```razor
<FluentTimePicker Label="Meeting time"
                  @bind-Value="@SelectedValue1" />

<FluentTimePicker Label="Meeting time"
                  @bind-Value="@SelectedValue2" />

@code
{
	DateTime? SelectedValue1 = new DateTime(2024, 6, 1, 14, 30, 0);
	DateTime? SelectedValue2 = null;
}
```

<img width="522" height="156" alt="image" src="https://github.com/user-attachments/assets/b88f46f8-c8d6-4441-8a48-b09ad138e1fe" />


Fix #4892