### PR TITLE
[dev-v5] FluentLabelInfo - Add MaxWidth

### DIFF
--- a/src/Core/Components/Field/FluentField.razor
+++ b/src/Core/Components/Field/FluentField.razor
@@ -31,7 +31,8 @@ else
                         <FluentLabelInfo InfoText="@Parameters.LabelInfo.InfoText"
                                          InfoActionLink="@Parameters.LabelInfo.InfoActionLink"
                                          InfoActionText="@Parameters.LabelInfo.InfoActionText"
-                                         InfoActionTarget="@Parameters.LabelInfo.InfoActionTarget">
+                                         InfoActionTarget="@Parameters.LabelInfo.InfoActionTarget"
+                                         MaxWidth="@Parameters.LabelInfo.MaxWidth">
                             @Parameters.Label
                             @Parameters.LabelTemplate
                         </FluentLabelInfo>

--- a/src/Core/Components/Label/FluentLabelInfo.razor.cs
+++ b/src/Core/Components/Label/FluentLabelInfo.razor.cs
@@ -63,7 +63,7 @@ public partial class FluentLabelInfo : FluentLabel, ILabelInfo
 
     /// <summary>
     /// Gets or sets the maximum width of the info popover. Can be any valid CSS width value, such as "200px" or "50%".
-    /// If not set, the popover will size to fit its content up (`fit-content`).
+    /// If not set, the popover will size to fit its content (`fit-content`).
     /// </summary>
     [Parameter]
     public string? MaxWidth { get; set; }

--- a/src/Core/Components/Label/FluentLabelInfo.razor.cs
+++ b/src/Core/Components/Label/FluentLabelInfo.razor.cs
@@ -29,6 +29,11 @@ public partial class FluentLabelInfo : FluentLabel, ILabelInfo
         .AddClass("fluent-label-info")
         .Build();
 
+/// <summary />
+    protected override string? StyleValue => DefaultStyleBuilder
+        .AddStyle("--fluent-label-info-width", MaxWidth, when: !string.IsNullOrEmpty(MaxWidth))
+        .Build();
+
     /// <summary>
     /// Gets or sets the FluentField component that this label is associated with.
     /// </summary>
@@ -55,6 +60,13 @@ public partial class FluentLabelInfo : FluentLabel, ILabelInfo
     /// </summary>
     [Parameter]
     public string? InfoText { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum width of the info popover. Can be any valid CSS width value, such as "200px" or "50%".
+    /// If not set, the popover will size to fit its content up (`fit-content`).
+    /// </summary>
+    [Parameter]
+    public string? MaxWidth { get; set; }
 
     /// <summary>
     /// Gets or sets the URL displayed as a "learn more" link inside the popover.

--- a/src/Core/Components/Label/FluentLabelInfo.razor.css
+++ b/src/Core/Components/Label/FluentLabelInfo.razor.css
@@ -1,6 +1,7 @@
 .fluent-label-info {
     display: inline-flex;
     align-items: center;
+    --fluent-label-info-width: fit-content;
 }
 
 .fluent-label-info>button {
@@ -16,6 +17,7 @@
 
 .fluent-label-info>fluent-popover-b::part(dialog) {
     padding: var(--spacingVerticalS, 8px) var(--spacingHorizontalS, 8px);
+    max-width: var(--fluent-label-info-width, fit-content);
 }
 
 .fluent-label-info>fluent-popover-b fluent-link[part="info-link"] {

--- a/src/Core/Components/Label/ILabelInfo.cs
+++ b/src/Core/Components/Label/ILabelInfo.cs
@@ -34,7 +34,7 @@ public interface ILabelInfo
 
     /// <summary>
     /// Gets or sets the maximum width of the info popover. Can be any valid CSS width value, such as "200px" or "50%".
-    /// If not set, the popover will size to fit its content up (`fit-content`).
+    /// If not set, the popover will size to fit its content (`fit-content`).
     /// </summary>
     string? MaxWidth { get; set; }
 }

--- a/src/Core/Components/Label/ILabelInfo.cs
+++ b/src/Core/Components/Label/ILabelInfo.cs
@@ -31,4 +31,10 @@ public interface ILabelInfo
     /// Defaults to <see cref="LinkTarget.Blank"/> to open the link in a new tab.
     /// </summary>
     LinkTarget InfoActionTarget { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum width of the info popover. Can be any valid CSS width value, such as "200px" or "50%".
+    /// If not set, the popover will size to fit its content up (`fit-content`).
+    /// </summary>
+    string? MaxWidth { get; set; }
 }

--- a/src/Core/Components/Label/LabelInfo.cs
+++ b/src/Core/Components/Label/LabelInfo.cs
@@ -23,12 +23,14 @@ public partial class LabelInfo : ILabelInfo
     /// <param name="actionLink">The URL displayed as a "learn more" link inside the popover.</param>
     /// <param name="actionText">The text displayed as a "learn more" link inside the popover.</param>
     /// <param name="actionTarget">The target for the "learn more" link inside the popover.</param>
-    public LabelInfo(string text, string? actionLink = null, string? actionText = null, LinkTarget actionTarget = LinkTarget.Blank)
+    /// <param name="maxWidth">The maximum width of the info popover. Can be any valid CSS width value, such as "200px" or "50%".</param>
+    public LabelInfo(string text, string? actionLink = null, string? actionText = null, LinkTarget actionTarget = LinkTarget.Blank, string? maxWidth = null)
     {
         InfoText = text;
         InfoActionLink = actionLink;
         InfoActionText = actionText;
         InfoActionTarget = actionTarget;
+        MaxWidth = maxWidth;
     }
 
     /// <inheritdoc />
@@ -42,4 +44,7 @@ public partial class LabelInfo : ILabelInfo
 
     /// <inheritdoc />
     public LinkTarget InfoActionTarget { get; set; } = LinkTarget.Blank;
+
+    /// <inheritdoc />
+    public string? MaxWidth { get; set; }
 }

--- a/src/Core/Components/Label/LabelInfoBuilder.cs
+++ b/src/Core/Components/Label/LabelInfoBuilder.cs
@@ -47,4 +47,15 @@ public partial class LabelInfo : ILabelInfo
         InfoActionTarget = actionTarget;
         return this;
     }
