### PR TITLE
[dev-v5] Update `Width` handling for FluentField

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/DebugPages/WidthParameterPage.razor
+++ b/examples/Demo/FluentUI.Demo.Client/DebugPages/WidthParameterPage.razor
@@ -52,8 +52,13 @@
         new("Selects", RenderSelect),
         new("Listboxes", RenderListbox),
         new("Comboboxes", RenderCombobox),
+        new("Calendars", RenderCalendar),
         new("Date Pickers", RenderDatePicker),
         new("Time Pickers", RenderTimePicker),
+        new("Color Picker Inputs", RenderColorPickerInput),
+        new("Radio Groups", RenderRadioGroup),
+        new("Sliders", RenderSlider),
+        new("Checkboxes", RenderCheckbox),
         new("Switches", RenderSwitch),
     ];
 
@@ -77,6 +82,15 @@
                                 Label="@(GetLabel(sampleLabelUsage))" />;
     }
 
+    /* FluentCheckbox */
+    RenderFragment RenderCheckbox(SampleLabelUsage sampleLabelUsage)
+    {
+        return @<FluentCheckbox LabelWidth="@(GetLabelWidth(sampleLabelUsage))"
+                                LabelPosition="@(GetLabelPosition(sampleLabelUsage))"
+                                Label="@(GetLabel(sampleLabelUsage))"
+                                @bind-Value="@checkboxValue" />;
+    }
+
     /* FluentNumberInput */
     RenderFragment RenderNumberInput(SampleLabelUsage sampleLabelUsage)    
     {
@@ -86,6 +100,18 @@
                                    LabelWidth="@(GetLabelWidth(sampleLabelUsage))"
                                    LabelPosition="@(GetLabelPosition(sampleLabelUsage))"
                                    Label="@(GetLabel(sampleLabelUsage))" />;
+    }
+
+    /* FluentRadioGroup */
+    RenderFragment RenderRadioGroup(SampleLabelUsage sampleLabelUsage)
+    {
+        return @<FluentRadioGroup TValue="string"
+                                  LabelWidth="@(GetLabelWidth(sampleLabelUsage))"
+                                  LabelPosition="@(GetLabelPosition(sampleLabelUsage))"
+                                  Label="@(GetLabel(sampleLabelUsage))"
+                                  Items="Colors"
+                                  Orientation="Orientation.Vertical"
+                                  @bind-Value="@SelectedRadioValue" />;
     }
 
     /* FluentAutocomplete */
@@ -100,6 +126,17 @@
                                     OptionValue="@(i => i?.Code)"
                                     Items="@Countries"
                                     @bind-SelectedItems="@SelectedCountries" />;
+    }
+
+    /* FluentColorPickerInput */
+    RenderFragment RenderColorPickerInput(SampleLabelUsage sampleLabelUsage)
+    {
+        return @<FluentColorPickerInput Width="@Width"
+                                        Placeholder="#000000"
+                                        LabelWidth="@(GetLabelWidth(sampleLabelUsage))"
+                                        LabelPosition="@(GetLabelPosition(sampleLabelUsage))"
+                                        Label="@(GetLabel(sampleLabelUsage))"
+                                        @bind-Value="@SelectedColor" />;
     }
 
     /* FluentSelect */
@@ -145,6 +182,29 @@
                         '
                     </FreeOption>
                 </FluentCombobox>;
+    }
+
+    /* FluentSlider */
+    RenderFragment RenderSlider(SampleLabelUsage sampleLabelUsage)
+    {
+        return @<FluentSlider TValue="int"
+                              LabelWidth="@(GetLabelWidth(sampleLabelUsage))"
+                              LabelPosition="@(GetLabelPosition(sampleLabelUsage))"
+                              Label="@(GetLabel(sampleLabelUsage))"
+                              Min="0"
+                              Max="100"
+                              Step="5"
+                              @bind-Value="@SliderValue" />;
+    }
+
+    /* FluentCalendar */
+    RenderFragment RenderCalendar(SampleLabelUsage sampleLabelUsage)
+    {
+        return @<FluentCalendar TValue="DateOnly?"
+                                LabelWidth="@(GetLabelWidth(sampleLabelUsage))"
+                                LabelPosition="@(GetLabelPosition(sampleLabelUsage))"
+                                Label="@(GetLabel(sampleLabelUsage))"
+                                @bind-Value="@SelectedCalendarValue" />;
     }
 
     /* FluentDadePicker */
@@ -222,9 +282,14 @@
     IEnumerable<SampleData.Olympics2024.Country> SelectedCountries = [];
 
     DateOnly? SelectedValue = null;
+    DateOnly? SelectedCalendarValue = null;
+    string? SelectedColor = "#FF0000";
+    string? SelectedRadioValue = "Red";
+    int SliderValue = 50;
     TimeOnly? SelectedTime = null;
     static string[] Colors = ["Red", "Green", "Blue"];
     string? Value;
+    bool checkboxValue = false;
     bool value = false;
 }
 

--- a/examples/Demo/FluentUI.Demo.Client/DebugPages/WidthParameterPage.razor
+++ b/examples/Demo/FluentUI.Demo.Client/DebugPages/WidthParameterPage.razor
@@ -1,4 +1,6 @@
 ﻿@page "/Debug/Width"
+@using System.ComponentModel
+@using Microsoft.FluentUI.AspNetCore.Components.Extensions;
 
 <FluentCard>
     <FluentTextInput @bind-Value="@Width"
@@ -9,148 +11,197 @@
                      LabelPosition="LabelPosition.Before" />
     <FluentCheckbox @bind-Value="@showLabelBorder"
                     Label="Show label border" />
+
+    <FluentStack HorizontalGap="20px">
+        <FluentStack Orientation="Orientation.Vertical">
+            <FluentLink OnClick="@(e => Width = null)">Width: unset</FluentLink>
+            <FluentLink OnClick="@(e => Width = "100%")">Width: 100%</FluentLink>
+            <FluentLink OnClick="@(e => Width = "50%")">Width: 50%</FluentLink>
+            <FluentLink OnClick="@(e => Width = "500px")">Width: 500px</FluentLink>
+        </FluentStack>    
+        <FluentStack Orientation="Orientation.Vertical">
+            <FluentLink OnClick="@(e => LabelWidth = null)">LabelWidth: unset</FluentLink>
+            <FluentLink OnClick="@(e => LabelWidth = "100%")">LabelWidth: 100%</FluentLink>
+            <FluentLink OnClick="@(e => LabelWidth = "50%")">LabelWidth: 50%</FluentLink>
+            <FluentLink OnClick="@(e => LabelWidth = "150px")">LabelWidth: 150px</FluentLink>
+        </FluentStack>    
+    </FluentStack>
 </FluentCard>
 
