### PR TITLE
[dev-v5] TextArea - Fix initial value value during render

### DIFF
--- a/src/Core.Scripts/src/Utilities/Attributes.ts
+++ b/src/Core.Scripts/src/Utilities/Attributes.ts
@@ -110,6 +110,13 @@ export namespace Microsoft.FluentUI.Blazor.Utilities.Attributes {
     const field = element as any;
     if (newValue !== field[propertyName]) {
       field[propertyName] = newValue;
+
+      // The TextArea component uses a preConnectControlEl to set the value before the control is fully connected
+      // so we need to update that as well to avoid issues with the value not being set correctly on initial render
+      const preConnect = (element as any).preConnectControlEl;
+      if (preConnect) {
+        preConnect.value = newValue;
+      }
     }
   }
 


### PR DESCRIPTION
# [dev-v5] TextArea - Fix initial value value during render

Ensure the **TextArea** component correctly sets its initial value during render by updating the `preConnectControlEl` if it exists. 
This change addresses issues with the value not being set properly on the initial render. See #4767

## Unit Tests

No change