### PR TITLE
[dev-v5] Charts lib - Pin minimum version of Microsoft.FluentUI.AspNetCore.Components

### DIFF
--- a/src/Charts/Microsoft.FluentUI.AspNetCore.Components.Charts.csproj
+++ b/src/Charts/Microsoft.FluentUI.AspNetCore.Components.Charts.csproj
@@ -88,6 +88,20 @@
     <ProjectReference Include="..\Core\Microsoft.FluentUI.AspNetCore.Components.csproj" />
   </ItemGroup>
 
+  <!-- Pin the minimum published Microsoft.FluentUI.AspNetCore.Components version in the produced nupkg dependencies -->
+  <!-- NOTE: To be removed when RC4+ is released -->
+  <PropertyGroup>
+    <FluentUICoreMinVersion>[5.0.0-0,5.0.0)</FluentUICoreMinVersion>
+  </PropertyGroup>
+  <Target Name="SetFluentUICoreDependencyVersion" AfterTargets="_GetProjectReferenceVersions">
+    <ItemGroup>
+      <_ProjectReferencesWithVersions Update="@(_ProjectReferencesWithVersions)"
+                                      Condition="'%(Filename)' == 'Microsoft.FluentUI.AspNetCore.Components'">
+        <ProjectVersion>$(FluentUICoreMinVersion)</ProjectVersion>
+      </_ProjectReferencesWithVersions>
+    </ItemGroup>
+  </Target>
+
   <!-- Enable deterministic builds for CI environments and Release configuration -->
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true' Or '$(TF_BUILD)' == 'true' Or '$(Configuration)' == 'Release'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>


### PR DESCRIPTION
# Charts lib - Pin minimum version of Microsoft.FluentUI.AspNetCore.Components

Set a minimum version for the `Microsoft.FluentUI.AspNetCore.Components` dependency in the **nupkg** to ensure compatibility until a stable release is available. This change will be removed when RC4 is released.