-<div show-label-border="@showLabelBorder">
-    <div class="panel-resizable">
-        <h2>Text Inputs</h2>
-        <FluentTextInput Width="@Width" />
-        <FluentTextInput Width="@Width"
-                         LabelWidth="@LabelWidth"
-                         Label="Label" />
-        <FluentTextInput Width="@Width"
-                         LabelWidth="@LabelWidth"
-                         LabelPosition="LabelPosition.Before"
-                         Label="Label before" />
+<div show-label-border="@showLabelBorder" style="overflow-y: auto; height: calc(100vh - 250px)">
 
-    </div>
+    @foreach (var renderer in LabelRenderers)
+    {
+        <div class="panel-resizable">
+            <h2>@renderer.Title</h2>
+            @renderer.Render(SampleLabelUsage.NoLabelNoLabelPosition)
+            @renderer.Render(SampleLabelUsage.WithLabelNoLabelPosition)
+            @renderer.Render(SampleLabelUsage.WithLabelAndLabelPosition)
+        </div>
+    }
+</div
 
-    <div class="panel-resizable">
-        <h2>Text Areas</h2>
-        <FluentTextArea Width="@Width" />
-        <FluentTextArea Width="@Width"
-                        LabelWidth="@LabelWidth"
-                        Label="Label" />
-        <FluentTextArea Width="@Width"
-                        LabelWidth="@LabelWidth"
-                        LabelPosition="LabelPosition.Before"
-                        Label="Label before" />
-    </div>
+@code
+{        
+    LabelRenderer[] LabelRenderers =>
+    [
+        new("Text Inputs", RenderTextInput),
+        new("Text Areas", RenderTextArea),
+        new("Number Inputs", RenderNumberInput),
+        new("Selects", RenderSelect),
+        new("Listboxes", RenderListbox),
+        new("Comboboxes", RenderCombobox),
+        new("Date Pickers", RenderDatePicker),
+        new("Time Pickers", RenderTimePicker),
+        new("Switches", RenderSwitch),
+    ];
 
-    <div class="panel-resizable">
-        <h2>Selects</h2>
-        <FluentSelect Width="@Width"
-                      Items="Colors"
-                      @bind-Value="Value" />
-        <FluentSelect Width="@Width"
-                      LabelWidth="@LabelWidth"
-                      Items="Colors"
-                      @bind-Value="Value"
-                      Label="Label" />
-        <FluentSelect Width="@Width"
-                      LabelWidth="@LabelWidth"
-                      Items="Colors"
-                      @bind-Value="Value"
-                      LabelPosition="LabelPosition.Before"
-                      Label="Label before" />
-    </div>
+    /* FluentTextInput */
+    RenderFragment RenderTextInput(SampleLabelUsage sampleLabelUsage)    
+    {
+        return @<FluentTextInput Width="@Width" 
+                                 Placeholder="@(sampleLabelUsage.GetDescription())"
+                                 LabelWidth="@(GetLabelWidth(sampleLabelUsage))"
+                                 LabelPosition="@(GetLabelPosition(sampleLabelUsage))"
+                                 Label="@(GetLabel(sampleLabelUsage))" />;
+    }
 
+    /* FluentTextArea */
+    RenderFragment RenderTextArea(SampleLabelUsage sampleLabelUsage)    
+    {
+        return @<FluentTextArea Width="@Width" 
+                                Placeholder="@(sampleLabelUsage.GetDescription())"
+                                LabelWidth="@(GetLabelWidth(sampleLabelUsage))"
+                                LabelPosition="@(GetLabelPosition(sampleLabelUsage))"
+                                Label="@(GetLabel(sampleLabelUsage))" />;
+    }
 
-    <div class="panel-resizable">
-        <h2>Listboxes</h2>
-        <FluentListbox Width="@Width"
-                       Height="200px"
-                       Items="Colors"
-                       @bind-Value="Value" />
-        <FluentListbox Width="@Width"
-                       LabelWidth="@LabelWidth"
-                       Height="200px"
-                       Items="Colors"
-                       @bind-Value="Value"
-                       Label="Label" />
-        <FluentListbox Width="@Width"
-                       LabelWidth="@LabelWidth"
-                       Height="200px"
-                       Items="Colors"
-                       @bind-Value="Value"
-                       LabelPosition="LabelPosition.Before"
-                       Label="Label before" />
-    </div>
+    /* FluentNumberInput */
+    RenderFragment RenderNumberInput(SampleLabelUsage sampleLabelUsage)    
+    {
+        return @<FluentNumberInput Width="@Width" 
+                                   TValue="int?"
+                                   Placeholder="@(sampleLabelUsage.GetDescription())"
+                                   LabelWidth="@(GetLabelWidth(sampleLabelUsage))"
+                                   LabelPosition="@(GetLabelPosition(sampleLabelUsage))"
+                                   Label="@(GetLabel(sampleLabelUsage))" />;
+    }
 
-    <div class="panel-resizable">
-        <h2>Comboboxes</h2>
-        <FluentCombobox Width="@Width"
-                        OptionText="@(i => i?.Name)"
-                        OptionValue="@(i => i?.Code)"
-                        Items="@Countries"
-                        @bind-SelectedItems="@SelectedCountries">
-            <FreeOption>
-                Search for '
-                <FreeOptionOutput />'
-            </FreeOption>
-        </FluentCombobox>
+    /* FluentSelect */
+    RenderFragment RenderSelect(SampleLabelUsage sampleLabelUsage)    
+    {
+        return @<FluentSelect Width="@Width" 
+                              Placeholder="@(sampleLabelUsage.GetDescription())"
+                              LabelWidth="@(GetLabelWidth(sampleLabelUsage))"
+                              LabelPosition="@(GetLabelPosition(sampleLabelUsage))"
+                              Label="@(GetLabel(sampleLabelUsage))"
+                              Items="Colors"
+                              @bind-Value="Value" />;
+    }
 
-        <FluentCombobox Width="@Width"
-                        LabelWidth="@LabelWidth"
-                        Label="Label"
-                        OptionText="@(i => i?.Name)"
-                        OptionValue="@(i => i?.Code)"
-                        Items="@Countries"
-                        @bind-SelectedItems="@SelectedCountries">
-            <FreeOption>
-                Search for '
-                <FreeOptionOutput />'
-            </FreeOption>
-        </FluentCombobox>
+    /* FluentListbox */
+    RenderFragment RenderListbox(SampleLabelUsage sampleLabelUsage)    
+    {
+        return @<FluentListbox Width="@Width" 
+                               Height="200px"
+                               Placeholder="@(sampleLabelUsage.GetDescription())"
+                               LabelWidth="@(GetLabelWidth(sampleLabelUsage))"
+                               LabelPosition="@(GetLabelPosition(sampleLabelUsage))"
+                               Label="@(GetLabel(sampleLabelUsage))"
+                               Items="Colors"
+                               @bind-Value="Value" />;
+    }
 
-    </div>
+    /* FluentCombobox */
+    RenderFragment RenderCombobox(SampleLabelUsage sampleLabelUsage)    
+    {
+        return @<FluentCombobox Width="@Width" 
+                                Placeholder="@(sampleLabelUsage.GetDescription())"
+                                LabelWidth="@(GetLabelWidth(sampleLabelUsage))"
+                                LabelPosition="@(GetLabelPosition(sampleLabelUsage))"
+                                Label="@(GetLabel(sampleLabelUsage))"
+                                OptionText="@(i => i?.Name)"
+                                OptionValue="@(i => i?.Code)"
+                                Items="@Countries"
+                                @bind-SelectedItems="@SelectedCountries">
+                    <FreeOption>
+                        Search for '
+                        <FreeOptionOutput />
+                        '
+                    </FreeOption>
+                </FluentCombobox>;
+    }
 
-    <div class="panel-resizable">
-        <h2>Date Pickers</h2>
-        <FluentDatePicker Width="@Width"
-                          @bind-Value="@SelectedValue" />
-        <FluentDatePicker Label="Label"
-                          LabelWidth="@LabelWidth"
-                          Width="@Width"
-                          @bind-Value="@SelectedValue" />
-        <FluentDatePicker LabelWidth="@LabelWidth"
-                          LabelPosition="LabelPosition.Before"
-                          Label="Label before"
-                          Width="@Width"
-                          @bind-Value="@SelectedValue" />
-    </div>
+    /* FluentDadePicker */
+    RenderFragment RenderDatePicker(SampleLabelUsage sampleLabelUsage)    
+    {
+        return @<FluentDatePicker Width="@Width" 
+                                  Placeholder="@(sampleLabelUsage.GetDescription())"
+                                  LabelWidth="@(GetLabelWidth(sampleLabelUsage))"
+                                  LabelPosition="@(GetLabelPosition(sampleLabelUsage))"
+                                  Label="@(GetLabel(sampleLabelUsage))"
+                                  @bind-Value="@SelectedValue" />;
+    }
 
-    <div class="panel-resizable">
-        <h2>Time Pickers</h2>
-        <FluentTimePicker @bind-Value="@SelectedTime"
-                          Width="@Width" />
-        <FluentTimePicker @bind-Value="@SelectedTime"
-                          Width="@Width"
-                          LabelWidth="@LabelWidth"
-                          Label="Label" />
-        <FluentTimePicker @bind-Value="@SelectedTime"
-                          Width="@Width"
-                          LabelWidth="@LabelWidth"
-                          LabelPosition="LabelPosition.Before"
-                          Label="Label before" />
-    </div>
+    /* FluentTimePicker */
+    RenderFragment RenderTimePicker(SampleLabelUsage sampleLabelUsage)    
+    {
+        return @<FluentTimePicker Width="@Width" 
+                                  Placeholder="@(sampleLabelUsage.GetDescription())"
+                                  LabelWidth="@(GetLabelWidth(sampleLabelUsage))"
+                                  LabelPosition="@(GetLabelPosition(sampleLabelUsage))"
+                                  Label="@(GetLabel(sampleLabelUsage))"
+                                  @bind-Value="@SelectedTime" />;
+    }
 
-    <div class="panel-resizable">
-        <h2>Switches</h2>
-        <FluentSwitch @bind-Value="@value"
-                      LabelWidth="@LabelWidth"
-                      Label="Label" />
-        <FluentSwitch @bind-Value="@value"
-                      LabelWidth="@LabelWidth"
-                      LabelPosition="LabelPosition.Before"
-                      Label="Label before" />
-    </div>
-</div>
+    /* FluentSwitch */
+    RenderFragment RenderSwitch(SampleLabelUsage sampleLabelUsage)    
+    {
+        return @<FluentSwitch LabelWidth="@(GetLabelWidth(sampleLabelUsage))"
+                              LabelPosition="@(GetLabelPosition(sampleLabelUsage))"
+                              Label="@(GetLabel(sampleLabelUsage))"
+                              @bind-Value="@value" />;
+    }
 
-@code {
-    string Width = "100%";
-    string LabelWidth = "";
-    bool showLabelBorder = false;
+    readonly record struct LabelRenderer(string Title, Func<SampleLabelUsage, RenderFragment> Render);
+
+    string? GetLabelWidth(SampleLabelUsage sampleLabelUsage) => sampleLabelUsage switch
+    {
+        SampleLabelUsage.NoLabelNoLabelPosition => null,
+        SampleLabelUsage.WithLabelNoLabelPosition => LabelWidth,
+        SampleLabelUsage.WithLabelAndLabelPosition => LabelWidth,
+        _ => throw new NotImplementedException(),
+    };
+
+    string? GetLabel(SampleLabelUsage sampleLabelUsage) => sampleLabelUsage switch
+    {
+        SampleLabelUsage.NoLabelNoLabelPosition => null,
+        SampleLabelUsage.WithLabelNoLabelPosition => "Label",
+        SampleLabelUsage.WithLabelAndLabelPosition => "Label",
+        _ => throw new NotImplementedException(),
+    };
+
+    LabelPosition? GetLabelPosition(SampleLabelUsage sampleLabelUsage) => sampleLabelUsage switch
+    {
+        SampleLabelUsage.NoLabelNoLabelPosition => null,
+        SampleLabelUsage.WithLabelNoLabelPosition => null,
+        SampleLabelUsage.WithLabelAndLabelPosition => LabelPosition.Before,
+        _ => throw new NotImplementedException(),
+    };
+
+    enum SampleLabelUsage
+    {
+        [Description("No label, no LabelPosition")]
+        NoLabelNoLabelPosition,
+        [Description("With label, no LabelPosition")]
+        WithLabelNoLabelPosition,
+        [Description("With label and LabelPosition")]
+        WithLabelAndLabelPosition,
+    }
+
+    string? Width = "50%";
+    string? LabelWidth = "";
+    bool showLabelBorder = true;
 
     IEnumerable<SampleData.Olympics2024.Country> Countries = SampleData.Olympics2024.Countries;
     IEnumerable<SampleData.Olympics2024.Country> SelectedCountries = [];
@@ -167,6 +218,11 @@
         padding: 1rem;
         overflow: hidden;
         resize: horizontal;
+        border: 1px solid var(--colorNeutralStroke1);
+    }
+
+    div[show-label-border] fluent-field {
+        border: 1px dashed var(--error);
     }
 
     div[show-label-border] fluent-field label {

--- a/examples/Demo/FluentUI.Demo.Client/DebugPages/WidthParameterPage.razor
+++ b/examples/Demo/FluentUI.Demo.Client/DebugPages/WidthParameterPage.razor
@@ -47,6 +47,7 @@
     [
         new("Text Inputs", RenderTextInput),
         new("Text Areas", RenderTextArea),
+        new("Autocomplete", RenderAutocomplete),
         new("Number Inputs", RenderNumberInput),
         new("Selects", RenderSelect),
         new("Listboxes", RenderListbox),
@@ -85,6 +86,20 @@
                                    LabelWidth="@(GetLabelWidth(sampleLabelUsage))"
                                    LabelPosition="@(GetLabelPosition(sampleLabelUsage))"
                                    Label="@(GetLabel(sampleLabelUsage))" />;
+    }
+
+    /* FluentAutocomplete */
+    RenderFragment RenderAutocomplete(SampleLabelUsage sampleLabelUsage)    
+    {
+        return @<FluentAutocomplete Width="@Width" 
+                                    Placeholder="@(sampleLabelUsage.GetDescription())"
+                                    LabelWidth="@(GetLabelWidth(sampleLabelUsage))"
+                                    LabelPosition="@(GetLabelPosition(sampleLabelUsage))"
+                                    Label="@(GetLabel(sampleLabelUsage))"
+                                    OptionText="@(i => i?.Name)"
+                                    OptionValue="@(i => i?.Code)"
+                                    Items="@Countries"
+                                    @bind-SelectedItems="@SelectedCountries" />;
     }
 
     /* FluentSelect */

--- a/examples/Demo/FluentUI.Demo.Client/DebugPages/WidthParameterPage.razor
+++ b/examples/Demo/FluentUI.Demo.Client/DebugPages/WidthParameterPage.razor
@@ -21,7 +21,6 @@
         </FluentStack>    
         <FluentStack Orientation="Orientation.Vertical">
             <FluentLink OnClick="@(e => LabelWidth = null)">LabelWidth: unset</FluentLink>
-            <FluentLink OnClick="@(e => LabelWidth = "100%")">LabelWidth: 100%</FluentLink>
             <FluentLink OnClick="@(e => LabelWidth = "50%")">LabelWidth: 50%</FluentLink>
             <FluentLink OnClick="@(e => LabelWidth = "150px")">LabelWidth: 150px</FluentLink>
         </FluentStack>    

--- a/examples/Demo/FluentUI.Demo.Client/DebugPages/WidthParameterPage.razor
+++ b/examples/Demo/FluentUI.Demo.Client/DebugPages/WidthParameterPage.razor
@@ -87,6 +87,7 @@
         return @<FluentCheckbox LabelWidth="@(GetLabelWidth(sampleLabelUsage))"
                                 LabelPosition="@(GetLabelPosition(sampleLabelUsage))"
                                 Label="@(GetLabel(sampleLabelUsage))"
+                                Width="@Width"
                                 @bind-Value="@checkboxValue" />;
     }
 
@@ -108,6 +109,7 @@
                                   LabelWidth="@(GetLabelWidth(sampleLabelUsage))"
                                   LabelPosition="@(GetLabelPosition(sampleLabelUsage))"
                                   Label="@(GetLabel(sampleLabelUsage))"
+                                  Width="@Width" 
                                   Items="Colors"
                                   Orientation="Orientation.Vertical"
                                   @bind-Value="@SelectedRadioValue" />;
@@ -187,6 +189,7 @@
     RenderFragment RenderSlider(SampleLabelUsage sampleLabelUsage)
     {
         return @<FluentSlider TValue="int"
+                              Width="@Width" 
                               LabelWidth="@(GetLabelWidth(sampleLabelUsage))"
                               LabelPosition="@(GetLabelPosition(sampleLabelUsage))"
                               Label="@(GetLabel(sampleLabelUsage))"
@@ -234,6 +237,7 @@
         return @<FluentSwitch LabelWidth="@(GetLabelWidth(sampleLabelUsage))"
                               LabelPosition="@(GetLabelPosition(sampleLabelUsage))"
                               Label="@(GetLabel(sampleLabelUsage))"
+                              Width="@Width"
                               @bind-Value="@value" />;
     }
 

--- a/src/Core/Components/Base/FluentInputBase.cs
+++ b/src/Core/Components/Base/FluentInputBase.cs
@@ -166,7 +166,7 @@ public abstract partial class FluentInputBase<TValue> : InputBase<TValue>, IFlue
     /// <summary>
     /// Gets the optional in-line styles. If given, these will be included in the style attribute of the component.
     /// </summary>
-    protected virtual string? StyleValue => DefaultStyleBuilder        
+    protected virtual string? StyleValue => DefaultStyleBuilder
         .Build();
 
     /// <summary>

--- a/src/Core/Components/Base/FluentInputBase.cs
+++ b/src/Core/Components/Base/FluentInputBase.cs
@@ -166,7 +166,7 @@ public abstract partial class FluentInputBase<TValue> : InputBase<TValue>, IFlue
     /// <summary>
     /// Gets the optional in-line styles. If given, these will be included in the style attribute of the component.
     /// </summary>
-    protected virtual string? StyleValue => DefaultStyleBuilder
+    protected virtual string? StyleValue => DefaultStyleBuilder        
         .Build();
 
     /// <summary>

--- a/src/Core/Components/Checkbox/FluentCheckbox.razor.cs
+++ b/src/Core/Components/Checkbox/FluentCheckbox.razor.cs
@@ -23,6 +23,17 @@ public partial class FluentCheckbox : FluentInputBase<bool>, IFluentComponentEle
         LabelPosition = Components.LabelPosition.After;
     }
 