+
+    /// <summary>
+    /// Sets the maximum width of the info popover.
+    /// </summary>
+    /// <param name="maxWidth">The maximum width of the info popover. Can be any valid CSS width value, such as "200px" or "50%".</param>
+    /// <returns>The current <see cref="LabelInfo"/> instance.</returns>
+    public LabelInfo WithMaxWidth(string? maxWidth)
+    {
+        MaxWidth = maxWidth;
+        return this;
+    }
 }

--- a/tests/Core/Components/Label/FluentLabelInfoTests.razor
+++ b/tests/Core/Components/Label/FluentLabelInfoTests.razor
@@ -229,4 +229,68 @@
         Assert.Throws<InvalidOperationException>(() =>
             Render(@<FluentLabelInfo Required="true">fluent label info</FluentLabelInfo>));
     }
+
+      [Fact]
+    public void FluentLabelInfo_MaxWidthIsSet_RendersCssVariable()
+    {
+        // Arrange & Act
+        var cut = Render<FluentLabelInfo>(parameters => parameters
+            .Add(p => p.MaxWidth, "200px")
+            .AddChildContent("My label"));
+
+        // Assert
+        var label = cut.Find(".fluent-label-info");
+        Assert.Contains("--fluent-label-info-width: 200px", label.GetAttribute("style"));
+    }
+
+    [Fact]
+    public void FluentLabelInfo_MaxWidthIsPercentage_RendersCssVariable()
+    {
+        // Arrange & Act
+        var cut = Render<FluentLabelInfo>(parameters => parameters
+            .Add(p => p.MaxWidth, "50%")
+            .AddChildContent("My label"));
+
+        // Assert
+        var label = cut.Find(".fluent-label-info");
+        Assert.Contains("--fluent-label-info-width: 50%", label.GetAttribute("style"));
+    }
+
+    [Fact]
+    public void FluentLabelInfo_MaxWidthIsNull_DoesNotRenderCssVariable()
+    {
+        // Arrange & Act
+        var cut = Render<FluentLabelInfo>(parameters => parameters
+            .Add(p => p.MaxWidth, null)
+            .AddChildContent("My label"));
+
+        // Assert
+        var label = cut.Find(".fluent-label-info");
+        Assert.DoesNotContain("--fluent-label-info-width", label.GetAttribute("style") ?? string.Empty);
+    }
+
+    [Fact]
+    public void FluentLabelInfo_MaxWidthIsEmpty_DoesNotRenderCssVariable()
+    {
+        // Arrange & Act
+        var cut = Render<FluentLabelInfo>(parameters => parameters
+            .Add(p => p.MaxWidth, string.Empty)
+            .AddChildContent("My label"));
+
+        // Assert
+        var label = cut.Find(".fluent-label-info");
+        Assert.DoesNotContain("--fluent-label-info-width", label.GetAttribute("style") ?? string.Empty);
+    }
+
+    [Fact]
+    public void FluentLabelInfo_MaxWidthNotSet_DoesNotRenderCssVariable()
+    {
+        // Arrange & Act
+        var cut = Render<FluentLabelInfo>(parameters => parameters
+            .AddChildContent("My label"));
+
+        // Assert
+        var label = cut.Find(".fluent-label-info");
+        Assert.DoesNotContain("--fluent-label-info-width", label.GetAttribute("style") ?? string.Empty);
+    }
 }

