### PR TITLE
[dev-v5] Autocomplete - Clear text input on click for multi-select

### DIFF
--- a/src/Core/Components/List/FluentAutocomplete.razor
+++ b/src/Core/Components/List/FluentAutocomplete.razor
@@ -163,6 +163,7 @@
                                        TValue="TValue"
                                        TOption="TOption"
                                        Appearance="@Appearance"
+                                       @onclick="@(e => _textInput = string.Empty)"
                                        Multiple="true"
                                        OptionText="@OptionText"
                                        OptionValue="@OptionValue"


### PR DESCRIPTION
# [dev-v5] Autocomplete - Clear text input on click for multi-select

Implement a feature that clears the text input when the multi-select component is clicked. 
This change enhances user experience by ensuring that the input field is reset, allowing for easier selection of options.

See #4772

## Unit Tests

No change