### PR TITLE
fix: restore DataGrid keyboard behavior in dialog focus trap

### DIFF
--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.js
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.js
@@ -1,5 +1,15 @@
 let grids = [];
 
+function getDeepActiveElement() {
+    let activeElement = document.activeElement;
+
+    while (activeElement?.shadowRoot?.activeElement) {
+        activeElement = activeElement.shadowRoot.activeElement;
+    }
+
+    return activeElement;
+}
+
 export function init(gridElement, autoFocus) {
     if (gridElement === undefined || gridElement === null) {
         return;
@@ -48,6 +58,9 @@ export function init(gridElement, autoFocus) {
         }
     }
     const keyDownHandler = event => {
+        const activeElement = getDeepActiveElement();
+        const activeTag = activeElement?.tagName?.toLowerCase();
+
         const columnOptionsElement = gridElement?.querySelector('.col-options');
         if (columnOptionsElement && columnOptionsElement.contains(event.target)) {
             if (event.key === "ArrowRight" || event.key === "ArrowLeft" || event.key === "ArrowDown" || event.key === "ArrowUp") {
@@ -64,12 +77,12 @@ export function init(gridElement, autoFocus) {
             }
         }
 
-        if (document.activeElement.tagName.toLowerCase() != 'table' && document.activeElement.tagName.toLowerCase() != 'td' && document.activeElement.tagName.toLowerCase() != 'th') {
+        if (!activeTag || (activeTag !== 'table' && activeTag !== 'td' && activeTag !== 'th')) {
             return;
         }
 
         // check if start is a child of gridElement
-        if (start !== null && (gridElement.contains(start) || gridElement === start) && document.activeElement === start && document.activeElement.tagName.toLowerCase() !== 'fluent-text-field' && document.activeElement.tagName.toLowerCase() !== 'fluent-menu-item') {
+        if (start !== null && (gridElement.contains(start) || gridElement === start) && activeElement === start && activeTag !== 'fluent-text-field' && activeTag !== 'fluent-menu-item') {
             const idx = start.cellIndex;
             const isRTL = getComputedStyle(gridElement).direction === 'rtl';
 
@@ -104,7 +117,7 @@ export function init(gridElement, autoFocus) {
             }
         }
         else {
-            start = document.activeElement;
+            start = activeElement;
         }
 
     };
@@ -393,8 +406,8 @@ export function resizeColumnDiscrete(gridElement, column, change) {
     let headerBeingResized;
 
     if (!column) {
-        const targetElement = document.activeElement.parentElement.parentElement.parentElement.parentElement;
-        if (!(targetElement.classList.contains("column-header") && targetElement.classList.contains("resizable"))) {
+        const targetElement = getDeepActiveElement()?.closest?.('.column-header.resizable');
+        if (!targetElement || !(targetElement.classList.contains("column-header") && targetElement.classList.contains("resizable"))) {
             return;
         }
         headerBeingResized = targetElement;


### PR DESCRIPTION
Use a deep active-element resolver so keyboard navigation and resize shortcuts continue to work when FluentDataGrid is hosted in fluent-dialog/panel shadow DOM focus contexts.

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [ ] I have modified an existing component
- [ ] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