+    /// <inheritdoc />
+    protected override string? StyleValue => DefaultStyleBuilder
+        .AddStyle("width", Width)
+        .Build();
+
+    /// <summary>
+    /// Gets or sets the width of the checkbox (e.g., <c>Width="300px"</c>).
+    /// </summary>
+    [Parameter]
+    public string? Width { get; set; }
+    
     /// <inheritdoc cref="IFluentComponentElementBase.Element" />
     [Parameter]
     public ElementReference Element { get; set; }

--- a/src/Core/Components/Field/FluentField.razor.cs
+++ b/src/Core/Components/Field/FluentField.razor.cs
@@ -31,6 +31,7 @@ public partial class FluentField : FluentComponentBase, IFluentField
 
     private string? LabelStyle => new StyleBuilder()
         .AddStyle("width", Parameters.LabelWidth)
+        .AddStyle("min-width", Parameters.LabelWidth, when: Parameters.LabelPosition == Components.LabelPosition.Before)
         .Build();
 
     /// <summary>

--- a/src/Core/Components/Field/FluentField.razor.cs
+++ b/src/Core/Components/Field/FluentField.razor.cs
@@ -31,7 +31,6 @@ public partial class FluentField : FluentComponentBase, IFluentField
 
     private string? LabelStyle => new StyleBuilder()
         .AddStyle("width", Parameters.LabelWidth)
