### PR TITLE
[dev-v5][AutoComplete Fix @bind:after being called twice

### DIFF
--- a/src/Core.Scripts/src/Components/List/ListBoxContainer.ts
+++ b/src/Core.Scripts/src/Components/List/ListBoxContainer.ts
@@ -44,6 +44,7 @@ export namespace Microsoft.FluentUI.Blazor.Components.ListBoxContainer {
     private container: HTMLElement;
     private listbox: FluentUIComponents.Listbox;
     private pendingSelectedOptionsChange: boolean = false;
+    private lastSelectedOptions: string = '';
 
     /**
      * Initializes a new instance of the ListboxExtended class.
@@ -57,6 +58,7 @@ export namespace Microsoft.FluentUI.Blazor.Components.ListBoxContainer {
       // Set initial selected options based on the current state
       setTimeout(() => {
         this.refresh(true);
+        this.lastSelectedOptions = this.listbox.selectedOptions.map(option => option.id).join(';');
         this.setupListboxObserver();
         this.isInitialized = true;
       }, 50);
@@ -281,11 +283,20 @@ export namespace Microsoft.FluentUI.Blazor.Components.ListBoxContainer {
         return;
       }
 
+      const currentSelectedOptions = this.listbox.selectedOptions.map(option => option.id).join(';');
+
+      // Skip if the selection hasn't actually changed (e.g. Blazor re-render updating DOM attributes)
+      if (currentSelectedOptions === this.lastSelectedOptions) {
+        return;
+      }
+
+      this.lastSelectedOptions = currentSelectedOptions;
+
       const event = new CustomEvent('listboxchange', {
         bubbles: true,
         composed: true,
         detail: {
-          selectedOptions: this.listbox.selectedOptions.map(option => option.id).join(';')
+          selectedOptions: currentSelectedOptions
         }
       });
 


### PR DESCRIPTION
Fix #4754 

## Why it fires twice
There are two separate triggers that both cause the `MutationObserver` to dispatch a listboxchange event:

1.	User click – the user picks an option → the fluent-option's selected/current-selected attribute changes → `MutationObserver` fires → listboxchange → `OnDropdownChangeHandlerAsync` (call #1).

2.	Blazor re-render – `OnDropdownChangeHandlerAsync` updates `SelectedItems`, `InternalSelectedItemsChangedHandlerAsync  ` updates `_internalSelectedItems`, Blazor re-renders the `FluentListbox` inside the popover, and `FluentOption` components write the selected attribute back to the DOM to match the new state → `MutationObserver` fires again → listboxchange → `OnDropdownChangeHandlerAsync` (call #2).

## The fix
`ListBoxContainer.ts` now tracks `lastSelectedOptions` . In `raiseSelectedOptionsChangeEvent`, if the current selection string equals `lastSelectedOptions`, the event is skipped. Blazor's re-render sets the DOM attributes back to the same values that are already selected, so the string matches and the duplicate is suppressed. A genuine user change always produces a different string, so real events still fire normally.
