### PR TITLE
[dev-v5][Toast] Allow setting Toast.IsDismissible through LibraryToastOptions. 

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Program.cs
+++ b/examples/Demo/FluentUI.Demo.Client/Program.cs
@@ -13,12 +13,7 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 
 // Add FluentUI services
-builder.Services.AddFluentUIComponents(options =>
-    {
-        // Configure FluentUI options here
-        options.Toast.Position = ToastPosition.TopEnd;
-        options.Toast.IsDismissable = true;
-    });
+builder.Services.AddFluentUIComponents();
 
 // Add Demo server services
 builder.Services.AddFluentUIDemoServices().ForClient();

--- a/examples/Demo/FluentUI.Demo.Client/Program.cs
+++ b/examples/Demo/FluentUI.Demo.Client/Program.cs
@@ -13,7 +13,12 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 
 // Add FluentUI services
-builder.Services.AddFluentUIComponents();
+builder.Services.AddFluentUIComponents(options =>
+    {
+        // Configure FluentUI options here
+        options.Toast.Position = ToastPosition.TopEnd;
+        options.Toast.IsDismissable = true;
+    });
 
 // Add Demo server services
 builder.Services.AddFluentUIDemoServices().ForClient();

--- a/src/Core/Components/Toast/FluentToastProvider.razor
+++ b/src/Core/Components/Toast/FluentToastProvider.razor
@@ -33,7 +33,7 @@
                          Subtitle="@toast.Options.Subtitle"
                          QuickAction1="@toast.Options.QuickAction1"
                          QuickAction2="@toast.Options.QuickAction2"
-                         IsDismissable="@toast.Options.IsDismissable"
+                         IsDismissable="@GetIsDismissable(toast)"
                          DismissAction="@toast.Options.DismissAction"
                          AdditionalAttributes="@toast.Options.AdditionalAttributes" />
         }

--- a/src/Core/Components/Toast/FluentToastProvider.razor.cs
+++ b/src/Core/Components/Toast/FluentToastProvider.razor.cs
@@ -81,6 +81,9 @@ public partial class FluentToastProvider : FluentComponentBase
     private bool GetPauseOnWindowBlur(IToastInstance toast)
         => toast.Options.PauseOnWindowBlur ?? configuration.Toast.PauseOnWindowBlur;
 
+    private bool GetIsDismissable(IToastInstance toast)
+        => toast.Options.IsDismissable ?? configuration.Toast.IsDismissable;
+
     private IEnumerable<IToastInstance> GetRenderedToasts()
         => ToastService?.Items.Values
             .Where(toast => toast.LifecycleStatus is ToastLifecycleStatus.Visible or ToastLifecycleStatus.Dismissed)

--- a/src/Core/Components/Toast/Services/LibraryToastOptions.cs
+++ b/src/Core/Components/Toast/Services/LibraryToastOptions.cs
@@ -15,6 +15,7 @@ public class LibraryToastOptions
     private const int _defaultHorizontalOffset = 20;
     private const bool _defaultPauseOnHover = true;
     private const bool _defaultPauseOnWindowBlur = true;
+    private const bool _defaultIsDismissable = false;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="LibraryToastOptions"/> class.
@@ -57,4 +58,9 @@ public class LibraryToastOptions
     /// Gets or sets a value indicating whether visible toasts pause timeout while the window is blurred.
     /// </summary>
     public bool PauseOnWindowBlur { get; set; } = _defaultPauseOnWindowBlur;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether visible toasts can be dismissed by the user.
+    /// </summary>
+    public bool IsDismissable { get; set; } = _defaultIsDismissable;
 }

--- a/src/Core/Components/Toast/Services/ToastOptions.cs
+++ b/src/Core/Components/Toast/Services/ToastOptions.cs
@@ -153,7 +153,7 @@ public class ToastOptions : IFluentComponentBase
     /// <summary>
     /// Gets or sets a value indicating whether the toast can be dismissed by the user.
     /// </summary>
-    public bool IsDismissable { get; set; }
+    public bool? IsDismissable { get; set; }
 
     /// <summary>
     /// Gets or sets dismiss action label.

