### PR TITLE
[dev-v5][Paginator] Do not use primary color for default icons

### DIFF
--- a/src/Core/Components/Button/FluentButton.razor.css
+++ b/src/Core/Components/Button/FluentButton.razor.css
@@ -21,7 +21,3 @@ fluent-button svg[slot="end"],
 fluent-button fluent-spinner[slot="end"] {
   margin-inline-start: 8px;
 }
-
-fluent-button[disabled] svg {
-    opacity: 0.4;
-}

--- a/src/Core/Components/Pagination/FluentPaginator.razor
+++ b/src/Core/Components/Pagination/FluentPaginator.razor
@@ -33,12 +33,12 @@
                           Disabled="@(!CanGoBack || Disabled)"
                           Title="@Localizer[Localization.LanguageResource.Paginator_GoFirstPage]"
                           aria-label="@Localizer[Localization.LanguageResource.Paginator_GoFirstPage]"
-                          IconStart="@(new CoreIcons.Regular.Size20.ChevronDoubleLeft().WithColor(Color.Primary))" />
+                          IconStart="@(new CoreIcons.Regular.Size20.ChevronDoubleLeft())" />
             <FluentButton OnClick="GoPreviousAsync"
                           Disabled="@(!CanGoBack || Disabled)"
                           Title="@Localizer[Localization.LanguageResource.Paginator_GoPreviousPage]"
                           aria-label="@Localizer[Localization.LanguageResource.Paginator_GoPreviousPage]"
-                          IconStart="@(new CoreIcons.Regular.Size20.ChevronLeft().WithColor(Color.Primary))" />
+                          IconStart="@(new CoreIcons.Regular.Size20.ChevronLeft())" />
             <div class="pagination-text">
                 @if (PaginationTextTemplate is not null)
                 {
@@ -54,12 +54,12 @@
                           Disabled="@(!CanGoForwards || Disabled)"
                           Title="@Localizer[Localization.LanguageResource.Paginator_GoNextPage]"
                           aria-label="@Localizer[Localization.LanguageResource.Paginator_GoNextPage]"
-                          IconStart="@(new CoreIcons.Regular.Size20.ChevronRight().WithColor(Color.Primary))" />
+                          IconStart="@(new CoreIcons.Regular.Size20.ChevronRight())" />
             <FluentButton Onclick="GoLastAsync"
                           Disabled="@(!CanGoForwards || Disabled)"
                           Title="@Localizer[Localization.LanguageResource.Paginator_GoLastPage]"
                           aria-label="@Localizer[Localization.LanguageResource.Paginator_GoLastPage]"
-                          IconStart="@(new CoreIcons.Regular.Size20.ChevronDoubleRight().WithColor(Color.Primary))" />
+                          IconStart="@(new CoreIcons.Regular.Size20.ChevronDoubleRight())" />
         </nav>
     }
 </div>

--- a/src/Core/Components/Pagination/FluentPaginator.razor
+++ b/src/Core/Components/Pagination/FluentPaginator.razor
@@ -55,7 +55,7 @@
                           Title="@Localizer[Localization.LanguageResource.Paginator_GoNextPage]"
                           aria-label="@Localizer[Localization.LanguageResource.Paginator_GoNextPage]"
                           IconStart="@(new CoreIcons.Regular.Size20.ChevronRight())" />
-            <FluentButton Onclick="GoLastAsync"
+            <FluentButton OnClick="GoLastAsync"
                           Disabled="@(!CanGoForwards || Disabled)"
                           Title="@Localizer[Localization.LanguageResource.Paginator_GoLastPage]"
                           aria-label="@Localizer[Localization.LanguageResource.Paginator_GoLastPage]"

