### PR TITLE
[dev-v5] Fix FluentLayout header height CSS variable

### DIFF
--- a/src/Core/Components/Layout/FluentLayout.razor.cs
+++ b/src/Core/Components/Layout/FluentLayout.razor.cs
@@ -148,6 +148,7 @@ public partial class FluentLayout : FluentComponentBase
         {
             case FluentLayoutItem layoutItem:
                 Areas.Add(layoutItem);
+                StateHasChanged();
                 break;
 
             case FluentLayoutHamburger layoutHamburger:

--- a/tests/Core/Components/Layout/FluentLayoutTests.razor
+++ b/tests/Core/Components/Layout/FluentLayoutTests.razor
@@ -99,6 +99,7 @@
         var layout = cut.FindComponent<FluentLayout>();
 
         // Assert
+        Assert.Contains("--layout-header-height: 40px;", cut.Markup);
         Assert.Equal("40px", layout.Instance.HeaderHeight);
         Assert.True(layout.Instance.HasHeader);
         Assert.True(layout.Instance.HeaderSticky);


### PR DESCRIPTION
# [dev-v5] Fix FluentLayout header height CSS variable

Set the correct value for the `--layout-header-height` CSS variable and ensure the component state updates accordingly. 
This change improves the layout rendering by correctly applying the header height.

Fix #4976