### PR TITLE
[dev-v5] Make browser native validation opt-in

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Forms/Forms.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Forms/Forms.md
@@ -5,9 +5,25 @@ icon: Form
 ---
 
 ## Validation
+
 The Fluent UI Razor components work with a validation summary in the same way the standard Blazor (input) components do. An extra component is provided to make it possible to show a validation summary that follows the Fluent Design guidelines:
 
 - FluentValidationSummary
+
+### Native constraint validation UI
+
+By default the Fluent UI components render validation feedback using the library's UI. If you prefer the browser's native HTML5 constraint validation UI (the built-in validation bubbles/messages driven by the Constraint Validation API), you can opt in at library registration time.
+
+```csharp
+// Program.cs
+builder.Services.AddFluentUIComponents(config =>
+{
+    // Default is false. Set to true to enable the browser's native constraint validation UI.
+    config.UseNativeConstraintValidationUi = true;
+});
+```
+
+The name "constraint" refers to the HTML5 Constraint Validation API (attributes like `required`, `pattern`, `min`, `max`, etc.) and the browser's native UI for reporting those violations. Use this option when you want parity with the browser's built-in validation experience; otherwise keep the library defaults for a consistent Fluent UI look-and-feel.
 
 See the [documentation](https://learn.microsoft.com/en-us/aspnet/core/blazor/forms/validation?view=aspnetcore-10.0#validation-summary-and-validation-message-components) on the Learn site for more information on the standard components. As the Fluent component is based on the standard component, the same documentation applies
 
@@ -20,8 +36,6 @@ Not all of the library's input components are used in this form. No data is actu
 
 {{ BasicForm }}
 
-
 ## API FluentValidationSummary
 
 {{ API Type=FluentValidationSummary }}
-

--- a/src/Core/Components/Base/FluentInputBase.cs
+++ b/src/Core/Components/Base/FluentInputBase.cs
@@ -37,7 +37,7 @@ public abstract partial class FluentInputBase<TValue> : InputBase<TValue>, IFlue
         // and can be overridden by setting the component parameter in markup.
         if (configuration is not null)
         {
-            UseNativeConstraintValidationUi = configuration.UseNativeConstraintValidationUi;
+            UseNativeConstraintValidationUI = configuration.UseNativeConstraintValidationUI;
         }
     }
 
@@ -218,7 +218,7 @@ public abstract partial class FluentInputBase<TValue> : InputBase<TValue>, IFlue
     /// Gets or sets whether the control will use the native browser constraint validation UI.
     /// </summary>
     [Parameter]
