### PR TITLE
# [dev-v5] FluentDatePicker - Add MinDate and MaxDate properties

### DIFF
--- a/src/Core/Components/DateTime/FluentDatePicker.razor
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor
@@ -50,6 +50,8 @@
                         TValue="TValue"
                         Culture="@Culture"
                         View="@View"
+                        MinDate="@MinDate"
+                        MaxDate="@MaxDate"
                         DayFormat="@DayFormat"
                         DisabledDateFunc="@DisabledDateFunc"
                         DisabledCheckAllDaysOfMonthYear="@DisabledCheckAllDaysOfMonthYear"

--- a/tests/Core/Components/DateTimes/FluentDatePickerTests.razor
+++ b/tests/Core/Components/DateTimes/FluentDatePickerTests.razor
@@ -190,6 +190,105 @@
     }
 
     [Fact]
+    public void FluentDatePicker_MinMaxDate_SetCorrectValues()
+    {
+        // Arrange
+        using var context = new DateTimeProviderContext(System.DateTime.Now);
+        var minDate = new System.DateTime(2022, 02, 10);
+        var maxDate = new System.DateTime(2022, 02, 20);
+
+        // Act
+        var picker = Render(@<FluentDatePicker TValue="DateTime?" Culture="@InvariantCulture" MinDate="@minDate" MaxDate="@maxDate" />);
+        var pickerInstance = picker.FindComponent<FluentDatePicker<DateTime?>>().Instance;
+
+        // Assert
+        Assert.Equal(minDate, pickerInstance.MinDate);
+        Assert.Equal(maxDate, pickerInstance.MaxDate);
+    }
+
+    [Fact]
+    public void FluentDatePicker_MinMaxDate_PassedToCalendar()
+    {
+        // Arrange
+        using var context = new DateTimeProviderContext(System.DateTime.Now);
+        var minDate = new System.DateTime(2022, 02, 10);
+        var maxDate = new System.DateTime(2022, 02, 20);
+
+        // Act
+        var picker = Render(@<FluentDatePicker TValue="DateTime?" Culture="@InvariantCulture" Value="@(new System.DateTime(2022, 02, 15))"
+            MinDate="@minDate" MaxDate="@maxDate" />);
+        var text = picker.Find("fluent-text-input");
+
+        // Click to open the calendar
+        text.Click();
+
+        // Assert
+        var calendar = picker.FindComponent<FluentCalendar<DateTime?>>().Instance;
+        Assert.Equal(minDate, calendar.MinDate);
+        Assert.Equal(maxDate, calendar.MaxDate);
+    }
+
+    [Fact]
+    public void FluentDatePicker_MinDate_DisablesEarlierDays()
+    {
+        // Arrange
+        using var context = new DateTimeProviderContext(System.DateTime.Now);
+        var minDate = new System.DateTime(2022, 02, 10);
+
+        // Act
+        var picker = Render(@<FluentDatePicker TValue="DateTime?" Culture="@InvariantCulture" Value="@(new System.DateTime(2022, 02, 15))"
+            MinDate="@minDate" />);
+        var text = picker.Find("fluent-text-input");
+
+        // Click to open the calendar
+        text.Click();
+
+        // Assert
+        Assert.True(picker.Find(".day[value='2022-02-09']").HasAttribute("disabled"));
+        Assert.False(picker.Find(".day[value='2022-02-10']").HasAttribute("disabled"));
+    }
+
+    [Fact]
+    public void FluentDatePicker_MaxDate_DisablesLaterDays()
+    {
+        // Arrange
+        using var context = new DateTimeProviderContext(System.DateTime.Now);
+        var maxDate = new System.DateTime(2022, 02, 20);
+
+        // Act
+        var picker = Render(@<FluentDatePicker TValue="DateTime?" Culture="@InvariantCulture" Value="@(new System.DateTime(2022, 02, 15))"
+            MaxDate="@maxDate" />);
+        var text = picker.Find("fluent-text-input");
+
+        // Click to open the calendar
+        text.Click();
+
+        // Assert
+        Assert.True(picker.Find(".day[value='2022-02-21']").HasAttribute("disabled"));
+        Assert.False(picker.Find(".day[value='2022-02-20']").HasAttribute("disabled"));
+    }
+
+    [Fact]
+    public void FluentDatePicker_MinMaxDate_DayWithinRangeIsEnabled()
+    {
+        // Arrange
+        using var context = new DateTimeProviderContext(System.DateTime.Now);
+        var minDate = new System.DateTime(2022, 02, 10);
+        var maxDate = new System.DateTime(2022, 02, 20);
+
+        // Act
+        var picker = Render(@<FluentDatePicker TValue="DateTime?" Culture="@InvariantCulture" Value="@(new System.DateTime(2022, 02, 15))"
+            MinDate="@minDate" MaxDate="@maxDate" />);
+        var text = picker.Find("fluent-text-input");
+
+        // Click to open the calendar
+        text.Click();
+
+        // Assert
+        Assert.False(picker.Find(".day[value='2022-02-15']").HasAttribute("disabled"));
+    }
+
+    [Fact]
     public void FluentDatePicker_ChangeValueWhenDefaultIsNull()
     {
         // Arrange


### PR DESCRIPTION
# [dev-v5] FluentDatePicker - Add MinDate and MaxDate properties

Enhance the **FluentDatePicker** component by introducing **MinDate** and **MaxDate** properties, allowing users to restrict date selection within a specified range. 

Corresponding tests ensure the functionality works as intended, validating that dates outside the range are disabled and that the properties are correctly passed to the calendar component.