-        .AddStyle("min-width", Parameters.LabelWidth, when: Parameters.LabelPosition == Components.LabelPosition.Before)
         .Build();
 
     /// <summary>

--- a/src/Core/Components/Field/FluentField.razor.css
+++ b/src/Core/Components/Field/FluentField.razor.css
@@ -7,9 +7,20 @@ fluent-field[label-position='before'] {
   display: inline-flex;
 }
 
-fluent-field[label-position='before'] > fluent-label[slot='label'] {
+fluent-field[label-position='before']>fluent-label[slot='label'] {
   margin-top: 8px;
   align-self: flex-start;
+}
+
+fluent-field[label-position="before"]>label[slot="label"] {
+  flex: 0 0 auto;
+  flex-shrink: 0;
+}
+
+fluent-field[label-position="before"]>[slot="input"] {
+  flex: 1 1 auto;
+  width: auto;
+  min-width: 0;
 }
 
 fluent-field label[disabled] {

--- a/src/Core/Components/Field/FluentField.razor.css
+++ b/src/Core/Components/Field/FluentField.razor.css
@@ -23,6 +23,10 @@ fluent-field[label-position="before"]>[slot="input"] {
   min-width: 0;
 }
 
+fluent-field[label-position="before"]>[slot="message"]:empty {
+  display: none;
+}
+
 fluent-field label[disabled] {
   color: var(--colorNeutralForegroundDisabled);
 }

--- a/src/Core/Components/Field/FluentField.razor.css
+++ b/src/Core/Components/Field/FluentField.razor.css
@@ -3,6 +3,10 @@
   margin-top: var(--spacingVerticalM);
 }
 
+fluent-field[label-position='before'] {
+  display: inline-flex;
+}
+
 fluent-field[label-position='before'] > fluent-label[slot='label'] {
   margin-top: 8px;
   align-self: flex-start;

--- a/src/Core/Components/Field/FluentField.razor.css
+++ b/src/Core/Components/Field/FluentField.razor.css
@@ -17,7 +17,7 @@ fluent-field[label-position="before"]>label[slot="label"] {
   flex-shrink: 0;
 }
 
-fluent-field[label-position="before"]>[slot="input"] {
+fluent-field[label-position="before"]:not(:has(fluent-slider, fluent-checkbox, fluent-switch, fluent-radio-group))>[slot="input"] {
   flex: 1 1 auto;
   width: auto;
   min-width: 0;

--- a/src/Core/Components/List/FluentListbox.razor.cs
+++ b/src/Core/Components/List/FluentListbox.razor.cs
@@ -19,7 +19,7 @@ public partial class FluentListbox<TOption, TValue> : FluentListBase<TOption, TV
 
     /// <summary />
     protected virtual string? ListStyle => new StyleBuilder()
-        .AddStyle("width", "100%")
+        .AddStyle("width", Width)
         .AddStyle("height", Height)
         .Build();
 

--- a/src/Core/Components/List/FluentListbox.razor.cs
+++ b/src/Core/Components/List/FluentListbox.razor.cs
@@ -19,7 +19,7 @@ public partial class FluentListbox<TOption, TValue> : FluentListBase<TOption, TV
 
     /// <summary />
     protected virtual string? ListStyle => new StyleBuilder()
-        .AddStyle("width", Width)
+        .AddStyle("width", "100%")
         .AddStyle("height", Height)
         .Build();
 

--- a/src/Core/Components/List/FluentListbox.razor.cs
+++ b/src/Core/Components/List/FluentListbox.razor.cs
@@ -19,7 +19,6 @@ public partial class FluentListbox<TOption, TValue> : FluentListBase<TOption, TV
 
     /// <summary />
     protected virtual string? ListStyle => new StyleBuilder()
-        .AddStyle("width", Width)
         .AddStyle("height", Height)
         .Build();
 

--- a/src/Core/Components/List/FluentListbox.razor.css
+++ b/src/Core/Components/List/FluentListbox.razor.css
@@ -15,6 +15,7 @@
   .fluent-listbox fluent-listbox {
     box-shadow: none;
     overflow-y: auto;
+    width: 100%;
   }
 
   .fluent-listbox[disabled],

--- a/src/Core/Components/List/FluentSelect.razor.cs
+++ b/src/Core/Components/List/FluentSelect.razor.cs
@@ -24,7 +24,7 @@ public partial class FluentSelect<TOption, TValue> : FluentListBase<TOption, TVa
 
     /// <summary />
     protected virtual string? DropdownStyle => new StyleBuilder()
-        .AddStyle("width", Width, when: !string.IsNullOrEmpty(Width))
+        .AddStyle("width", "100%")
         .Build();
 
     /// <summary />

--- a/src/Core/Components/List/FluentSelect.razor.cs
+++ b/src/Core/Components/List/FluentSelect.razor.cs
@@ -24,7 +24,7 @@ public partial class FluentSelect<TOption, TValue> : FluentListBase<TOption, TVa
 
     /// <summary />
     protected virtual string? DropdownStyle => new StyleBuilder()
-        .AddStyle("width", "100%")
+        .AddStyle("width", Width, when: !string.IsNullOrEmpty(Width))
         .Build();
 
     /// <summary />

--- a/src/Core/Components/List/FluentSelect.razor.cs
+++ b/src/Core/Components/List/FluentSelect.razor.cs
@@ -24,7 +24,6 @@ public partial class FluentSelect<TOption, TValue> : FluentListBase<TOption, TVa
 
     /// <summary />
     protected virtual string? DropdownStyle => new StyleBuilder()
-        .AddStyle("width", Width, when: !string.IsNullOrEmpty(Width))
         .Build();
 
     /// <summary />

--- a/src/Core/Components/List/FluentSelect.razor.css
+++ b/src/Core/Components/List/FluentSelect.razor.css
@@ -7,6 +7,10 @@ fluent-dropdown[readonly] {
   user-select: none;
 }
 
+fluent-dropdown {
+  width: 100%;
+}
+
 fluent-dropdown[size="small"] button[slot="control"] {
   max-height: var(--lineHeightBase200);
 }

--- a/src/Core/Components/NumberInput/FluentNumberInput.razor.cs
+++ b/src/Core/Components/NumberInput/FluentNumberInput.razor.cs
@@ -73,7 +73,6 @@ public partial class FluentNumberInput<TValue> : FluentInputImmediateBase<TValue
     /// Gets the CSS class to apply to the internal web-component.
     /// </summary>
     protected virtual string? ComponentStyleValue => new StyleBuilder()
-        .AddStyle("width", Width)
         .Build();
 
     /// <inheritdoc cref="IFluentComponentElementBase.Element" />

--- a/src/Core/Components/NumberInput/FluentNumberInput.razor.cs
+++ b/src/Core/Components/NumberInput/FluentNumberInput.razor.cs
@@ -73,7 +73,7 @@ public partial class FluentNumberInput<TValue> : FluentInputImmediateBase<TValue
     /// Gets the CSS class to apply to the internal web-component.
     /// </summary>
     protected virtual string? ComponentStyleValue => new StyleBuilder()
-        .AddStyle("width", "100%")
+        .AddStyle("width", Width)
         .Build();
 
     /// <inheritdoc cref="IFluentComponentElementBase.Element" />

--- a/src/Core/Components/NumberInput/FluentNumberInput.razor.cs
+++ b/src/Core/Components/NumberInput/FluentNumberInput.razor.cs
@@ -73,7 +73,7 @@ public partial class FluentNumberInput<TValue> : FluentInputImmediateBase<TValue
     /// Gets the CSS class to apply to the internal web-component.
     /// </summary>
     protected virtual string? ComponentStyleValue => new StyleBuilder()
-        .AddStyle("width", Width)
+        .AddStyle("width", "100%")
         .Build();
 
     /// <inheritdoc cref="IFluentComponentElementBase.Element" />

--- a/src/Core/Components/Radio/FluentRadioGroup.razor.cs
+++ b/src/Core/Components/Radio/FluentRadioGroup.razor.cs
@@ -27,6 +27,17 @@ public partial class FluentRadioGroup<TValue> : FluentInputBase<TValue>, IFluent
     /// <param name="configuration">The configuration settings used to initialize the radio group. This parameter cannot be null.</param>
     public FluentRadioGroup(LibraryConfiguration configuration) : base(configuration) { }
 
+    /// <inheritdoc />
+    protected override string? StyleValue => DefaultStyleBuilder
+        .AddStyle("width", Width)
+        .Build();
+
+    /// <summary>
+    /// Gets or sets the width of the radio group (e.g., <c>Width="300px"</c>).
+    /// </summary>
+    [Parameter]
+    public string? Width { get; set; }
+
     /// <inheritdoc cref="IFluentComponentElementBase.Element" />
     [Parameter]
     public ElementReference Element { get; set; }

--- a/src/Core/Components/Slider/FluentSlider.razor.cs
+++ b/src/Core/Components/Slider/FluentSlider.razor.cs
@@ -41,6 +41,17 @@ public partial class FluentSlider<TValue> : FluentInputBase<TValue>, ITooltipCom
         }
     }
 
+    /// <inheritdoc />
+    protected override string? StyleValue => DefaultStyleBuilder
+        .AddStyle("width", Width)
+        .Build();
+
+    /// <summary>
+    /// Gets or sets the width of the slider (e.g., <c>Width="300px"</c>).
+    /// </summary>
+    [Parameter]
+    public string? Width { get; set; }
+
     /// <summary>
     /// Gets or sets the size for the slider.
     /// </summary>

--- a/src/Core/Components/Switch/FluentSwitch.razor.cs
+++ b/src/Core/Components/Switch/FluentSwitch.razor.cs
@@ -22,6 +22,17 @@ public partial class FluentSwitch : FluentInputBase<bool>, ITooltipComponent, IF
         LabelPosition ??= Components.LabelPosition.After;
     }
 
+    /// <inheritdoc />
+    protected override string? StyleValue => DefaultStyleBuilder
+        .AddStyle("width", Width)
+        .Build();
+
+    /// <summary>
+    /// Gets or sets the width of the switch (e.g., <c>Width="300px"</c>).
+    /// </summary>
+    [Parameter]
+    public string? Width { get; set; }
+    
     /// <inheritdoc cref="IFluentComponentElementBase.Element" />
     [Parameter]
     public ElementReference Element { get; set; }

--- a/src/Core/Components/TextArea/FluentTextArea.razor.cs
+++ b/src/Core/Components/TextArea/FluentTextArea.razor.cs
@@ -44,7 +44,7 @@ public partial class FluentTextArea : FluentInputImmediateBase<string?>, IFluent
     /// Gets the CSS class to apply to the internal web-component.
     /// </summary>
     protected virtual string? ComponentStyleValue => new StyleBuilder()
-        .AddStyle("width", Width)
+        .AddStyle("width", "100%")
         .AddStyle("height", Height)
         .Build();
 

--- a/src/Core/Components/TextArea/FluentTextArea.razor.cs
+++ b/src/Core/Components/TextArea/FluentTextArea.razor.cs
@@ -38,14 +38,12 @@ public partial class FluentTextArea : FluentInputImmediateBase<string?>, IFluent
     /// <inheritdoc />
     protected override string? StyleValue => DefaultStyleBuilder
         .AddStyle("width", Width)
-        .AddStyle("min-width", "180px", when: () => string.IsNullOrEmpty(Width))
         .Build();
 
     /// <summary>
     /// Gets the CSS class to apply to the internal web-component.
     /// </summary>
     protected virtual string? ComponentStyleValue => new StyleBuilder()
-        .AddStyle("width", Width)
         .AddStyle("height", Height)
         .Build();
 

--- a/src/Core/Components/TextArea/FluentTextArea.razor.cs
+++ b/src/Core/Components/TextArea/FluentTextArea.razor.cs
@@ -45,7 +45,7 @@ public partial class FluentTextArea : FluentInputImmediateBase<string?>, IFluent
     /// Gets the CSS class to apply to the internal web-component.
     /// </summary>
     protected virtual string? ComponentStyleValue => new StyleBuilder()
-        .AddStyle("width", "100%")
+        .AddStyle("width", Width)
         .AddStyle("height", Height)
         .Build();
 

--- a/src/Core/Components/TextArea/FluentTextArea.razor.cs
+++ b/src/Core/Components/TextArea/FluentTextArea.razor.cs
@@ -38,6 +38,7 @@ public partial class FluentTextArea : FluentInputImmediateBase<string?>, IFluent
     /// <inheritdoc />
     protected override string? StyleValue => DefaultStyleBuilder
         .AddStyle("width", Width)
+        .AddStyle("min-width", "180px", when: () => string.IsNullOrEmpty(Width))
         .Build();
 
     /// <summary>

--- a/src/Core/Components/TextArea/FluentTextArea.razor.css
+++ b/src/Core/Components/TextArea/FluentTextArea.razor.css
@@ -1,3 +1,7 @@
+fluent-textarea {
+  width: 100%;
+}
+
 fluent-textarea[style~="width:"]::part(root) {
   width: 100%;
 }

--- a/src/Core/Components/TextArea/FluentTextArea.razor.css
+++ b/src/Core/Components/TextArea/FluentTextArea.razor.css
@@ -2,7 +2,11 @@ fluent-textarea {
   width: 100%;
 }
 
-fluent-textarea[style~="width:"]::part(root) {
+fluent-field:not([style~="width:"]):has(fluent-textarea) {
+  min-width: 180px;
+}
+
+fluent-textarea::part(root) {
   width: 100%;
 }
 

--- a/src/Core/Components/TextInput/FluentTextInput.razor.cs
+++ b/src/Core/Components/TextInput/FluentTextInput.razor.cs
@@ -44,7 +44,6 @@ public partial class FluentTextInput : FluentInputImmediateBase<string?>, IFluen
     /// Gets the CSS class to apply to the internal web-component.
     /// </summary>
     protected virtual string? ComponentStyleValue => new StyleBuilder()
-        .AddStyle("width", "100%")
         .Build();
 
     /// <inheritdoc cref="IFluentComponentElementBase.Element" />

--- a/src/Core/Components/TextInput/FluentTextInput.razor.cs
+++ b/src/Core/Components/TextInput/FluentTextInput.razor.cs
@@ -44,7 +44,7 @@ public partial class FluentTextInput : FluentInputImmediateBase<string?>, IFluen
     /// Gets the CSS class to apply to the internal web-component.
     /// </summary>
     protected virtual string? ComponentStyleValue => new StyleBuilder()
-        .AddStyle("width", Width)
+        .AddStyle("width", "100%")
         .Build();
 
     /// <inheritdoc cref="IFluentComponentElementBase.Element" />

--- a/src/Core/Components/TextInput/FluentTextInput.razor.css
+++ b/src/Core/Components/TextInput/FluentTextInput.razor.css
@@ -1,3 +1,9 @@
+fluent-text-input {
+  width: 100%;
+  max-width: unset;
+}
+
 fluent-text-input[style~="width:"] {
   max-width: unset;
 }
+

--- a/tests/Core/Components/List/FluentAutocompleteTests.FluentAutocomplete_Default_Items.verified.razor.html
+++ b/tests/Core/Components/List/FluentAutocompleteTests.FluentAutocomplete_Default_Items.verified.razor.html
@@ -2,7 +2,7 @@
 	<head></head>
 	<body>
 		<fluent-field id="xxx" label-position="above" style="width: 160px;">
-			<fluent-text-input style="width: 160px;" appearance="outline" autocomplete="false" id="xxx" placeholder="Select a digit" slot="input" blazor:onfocusout="2" blazor:onchange="3" blazor:ontextimmediate="4" auto-complete="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+			<fluent-text-input appearance="outline" autocomplete="false" id="xxx" placeholder="Select a digit" slot="input" blazor:onfocusout="2" blazor:onchange="3" blazor:ontextimmediate="4" auto-complete="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
 				<div slot="start"><div style=""></div></div>
 				</div>
 				<div slot="end">

--- a/tests/Core/Components/List/FluentAutocompleteTests.FluentAutocomplete_Label.verified.razor.html
+++ b/tests/Core/Components/List/FluentAutocompleteTests.FluentAutocomplete_Label.verified.razor.html
@@ -4,7 +4,7 @@
 		<fluent-field id="xxx" label-position="above" class="my-3-o" style="width: 160px;">
 			<label id="xxx" slot="label" for="xxx" required="">List of digits
 			</label>
-			<fluent-text-input style="width: 160px;" appearance="outline" autocomplete="false" id="xxx" required="" slot="input" blazor:onfocusout="2" blazor:onchange="3" blazor:ontextimmediate="4" auto-complete="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+			<fluent-text-input appearance="outline" autocomplete="false" id="xxx" required="" slot="input" blazor:onfocusout="2" blazor:onchange="3" blazor:ontextimmediate="4" auto-complete="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
 				<div slot="start"><div style=""></div></div>
 				</div>
 				<div slot="end">

--- a/tests/Core/Components/List/FluentListboxTests.razor
+++ b/tests/Core/Components/List/FluentListboxTests.razor
@@ -379,8 +379,10 @@
 
         // Assert - Width and Height are applied to the listbox
         var listbox = cut.Find("fluent-listbox");
+        var field = cut.Find("fluent-field");
         var listboxStyle = listbox.GetAttribute("style");
-        Assert.Contains("width: 200px", listboxStyle);
+        var fieldStyle = field.GetAttribute("style");
+        Assert.Contains("width: 200px", fieldStyle);
         Assert.Contains("height: 300px", listboxStyle);
     }
 

--- a/tests/Core/Components/List/FluentSelectTests.FluentSelect_Width_And_Height.verified.razor.html
+++ b/tests/Core/Components/List/FluentSelectTests.FluentSelect_Width_And_Height.verified.razor.html
@@ -2,7 +2,7 @@
 	<head></head>
 	<body>
 		<fluent-field id="xxx" label-position="above" style="width: 200px;">
-			<fluent-dropdown id="xxx" slot="input" style="width: 200px;" type="dropdown" blazor:ondropdownchange="1" blazor:onfocusout="2">
+			<fluent-dropdown id="xxx" slot="input" type="dropdown" blazor:ondropdownchange="1" blazor:onfocusout="2">
 				<fluent-listbox style="max-height: 300px;">
 					<fluent-option id="xxx"></fluent-option>
 					<fluent-option id="xxx" text="One" value="One">One</fluent-option>

--- a/tests/Core/Components/List/FluentSelectTests.razor
+++ b/tests/Core/Components/List/FluentSelectTests.razor
@@ -498,9 +498,12 @@
         var cut = Render(@<FluentSelect Items="@Digits" TOption="string" TValue="string" Width="200px" Height="300px" />);
 
         // Assert - Width is applied to the dropdown, Height to the listbox
+        var field = cut.Find("fluent-field");
         var dropdown = cut.Find("fluent-dropdown");
         var dropdownStyle = dropdown.GetAttribute("style");
-        Assert.Contains("width: 200px", dropdownStyle);
+        var fieldStyle = field.GetAttribute("style");
+        
+        Assert.Contains("width: 200px", fieldStyle);
 
         var listbox = cut.Find("fluent-listbox");
         var listboxStyle = listbox.GetAttribute("style");

--- a/tests/Core/Components/Number/FluentNumberTests.FluentNumber_Default_Double.verified.razor.html
+++ b/tests/Core/Components/Number/FluentNumberTests.FluentNumber_Default_Double.verified.razor.html
@@ -4,7 +4,7 @@
 		<fluent-field id="xxx" label-position="above" class="my-3-o" style="width: 100px;">
 			<label id="xxx" slot="label" for="xxx">double
 			</label>
-			<fluent-text-input style="width: 100px;" appearance="outline" autocomplete="off" id="xxx" inputmode="numeric" slot="input" spellcheck="false" value="1,234.56" blazor:onfocusout="1" blazor:onchange="2" blazor:ontextimmediate="3" blazor:elementreference="xxx">
+			<fluent-text-input appearance="outline" autocomplete="off" id="xxx" inputmode="numeric" slot="input" spellcheck="false" value="1,234.56" blazor:onfocusout="1" blazor:onchange="2" blazor:ontextimmediate="3" blazor:elementreference="xxx">
 				<div slot="end">
 					<div auto-hide="true">
 						<div button-step="up">

--- a/tests/Core/Components/Number/FluentNumberTests.FluentNumber_Default_Integer.verified.razor.html
+++ b/tests/Core/Components/Number/FluentNumberTests.FluentNumber_Default_Integer.verified.razor.html
@@ -4,7 +4,7 @@
 		<fluent-field id="xxx" label-position="above" class="my-3-o" style="width: 100px;">
 			<label id="xxx" slot="label" for="xxx">int
 			</label>
-			<fluent-text-input style="width: 100px;" appearance="outline" autocomplete="off" id="xxx" inputmode="numeric" slot="input" spellcheck="false" value="1234" blazor:onfocusout="1" blazor:onchange="2" blazor:ontextimmediate="3" blazor:elementreference="xxx">
+			<fluent-text-input appearance="outline" autocomplete="off" id="xxx" inputmode="numeric" slot="input" spellcheck="false" value="1234" blazor:onfocusout="1" blazor:onchange="2" blazor:ontextimmediate="3" blazor:elementreference="xxx">
 				<div slot="end">
 					<div auto-hide="true">
 						<div button-step="up">

--- a/tests/Core/Components/Number/FluentNumberTests.FluentNumber_NoStepButtons.verified.razor.html
+++ b/tests/Core/Components/Number/FluentNumberTests.FluentNumber_NoStepButtons.verified.razor.html
@@ -4,7 +4,7 @@
 		<fluent-field id="xxx" label-position="above" class="my-3-o" style="width: 100px;">
 			<label id="xxx" slot="label" for="xxx">int
 			</label>
-			<fluent-text-input style="width: 100px;" appearance="outline" autocomplete="off" id="xxx" inputmode="numeric" slot="input" spellcheck="false" value="1234" blazor:onfocusout="1" blazor:onchange="2" blazor:ontextimmediate="3" blazor:elementreference="xxx">
+			<fluent-text-input appearance="outline" autocomplete="off" id="xxx" inputmode="numeric" slot="input" spellcheck="false" value="1234" blazor:onfocusout="1" blazor:onchange="2" blazor:ontextimmediate="3" blazor:elementreference="xxx">
 				<div slot="end"></div>
 			</fluent-text-input>
 		</fluent-field>

--- a/tests/Core/Components/Number/FluentNumberTests.FluentNumber_Width.verified.razor.html
+++ b/tests/Core/Components/Number/FluentNumberTests.FluentNumber_Width.verified.razor.html
@@ -4,7 +4,7 @@
 		<fluent-field id="xxx" label-position="above" class="my-3-o" style="width: 250px;">
 			<label id="xxx" slot="label" for="xxx">number
 			</label>
-			<fluent-text-input style="width: 250px;" appearance="outline" autocomplete="off" id="xxx" inputmode="numeric" slot="input" spellcheck="false" value="0" blazor:onfocusout="1" blazor:onchange="2" blazor:ontextimmediate="3" blazor:elementreference="xxx">
+			<fluent-text-input appearance="outline" autocomplete="off" id="xxx" inputmode="numeric" slot="input" spellcheck="false" value="0" blazor:onfocusout="1" blazor:onchange="2" blazor:ontextimmediate="3" blazor:elementreference="xxx">
 				<div slot="end">
 					<div auto-hide="true">
 						<div button-step="up">

--- a/tests/Core/Components/TextArea/FluentTextAreaTests.razor
+++ b/tests/Core/Components/TextArea/FluentTextAreaTests.razor
@@ -197,6 +197,7 @@
         var cut = Render(@<FluentTextArea Width="150px" Height="100px" />);
 
         // Assert
-        Assert.Equal("width: 150px; height: 100px;", cut.Find("fluent-textarea").GetAttribute("style"));
+        Assert.Equal("height: 100px;", cut.Find("fluent-textarea").GetAttribute("style"));
+        Assert.Equal("width: 150px;", cut.Find("fluent-field").GetAttribute("style"));
     }
 }

