### PR TITLE
[dev-v5] FluentDrawer - Add medium width

### DIFF
--- a/src/Core/Components/Dialog/FluentDialog.razor.css
+++ b/src/Core/Components/Dialog/FluentDialog.razor.css
@@ -26,3 +26,8 @@ fluent-dialog[fuib][size="full"]::part(dialog) {
 fluent-dialog-body::part(content) { 
   overflow: auto;
 }
+
+fluent-drawer[fuib][size="medium"]::part(dialog) {
+  width: 592px;
+  max-width: min(592px, 100vw);
+}


### PR DESCRIPTION
# [dev-v5] FluentDrawer - Add medium width

Introduce medium size styling for the `fluent-drawer` component to enhance layout flexibility. 
This change addresses the need for a specific width and maximum width for medium-sized drawers.