--- a/src/Core/Components/Pagination/FluentPaginator.razor.css
+++ b/src/Core/Components/Pagination/FluentPaginator.razor.css
@@ -1,6 +1,5 @@
 .fluent-paginator {
   display: flex;
-  /*border-top: 1px solid var(--neutral-stroke-divider-rest);*/
   margin-top: 0.5rem;
   padding: 0.25rem 0;
   align-items: center;

--- a/tests/Core/Components/Paginator/FluentPaginatorTests.FluentPaginator_Renders_CustomPaginationTextTemplate.verified.razor.html
+++ b/tests/Core/Components/Paginator/FluentPaginatorTests.FluentPaginator_Renders_CustomPaginationTextTemplate.verified.razor.html
@@ -7,12 +7,12 @@
 			</div>
 			<nav role="navigation" class="paginator-nav">
 				<fluent-button icon-only="" disabled="" title="Go to first page" blazor:onclick="x" aria-label="Go to first page">
-					<svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+					<svg style="width: 20px; fill: currentColor;" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
 						<path d="M11.35 15.85a.5.5 0 0 1-.7 0L5.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L6.2 10l5.16 5.15c.2.2.2.5 0 .7Zm4 0a.5.5 0 0 1-.7 0L9.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L10.2 10l5.16 5.15c.2.2.2.5 0 .7Z"></path>
 					</svg>
 				</fluent-button>
 				<fluent-button icon-only="" disabled="" title="Go to previous page" blazor:onclick="x" aria-label="Go to previous page">
-					<svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+					<svg style="width: 20px; fill: currentColor;" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
 						<path d="M12.35 15.85a.5.5 0 0 1-.7 0L6.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L7.2 10l5.16 5.15c.2.2.2.5 0 .7Z"></path>
 					</svg>
 				</fluent-button>
@@ -20,12 +20,12 @@
 					<span class="custom-pagination-text">Page 1 of 10</span>
 				</div>
 				<fluent-button icon-only="" title="Go to next page" blazor:onclick="x" aria-label="Go to next page">
-					<svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+					<svg style="width: 20px; fill: currentColor;" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
 						<path d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"></path>
 					</svg>
 				</fluent-button>
 				<fluent-button icon-only="" title="Go to last page" blazor:onclick="x" aria-label="Go to last page">
-					<svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+					<svg style="width: 20px; fill: currentColor;" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
 						<path d="M8.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L13.8 10 8.65 4.85a.5.5 0 0 1 0-.7Zm-4 0c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L9.8 10 4.65 4.85a.5.5 0 0 1 0-.7Z"></path>
 					</svg>
 				</fluent-button>

--- a/tests/Core/Components/Paginator/FluentPaginatorTests.FluentPaginator_Renders_CustomSummaryTemplate.verified.razor.html
+++ b/tests/Core/Components/Paginator/FluentPaginatorTests.FluentPaginator_Renders_CustomSummaryTemplate.verified.razor.html
@@ -1,29 +1,33 @@
-
-<div class="fluent-paginator">
-  <div class="summary">
-    <span class="custom-summary">Total: 100 items</span>
-  </div>
-  <nav role="navigation" class="paginator-nav">
-    <fluent-button icon-only="" disabled="" title="Go to first page" blazor:onclick="x" aria-label="Go to first page">
-      <svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
-        <path d="M11.35 15.85a.5.5 0 0 1-.7 0L5.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L6.2 10l5.16 5.15c.2.2.2.5 0 .7Zm4 0a.5.5 0 0 1-.7 0L9.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L10.2 10l5.16 5.15c.2.2.2.5 0 .7Z"></path>
-      </svg>
-    </fluent-button>
-    <fluent-button icon-only="" disabled="" title="Go to previous page" blazor:onclick="x" aria-label="Go to previous page">
-      <svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
-        <path d="M12.35 15.85a.5.5 0 0 1-.7 0L6.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L7.2 10l5.16 5.15c.2.2.2.5 0 .7Z"></path>
-      </svg>
-    </fluent-button>
-    <div class="pagination-text">Page 1 of 10</div>
-    <fluent-button icon-only="" title="Go to next page" blazor:onclick="x" aria-label="Go to next page">
-      <svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
-        <path d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"></path>
-      </svg>
-    </fluent-button>
-    <fluent-button icon-only="" title="Go to last page" blazor:onclick="x" aria-label="Go to last page">
-      <svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
-        <path d="M8.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L13.8 10 8.65 4.85a.5.5 0 0 1 0-.7Zm-4 0c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L9.8 10 4.65 4.85a.5.5 0 0 1 0-.7Z"></path>
-      </svg>
-    </fluent-button>
-  </nav>
-</div>
+<html>
+	<head></head>
+	<body>
+		<div class="fluent-paginator">
+			<div class="summary">
+				<span class="custom-summary">Total: 100 items</span>
+			</div>
+			<nav role="navigation" class="paginator-nav">
+				<fluent-button icon-only="" disabled="" title="Go to first page" blazor:onclick="x" aria-label="Go to first page">
+					<svg style="width: 20px; fill: currentColor;" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+						<path d="M11.35 15.85a.5.5 0 0 1-.7 0L5.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L6.2 10l5.16 5.15c.2.2.2.5 0 .7Zm4 0a.5.5 0 0 1-.7 0L9.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L10.2 10l5.16 5.15c.2.2.2.5 0 .7Z"></path>
+					</svg>
+				</fluent-button>
+				<fluent-button icon-only="" disabled="" title="Go to previous page" blazor:onclick="x" aria-label="Go to previous page">
+					<svg style="width: 20px; fill: currentColor;" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+						<path d="M12.35 15.85a.5.5 0 0 1-.7 0L6.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L7.2 10l5.16 5.15c.2.2.2.5 0 .7Z"></path>
+					</svg>
+				</fluent-button>
+				<div class="pagination-text">Page 1 of 10</div>
+				<fluent-button icon-only="" title="Go to next page" blazor:onclick="x" aria-label="Go to next page">
+					<svg style="width: 20px; fill: currentColor;" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+						<path d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"></path>
+					</svg>
+				</fluent-button>
+				<fluent-button icon-only="" title="Go to last page" blazor:onclick="x" aria-label="Go to last page">
+					<svg style="width: 20px; fill: currentColor;" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+						<path d="M8.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L13.8 10 8.65 4.85a.5.5 0 0 1 0-.7Zm-4 0c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L9.8 10 4.65 4.85a.5.5 0 0 1 0-.7Z"></path>
+					</svg>
+				</fluent-button>
+			</nav>
+		</div>
+	</body>
+</html>

--- a/tests/Core/Components/Paginator/FluentPaginatorTests.FluentPaginator_Renders_WithDefaultState.verified.razor.html
+++ b/tests/Core/Components/Paginator/FluentPaginatorTests.FluentPaginator_Renders_WithDefaultState.verified.razor.html
@@ -7,23 +7,23 @@
 			</div>
 			<nav role="navigation" class="paginator-nav">
 				<fluent-button icon-only="" disabled="" title="Go to first page" blazor:onclick="x" aria-label="Go to first page">
-					<svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+					<svg style="width: 20px; fill: currentColor;" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
 						<path d="M11.35 15.85a.5.5 0 0 1-.7 0L5.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L6.2 10l5.16 5.15c.2.2.2.5 0 .7Zm4 0a.5.5 0 0 1-.7 0L9.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L10.2 10l5.16 5.15c.2.2.2.5 0 .7Z"></path>
 					</svg>
 				</fluent-button>
 				<fluent-button icon-only="" disabled="" title="Go to previous page" blazor:onclick="x" aria-label="Go to previous page">
-					<svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+					<svg style="width: 20px; fill: currentColor;" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
 						<path d="M12.35 15.85a.5.5 0 0 1-.7 0L6.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L7.2 10l5.16 5.15c.2.2.2.5 0 .7Z"></path>
 					</svg>
 				</fluent-button>
 				<div class="pagination-text">Page 1 of 10</div>
 				<fluent-button icon-only="" title="Go to next page" blazor:onclick="x" aria-label="Go to next page">
-					<svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+					<svg style="width: 20px; fill: currentColor;" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
 						<path d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"></path>
 					</svg>
 				</fluent-button>
 				<fluent-button icon-only="" title="Go to last page" blazor:onclick="x" aria-label="Go to last page">
-					<svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+					<svg style="width: 20px; fill: currentColor;" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
 						<path d="M8.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L13.8 10 8.65 4.85a.5.5 0 0 1 0-.7Zm-4 0c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L9.8 10 4.65 4.85a.5.5 0 0 1 0-.7Z"></path>
 					</svg>
 				</fluent-button>

--- a/tests/Core/Components/Paginator/FluentPaginatorTests.FluentPaginator_SetItemsPerPage.verified.razor.html
+++ b/tests/Core/Components/Paginator/FluentPaginatorTests.FluentPaginator_SetItemsPerPage.verified.razor.html
@@ -7,23 +7,23 @@
 			</div>
 			<nav role="navigation" class="paginator-nav">
 				<fluent-button icon-only="" disabled="" title="Go to first page" blazor:onclick="x" aria-label="Go to first page">
-					<svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+					<svg style="width: 20px; fill: currentColor;" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
 						<path d="M11.35 15.85a.5.5 0 0 1-.7 0L5.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L6.2 10l5.16 5.15c.2.2.2.5 0 .7Zm4 0a.5.5 0 0 1-.7 0L9.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L10.2 10l5.16 5.15c.2.2.2.5 0 .7Z"></path>
 					</svg>
 				</fluent-button>
 				<fluent-button icon-only="" disabled="" title="Go to previous page" blazor:onclick="x" aria-label="Go to previous page">
-					<svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+					<svg style="width: 20px; fill: currentColor;" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
 						<path d="M12.35 15.85a.5.5 0 0 1-.7 0L6.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L7.2 10l5.16 5.15c.2.2.2.5 0 .7Z"></path>
 					</svg>
 				</fluent-button>
 				<div class="pagination-text">Page 1 of 4</div>
 				<fluent-button icon-only="" title="Go to next page" blazor:onclick="x" aria-label="Go to next page">
-					<svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+					<svg style="width: 20px; fill: currentColor;" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
 						<path d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"></path>
 					</svg>
 				</fluent-button>
 				<fluent-button icon-only="" title="Go to last page" blazor:onclick="x" aria-label="Go to last page">
-					<svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+					<svg style="width: 20px; fill: currentColor;" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
 						<path d="M8.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L13.8 10 8.65 4.85a.5.5 0 0 1 0-.7Zm-4 0c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L9.8 10 4.65 4.85a.5.5 0 0 1 0-.7Z"></path>
 					</svg>
 				</fluent-button>


### PR DESCRIPTION
- Do not use primary color for paginator icons and do not put opacity  on a disabled button with an SVG.
- Update verified files

## Before
<img width="286" height="66" alt="image" src="https://github.com/user-attachments/assets/70835e6d-cbdb-4498-8bd8-5074432bcb95" />


## After
<img width="292" height="65" alt="image" src="https://github.com/user-attachments/assets/2e6cadde-1525-40f2-8bbf-cecbfb098b5c" />