-    public bool UseNativeConstraintValidationUi { get; set; }
+    public bool UseNativeConstraintValidationUI { get; set; }
 
     /// <summary />
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0059:Unnecessary assignment of a value", Justification = "TODO")]
@@ -244,8 +244,8 @@ public abstract partial class FluentInputBase<TValue> : InputBase<TValue>, IFlue
     protected virtual async Task ReportValidityAsync()
     {
         // Only call the browser native constraint validation UI when enabled.
-        // This behavior is opt-in via UseNativeValidationUi (default is false).
-        if (!UseNativeConstraintValidationUi)
+        // This behavior is opt-in via UseNativeConstraintValidationUi (default is false).
+        if (!UseNativeConstraintValidationUI)
         {
             return;
         }

--- a/src/Core/Components/Base/FluentInputBase.cs
+++ b/src/Core/Components/Base/FluentInputBase.cs
@@ -31,6 +31,14 @@ public abstract partial class FluentInputBase<TValue> : InputBase<TValue>, IFlue
     {
         ValueExpression = () => CurrentValueOrDefault;
         configuration?.DefaultValues.ApplyDefaults(this);
+
+        // Apply the library configured default for using the native browser
+        // constraint validation UI. This value acts as the component default
+        // and can be overridden by setting the component parameter in markup.
+        if (configuration is not null)
+        {
+            UseNativeConstraintValidationUi = configuration.UseNativeConstraintValidationUi;
+        }
     }
 
     [Inject]
@@ -206,6 +214,12 @@ public abstract partial class FluentInputBase<TValue> : InputBase<TValue>, IFlue
     [Parameter]
     public virtual bool ReadOnly { get; set; }
 
+    /// <summary>
+    /// Gets or sets whether the control will use the native browser constraint validation UI.
+    /// </summary>
+    [Parameter]
+    public bool UseNativeConstraintValidationUi { get; set; }
+
     /// <summary />
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0059:Unnecessary assignment of a value", Justification = "TODO")]
     protected virtual async Task ChangeHandlerAsync(ChangeEventArgs e)
@@ -229,6 +243,13 @@ public abstract partial class FluentInputBase<TValue> : InputBase<TValue>, IFlue
     /// </summary>
     protected virtual async Task ReportValidityAsync()
     {
+        // Only call the browser native constraint validation UI when enabled.
+        // This behavior is opt-in via UseNativeValidationUi (default is false).
+        if (!UseNativeConstraintValidationUi)
+        {
+            return;
+        }
+
         if (string.IsNullOrWhiteSpace(Id))
         {
             return;

--- a/src/Core/Infrastructure/LibraryConfiguration.cs
+++ b/src/Core/Infrastructure/LibraryConfiguration.cs
@@ -61,7 +61,7 @@ public class LibraryConfiguration
     /// validation bubbles). Default is false. Consumers can opt-in to enable the
     /// native validation UI for parity with existing browser behavior.
     /// </summary>
-    public bool UseNativeConstraintValidationUi { get; set; }
+    public bool UseNativeConstraintValidationUI { get; set; }
 
     /// <summary>
     /// Gets the sanitized markup string for safe rendering in HTML/Styles contexts.

--- a/src/Core/Infrastructure/LibraryConfiguration.cs
+++ b/src/Core/Infrastructure/LibraryConfiguration.cs
@@ -56,6 +56,14 @@ public class LibraryConfiguration
     public LibraryToastOptions Toast { get; } = new LibraryToastOptions();
 
     /// <summary>
+    /// Gets or sets a value indicating whether Fluent input components should use the
+    /// browser's native constraint validation UI by default (e.g., showing built-in
+    /// validation bubbles). Default is false. Consumers can opt-in to enable the
+    /// native validation UI for parity with existing browser behavior.
+    /// </summary>
+    public bool UseNativeConstraintValidationUi { get; set; }
+
+    /// <summary>
     /// Gets the sanitized markup string for safe rendering in HTML/Styles contexts.
     /// </summary>
     public MarkupSanitizedOptions MarkupSanitized { get; } = new MarkupSanitizedOptions();

--- a/tests/Core/Components/Switch/FluentSwitchTests.razor
+++ b/tests/Core/Components/Switch/FluentSwitchTests.razor
@@ -1,5 +1,4 @@
-﻿@using Microsoft.FluentUI.AspNetCore.Components.Utilities
-@using Xunit;
+﻿@using Xunit;
 @inherits FluentUITestContext
 
 @code
@@ -82,25 +81,6 @@
 
         // Assert
         Assert.Equal(expectedValue, value);
-    }
-
-    [Fact]
-    public void FluentSwitch_OnChange_ReportsValidity()
-    {
-        // Arrange
-        using var context = new IdentifierContext(i => "myId");
-        var value = false;
-        var cut = Render(@<FluentSwitch Id="myId" @bind-Value="@value" />);
-
-        // Act
-        cut.Find("fluent-switch").Change("");
-
-        // Assert
-        var reportValidityInvocations = JSInterop.Invocations
-            .Where(invocation => invocation.Identifier == "Microsoft.FluentUI.Blazor.Utilities.Attributes.reportValidity")
-            .ToList();
-
-        Assert.Single(reportValidityInvocations);
     }
 
     [Fact]

--- a/tests/Core/Components/TextArea/FluentTextAreaTests.razor
+++ b/tests/Core/Components/TextArea/FluentTextAreaTests.razor
@@ -130,25 +130,6 @@
            .MarkupMatches("<fluent-textarea id=\"myId\" slot=\"input\" value=\"new value\" />");
     }
 
-    [Fact]
-    public void FluentTextArea_OnChange_ReportsValidity()
-    {
-        // Arrange
-        using var context = new IdentifierContext(i => "myId");
-        var value = "init";
-        var cut = Render(@<FluentTextArea @bind-Value="@value" />);
-
-        // Act
-        cut.Find("fluent-textarea").Change("new value");
-
-        // Assert
-        var reportValidityInvocations = JSInterop.Invocations
-            .Where(invocation => invocation.Identifier == "Microsoft.FluentUI.Blazor.Utilities.Attributes.reportValidity")
-            .ToList();
-
-        Assert.Single(reportValidityInvocations);
-    }
-
     [Theory]
     [InlineData(false, 0, "init", "init")]              // No Immediate
     [InlineData(true, 0, "new value", "new value")]     // With Immediate and Delay = 0 ms

--- a/tests/Core/Components/Validation/FluentInputValidationDefaultsTests.cs
+++ b/tests/Core/Components/Validation/FluentInputValidationDefaultsTests.cs
@@ -1,0 +1,62 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using AngleSharp.Html.Parser;
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.FluentUI.AspNetCore.Components;
+using Xunit;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Tests.Components.Validation;
+
+public class FluentInputValidationDefaultsTests
+{
+    [Fact]
+    public void Default_NoOptIn_ReportValidityNotCalled()
+    {
+        using var ctx = new Bunit.BunitContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+        ctx.Services.AddSingleton<IHtmlParser>(new HtmlParser());
+        ctx.Services.AddFluentUIComponents();
+
+        // Arrange
+#pragma warning disable CS0619 // RenderComponent is obsolete in current bUnit, but safe for tests
+        var cut = ctx.Render<FluentTextArea>(parameters => parameters.Add(p => p.Id, "myId").Add(p => p.Value, "init"));
+#pragma warning restore CS0619
+
+        // Act
+        cut.Find("fluent-textarea").Change("new value");
+
+        // Assert
+        var reportValidityInvocations = ctx.JSInterop.Invocations
+            .Where(invocation => invocation.Identifier == "Microsoft.FluentUI.Blazor.Utilities.Attributes.reportValidity")
+            .ToList();
+
+        Assert.Empty(reportValidityInvocations);
+    }
+
+    [Fact]
+    public void OptIn_ReportsValidity()
+    {
+        using var ctx = new Bunit.BunitContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+        ctx.Services.AddSingleton<IHtmlParser>(new HtmlParser());
+        ctx.Services.AddFluentUIComponents(config => config.UseNativeConstraintValidationUi = true);
+
+        // Arrange
+#pragma warning disable CS0619 // RenderComponent is obsolete in current bUnit, but safe for tests
+        var cut = ctx.Render<FluentTextArea>(parameters => parameters.Add(p => p.Id, "myId").Add(p => p.Value, "init"));
+#pragma warning restore CS0619
+
+        // Act
+        cut.Find("fluent-textarea").Change("new value");
+
+        // Assert
+        var reportValidityInvocations = ctx.JSInterop.Invocations
+            .Where(invocation => invocation.Identifier == "Microsoft.FluentUI.Blazor.Utilities.Attributes.reportValidity")
+            .ToList();
+
+        Assert.Single(reportValidityInvocations);
+    }
+}

--- a/tests/Core/Components/Validation/FluentInputValidationDefaultsTests.cs
+++ b/tests/Core/Components/Validation/FluentInputValidationDefaultsTests.cs
@@ -21,9 +21,7 @@ public class FluentInputValidationDefaultsTests
         ctx.Services.AddFluentUIComponents();
 
         // Arrange
-#pragma warning disable CS0619 // RenderComponent is obsolete in current bUnit, but safe for tests
         var cut = ctx.Render<FluentTextArea>(parameters => parameters.Add(p => p.Id, "myId").Add(p => p.Value, "init"));
-#pragma warning restore CS0619
 
         // Act
         cut.Find("fluent-textarea").Change("new value");
@@ -45,9 +43,7 @@ public class FluentInputValidationDefaultsTests
         ctx.Services.AddFluentUIComponents(config => config.UseNativeConstraintValidationUi = true);
 
         // Arrange
-#pragma warning disable CS0619 // RenderComponent is obsolete in current bUnit, but safe for tests
         var cut = ctx.Render<FluentTextArea>(parameters => parameters.Add(p => p.Id, "myId").Add(p => p.Value, "init"));
-#pragma warning restore CS0619
 
         // Act
         cut.Find("fluent-textarea").Change("new value");

--- a/tests/Core/Components/Validation/ReportValidityTests.cs
+++ b/tests/Core/Components/Validation/ReportValidityTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Microsoft.FluentUI.AspNetCore.Components.Tests.Components.Validation;
 
-public class FluentInputValidationDefaultsTests
+public class ReportValidityTests
 {
     [Fact]
     public void Default_NoOptIn_ReportValidityNotCalled()
@@ -40,7 +40,7 @@ public class FluentInputValidationDefaultsTests
         using var ctx = new Bunit.BunitContext();
         ctx.JSInterop.Mode = JSRuntimeMode.Loose;
         ctx.Services.AddSingleton<IHtmlParser>(new HtmlParser());
-        ctx.Services.AddFluentUIComponents(config => config.UseNativeConstraintValidationUi = true);
+        ctx.Services.AddFluentUIComponents(config => config.UseNativeConstraintValidationUI = true);
 
         // Arrange
         var cut = ctx.Render<FluentTextArea>(parameters => parameters.Add(p => p.Id, "myId").Add(p => p.Value, "init"));


### PR DESCRIPTION
When using the `FluentValidationMessage` (introduced with RC4) we now also hook into the browser native validation (the Constrained Validation API). This means that when an input looses focus (_not on submit!_), it is checked against the set constraints and shows browser native UI (see image below)

With this PR we make that behavior opt-in. 

You opt-in by setting `UseNativeConstraintValidationUI=true` on the `LibraryConfiguration` when calling the `AddFluentUIComponents()` extension method in `Program.cs`:

```
// Add FluentUI services
builder.Services.AddFluentUIComponents(config  => 
        config.UseNativeConstraintValidationUI = true);
```

### Before
<img width="525" height="395" alt="image" src="https://github.com/user-attachments/assets/389affe7-e1ca-4331-9be1-1a11947be006" />

### After
<img width="549" height="350" alt="image" src="https://github.com/user-attachments/assets/21a9dd7f-7e06-4cc4-bf07-54146ccce595" />

Note that you still get the red border on the input. That is part of the web component where it is applying the `:user-invalid` state 


Unit tests to validate whether the `reportValidity` function is called, have been added.