--- a/tests/Core/Components/TextInput/FluentTextInputTests.razor
+++ b/tests/Core/Components/TextInput/FluentTextInputTests.razor
@@ -212,7 +212,7 @@
         var cut = Render(@<FluentTextInput Width="100px" />);
 
         // Assert
-        Assert.Equal("width: 100px;", cut.Find("fluent-text-input").GetAttribute("style"));
+        Assert.Equal("width: 100px;", cut.Find("fluent-field").GetAttribute("style"));
     }
 
     [Fact]


### PR DESCRIPTION
# [dev-v5] Update `Width` handling for FluentField

Enhance the default `Width` handling for various **Fluent Input** components to 100% for improved layout and responsiveness. Introduce new components with `Width` parameters and refactor existing components to streamline width management. 

This change aims to provide a more consistent and user-friendly interface across the application.

To fix #4938

## Example

<img width="894" height="506" alt="image" src="https://github.com/user-attachments/assets/a8a191e4-b613-4376-a418-e8ac0745b514" />

<img width="914" height="508" alt="image" src="https://github.com/user-attachments/assets/6ab20d48-66a4-4550-bbca-204265d92e61" />

<img width="915" height="508" alt="image" src="https://github.com/user-attachments/assets/0b4a03c3-9780-40b1-9035-d6a6d7dcd785" />


## Demo

See: `/Debug/Width`


https://github.com/user-attachments/assets/5a5ab164-4a53-44fc-80d2-43f63faa0e9c


