### PR TITLE
[Chore] Publish symbols from CI builds to internal symbol server

### DIFF
--- a/eng/pipelines/build-all-lib.yml
+++ b/eng/pipelines/build-all-lib.yml
@@ -180,6 +180,14 @@ extends:
             projects: ${{ parameters.Projects }}
             arguments: '--configuration Release /p:ContinuousIntegrationBuild=true /p:DebugType=portable /p:DebugSymbols=true'
 
+        # Stage shipping binaries for symbol upload BEFORE the test step;
+        # see publish-symbols-stage.yml for why this must run pre-test.
+        # Pipeline only triggers on v* tags, but condition is explicit so
+        # a manual queue against a branch does not unintentionally upload.
+        - template: /eng/pipelines/publish-symbols-stage.yml@self
+          parameters:
+            condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
+
         # Test and generate Code Coverage
         - task: DotNetCoreCLI@2
           condition: eq(variables['ShouldTest'], 'true')
@@ -214,6 +222,10 @@ extends:
           inputs:
             SearchPattern: '**/bin/**/*.pdb' # string. Required. Search pattern. Default: **/bin/**/*.pdb.
             SymbolServerType: 'TeamServices'
+
+        - template: /eng/pipelines/publish-symbols-upload.yml@self
+          parameters:
+            condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
 
         # Since NuGet packages are generated during the build, we need to copy them to the artifacts folder.
         - task: CopyFiles@2

--- a/eng/pipelines/build-core-lib.yml
+++ b/eng/pipelines/build-core-lib.yml
@@ -211,6 +211,12 @@ extends:
             #arguments: '--configuration Release /p:ContinuousIntegrationBuild=true -warnaserror' temp remove warnaserror
             arguments: '--configuration Release /p:ContinuousIntegrationBuild=true'
 
+        # Stage shipping binaries for symbol upload BEFORE the test step;
+        # see publish-symbols-stage.yml for why this must run pre-test.
+        - template: /eng/pipelines/publish-symbols-stage.yml@self
+          parameters:
+            condition: and(succeeded(), or(in(variables['Build.SourceBranch'], 'refs/heads/main', 'refs/heads/dev', 'refs/heads/dev-v5'), startsWith(variables['Build.SourceBranch'], 'refs/heads/archives/')))
+
         # Test and generate Code Coverage
         - task: DotNetCoreCLI@2
           condition: eq(variables['ShouldTest'], 'true')
@@ -238,6 +244,10 @@ extends:
             codeCoverageTool: Cobertura
             summaryFileLocation: '**/*.cobertura.xml'
             reportDirectory: CoverageFolder
+
+        - template: /eng/pipelines/publish-symbols-upload.yml@self
+          parameters:
+            condition: and(succeeded(), or(in(variables['Build.SourceBranch'], 'refs/heads/main', 'refs/heads/dev', 'refs/heads/dev-v5'), startsWith(variables['Build.SourceBranch'], 'refs/heads/archives/')))
 
         # Index sources and publish symbols
         - task: PublishSymbols@2