--- a/tests/Core/Components/Label/FluentLabelInfoTests.razor
+++ b/tests/Core/Components/Label/FluentLabelInfoTests.razor
@@ -230,7 +230,7 @@
             Render(@<FluentLabelInfo Required="true">fluent label info</FluentLabelInfo>));
     }
 
-      [Fact]
+    [Fact]
     public void FluentLabelInfo_MaxWidthIsSet_RendersCssVariable()
     {
         // Arrange & Act

--- a/tests/Core/Components/Label/LabelInfoTests.cs
+++ b/tests/Core/Components/Label/LabelInfoTests.cs
@@ -140,4 +140,67 @@ public class LabelInfoTests
         Assert.Equal("Read", info.InfoActionText);
         Assert.Equal(LinkTarget.Self, info.InfoActionTarget);
     }
+
+     [Fact]
+    public void LabelInfo_MaxWidthProperty_CanBeSet()
+    {
+        // Arrange & Act
+        var labelInfo = new LabelInfo { MaxWidth = "300px" };
+
+        // Assert
+        Assert.Equal("300px", labelInfo.MaxWidth);
+    }
+
+    [Fact]
+    public void LabelInfo_Constructor_SetsMaxWidth()
+    {
+        // Arrange & Act
+        var labelInfo = new LabelInfo("Info text", maxWidth: "150px");
+
+        // Assert
+        Assert.Equal("150px", labelInfo.MaxWidth);
+    }
+
+    [Fact]
+    public void LabelInfo_ConstructorWithoutMaxWidth_MaxWidthIsNull()
+    {
+        // Arrange & Act
+        var labelInfo = new LabelInfo("Info text");
+
+        // Assert
+        Assert.Null(labelInfo.MaxWidth);
+    }
+
+    [Fact]
+    public void LabelInfo_WithMaxWidth_SetsMaxWidth()
+    {
+        // Arrange & Act
+        var labelInfo = LabelInfo.WithText("Info text").WithMaxWidth("250px");
+
+        // Assert
+        Assert.Equal("250px", labelInfo.MaxWidth);
+    }
+
+    [Fact]
+    public void LabelInfo_WithMaxWidth_ReturnsSameInstance()
+    {
+        // Arrange
+        var labelInfo = LabelInfo.WithText("Info text");
+
+        // Act
+        var result = labelInfo.WithMaxWidth("250px");
+
+        // Assert
+        Assert.Same(labelInfo, result);
+    }
+
+    [Fact]
+    public void LabelInfo_WithMaxWidthNull_SetsMaxWidthToNull()
+    {
+        // Arrange & Act
+        var labelInfo = LabelInfo.WithText("Info text").WithMaxWidth(null);
+
+        // Assert
+        Assert.Null(labelInfo.MaxWidth);
+    }
 }

--- a/tests/Core/Components/Label/LabelInfoTests.cs
+++ b/tests/Core/Components/Label/LabelInfoTests.cs
@@ -141,7 +141,7 @@ public class LabelInfoTests
         Assert.Equal(LinkTarget.Self, info.InfoActionTarget);
     }
 
-     [Fact]
+    [Fact]
     public void LabelInfo_MaxWidthProperty_CanBeSet()
     {
         // Arrange & Act


### PR DESCRIPTION
# [dev-v5] FluentLabelInfo - Add MaxWidth

Introduce a `MaxWidth` parameter to the `FluentLabelInfo` component, allowing customization of the popover's maximum width. 
This change enhances flexibility in UI design. 

```razor
<FluentLabelInfo InfoText="This is example information for an InfoLabel."
                 InfoActionLink="https://dotnet.microsoft.com/"
                 MaxWidth="100px"> 👈
    Example label
</FluentLabelInfo>


<FluentTextInput Placeholder="Example input" 
                 Label="Example label"
                 LabelInfo="@(LabelInfo.WithText("This is example information for an InfoLabel.")
                                       .WithActionLink("https://dotnet.microsoft.com/")
                                       .WithMaxWidth("100px"))" /> 👈
```

## Unit Tests

- Add corresponding tests to ensure the `MaxWidth` property functions as intended.
- Code Coverage: 100%

