### PR TITLE
[dev-v5] Menu WASM - Fix type initialization logic

### DIFF
--- a/src/Core.Scripts/src/Components/Menu/FluentMenu.ts
+++ b/src/Core.Scripts/src/Components/Menu/FluentMenu.ts
@@ -8,16 +8,30 @@ export namespace Microsoft.FluentUI.Blazor.Components.Menu {
    * @param triggerId The id of the trigger element that will open the menu when clicked.
    */
   export function Initialize(id: string, triggerId: string) {
-    const trigger = document.getElementById(triggerId) as HTMLElement;
+    const trigger = document.getElementById(triggerId) as HTMLElement | null;
+    if (!trigger) return;
 
-    if (trigger) {
-      trigger.style["anchor-name" as any] = `--anchor-${triggerId}`;
+    trigger.style["anchor-name" as any] = `--anchor-${triggerId}`;
+    const menuElement = document.getElementById(id) as Menu | null;
+    if (!menuElement) return;
 
-      const menu = document.getElementById(id) as Menu;
-      if (menu && menu.slottedMenuList.length) {
+    // Set the anchor name for the menu list to position it relative to the trigger
+    const doInit = () => {
+      const menu = document.getElementById(id) as Menu | null;
+      if (menu && menu.slottedMenuList?.length) {
         menu.slottedMenuList[0].style["position-anchor" as any] = `--anchor-${triggerId}`;
         menu.slottedTriggersChanged(menu.slottedTriggers, [trigger]);
       }
+    };
+
+    // already populated (e.g. hot-reload / re-render)
+    if (menuElement.slottedMenuList?.length) {
+      doInit();
+    }
+
+    // wait for slotchange macrotask
+    else {
+      requestAnimationFrame(doInit);
     }
   }
 
@@ -26,7 +40,7 @@ export namespace Microsoft.FluentUI.Blazor.Components.Menu {
    * @param id 
    */
   export function CloseMenu(id: string) {
-    const menu = document.getElementById(id) as Menu;
+    const menu = document.getElementById(id) as Menu | null;
     if (menu) {
       menu.closeMenu();
     }


### PR DESCRIPTION
# [dev-v5] Menu WASM - Fix type initialization logic

Improve type handling and initialization logic in the **FluentMenu** component to ensure proper element retrieval and initialization. 

See #4919

This change addresses potential null references and enhances the component's robustness during rendering and re-initialization.

## Unit Tests

No change


