### PR TITLE
[dev-v5][LabelInfo] Make default FluentLabelInfo texts localizable

### DIFF
--- a/src/Core/Components/Label/FluentLabelInfo.razor
+++ b/src/Core/Components/Label/FluentLabelInfo.razor
@@ -1,4 +1,4 @@
-@namespace Microsoft.FluentUI.AspNetCore.Components
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 @using Microsoft.FluentUI.AspNetCore.Components.Extensions
 @inherits FluentLabel
 
@@ -25,7 +25,7 @@
     {
         <button id="@_infoButtonId"
                 type="button"
-                aria-label="@(string.IsNullOrEmpty(InfoText) ? "More information" : InfoText)"
+                aria-label="@(string.IsNullOrEmpty(InfoText) ? Localizer[Localization.LanguageResource.LabelInfo_InfoText] : InfoText)"
                 aria-expanded="@(_infoOpened ? "true" : "false")"
                 @onclick="OnInfoToggleAsync">
             <FluentIcon Value="@InfoIcon"
@@ -55,7 +55,7 @@
                     <FluentLink Href="@InfoActionLink"
                                 part="info-link"
                                 Target="@InfoActionTarget">
-                        @(InfoActionText ?? "Learn more")
+                        @(InfoActionText ?? Localizer[Localization.LanguageResource.LabelInfo_InfoActionText])
                     </FluentLink>
                 }
             }

--- a/src/Core/Localization/LanguageResource.resx
+++ b/src/Core/Localization/LanguageResource.resx
@@ -384,4 +384,10 @@
   <data name="Wizard_LabelButtonDone" xml:space="preserve">
     <value>Done</value>
   </data>
+  <data name="LabelInfo_InfoActionText" xml:space="preserve">
+    <value>Learn more</value>
+  </data>
+  <data name="LabelInfo_InfoText" xml:space="preserve">
+    <value>More information</value>
+  </data>
 </root>


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR exchanges the hardcoded fallback texts in `FluentLabelInfo` with proper a localized strings which can be set via the built in `IFluentLocalizer`

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

