### PR TITLE
[dev-v5] Update @fluentui/web-components to 3.0.0-rc.27

### DIFF
--- a/src/Charts.Scripts/package-lock.json
+++ b/src/Charts.Scripts/package-lock.json
@@ -7,7 +7,7 @@
       "name": "microsoft.fluentui.aspnetcore.components.charts.assets",
       "license": "ISC",
       "dependencies": {
-        "@fluentui/web-components": "^3.0.0-rc.18",
+        "@fluentui/web-components": "^3.0.0-rc.27",
         "@microsoft/fast-element": "^2.0.0",
         "@microsoft/fast-web-utilities": "^6.0.0",
         "d3-format": "^3.0.0",
@@ -480,9 +480,9 @@
       }
     },
     "node_modules/@fluentui/web-components": {
-      "version": "3.0.0-rc.18",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@fluentui/web-components/-/web-components-3.0.0-rc.18.tgz",
-      "integrity": "sha1-9G1wtr6T19+qSkZrC82xwMEsbvg=",
+      "version": "3.0.0-rc.27",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@fluentui/web-components/-/web-components-3.0.0-rc.27.tgz",
+      "integrity": "sha1-AWWJwqdrtjaTY/nmuEeJ2JjW+W0=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/tokens": "1.0.0-alpha.23",
@@ -493,7 +493,13 @@
       },
       "peerDependencies": {
         "@microsoft/fast-element": "^2.0.0",
+        "@microsoft/fast-html": "^1.0.0-alpha.53",
         "@microsoft/focusgroup-polyfill": "^1.4.1"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/fast-html": {
+          "optional": true
+        }
       }
     },
     "node_modules/@microsoft/fast-element": {

--- a/src/Charts.Scripts/package.json
+++ b/src/Charts.Scripts/package.json
@@ -31,7 +31,7 @@
     "rimraf": "6.1.3"
   },
   "dependencies": {
-    "@fluentui/web-components": "^3.0.0-rc.18",
+    "@fluentui/web-components": "^3.0.0-rc.27",
     "@microsoft/fast-element": "^2.0.0",
     "@microsoft/fast-web-utilities": "^6.0.0",
     "d3-format": "^3.0.0",

--- a/src/Core.Scripts/package-lock.json
+++ b/src/Core.Scripts/package-lock.json
@@ -7,15 +7,15 @@
       "name": "microsoft.fluentui.aspnetcore.components.assets",
       "license": "ISC",
       "dependencies": {
-        "@fluentui/web-components": "^3.0.0-rc.18"
+        "@fluentui/web-components": "^3.0.0-rc.27"
       },
       "devDependencies": {
         "@types/sortablejs": "^1.15.9",
-        "@typescript-eslint/eslint-plugin": "8.59.2",
-        "@typescript-eslint/parser": "8.59.2",
+        "@typescript-eslint/eslint-plugin": "8.61.0",
+        "@typescript-eslint/parser": "8.61.0",
         "esbuild": "0.28.0",
         "esbuild-plugin-inline-css": "0.0.1",
-        "eslint": "10.3.0",
+        "eslint": "10.4.1",
         "glob": "^13.0.6",
         "imask": "^7.6.1",
         "rimraf": "6.1.3",
@@ -24,9 +24,9 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.29.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/runtime-corejs3/-/runtime-corejs3-7.29.2.tgz",
-      "integrity": "sha1-y4atBueh05Ikr7Eqh0MBCF4HGEY=",
+      "version": "7.29.7",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/runtime-corejs3/-/runtime-corejs3-7.29.7.tgz",
+      "integrity": "sha1-IDD9o080M2R4GGYAk3Ufscot6/A=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -523,9 +523,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.5",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
-      "integrity": "sha1-rhYTTkeSrF+9xTNUiiSsHqn3864=",
+      "version": "0.6.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha1-75o2iB0539Xb6sIrDamX+r+wiwM=",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -559,9 +559,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
-      "integrity": "sha1-xBJf0BXs7rCbeTEJ/bzU3QoC00Y=",
+      "version": "0.7.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha1-Swli8/LHzovJiz7P40UlwJ0styk=",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -582,9 +582,9 @@
       }
     },
     "node_modules/@fluentui/web-components": {
-      "version": "3.0.0-rc.18",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@fluentui/web-components/-/web-components-3.0.0-rc.18.tgz",
-      "integrity": "sha1-9G1wtr6T19+qSkZrC82xwMEsbvg=",
+      "version": "3.0.0-rc.27",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@fluentui/web-components/-/web-components-3.0.0-rc.27.tgz",
+      "integrity": "sha1-AWWJwqdrtjaTY/nmuEeJ2JjW+W0=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/tokens": "1.0.0-alpha.23",
@@ -595,7 +595,13 @@
       },
       "peerDependencies": {
         "@microsoft/fast-element": "^2.0.0",
+        "@microsoft/fast-html": "^1.0.0-alpha.53",
         "@microsoft/focusgroup-polyfill": "^1.4.1"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/fast-html": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -672,16 +678,16 @@
       "peer": true
     },
     "node_modules/@microsoft/focusgroup-polyfill": {
-      "version": "1.4.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@microsoft/focusgroup-polyfill/-/focusgroup-polyfill-1.4.1.tgz",
-      "integrity": "sha1-DT/u5nV3X3ppKjsel07qEHUDx44=",
+      "version": "1.5.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@microsoft/focusgroup-polyfill/-/focusgroup-polyfill-1.5.0.tgz",
+      "integrity": "sha1-9Zq5CRabPIKSHYReIDT1BCbuq4c=",
       "license": "MIT",
       "peer": true
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha1-CxsCAxfuEoKGDKZvfpp8d5DwWuA=",
+      "version": "0.5.23",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha1-GSh9DYbZYrERN2A5pQx5KQLJqGo=",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -716,17 +722,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.59.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
-      "integrity": "sha1-83ssGJoBdxQf4947CPKoOZG/2/o=",
+      "version": "8.61.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.0.tgz",
+      "integrity": "sha1-2yAnGXS5SjpU07lUTl9bNIFEhAA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/type-utils": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/type-utils": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -739,22 +745,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.59.2",
+        "@typescript-eslint/parser": "^8.61.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/parser/-/parser-8.59.2.tgz",
-      "integrity": "sha1-4v0AhLql3QwkzXia8ccsvDp6HGI=",
+      "version": "8.61.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/parser/-/parser-8.61.0.tgz",
+      "integrity": "sha1-Gv5zyczOFreibWuV+UALDMw0r4c=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -770,14 +776,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
-      "integrity": "sha1-+LjL+GkuOlHCw5Ss+M9pAPfnVa8=",
+      "version": "8.61.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/project-service/-/project-service-8.61.0.tgz",
+      "integrity": "sha1-QXov6sMujr0zbWPwaMO0K3Nuoaw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.2",
-        "@typescript-eslint/types": "^8.59.2",
+        "@typescript-eslint/tsconfig-utils": "^8.61.0",
+        "@typescript-eslint/types": "^8.61.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -792,14 +798,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
-      "integrity": "sha1-Y8vQry4xgJSda+gRIsxVW8cec20=",
+      "version": "8.61.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/scope-manager/-/scope-manager-8.61.0.tgz",
+      "integrity": "sha1-k8JSDQVlP+Zeue6Y78dP0BNKeFI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2"
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -810,9 +816,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
-      "integrity": "sha1-bpK8QSCDdTGFp5yfFDHngWnZIy8=",
+      "version": "8.61.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.0.tgz",
+      "integrity": "sha1-Bdbj/yAAFnTrzSLQPawp7kSAQ7o=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -827,15 +833,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.59.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
-      "integrity": "sha1-pgoRkqgE+kcqksQWVoU6xqm6cXY=",
+      "version": "8.61.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/type-utils/-/type-utils-8.61.0.tgz",
+      "integrity": "sha1-UCGbV+a4nOz7GhXwk7Feye4BmXQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -852,9 +858,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/types/-/types-8.59.2.tgz",
-      "integrity": "sha1-AcqrzX5HFcM61eEcqyYIKXFNa5w=",
+      "version": "8.61.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/types/-/types-8.61.0.tgz",
+      "integrity": "sha1-DdtG4BKkKIKSlQvdJT20LyeM5k0=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -866,16 +872,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
-      "integrity": "sha1-aiF+9lsY29EscY/IamddHXoUFMw=",
+      "version": "8.61.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.0.tgz",
+      "integrity": "sha1-mMpHJgu/Yn/CjwGLOgq/AOMJBpA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.59.2",
-        "@typescript-eslint/tsconfig-utils": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/project-service": "8.61.0",
+        "@typescript-eslint/tsconfig-utils": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -894,16 +900,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.59.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/utils/-/utils-8.59.2.tgz",
-      "integrity": "sha1-/2GaajB19AF/qRuGELdSqMozZqo=",
+      "version": "8.61.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/utils/-/utils-8.61.0.tgz",
+      "integrity": "sha1-7TVGoFJ4foTqbFBk0JGfxe6oUi8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2"
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -918,13 +924,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
-      "integrity": "sha1-XMxIaRPNNHiD1pFYg2sRiaZgv+Y=",
+      "version": "8.61.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.0.tgz",
+      "integrity": "sha1-ObThq4k20jvqlz05/QkvmqIfJ14=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/types": "8.61.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1143,18 +1149,18 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.3.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint/-/eslint-10.3.0.tgz",
-      "integrity": "sha1-7VuBDrjgGRvyS93PnNtFuXTgoW0=",
+      "version": "10.4.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint/-/eslint-10.4.1.tgz",
+      "integrity": "sha1-9mQLF24JEiRtndv4/Ppei38CRFo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/config-helpers": "^0.6.0",
         "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -1618,9 +1624,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.3.6",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lru-cache/-/lru-cache-11.3.6.tgz",
-      "integrity": "sha1-8DBq1unwpdwlsWrrpOj1e37C31U=",
+      "version": "11.5.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha1-89qjVAhHuXN+vAJJnds2dl5U20o=",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -1836,9 +1842,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha1-7QZhA5/LzaLOcfAfpq2++qdwQN8=",
+      "version": "7.8.4",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha1-xz7O664GFpNL6N/yin/XB1fI5pY=",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1889,9 +1895,9 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha1-HDt+uVP85Csia8Wh7gZCgoGv89Y=",
+      "version": "0.2.17",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha1-ViqabJ6ys7Ej05cZ+a9btE/NdjE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/Core.Scripts/package.json
+++ b/src/Core.Scripts/package.json
@@ -15,11 +15,11 @@
   "type": "module",
   "devDependencies": {
     "@types/sortablejs": "^1.15.9",
-    "@typescript-eslint/eslint-plugin": "8.59.2",
-    "@typescript-eslint/parser": "8.59.2",
+    "@typescript-eslint/eslint-plugin": "8.61.0",
+    "@typescript-eslint/parser": "8.61.0",
     "esbuild": "0.28.0",
     "esbuild-plugin-inline-css": "0.0.1",
-    "eslint": "10.3.0",
+    "eslint": "10.4.1",
     "glob": "^13.0.6",
     "imask": "^7.6.1",
     "rimraf": "6.1.3",
@@ -27,6 +27,6 @@
     "typescript": "5.9.3"
   },
   "dependencies": {
-    "@fluentui/web-components": "^3.0.0-rc.18"
+    "@fluentui/web-components": "^3.0.0-rc.27"
   }
 }


### PR DESCRIPTION
# [dev-v5] Update @fluentui/web-components and related dependencies to 3.0.0-rc.27

Upgrade the @fluentui/web-components package and related dependencies to the latest release candidate version. This change ensures compatibility with the latest features and improvements. No breaking changes are introduced.

