### PR TITLE
[dev-v5] Enhance option styling with customizable CSS class

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/List/Select/Examples/SelectCustomized.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/List/Select/Examples/SelectCustomized.razor
@@ -3,28 +3,16 @@
 <FluentSelect Label="Coworker"
               Placeholder="Select a coworker"
               Items="@Coworkers"
-              Width="250px"
               @bind-Value="@Value"
               OptionText="@(item => $"{item?.FirstName} {item?.LastName}")"
-              OptionValueToString="@(item => item?.Id)"
-              OptionClass="my-option"
-              OptionDisabled="@(item => item == Coworkers.ElementAt(3))" />
+              OptionValueToString="@(item => item?.Id)"              
+              OptionDisabled="@(item => item == Coworkers.ElementAt(3))"
+              OptionNoWrapMaxWidth="250px"
+              Width="250px" />
 
 <div>
     Selected: @Value?.Id - @Value?.FirstName
 </div>
-
-<style>
-    @* Add custom styling for options with long content *@
-    .my-option::part(content) {
-        display: inline-block;
-        max-width: 200px;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        height: 16px;
-    }
-</style>
 
 @code {
     static Samples.Person?[] OneNullPerson = new Samples.Person?[] { null, Samples.VeryLongNamePerson };

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/List/Select/Examples/SelectCustomized.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/List/Select/Examples/SelectCustomized.razor
@@ -3,18 +3,32 @@
 <FluentSelect Label="Coworker"
               Placeholder="Select a coworker"
               Items="@Coworkers"
+              Width="250px"
               @bind-Value="@Value"
-              OptionText="@(item => item?.FirstName)"
+              OptionText="@(item => $"{item?.FirstName} {item?.LastName}")"
               OptionValueToString="@(item => item?.Id)"
+              OptionClass="my-option"
               OptionDisabled="@(item => item == Coworkers.ElementAt(3))" />
 
 <div>
     Selected: @Value?.Id - @Value?.FirstName
 </div>
 
+<style>
+    @* Add custom styling for options with long content *@
+    .my-option::part(content) {
+        display: inline-block;
+        max-width: 200px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        height: 16px;
+    }
+</style>
+
 @code {
-    static Samples.Person?[] OneNullPerson = new Samples.Person?[] { null };
-    static Samples.Person?[] Coworkers = OneNullPerson.Union(Samples.Persons.Take(5).ToArray()).ToArray();
+    static Samples.Person?[] OneNullPerson = new Samples.Person?[] { null, Samples.VeryLongNamePerson };
+    static Samples.Person?[] Coworkers = OneNullPerson.Union(Samples.Persons.Take(5)).ToArray();
 
     Samples.Person? Value = Coworkers.ElementAt(2);
 }

--- a/src/Core/Components/List/FluentAutocomplete.razor
+++ b/src/Core/Components/List/FluentAutocomplete.razor
@@ -170,6 +170,7 @@
                                        OptionTemplate="@OptionTemplate"
                                        OptionValueToString="@OptionValueToString"
                                        OptionSelectedComparer="@OptionSelectedComparer"
+                                       OptionNoWrapMaxWidth="@OptionNoWrapMaxWidth"
                                        Height="@Height"
                                        Items="@_internalFilteredItems"
                                        SelectedItems="@_internalSelectedItems"

--- a/src/Core/Components/List/FluentListBase.razor
+++ b/src/Core/Components/List/FluentListBase.razor
@@ -31,6 +31,7 @@
                               Text="@GetOptionText(item)"
                               Value="@GetOptionValue(item)"
                               Selected="@(GetOptionSelected(item))"
+                              Class="@OptionClass"
                               Disabled="@(GetOptionDisabled(item))">
                     @if (OptionTemplate is not null)
                     {

--- a/src/Core/Components/List/FluentListBase.razor.cs
+++ b/src/Core/Components/List/FluentListBase.razor.cs
@@ -129,6 +129,17 @@ public abstract partial class FluentListBase<TOption, TValue> : FluentInputBase<
     public virtual Func<TOption?, bool>? OptionDisabled { get; set; }
 
     /// <summary>
+    /// Gets or sets the CSS class to apply to options.
+    /// The class is applied to the host <c>&lt;fluent-option&gt;</c> element.
+    /// To style an internal part (such as the content area),
+    /// target it from your stylesheet using the <c>::part()</c> selector,
+    /// for example: <c>.my-option::part(content) { ... }</c>.
+    /// The part names available for styling are `description` and `content`.
+    /// </summary>
+    [Parameter]
+    public virtual string? OptionClass { get; set; }
+
+    /// <summary>
     /// Gets or sets the equality comparer used to determine whether two options are considered equal for selection purposes.
     /// </summary>
     [Parameter]

--- a/src/Core/Components/List/FluentListBase.razor.cs
+++ b/src/Core/Components/List/FluentListBase.razor.cs
@@ -36,6 +36,7 @@ public abstract partial class FluentListBase<TOption, TValue> : FluentInputBase<
     /// <inheritdoc />
     protected override string? StyleValue => DefaultStyleBuilder
         .AddStyle("width", Width)
+        .AddStyle("--no-wrap-max-width", OptionNoWrapMaxWidth, when: !string.IsNullOrEmpty(OptionNoWrapMaxWidth))
         .Build();
 
     /// <summary>
@@ -138,6 +139,13 @@ public abstract partial class FluentListBase<TOption, TValue> : FluentInputBase<
     /// </summary>
     [Parameter]
     public virtual string? OptionClass { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum width for options that should not wrap.
+    /// This parameters is the max width for options that have text long enough to wrap but should be prevented from doing so.
+    /// </summary>
+    [Parameter]
+    public virtual string? OptionNoWrapMaxWidth { get; set; }
 
     /// <summary>
     /// Gets or sets the equality comparer used to determine whether two options are considered equal for selection purposes.

--- a/src/Core/Components/List/FluentListbox.razor
+++ b/src/Core/Components/List/FluentListbox.razor
@@ -21,7 +21,7 @@
                  @onlistchange="@OnDropdownChangeHandlerAsync"
                  @onfocusout="@FocusOutHandlerAsync"
                  @attributes="@AdditionalAttributes">
-                <fluent-listbox style="@ListStyle">
+                <fluent-listbox style="@ListStyle" no-wrap="@OptionNoWrapMaxWidth">
                     @if (ChildContent is null && (Items is null || !Items.Any()))
                     {
                         @* The web component requires at least one option *@

--- a/src/Core/Components/List/FluentSelect.razor
+++ b/src/Core/Components/List/FluentSelect.razor
@@ -24,7 +24,7 @@
                              @ondropdownchange="@OnDropdownChangeHandlerAsync"
                              @onfocusout="@FocusOutHandlerAsync"
                              @attributes="@AdditionalAttributes">
-                <fluent-listbox style="@ListStyle">
+                <fluent-listbox style="@ListStyle" no-wrap="@OptionNoWrapMaxWidth">
                     @RenderOptions()
                 </fluent-listbox>
 

--- a/src/Core/Components/List/FluentSelect.razor.css
+++ b/src/Core/Components/List/FluentSelect.razor.css
@@ -11,10 +11,18 @@ fluent-dropdown[size="small"] button[slot="control"] {
   max-height: var(--lineHeightBase200);
 }
 
-fluent-dropdown:not([size="small"]):not([size="large"]) button[slot="control"]{
+fluent-dropdown:not([size="small"]):not([size="large"]) button[slot="control"] {
   max-height: var(--lineHeightBase300);
 }
 
 fluent-dropdown[size="large"] button[slot="control"] {
   max-height: var(--lineHeightBase400);
+}
+
+fluent-listbox[no-wrap]>fluent-option::part(content) {
+  display: inline-block;
+  max-width: var(--no-wrap-max-width, 250px);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/src/Core/Components/List/FluentSelect.razor.css
+++ b/src/Core/Components/List/FluentSelect.razor.css
@@ -6,3 +6,15 @@ fluent-dropdown[readonly] {
   pointer-events: none;
   user-select: none;
 }
+
+fluent-dropdown[size="small"] button[slot="control"] {
+  max-height: var(--lineHeightBase200);
+}
+
+fluent-dropdown:not([size="small"]):not([size="large"]) button[slot="control"]{
+  max-height: var(--lineHeightBase300);
+}
+
+fluent-dropdown[size="large"] button[slot="control"] {
+  max-height: var(--lineHeightBase400);
+}

--- a/tests/Core/Components/List/FluentAutocompleteTests.razor
+++ b/tests/Core/Components/List/FluentAutocompleteTests.razor
@@ -1156,6 +1156,26 @@
     }
 
     [Fact]
+    public void FluentAutocomplete_OptionNoWrapMaxWidth()
+    {
+        // Arrange
+        var cut = Render(@<FluentAutocomplete Id="my-list"
+                                TOption="string"
+                                TValue="string"
+                                OptionNoWrapMaxWidth="200px"
+                                OnOptionsSearch="@OnOptionsSearch" />);
+
+        // Act - Open the dropdown to display the listbox
+        cut.Find("fluent-text-input").Click();
+
+        // Assert - the no-wrap attribute is applied to the listbox with the provided max width
+        var listbox = cut.Find("fluent-listbox");
+
+        Assert.True(listbox.HasAttribute("no-wrap"));
+        Assert.Equal("200px", listbox.GetAttribute("no-wrap"));
+    }
+
+    [Fact]
     public void FluentAutocomplete_DefaultOptionSelectedComparer_UsesTOptionAsComparer()
     {
         // Arrange & Act - TOption (Person) implements IEqualityComparer<Person> and has a public parameterless ctor

--- a/tests/Core/Components/List/FluentListboxTests.razor
+++ b/tests/Core/Components/List/FluentListboxTests.razor
@@ -385,6 +385,19 @@
     }
 
     [Fact]
+    public void FluentListbox_OptionNoWrapMaxWidth()
+    {
+        // Arrange and Act
+        var cut = Render(@<FluentListbox Items="@Digits" TOption="string" TValue="string" OptionNoWrapMaxWidth="200px" />);
+
+        // Assert - the no-wrap attribute is applied to the listbox with the provided max width
+        var listbox = cut.Find("fluent-listbox");
+
+        Assert.True(listbox.HasAttribute("no-wrap"));
+        Assert.Equal("200px", listbox.GetAttribute("no-wrap"));
+    }
+
+    [Fact]
     public void FluentListbox_Disabled()
     {
         // Arrange and Act

--- a/tests/Core/Components/List/FluentSelectTests.razor
+++ b/tests/Core/Components/List/FluentSelectTests.razor
@@ -120,6 +120,19 @@
     }
 
     [Fact]
+    public void FluentSelect_OptionNoWrapMaxWidth()
+    {
+        // Arrange and Act
+        var cut = Render(@<FluentSelect Items="@Digits" OptionNoWrapMaxWidth="200px" TOption="string" TValue="string" />);
+
+        // Assert - the no-wrap attribute is applied to the listbox with the provided max width
+        var listbox = cut.Find("fluent-listbox");
+
+        Assert.True(listbox.HasAttribute("no-wrap"));
+        Assert.Equal("200px", listbox.GetAttribute("no-wrap"));
+    }
+
+    [Fact]
     public void FluentSelect_Default_InitialSelection()
     {
         string? value = "Two";

--- a/tests/Core/Components/List/FluentSelectTests.razor
+++ b/tests/Core/Components/List/FluentSelectTests.razor
@@ -107,6 +107,19 @@
     }
 
     [Fact]
+    public void FluentSelect_OptionClass()
+    {
+        // Arrange and Act
+        var cut = Render(@<FluentSelect Items="@Digits" OptionClass="my-option" TOption="string" TValue="string" />);
+
+        // Assert - the custom CSS class is applied to every rendered option
+        var options = cut.FindAll("fluent-option");
+
+        Assert.NotEmpty(options);
+        Assert.All(options, option => Assert.Contains("my-option", option.GetAttribute("class")));
+    }
+
+    [Fact]
     public void FluentSelect_Default_InitialSelection()
     {
         string? value = "Two";


### PR DESCRIPTION
[dev-v5] Enhance option styling with customizable CSS class

1. Introduce an `OptionClass` parameter to allow custom CSS class application for options in the **FluentSelect** component. This change enhances styling flexibility and includes tests to verify the correct application of the custom class. 
2. Add an `OptionNoWrapMaxWidth` parameter to automatically add CSS code to **fluent-options** to prevent line breaks and enforce a maximum width

No breaking changes are introduced.

## Example 1
```razor
<FluentSelect Items="@Coworkers"
              Width="250px"
              OptionClass="my-option" /> 👈

<style>
    .my-option::part(content) {
        display: inline-block;
        max-width: 200px;
        white-space: nowrap;
        overflow: hidden;
        text-overflow: ellipsis;
    }
</style>
```

## Example 2 (same but simplified)
```razor
<FluentSelect Items="@Coworkers"
              Width="250px"
              OptionNoWrapMaxWidth="200px" /> 👈
```

<img width="332" height="292" alt="image" src="https://github.com/user-attachments/assets/90f02742-3882-46fa-b0f0-1da83625c716" />


Fixed #4909

## Unit Tests

Updated