### PR TITLE
[dev-v5] Toast service for non-blocking notifications

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,8 @@
         { "label": "Fluent UI Blazor v5", "url": "https://fluentui-blazor-v5.azurewebsites.net/" }
     ],
     "dotnetPulse.projectBuildToConsole": "externalTerminal",
-    "dotnetPulse.projectUri": "examples/Demo/FluentUI.Demo/FluentUI.Demo.csproj"
+    "dotnetPulse.projectUri": "examples/Demo/FluentUI.Demo/FluentUI.Demo.csproj",
+
+    // C# Dev Kit: solution open by default 
+    "dotnet.defaultSolution": "Microsoft.FluentUI-v5.slnx"
 }

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Toast/Examples/FluentToastDefaultOptions.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Toast/Examples/FluentToastDefaultOptions.razor
@@ -31,6 +31,7 @@
             options.Message = "Toasts are used to show brief messages to the user.";
             options.Subtitle = "Sent by Fluent UI Blazor";
             options.Lifetime = TimeSpan.FromSeconds(10);
+            options.ResultTiming = ToastResultTiming.Closed;
             options.AllowDismiss = true;
             options.OnStatusChange = (e) =>
             {

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Toast/FluentToast.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Toast/FluentToast.md
@@ -138,16 +138,39 @@ builder.Services.AddFluentUIComponents(config =>
 This example shows the fastest helper methods to display **success**, **info**, **warning**, **error** and **progress** toasts 
 by using a required title plus optional message and dismiss button details.
 
+In this example, **Success**, **Warning**, **Error**, **Info**, and **Progress** toasts are shown for 7 seconds (`lifetime = 7`) 
+and then close automatically.
+
+These five helper methods are non-blocking. Because they use `ToastResultTiming.Queued`, the awaited call completes 
+as soon as the toast is queued, so the code after `await` continues to run immediately, without waiting for the toast 
+to be rendered or closed:
+
+```csharp
+await NotificationService.ShowSuccessToastAsync("Saved");
+```
+
+The **Progress** toast follows the same pattern, returning the `ToastResult` instance immediately so you can keep a 
+reference to it:
+
+```csharp
+// Show the Progress Toast
+var ProgressResult = await NotificationService.ShowProgressToastAsync("Working...");
+
+// Use the kept reference later to interact with the toast
+await ProgressResult.Instance.CloseAsync();
+```
+
+When `ProgressResult` is not `null`, the **Close Progress** button is enabled so the user can close that toast manually.
+
+
 {{ FluentToastDefault }}
 
 ### Default
 
 This example shows the standard toast setup with default behavior and intent. Use it as the baseline pattern for simple status feedback.
 
-In this example, **Success**, **Warning**, **Error**, and **Info** toasts are shown for 7 seconds (`lifetime = 7`) and then close automatically.
-The **Progress** toast behaves differently: the line `ProgressResult = await NotificationService.ShowProgressToastAsync()` returns immediately 
-a toast instance that is stored in `ProgressResult.Instance`.
-When `ProgressResult` is available, the [Close Progress] button is enabled so the user can close that toast manually.
+**Note:** By default `ResultTiming = ToastResultTiming.Closed`, so the code flow after `await` resumes only when the toast is closed. 
+In other words, the process is blocked until the toast is dismissed.
 
 {{ FluentToastDefaultOptions }}
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Toast/FluentToast.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Toast/FluentToast.md
@@ -169,11 +169,10 @@ When `ProgressResult` is not `null`, the **Close Progress** button is enabled so
 
 This example shows the standard toast setup with default behavior and intent. Use it as the baseline pattern for simple status feedback.
 
-> **Note**: By default, `ResultTiming = ToastResultTiming.Queued`. The code after `await` resumes as soon as the toast is queued
-> (just before it becomes visible). 
-> 
-> Set this property to `ToastResultTiming.Visible` to block execution until the toast is visible.
-> Set this property to `ToastResultTiming.Closed` to block execution until the toast is dismissed.
+**Notes**: 
+- By default, `ResultTiming = ToastResultTiming.Queued`. The code after `await` resumes as soon as the toast is queued (just before it becomes visible). 
+- Set this property to `ToastResultTiming.Visible` to block execution until the toast is visible.
+- Set this property to `ToastResultTiming.Closed` to block execution until the toast is dismissed.
 
 {{ FluentToastDefaultOptions }}
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Toast/FluentToast.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Toast/FluentToast.md
@@ -169,8 +169,11 @@ When `ProgressResult` is not `null`, the **Close Progress** button is enabled so
 
 This example shows the standard toast setup with default behavior and intent. Use it as the baseline pattern for simple status feedback.
 
-**Note:** By default `ResultTiming = ToastResultTiming.Closed`, so the code flow after `await` resumes only when the toast is closed. 
-In other words, the process is blocked until the toast is dismissed.
+> **Note**: By default, `ResultTiming = ToastResultTiming.Queued`. The code after `await` resumes as soon as the toast is queued
+> (just before it becomes visible). 
+> 
+> Set this property to `ToastResultTiming.Visible` to block execution until the toast is visible.
+> Set this property to `ToastResultTiming.Closed` to block execution until the toast is dismissed.
 
 {{ FluentToastDefaultOptions }}
 

--- a/src/Core/Components/Toast/Services/NotificationService.cs
+++ b/src/Core/Components/Toast/Services/NotificationService.cs
@@ -51,7 +51,7 @@ public partial class NotificationService : FluentServiceBase<INotificationInstan
 
     /// <inheritdoc cref="INotificationService.ShowProgressToastAsync(string, string?, int?, string?, Func{ToastEventArgs, Task}?)"/>
     public Task<ToastResult> ShowProgressToastAsync(string title, string? message = null, int? lifetime = LibraryToastOptions.DefaultLifetimeSeconds, string? dismissLabel = null, Func<ToastEventArgs, Task>? dismissOnClickAsync = null)
-        => ShowSimpleToastAsync(ToastIntent.Progress, title, message, lifetime, dismissLabel, dismissOnClickAsync, ToastResultTiming.Visible);
+        => ShowSimpleToastAsync(ToastIntent.Progress, title, message, lifetime, dismissLabel, dismissOnClickAsync);
 
     /// <inheritdoc cref="INotificationService.ShowToastAsync(ToastOptions)"/>
     public async Task<ToastResult> ShowToastAsync(ToastOptions options)
@@ -124,7 +124,7 @@ public partial class NotificationService : FluentServiceBase<INotificationInstan
             Intent = intent,
             Title = title,
             Message = message,
-            ResultTiming = resultTiming ?? ToastResultTiming.Closed,
+            ResultTiming = resultTiming ?? ToastResultTiming.Queued,
             Lifetime = lifetime.HasValue ? TimeSpan.FromSeconds(lifetime.Value) : null,
         };
 

--- a/src/Core/Components/Toast/Services/ToastOptions.cs
+++ b/src/Core/Components/Toast/Services/ToastOptions.cs
@@ -182,9 +182,9 @@ public class ToastOptions : IFluentComponentBase
 
     /// <summary>
     /// Gets or sets when the <see cref="IToastInstance.Result"/> task is completed.
-    /// The default is <see cref="ToastResultTiming.Closed"/>.
+    /// The default is <see cref="ToastResultTiming.Queued"/>.
     /// </summary>
-    public ToastResultTiming ResultTiming { get; set; } = ToastResultTiming.Closed;
+    public ToastResultTiming ResultTiming { get; set; } = ToastResultTiming.Queued;
 
     /// <summary>
     /// Gets the class, including the optional <see cref="Margin"/> and <see cref="Padding"/> values.

--- a/tests/Core/Components/Toast/NotificationServiceToastTests.cs
+++ b/tests/Core/Components/Toast/NotificationServiceToastTests.cs
@@ -260,7 +260,7 @@ public class NotificationServiceToastTests : Bunit.BunitContext
     {
         // Arrange
         var service = GetServiceWithProvider();
-        _ = service.ShowToastAsync(new ToastOptions { Id = "close-id", Title = "Title" });
+        _ = service.ShowToastAsync(new ToastOptions { Id = "close-id", Title = "Title", ResultTiming = ToastResultTiming.Closed });
         var instance = service.GetToastInstance("close-id")!;
         var providedResult = ToastResult.OfQuickAction(instance, "payload");
 

--- a/tests/Core/Components/Toast/NotificationServiceToastTests.cs
+++ b/tests/Core/Components/Toast/NotificationServiceToastTests.cs
@@ -69,6 +69,7 @@ public class NotificationServiceToastTests : Bunit.BunitContext
 
         // Assert
         var instance = SingleToast(service);
+        Assert.Equal(ToastResultTiming.Queued, instance.Options.ResultTiming);
         Assert.Equal(ToastIntent.Success, instance.Options.Intent);
         Assert.Equal("Title", instance.Options.Title);
         Assert.Equal("Message", instance.Options.Message);
@@ -125,7 +126,7 @@ public class NotificationServiceToastTests : Bunit.BunitContext
         // Assert
         var instance = SingleToast(service);
         Assert.Equal(ToastIntent.Progress, instance.Options.Intent);
-        Assert.Equal(ToastResultTiming.Visible, instance.Options.ResultTiming);
+        Assert.Equal(ToastResultTiming.Queued, instance.Options.ResultTiming);
     }
 
     [Fact]

--- a/tests/Core/Components/Toast/ToastInstanceTests.cs
+++ b/tests/Core/Components/Toast/ToastInstanceTests.cs
@@ -234,7 +234,7 @@ public class ToastInstanceTests : Bunit.BunitContext
     {
         // Arrange
         var service = GetService();
-        var instance = ShowRegisteredToast(service, new ToastOptions { Id = "close-2", Title = "Title" });
+        var instance = ShowRegisteredToast(service, new ToastOptions { Id = "close-2", Title = "Title", ResultTiming = ToastResultTiming.Closed });
 
         // Act
         await instance.CloseAsync(ToastCloseReason.QuickAction, "payload");
@@ -252,13 +252,14 @@ public class ToastInstanceTests : Bunit.BunitContext
     {
         // Arrange
         var service = GetService();
-        var instance = ShowRegisteredToast(service, new ToastOptions { Id = "close-3", Title = "Title" });
+        var instance = ShowRegisteredToast(service, new ToastOptions { Id = "close-3", Title = "Title", ResultTiming = ToastResultTiming.Closed });
 
         // Act
         await instance.CloseAsync(ToastCloseReason.TimedOut);
         var result = await instance.Result;
 
         // Assert
+        Assert.Equal(ToastLifecycleStatus.Dismissed, instance.LifecycleStatus);
         Assert.Equal(ToastCloseReason.TimedOut, result.Reason);
         Assert.Null(result.Data);
     }

--- a/tests/Core/Components/Toast/ToastOptionsTests.cs
+++ b/tests/Core/Components/Toast/ToastOptionsTests.cs
@@ -43,7 +43,7 @@ public class ToastOptionsTests
         Assert.NotNull(options.DismissAction);
         Assert.NotNull(options.QuickAction1);
         Assert.NotNull(options.QuickAction2);
-        Assert.Equal(ToastResultTiming.Closed, options.ResultTiming);
+        Assert.Equal(ToastResultTiming.Queued, options.ResultTiming);
     }
 
     [Fact]


### PR DESCRIPTION
# [dev-v5] Toast service for non-blocking notifications

Enhance the Toast service to support **non-blocking notifications** by adjusting the default result timing to allow immediate continuation of code execution after showing a toast. This change improves user experience by enabling asynchronous handling of toast notifications without blocking the main thread.

## Helper methods

This example shows the fastest helper methods to display **success**, **info**, **warning**, **error** and **progress** toasts 
by using a required title plus optional message and dismiss button details.

In this example, **Success**, **Warning**, **Error**, **Info**, and **Progress** toasts are shown for 7 seconds (`lifetime = 7`) 
and then close automatically.

These five helper methods are non-blocking. Because they use `ToastResultTiming.Queued`, the awaited call completes 
as soon as the toast is queued, so the code after `await` continues to run immediately, without waiting for the toast 
to be rendered or closed:

```csharp
await NotificationService.ShowSuccessToastAsync("Saved");
```

The **Progress** toast follows the same pattern, returning the `ToastResult` instance immediately so you can keep a 
reference to it:

```csharp
// Show the Progress Toast
var ProgressResult = await NotificationService.ShowProgressToastAsync("Working...");

// Use the kept reference later to interact with the toast
await ProgressResult.Instance.CloseAsync();
```


## Unit Tests

Updated