--- a/eng/pipelines/publish-symbols-stage.yml
+++ b/eng/pipelines/publish-symbols-stage.yml
@@ -1,0 +1,30 @@
+# Stage shipping binaries for symbol upload. Place this immediately after
+# the Build step, BEFORE any task that runs `dotnet test` with a different
+# /p:DebugType. The test step passes /p:DebugType=Full as a global MSBuild
+# property, which propagates through P2P refs and rebuilds Core with a
+# different MVID; if we staged after the test step, the binaries we upload
+# would not match the binaries inside the shipping nupkg.
+#
+# The .pdb pattern is included for pipelines that build with
+# /p:DebugType=portable (standalone PDBs). For pipelines using the csproj
+# default of <DebugType>embedded</DebugType>, the PDB rides inside the DLL
+# and the .pdb pattern matches nothing — harmless. We deliberately stay on
+# SymWeb only (see publish-symbols-upload.yml's SubmitToInternet:false),
+# so embedded-in-DLL is fine here.
+parameters:
+- name: condition
+  type: string
+
+steps:
+- task: CopyFiles@2
+  displayName: 'Collect shipping binaries for symbol upload'
+  condition: ${{ parameters.condition }}
+  inputs:
+    SourceFolder: '$(Build.SourcesDirectory)'
+    Contents: |
+      src/**/bin/Release/**/Microsoft.FluentUI.*.dll
+      src/**/bin/Release/**/Microsoft.FluentUI.*.pdb
+      !src/Templates/**
+    TargetFolder: '$(Build.ArtifactStagingDirectory)/Symbols'
+    CleanTargetFolder: true
+    flattenFolders: false

--- a/eng/pipelines/publish-symbols-upload.yml
+++ b/eng/pipelines/publish-symbols-upload.yml
@@ -1,0 +1,27 @@
+# Upload the staged DLL (+ PDB, if standalone) pairs to the internal
+# symbol server. SubmitToInternet:false keeps these out of the public
+# symbol server (MSDL); the task will print a warning about that override
+# which is intentional and safe to ignore. The pair to this template is
+# publish-symbols-stage.yml, which must run earlier in the same job.
+parameters:
+- name: condition
+  type: string
+
+steps:
+- task: MicroBuildArchiveSymbols@6
+  displayName: 'Archive symbols to internal symbol server'
+  condition: ${{ parameters.condition }}
+  inputs:
+    azureSubscription: 'VSEng-SymbolsUpload'
+    SymbolsFeatureName: 'FluentUIBlazor'
+    SymbolsProject: 'DDE'
+    SymbolsAgentPath: '$(Build.ArtifactStagingDirectory)/Symbols'
+    # FluentUI is a public Blazor library; we publish to SymWeb for
+    # internal debugging but intentionally skip MSDL because we do not
+    # currently publish symbols there for our packages. The task warns
+    # when SubmitToInternet is overridden — SuppressSymwebOnlyWarning
+    # acknowledges the override is deliberate.
+    SubmitToInternet: false
+    SuppressSymwebOnlyWarning: true
+  env:
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/eng/pipelines/publish-symbols-upload.yml
+++ b/eng/pipelines/publish-symbols-upload.yml
@@ -1,8 +1,8 @@
 # Upload the staged DLL (+ PDB, if standalone) pairs to the internal
 # symbol server. SubmitToInternet:false keeps these out of the public
 # symbol server (MSDL); the task will print a warning about that override
-# which is intentional and safe to ignore. The pair to this template is
-# publish-symbols-stage.yml, which must run earlier in the same job.
+# which is intentional and safe to ignore. The counterpart to this template
+# is publish-symbols-stage.yml, which must run earlier in the same job.
 parameters:
 - name: condition
   type: string


### PR DESCRIPTION
# Pull Request

## 📖 Description

Adds symbol publishing to both internal CI pipelines so PDBs for the shipping `Microsoft.FluentUI.*` assemblies are archived for long-term debugging support. There is no change to the public NuGet packages or to what is published to nuget.org / public symbol servers.

Two small shared templates (`publish-symbols-stage.yml`, `publish-symbols-upload.yml`) keep the logic in one place so both pipelines stay in sync. Conditions are scoped to the branches each pipeline actually produces shipping artifacts from — `main`/`dev`/`dev-v5`/`archives/*` for the per-commit pipeline, and `refs/tags/v*` for the release pipeline — so PR validation builds and one-off manual queues do not trigger the upload.

This is a chore / infrastructure change. Not a breaking change. No runtime behavior changes for consumers of the NuGet packages.

### 🎫 Issues

#1607 

## 👩‍💻 Reviewer Notes

Only the internal CI YAML is changed; no product code is touched and no public outputs are altered. The diff is purely additive — no existing line of either pipeline is modified or removed.

Things worth a look:

- The two new template files under `eng/pipelines/` and how they're invoked from `build-core-lib.yml` and `build-all-lib.yml`.
- The staging step is intentionally placed before the test step so the symbols we capture come from the build step's output (matching what gets packaged), not from any intermediate state.
- Templates package output is excluded from staging because `Microsoft.FluentUI.AspNetCore.Templates.csproj` sets `IncludeBuildOutput=false` and its placeholder DLL doesn't ship in any nupkg.

## 📑 Test Plan

Verified by manually queuing the full build against this branch in the internal CI mirror and inspecting the run logs. The symbol-archive step in `fluentui-blazor-build-all` reported successful upload of 88 files (Core + Generators + Icons sub-packages + Emoji sub-packages + both DataGrid adapters, across `net8.0`/`net9.0`/`net10.0`) and the run completed.

No new unit tests are added; this change is purely pipeline infrastructure.

## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!-- Component-specific section removed — not applicable, infrastructure change. -->

## ⏭ Next Steps

Decide if we want to publish the symbols publicly as well - would potentially involve changing the debug type for some projects and then a small tweak to the yaml. Out of scope for this particular requirement but can be added easily as a second step. 

