### PR TITLE
[dev-v5][Popover] Make fluent-popover-b fixed

### DIFF
--- a/src/Core/Components/Popover/FluentPopover.razor.css
+++ b/src/Core/Components/Popover/FluentPopover.razor.css
@@ -1,0 +1,3 @@
+fluent-popover-b {
+    position: fixed; /* When the base component is not fixed it will impact the DOM and moves content around when the popover is being shown */
+}


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR sets `fluent-popover-b` to `position: fixed` by default. If the base elemtent is not set to fixed it will move content in the DOM whenever a Popover is being opened/closed.

Before FluentDatePicker:

<img width="534" height="365" alt="before_datepicker" src="https://github.com/user-attachments/assets/3c20992f-b8a9-4e04-9aae-756118f7b178" />

After FluentDatePicker:

<img width="534" height="365" alt="after_datepicker" src="https://github.com/user-attachments/assets/16c4be16-97b6-4440-8b70-14fd05e8ec8d" />

Before FluentAutocomplete:

<img width="534" height="365" alt="before_autocomplete" src="https://github.com/user-attachments/assets/704a9113-a7c4-40ea-a84b-ff30c67a3b4b" />

After FluentAutocomplete:

<img width="534" height="365" alt="after_autocomplete" src="https://github.com/user-attachments/assets/b78d5ce4-6887-49be-a445-ff0265ad3f85" />


This PR also affects the components `FluentTimePicker` and `FluentColorInput`


### 🎫 Issues

Fixes #4861

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