--- a/tests/Core/Components/Toast/FluentToastProviderTests.razor
+++ b/tests/Core/Components/Toast/FluentToastProviderTests.razor
@@ -16,6 +16,7 @@
             config.Toast.HorizontalOffset = 55;
             config.Toast.PauseOnHover = true;
             config.Toast.PauseOnWindowBlur = true;
+            config.Toast.IsDismissable = true;
         });
 
         ToastService = Services.GetRequiredService<IToastService>();
@@ -64,6 +65,7 @@
         Assert.Equal(55, toast.Instance.HorizontalOffset);
         Assert.True(toast.Instance.PauseOnHover);
         Assert.True(toast.Instance.PauseOnWindowBlur);
+        Assert.True(toast.Instance.IsDismissable);
     }
 
     [Fact]
@@ -80,6 +82,7 @@
             options.HorizontalOffset = 22;
             options.PauseOnHover = true;
             options.PauseOnWindowBlur = true;
+            options.IsDismissable = true;
         });
 
         await Task.CompletedTask;
@@ -91,6 +94,7 @@
         Assert.Equal(22, toast.Instance.HorizontalOffset);
         Assert.True(toast.Instance.PauseOnHover);
         Assert.True(toast.Instance.PauseOnWindowBlur);
+        Assert.True(toast.Instance.IsDismissable);
     }
 
     [Fact]

--- a/tests/Core/Components/Toast/FluentToastProviderTests.razor
+++ b/tests/Core/Components/Toast/FluentToastProviderTests.razor
@@ -16,7 +16,7 @@
             config.Toast.HorizontalOffset = 55;
             config.Toast.PauseOnHover = true;
             config.Toast.PauseOnWindowBlur = true;
-            config.Toast.IsDismissable = true;
+            config.Toast.IsDismissable = false;
         });
 
         ToastService = Services.GetRequiredService<IToastService>();
@@ -65,7 +65,7 @@
         Assert.Equal(55, toast.Instance.HorizontalOffset);
         Assert.True(toast.Instance.PauseOnHover);
         Assert.True(toast.Instance.PauseOnWindowBlur);
-        Assert.True(toast.Instance.IsDismissable);
+        Assert.False(toast.Instance.IsDismissable);
     }
 
     [Fact]


### PR DESCRIPTION
Fix #4769
This pull request introduces improvements to the configuration and behavior of toast notifications, specifically around making toasts dismissable by the user. The changes add a new `IsDismissable` option at both the global and per-toast level, update the default values, and ensure proper fallback logic. Additionally, tests have been updated to cover these changes.

### Toast Dismissability Configuration

* Added a new `IsDismissable` property to `LibraryToastOptions` with a default value of `false`, allowing global configuration of whether toasts can be dismissed by the user. [[1]](diffhunk://#diff-79ba74a6eb0f85b76596fe3389faccea78e0fb9b258ea5596c47ea38b13b05d7R18) [[2]](diffhunk://#diff-79ba74a6eb0f85b76596fe3389faccea78e0fb9b258ea5596c47ea38b13b05d7R61-R65)
* Updated `ToastOptions.IsDismissable` to be nullable, so individual toasts can override the global setting or fall back to it.
* Updated `FluentToastProvider` to use a new `GetIsDismissable` method that properly resolves the dismissable state based on per-toast and global options. [[1]](diffhunk://#diff-b0c3ea834ed3441c654b610291439e423f6d672b190941c9822a06d5f049c98fL36-R36) [[2]](diffhunk://#diff-cc754212b41b8734409dcf00a657d3dd43c0bc6ef0403a083741c8ff9691b086R84-R86)

### Testing

* Extended the toast provider tests to cover the new `IsDismissable` configuration, ensuring correct behavior for both global and per-toast settings. [[1]](diffhunk://#diff-2dcbd641258653488b479c2e7f68cb60992bba56410a175f2e75da5ac7dd9543R19) [[2]](diffhunk://#diff-2dcbd641258653488b479c2e7f68cb60992bba56410a175f2e75da5ac7dd9543R68) [[3]](diffhunk://#diff-2dcbd641258653488b479c2e7f68cb60992bba56410a175f2e75da5ac7dd9543R85) [[4]](diffhunk://#diff-2dcbd641258653488b479c2e7f68cb60992bba56410a175f2e75da5ac7dd9543R97)