### PR TITLE
[dev-v5][Toast] Allow setting Inverted in LibraryToastOptions

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Toast/FluentToast.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Toast/FluentToast.md
@@ -94,6 +94,7 @@ and has the following properties (and default values):
 - PauseOnHover (true);
 - PauseOnWindowBlur (true);
 - IsDismissable (false);
+- Inverted (false);
 
 The preferred defaults can be set in the `AddFluentUIComponents` method when configuring services.
 

--- a/src/Core/Components/Toast/FluentToastProvider.razor
+++ b/src/Core/Components/Toast/FluentToastProvider.razor
@@ -19,7 +19,7 @@
                          VerticalOffset="@GetVerticalOffset(toast)"
                          HorizontalOffset="@GetHorizontalOffset(toast)"
                          Type="@toast.Options.Type"
-                         Inverted="@toast.Options.Inverted"
+                         Inverted="@GetInverted(toast)"
                          Intent="@toast.Options.Intent"
                          Politeness="@toast.Options.Politeness"
                          PauseOnHover="@GetPauseOnHover(toast)"

--- a/src/Core/Components/Toast/FluentToastProvider.razor.cs
+++ b/src/Core/Components/Toast/FluentToastProvider.razor.cs
@@ -84,6 +84,9 @@ public partial class FluentToastProvider : FluentComponentBase
     private bool GetIsDismissable(IToastInstance toast)
         => toast.Options.IsDismissable ?? configuration.Toast.IsDismissable;
 
+    private bool GetInverted(IToastInstance toast)
+        => toast.Options.Inverted ?? configuration.Toast.Inverted;
+
     private IEnumerable<IToastInstance> GetRenderedToasts()
         => ToastService?.Items.Values
             .Where(toast => toast.LifecycleStatus is ToastLifecycleStatus.Visible or ToastLifecycleStatus.Dismissed)

--- a/src/Core/Components/Toast/Services/LibraryToastOptions.cs
+++ b/src/Core/Components/Toast/Services/LibraryToastOptions.cs
@@ -16,6 +16,7 @@ public class LibraryToastOptions
     private const bool _defaultPauseOnHover = true;
     private const bool _defaultPauseOnWindowBlur = true;
     private const bool _defaultIsDismissable = false;
+    private const bool _defaultInverted = false;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="LibraryToastOptions"/> class.
@@ -63,4 +64,9 @@ public class LibraryToastOptions
     /// Gets or sets a value indicating whether visible toasts can be dismissed by the user.
     /// </summary>
     public bool IsDismissable { get; set; } = _defaultIsDismissable;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the toast uses inverted colors.
+    /// </summary>
+    public bool Inverted { get; set; } = _defaultInverted;
 }

--- a/src/Core/Components/Toast/Services/ToastOptions.cs
+++ b/src/Core/Components/Toast/Services/ToastOptions.cs
@@ -93,7 +93,7 @@ public class ToastOptions : IFluentComponentBase
     /// <summary>
     /// Gets or sets a value indicating whether the toast uses inverted colors.
     /// </summary>
-    public bool Inverted { get; set; }
+    public bool? Inverted { get; set; }
 
     /// <summary>
     /// Gets or sets the toast intent.

--- a/tests/Core/Components/Toast/FluentToastProviderTests.razor
+++ b/tests/Core/Components/Toast/FluentToastProviderTests.razor
@@ -17,6 +17,7 @@
             config.Toast.PauseOnHover = true;
             config.Toast.PauseOnWindowBlur = true;
             config.Toast.IsDismissable = false;
+            config.Toast.Inverted = false;
         });
 
         ToastService = Services.GetRequiredService<IToastService>();
@@ -66,6 +67,7 @@
         Assert.True(toast.Instance.PauseOnHover);
         Assert.True(toast.Instance.PauseOnWindowBlur);
         Assert.False(toast.Instance.IsDismissable);
+        Assert.False(toast.Instance.Inverted);
     }
 
     [Fact]
@@ -83,6 +85,7 @@
             options.PauseOnHover = true;
             options.PauseOnWindowBlur = true;
             options.IsDismissable = true;
+            options.Inverted = true;
         });
 
         await Task.CompletedTask;
@@ -95,6 +98,7 @@
         Assert.True(toast.Instance.PauseOnHover);
         Assert.True(toast.Instance.PauseOnWindowBlur);
         Assert.True(toast.Instance.IsDismissable);
+        Assert.True(toast.Instance.Inverted);
     }
 
     [Fact]


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR allows the user to set the `Inverted` property in `LibraryToastOptions` so the user does not need to specify this parameter for each toast shown on the website again.

Example:
```cs
Services.AddFluentUIComponents(config =>
{
    config.Toast.Inverted = false;
});
```

### 🎫 Issues

Related to #4769


## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
