### PR TITLE
[dev-v5][Docs] Updates to documentation and presentation

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationColor.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationColor.md
@@ -4,14 +4,14 @@ route: /Migration/Color
 hidden: true
 ---
 
-- ### Renamed values 🔃
+- ### Renamed values 
   `Default` is equivalent of previous `Neutral` and `Primary` is equivalent of previous `Accent` values.
 
   The icon default color was changed from `Color.Accent` to [currentColor](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#currentcolor_keyword), 
   which means that the icon will inherit the color from its parent element.
   You can set the icon color to `Color.Primary` to get the previous behavior.
 
-- ### Removed values💥
+- ### Removed values
   `Neutral`, `Accent`, `Fill`, `FillInverse` values have been flagged as `Obsolete` and will be removed in the next version.
 
   |v3 & v4|v5|

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationDrag.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationDrag.md
@@ -4,7 +4,7 @@ route: /Migration/Drag
 hidden: true
 ---
 
-### General changes 💥
+### General changes 
 
 All events associated with this component have been updated to use `EventCallback<FluentDragEventArgs<TItem>>` instead of `Action<FluentDragEventArgs<TItem>>`. This change allows developers to use different method signatures and properly await tasks.
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentAccordion.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentAccordion.md
@@ -4,17 +4,17 @@ route: /Migration/Accordion
 hidden: true
 ---
 
-### FluentAccordionItem - Renamed parameters 💥
+### FluentAccordionItem - Renamed parameters 
 
 - `Heading` → `Header`
 - `HeadingTemplate` → `HeaderTemplate`
 - `HeadingTooltip` → `HeaderTooltip`
 
-### FluentAccordionItem - Type-changed parameters 💥
+### FluentAccordionItem - Type-changed parameters 
 
 - `HeadingLevel`: Changed from `string?` to `int?`.
 
-### FluentAccordion - Type-changed parameters 💥
+### FluentAccordion - Type-changed parameters 
 
 - `OnAccordionItemChange`: Changed from `EventCallback<FluentAccordionItem>` to `EventCallback<AccordionItemEventArgs>`.
   The affected item can be found in the event arguments via the `Item` property.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentAnchor.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentAnchor.md
@@ -4,7 +4,7 @@ route: /Migration/Anchor
 hidden: true
 ---
 
-- ### Component removed 💥
+- ### Component removed 
 
   `FluentAnchor` has been **removed** in V5.
   Use `FluentLink` as the replacement for hyperlinks,

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentAutocomplete.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentAutocomplete.md
@@ -4,7 +4,7 @@ route: /Migration/Autocomplete
 hidden: true
 ---
 
-### Type parameter change 💥
+### Type parameter change 
 
 The component now requires **two** type parameters: `TOption` and `TValue`.
 
@@ -16,7 +16,7 @@ The component now requires **two** type parameters: `TOption` and `TValue`.
 <FluentAutocomplete TOption="Country" TValue="string" ... />
 ```
 
-### Renamed parameters 💥
+### Renamed parameters 
 
 - `@bind-SelectedOptions` → `@bind-SelectedItems`
 - `@bind-SelectedOption` → Use `Multiple="false"` with `@bind-SelectedItems`
@@ -24,7 +24,7 @@ The component now requires **two** type parameters: `TOption` and `TValue`.
 - `OptionComparer` → `OptionSelectedComparer`
 - `ValueText` / `ValueTextChangedAsync` → `@bind-Value`
 
-### Removed parameters 💥
+### Removed parameters 
 
 - `AutoComplete` — browser autocomplete attribute, no longer exposed.
 - `Position` (`SelectPosition?`) — popup positioning is now handled internally.
@@ -44,13 +44,13 @@ The component now requires **two** type parameters: `TOption` and `TValue`.
 - `OptionValueToString` (`Func<TValue, string>?`) — function to convert a value to string.
 - Various inherited input parameters: `Message`, `MessageTemplate`, `MessageState`, `MessageIcon`, `LabelPosition`, `LabelWidth`, `Margin`, `Padding`, `Tooltip`.
 
-### HeaderContent / FooterContent context type change 💥
+### HeaderContent / FooterContent context type change 
 
 The context type for `HeaderContent` and `FooterContent` has been renamed
 from `HeaderFooterContent<TOption>` to `AutocompleteHeaderFooterContent<TOption>`.
 The properties remain the same (`Items` and `InProgress`).
 
-### Single selection mode 💥
+### Single selection mode 
 
 In v4, single selection used a separate `@bind-SelectedOption` binding.
 In v5, use `Multiple="false"` with `@bind-SelectedItems`.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentBadge.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentBadge.md
@@ -9,7 +9,7 @@ hidden: true
 The text displayed in a badge is now set using the `Content` parameter. The `ChildContent`
 parameter is now used to specify the element the badge 'wraps' (i.e. the anchor element for positioning).
 
-### Removed parameters 💥
+### Removed parameters 
 
 - `Fill`
 - `Circular`; use `Shape` instead.
@@ -17,7 +17,7 @@ parameter is now used to specify the element the badge 'wraps' (i.e. the anchor 
 - `OnClick`; a `Badge` should not be used as a button.
 - `DismissIcon`, `DismissTitle` and `OnDismissClick`; there may be a more general dismissable component in the future.
 
-### Appearance 💥
+### Appearance 
 
 The `Appearance` parameter has been updated to use the `BadgeAppearance` enum
 instead of the `Appearance` enum.
@@ -28,7 +28,7 @@ instead of the `Appearance` enum.
 - `Outline`
 - `Tint`
 
-### Color 💥
+### Color 
 
 The `Color` parameter has been updated to use the `BadgeColor` enum
 instead of being of type `string?`.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentBreadcrumb.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentBreadcrumb.md
@@ -4,7 +4,7 @@ route: /Migration/Breadcrumb
 hidden: true
 ---
 
-- ### Component removed 💥
+- ### Component removed 
 
   `FluentBreadcrumb` and `FluentBreadcrumbItem` have been **removed** in V5.
   There is no direct replacement component.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentButton.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentButton.md
@@ -4,7 +4,7 @@ route: /Migration/Button
 hidden: true
 ---
 
-### Renamed parameters 💥
+### Renamed parameters 
 
 - `Autofocus` → `AutoFocus` (also changed from `bool?` to `bool`)
 - `Action` → `FormAction`
@@ -13,7 +13,7 @@ hidden: true
 - `NoValidate` → `FormNoValidate`
 - `Target` → `FormTarget`
 
-### Appearance 💥
+### Appearance 
 
 The `Appearance` parameter has been updated to use the `ButtonAppearance` enum
 instead of the `Appearance` enum.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentCard.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentCard.md
@@ -4,7 +4,7 @@ route: /Migration/Card
 hidden: true
 ---
 
-### Removed parameters 💥
+### Removed parameters 
 
 - `AreaRestricted` — no longer applicable since the web component has been removed.
 - `MinimalStyle` — use the `Appearance` parameter instead to control the visual style.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentCombobox.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentCombobox.md
@@ -4,7 +4,7 @@ route: /Migration/Combobox
 hidden: true
 ---
 
-### Base class change 💥
+### Base class change 
 
 `FluentCombobox` now inherits directly from `FluentSelect` instead of `ListComponentBase`.
 This means all [FluentSelect migration changes](/Migration/Select) also apply to `FluentCombobox`.
@@ -24,7 +24,7 @@ All list components (`FluentSelect`, `FluentCombobox`, `FluentListbox`) now requ
                 @bind-Value="selectedCountryCode" />
 ```
 
-### Appearance 💥
+### Appearance 
 
 The `Appearance` property type has changed from `Appearance?` to `ListAppearance?`.
 
@@ -34,7 +34,7 @@ The `Appearance` property type has changed from `Appearance?` to `ListAppearance
 - `Outline`
 - `Transparent`
 
-### Changed properties 💥
+### Changed properties 
 
 | V4 Property | V5 Property | Change |
 |-------------|-------------|--------|
@@ -47,7 +47,7 @@ The `Appearance` property type has changed from `Appearance?` to `ListAppearance
 | `SelectedOptions` (`IEnumerable<TOption>?`) | `SelectedItems` (`IEnumerable<TOption>`) | **Renamed**, now non-nullable (defaults to `[]`) |
 | `SelectedOptionsChanged` | `SelectedItemsChanged` | **Renamed** |
 
-### Removed properties 💥
+### Removed properties 
 
 - `Autocomplete` (`ComboboxAutocomplete?`) — browser autocomplete is no longer exposed.
 - `ChangeOnEnterOnly`

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentCounterBadge.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentCounterBadge.md
@@ -11,7 +11,7 @@ accepts `ChildContent`, `BadgeContent` or `BadgeTemplate` render fragments. Posi
 parameters have been removed — use `FluentBadge` with `Positioning` if you need to anchor
 a counter to an element.
 
-### Removed parameters 💥
+### Removed parameters 
 
 - `ChildContent` and `BadgeContent` — the component no longer wraps other content.
 - `BadgeTemplate` (`RenderFragment<int?>`) — custom badge rendering template removed.
@@ -21,11 +21,11 @@ a counter to an element.
 - `BackgroundColor` and `Color` — no longer supported on `FluentCounterBadge`.
 - `ShowOverflow` — overflow display is now controlled by `OverflowCount`.
 
-### Renamed parameters 💥
+### Renamed parameters 
 
 - `Max` → `OverflowCount` — the maximum count value before showing overflow (e.g. "99+").
 
-### Type-changed parameters 💥
+### Type-changed parameters 
 
 - `ShowZero`: Changed from `bool` to `bool?`.
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentDataGrid.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentDataGrid.md
@@ -13,7 +13,7 @@ These `...UISettings` parameters are now only used to set a custom icon and icon
 have now been replaced with our standard Localization capabilities. You can use a custom localizer to set custom labels for these UI settings.
 An example of this can be found in the `Server` project of the demo application, where a custom localizer is registered in the `Program.cs` file.
 
-### Removed properties 💥
+### Removed properties 
 - `NoTabbing` (`bool`) — removed.
 
 ### Type changes

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentDateTime.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentDateTime.md
@@ -4,7 +4,7 @@ route: /Migration/DateTime
 hidden: true
 ---
 
-- ### Generic type parameter 💥
+- ### Generic type parameter 
 
   Both `FluentDatePicker` and `FluentTimePicker` are now generic components.
 
@@ -32,13 +32,13 @@ hidden: true
   | `DoubleClickToDate` (`DateTime?`) | `DoubleClickToDate` (`TValue?`) | Now generic |
   | `DayFormat` (`DayFormat?` enum) | `DayFormat` (`CalendarDayFormat?` enum) | Enum renamed |
 
-  #### Removed properties 💥
+  #### Removed properties 
   - `PopupHorizontalPosition` — the popover now uses `FluentPopover` for positioning.
   - `ParsingErrorMessage` — handled by the localization system.
 
 - ### FluentTimePicker changes
 
-  #### Completely new UX 💥
+  #### Completely new UX 
 
   The time picker has been fully redesigned. V4 used a native HTML `<input type="time">`.
   V5 uses a `FluentCombobox` with a dropdown list of time slots.
@@ -49,7 +49,7 @@ hidden: true
   |-------------|-------------|--------|
   | `Appearance` (`FluentInputAppearance`) | `Appearance` (`ListAppearance`) | Enum type changed |
 
-  #### Removed properties 💥
+  #### Removed properties 
   - `TimeDisplay` (`TimeDisplay` enum) — no longer applicable with the new combobox UX.
 
   #### Migration example

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentDesignTheme.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentDesignTheme.md
@@ -4,7 +4,7 @@ route: /Migration/DesignTheme
 hidden: true
 ---
 
-- ### Components removed 💥
+- ### Components removed 
 
   Both `FluentDesignSystemProvider` and `FluentDesignTheme` have been **removed** in V5.
   Theming is now CSS-variable-based rather than component-based.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentDialog.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentDialog.md
@@ -4,11 +4,11 @@ route: /Migration/Dialog
 hidden: true
 ---
 
-- ### Major rearchitecture 💥
+- ### Major rearchitecture 
 
   The dialog system has been completely redesigned in V5. This is one of the most impactful migration changes.
 
-- ### DialogParameters → DialogOptions 💥
+- ### DialogParameters → DialogOptions 
 
   V4's `DialogParameters` class is replaced by V5's `DialogOptions` with a restructured API:
 
@@ -36,7 +36,7 @@ hidden: true
 
 - ### Dialog component changes
 
-  #### Removed properties 💥
+  #### Removed properties 
   - `Hidden` / `HiddenChanged` — use `ShowAsync()` / `HideAsync()` methods instead.
   - `TrapFocus`
   - `PreventScroll`
@@ -50,7 +50,7 @@ hidden: true
   | `Modal` (`bool?`) | `Modal` (`bool`, default `true`) | No longer nullable |
   | `Instance` (`DialogInstance`) | `Instance` (`IDialogInstance?`) | Type changed to interface |
 
-- ### FluentDialogHeader and FluentDialogFooter removed 💥
+- ### FluentDialogHeader and FluentDialogFooter removed 
 
   V4's `FluentDialogHeader` and `FluentDialogFooter` components are **removed**.
   Header and footer are now configured through `DialogOptions`:
@@ -76,7 +76,7 @@ hidden: true
   };
   ```
 
-- ### Dialog vs Drawer 💥
+- ### Dialog vs Drawer 
 
   V4 used `DialogType` to distinguish dialogs from panels/drawers.
   V5 uses the `Alignment` property:
@@ -96,7 +96,7 @@ hidden: true
 
   V4's `IDialogContentComponent<T>` is replaced by V5's `FluentDialogInstance` abstract base class.
 
-- ### Lifecycle model 💥
+- ### Lifecycle model 
 
   | V4 | V5 |
   |----|----|

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentDivider.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentDivider.md
@@ -4,7 +4,7 @@ route: /Migration/Divider
 hidden: true
 ---
 
-- ### Removed properties 💥
+- ### Removed properties 
 
   - `Role` (`DividerRole?`) — the role attribute is no longer configurable.
   - `Orientation` (`Orientation?`) — use `Vertical="true"` instead.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentGrid.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentGrid.md
@@ -6,7 +6,7 @@ hidden: true
 
 - ### FluentGrid changes
 
-  #### Default spacing changed 💥
+  #### Default spacing changed 
 
   The `Spacing` parameter default has changed from `3` to `0`.
   If you relied on the default spacing, you must now set it explicitly.
@@ -19,7 +19,7 @@ hidden: true
   <FluentGrid Spacing="3">...</FluentGrid>
   ```
 
-- ### FluentGridItem changes (reminder) 💥
+- ### FluentGridItem changes (reminder) 
 
   Properties have been renamed to PascalCase:
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentGridItem.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentGridItem.md
@@ -4,7 +4,7 @@ route: /Migration/GridItem
 hidden: true
 ---
 
-- ### Renamed properties 🔃
+- ### Renamed properties 
   These properties have been renamed to comply with the Blazor naming convention (Pascal case):
   - `xs`, `sm`, `md`, `lg`, `xl`, `xxl` properties have been renamed to
   - `Xs`, `Sm`, `Md`, `Lg`, `Xl`, `Xxl`.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentIcon.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentIcon.md
@@ -4,7 +4,7 @@ route: /Migration/Icon
 hidden: true
 ---
 
-- ### Default color changed 💥
+- ### Default color changed 
 
   The default icon color has changed from `Color.Accent` to `currentColor` (inherits from the parent element's CSS color).
   If you relied on the accent color being applied automatically, you now need to set it explicitly.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentInputFile.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentInputFile.md
@@ -11,7 +11,7 @@ hidden: true
   | `OnFileError` (`EventCallback<FluentInputFileEventArgs>`) | `OnFileError` (`EventCallback<FluentInputFileErrorEventArgs>`) | Type changed to new error-specific event args |
   | `AnchorId` (`string`, default `""`) | `AnchorId` (`string?`) | Now nullable |
 
-- ### Removed properties 💥
+- ### Removed properties 
 
   - `OnFileCountExceeded` (`EventCallback<int>`) — merged into `OnFileError`.
     The file count exceeded scenario is now reported via `FluentInputFileErrorEventArgs.FileCountExceeded`.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentLabel.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentLabel.md
@@ -4,10 +4,10 @@ route: /Migration/Label
 hidden: true
 ---
 
-### Changed properties 🔃
+### Changed properties 
 - `Weight`, now used to determine if the label text is shown regular or semibold
 
-### Removed properties💥
+### Removed properties
 
 - `Alignment`
 - `Color`

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentLayout.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentLayout.md
@@ -20,7 +20,7 @@ hidden: true
    </FluentLayout>
    ```
 
-- ### Removed components💥
+- ### Removed components
   The `FluentHeader`, `FluentBodyContent`, `FluentFooter`, `FluentMainLayout` components have been removed.
 
   Use the `FluentLayoutItem Area="..."` component instead.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentList.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentList.md
@@ -4,7 +4,7 @@ route: /Migration/List
 hidden: true
 ---
 
-- ### Two type parameters required 💥
+- ### Two type parameters required 
 
   All list components now require two type parameters: `TOption` and `TValue`.
   See the [FluentSelect migration page](/Migration/Select) for full details on the base class change
@@ -14,7 +14,7 @@ hidden: true
 
   `FluentCombobox` now inherits from `FluentSelect` instead of `ListComponentBase` directly.
 
-  #### Removed properties 💥
+  #### Removed properties 
   - `Autocomplete` (`ComboboxAutocomplete?`)
   - `Open` (`bool?`)
   - `EnableClickToClose` (`bool?`)
@@ -25,7 +25,7 @@ hidden: true
 
 - ### FluentListbox changes
 
-  #### Removed properties 💥
+  #### Removed properties 
   - `Size` (`int`) — the integer size parameter is removed.
 
   #### Renamed properties

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentMenu.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentMenu.md
@@ -10,7 +10,7 @@ displaying the menu (using `popover` when available).
 
 
 
-### Removed parameters💥
+### Removed parameters
   - `UseMenuService`
   - `Anchor`
   - `Open` and `OpenChanged`
@@ -48,7 +48,7 @@ displaying the menu (using `popover` when available).
 
 ### FluentMenuItem changes
 
-#### Removed properties 💥
+#### Removed properties 
 - `Expanded` (`bool`)
 - `KeepOpen` (`bool`)
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentMessageBar.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentMessageBar.md
@@ -4,10 +4,10 @@ route: /Migration/MessageBar
 hidden: true
 ---
 
-### Renamed properties 🔃
+### Renamed properties 
   The `FadeIn` property has been renamed to `Animation`.
 
-### Removed properties💥
+### Removed properties
   The `IconColor` property has been removed. Use `Icon.WithColor()` method instead.
 
   The `Intent.Custom` property has been removed. Don't use the `Intent` property and set `Icon` and `ChildContent` instead to customize the message bar.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentNavMenu.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentNavMenu.md
@@ -4,7 +4,7 @@ route: /Migration/NavMenu
 hidden: true
 ---
 
-- ### Components removed and replaced 💥
+- ### Components removed and replaced 
 
   `FluentNavMenu`, `FluentNavGroup`, `FluentNavLink` have been **removed** in V5.
   `FluentNavMenuTree`, `FluentNavMenuGroup`, `FluentNavMenuLink` (already obsolete in V4) are also removed.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentOverlay.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentOverlay.md
@@ -4,7 +4,7 @@ route: /Migration/Overlay
 hidden: true
 ---
 
-- ### Web component migration 💥
+- ### Web component migration 
 
   `FluentOverlay` has been rewritten to use the `<fluent-overlay>` web component
   instead of a plain `<div>`. This is a major change.
@@ -26,7 +26,7 @@ hidden: true
   | `Opacity` (`double?`) | `Opacity` (`int`, default `40`) | Type changed: double → int (percentage) |
   | `BackgroundColor` (`string?`) | `BackgroundColor` (`string`, default `"var(--colorBackgroundOverlay)"`) | Now non-nullable with default using CSS variable |
 
-- ### Removed properties 💥
+- ### Removed properties 
 
   - `OnClose` (`EventCallback<MouseEventArgs>`) — use `VisibleChanged` callback instead.
   - `Transparent` (`bool`) — configure `Opacity = 0` instead.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentPopover.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentPopover.md
@@ -4,7 +4,7 @@ route: /Migration/Popover
 hidden: true
 ---
 
-- ### Complete rewrite 💥
+- ### Complete rewrite 
 
   The popover has been completely rewritten. V4 used a composition of `FluentAnchoredRegion` + `FluentOverlay` + `FluentKeyCode`.
   V5 uses a native `<fluent-popover-b>` web component.
@@ -30,7 +30,7 @@ hidden: true
   |-------------|-------------|--------|
   | `AnchorId` (`string`, default `""`) | `AnchorId` (`required string`) | Now **required** |
 
-- ### Removed properties 💥
+- ### Removed properties 
 
   All custom positioning and focus management has been removed — now handled by the web component:
 
@@ -43,7 +43,7 @@ hidden: true
   - `AutoFocus` (`bool`)
   - `CloseKeys` (`KeyCode[]?`)
 
-- ### Content structure changed 💥
+- ### Content structure changed 
 
   V4 had separate `Header`, `Body`, and `Footer` render fragments.
   V5 uses a single `ChildContent` render fragment.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentProgressBar.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentProgressBar.md
@@ -7,12 +7,12 @@ hidden: true
 The component itself has been renamed from `FluentProgress` to `FluentProgressBar`
 to be coherent with the Web Components and React naming conventions.
 
-### Renamed properties 🔃
+### Renamed properties 
 
   `Stroke` property has been renamed to `Thickness`.
   The `Stroke` property has been flagged as obsolete and will be removed in the next major version.
 
-### Removed properties💥
+### Removed properties
   The `ChildContent` property has been removed. Use `FluentField` instead, to display
   a message below the ProgressBar.
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentProgressRing.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentProgressRing.md
@@ -10,12 +10,12 @@ to be coherent with the Web Components and React naming conventions.
 > [!NOTE] The new component `FluentSpinner` cannot be paused. It must always be spinning.
 > So, the `Paused`, `Min`, `Max`, `Value` properties has been removed.
 
-### Renamed properties 🔃
+### Renamed properties 
 
   `Stroke` property has been renamed to `Size`.
   The `Stroke` property has been flagged as obsolete and will be removed in the next major version.
 
-### Removed properties💥
+### Removed properties
   The `ChildContent` property has been removed. Use `FluentField` instead, to display
   a message below the ProgressBar.
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentRadio.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentRadio.md
@@ -8,7 +8,7 @@ hidden: true
 - Using the `ChildContent` parameter to specify the contents/label of a Radio item is no longer supported. Use the `Label` or `LabelTemplate` parameters instead.
 - The `ReadOnly` parameter is not supported. Use the `Disabled` parameter instead.
 
-### FluentRadio removed properties💥
+### FluentRadio removed properties
 - `ChildContent` — use `Label` or `LabelTemplate`.
 - `ReadOnly` (`bool`)
 - `AriaLabel` (`string?`)
@@ -22,7 +22,7 @@ hidden: true
 ### FluentRadio new properties
 - `LabelWidth` (`string?`) — controls the width of the label area.
 
-### FluentRadioGroup removed properties💥
+### FluentRadioGroup removed properties
 - `ParsingErrorMessage` (`string`)
 
 ### FluentRadioGroup new properties

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentSelect.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentSelect.md
@@ -4,7 +4,7 @@ route: /Migration/Select
 hidden: true
 ---
 
-- ### Base class change 💥
+- ### Base class change 
 
   The base class for all list components has changed:
   - V4: `ListComponentBase<TOption>` inheriting from `FluentInputBase<string?>`
@@ -25,7 +25,7 @@ hidden: true
                 @bind-Value="selectedCountryCode" />
   ```
 
-- ### Appearance 💥
+- ### Appearance 
 
   The `Appearance` property has been updated to use the `ListAppearance` enum
   instead of `Appearance` enum.
@@ -36,7 +36,7 @@ hidden: true
   - `Outline`
   - `Transparent`
 
-- ### Changed properties 💥
+- ### Changed properties 
 
   | V4 Property | V5 Property | Change |
   |-------------|-------------|--------|
@@ -49,7 +49,7 @@ hidden: true
   | `SelectedOptions` (`IEnumerable<TOption>?`) | `SelectedItems` (`IEnumerable<TOption>`) | **Renamed**, now non-nullable (defaults to `[]`) |
   | `SelectedOptionsChanged` | `SelectedItemsChanged` | **Renamed** |
 
-- ### Removed properties 💥
+- ### Removed properties 
 
   - `ChangeOnEnterOnly`
   - `Embedded`

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentSkeleton.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentSkeleton.md
@@ -4,7 +4,7 @@ route: /Migration/Skeleton
 hidden: true
 ---
 
-- ### No longer a web component 💥
+- ### No longer a web component 
 
   V4 rendered `<fluent-skeleton>`. V5 renders a plain `<div>` with CSS classes.
 
@@ -22,7 +22,7 @@ hidden: true
   | `Width` (`string`, default `"50px"`) | `Width` (`string?`, default `"100%"`) | Default changed |
   | `Height` (`string`, default `"50px"`) | `Height` (`string?`, default `"48px"`) | Default changed |
 
-- ### Removed properties 💥
+- ### Removed properties 
 
   - `Fill` (`string?`) — no longer supported.
   - `Shape` (`SkeletonShape?`) — use `Circular="true"` for circle shapes, default is rectangle.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentSlider.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentSlider.md
@@ -10,7 +10,7 @@ hidden: true
   |-------------|-------------|--------|
   | `Orientation` (`Orientation?`) | `Orientation` (`Orientation`, default `Horizontal`) | No longer nullable |
 
-- ### Removed properties 💥
+- ### Removed properties 
 
   - `Mode` (`SliderMode?`) — the slider mode enum is no longer supported.
   - `FluentSliderLabel<TValue>` — the companion label component has been removed.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentSplitter.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentSplitter.md
@@ -4,7 +4,7 @@ route: /Migration/Splitter
 hidden: true
 ---
 
-- ### FluentSplitter removed 💥
+- ### FluentSplitter removed 
 
   The `FluentSplitter` component has been **removed** in V5. Only `FluentMultiSplitter` remains.
   Migrate from `FluentSplitter` to `FluentMultiSplitter` with two `FluentMultiSplitterPane` children.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentSwitch.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentSwitch.md
@@ -4,7 +4,7 @@ route: /Migration/Switch
 hidden: true
 ---
 
-### Removed values💥
+### Removed values
 
 The `CheckedMessage` and `UncheckedMessage` properties have been removed.
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentTabs.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentTabs.md
@@ -14,7 +14,7 @@ hidden: true
   | `ActiveTabId` (`string`) | `ActiveTabId` (`string?`) | Now nullable |
   | `Orientation` (`Orientation`) | `Orientation` (`Orientation?`) | Now nullable |
 
-  #### Removed properties 💥
+  #### Removed properties 
   - `OnTabSelect` (`EventCallback<FluentTab>`) — use `ActiveTabChanged` instead.
   - `OnTabClose` (`EventCallback<FluentTab>`) — no built-in close/dismiss UI in V5.
   - `OnTabChange` (`EventCallback<FluentTab>`) — use `ActiveTabChanged` instead.
@@ -29,7 +29,7 @@ hidden: true
 
 - ### FluentTab changes
 
-  #### Renamed properties 💥
+  #### Renamed properties 
 
   | V4 Property | V5 Property |
   |-------------|-------------|
@@ -40,7 +40,7 @@ hidden: true
   | `Icon` (`Icon?`) | `IconStart` (`Icon?`) |
   | `LoadingContent` (`RenderFragment?`) | `LoadingTemplate` (`RenderFragment?`) |
 
-  #### Removed properties 💥
+  #### Removed properties 
   - `Label` — use `Header` instead.
   - `LabelChanged` (`EventCallback<string>`) — no longer editable inline.
   - `LabelEditable` (`bool`) — inline label editing is no longer supported.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentTextArea.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentTextArea.md
@@ -10,7 +10,7 @@ hidden: true
   |-------------|-------------|--------|
   | `Appearance` (`FluentInputAppearance`) | `Appearance` (`TextAreaAppearance?`) | Enum renamed |
 
-### Removed properties💥
+### Removed properties
 
 - `Cols` — use `Width` instead.
 - `Rows` — use `Height` instead.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentTextField.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentTextField.md
@@ -4,7 +4,7 @@ route: /Migration/TextField
 hidden: true
 ---
 
-- ### Three components merged into one 💥
+- ### Three components merged into one 
 
   `FluentTextField`, `FluentNumberField`, and `FluentSearch` have been **removed** in V5.
   They are all replaced by `FluentTextInput`.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentToast.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentToast.md
@@ -4,7 +4,7 @@ route: /Migration/Toast
 hidden: true
 ---
 
-## Removed from toast system 💥
+## Removed from toast system 
 
 - Content components: `CommunicationToast`, `ConfirmationToast`, `ProgressToast`
 - Content types: `CommunicationToastContent`, `ConfirmationToastContent`, `ProgressToastContent`

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentToolbar.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentToolbar.md
@@ -4,7 +4,7 @@ route: /Migration/Toolbar
 hidden: true
 ---
 
-- ### Component removed 💥
+- ### Component removed 
 
   `FluentToolbar` has been **removed** in V5.
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentTooltip.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentTooltip.md
@@ -4,11 +4,11 @@ route: /Migration/Tooltip
 hidden: true
 ---
 
-### Removed properties💥
+### Removed properties
   The `Visible` property has been removed. The tooltip is now visible when the user hovers over the target element.
   The `OnToggle` event is triggered when the tooltip is shown or hidden.
 
-### Position 💥
+### Position 
   The `Position` property has been updated to use the `Positioning` property name and the `Positioning` enum
   instead of `TooltipPosition` enum.
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentTreeView.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentTreeView.md
@@ -4,7 +4,7 @@ route: /Migration/TreeView
 hidden: true
 ---
 
-### Removed properties💥
+### Removed properties
   - The `RenderCollapsedNodes` property has been removed.
   Use `LazyLoadItems` instead.
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentWizard.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentWizard.md
@@ -9,7 +9,7 @@ hidden: true
   `FluentWizard` and `FluentWizardStep` have been **re-introduced** in V5.
   The component preserves the same API and functionality from V4 with the following changes.
 
-- ### Breaking changes 💥
+- ### Breaking changes 
 
   | V4 | V5 |
   |----|-----|

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationGeneral.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationGeneral.md
@@ -4,7 +4,7 @@ route: /Migration/General
 hidden: true
 ---
 
-- ### FluentComponentBase changes 💥
+## FluentComponentBase changes
 
   All components inherit from `FluentComponentBase`, which has significant changes in V5:
 
@@ -16,7 +16,7 @@ hidden: true
 
   > ⚠️ If you have custom components inheriting from `FluentComponentBase`, you must update them to pass `LibraryConfiguration` to the base constructor.
 
-- ### FluentProviders
+## FluentProviders
 
   V5 introduces a `FluentProviders` component that should be placed at the root of your application.
   It provides cascading values (like `LibraryConfiguration`) needed by all Fluent UI components.
@@ -28,7 +28,7 @@ hidden: true
   </FluentProviders>
   ```
 
-- ### FluentField — New input wrapping pattern
+## FluentField — New input wrapping pattern
 
   V5 introduces `FluentField` as the standard way to wrap input components with a label, validation message, and hint text.
   V4's `FluentValidationMessage<T>` component is **removed** — use `FluentField`'s `Message`, `MessageCondition`, and `MessageState` instead.
@@ -47,7 +47,7 @@ hidden: true
                    MessageState="MessageState.Error" />
   ```
 
-- ### Scoped Css Bundling
+## Scoped Css Bundling
 
   The csproj contains `<DisableScopedCssBundling>true</DisableScopedCssBundling>`
   and `<ScopedCssEnabled>false</ScopedCssEnabled>` to prevent the bundling of scoped css files.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationIndex.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationIndex.md
@@ -12,15 +12,14 @@ hidden: false
 This guide helps you migrate from **Fluent UI Blazor V4** to **V5**.
 Each page below covers specific component changes, removed components, and new additions.
 
-- ### General
+### General
 
   Start here for cross-cutting changes that affect all components.
 
   - [General changes](/Migration/General) — Base class, CSS, JS interop, localization, `DefaultValues`
   - [Color changes](/Migration/Color) — Enum renames (`Neutral` → `Default`, `Accent` → `Primary`)
-  - [Copilot Instructions](/Migration/CopilotInstructions) — Use GitHub Copilot to assist migration
 
-- ### Component changes
+### Component changes
 
   Components that exist in both V4 and V5 but have breaking changes.
 
@@ -68,7 +67,7 @@ Each page below covers specific component changes, removed components, and new a
   | FluentTooltip | Medium | [Migration](/Migration/Tooltip) |
   | FluentTreeView | Medium | [Migration](/Migration/TreeView) |
 
-- ### Removed components 💥
+### Removed components
 
   Components that have been removed in V5. Each page explains the replacement strategy.
 
@@ -84,7 +83,7 @@ Each page below covers specific component changes, removed components, and new a
   | FluentWizard | *(no direct replacement)* | [Migration](/Migration/Wizard) |
   | Other minor components | — | [Migration](/Migration/RemovedComponents) |
 
-- ### New V5 components that replace V4 functionality
+### New components (which replace V4 functionality)
 
   | V5 Component | Replaces V4 | Migration details |
   |-------------|-------------|------|

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationRemovedComponents.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationRemovedComponents.md
@@ -4,14 +4,14 @@ route: /Migration/RemovedComponents
 hidden: true
 ---
 
-- ### Overview
+## Overview
 
   The following V4 components have been **removed** in V5 with no direct replacement.
   This page covers the smaller components that don't warrant their own migration page.
 
 ---
 
-- ### FluentFlipper — Removed
+## FluentFlipper
 
   `FluentFlipper` (left/right navigation arrows) has been removed.
 
@@ -31,7 +31,7 @@ hidden: true
 
 ---
 
-- ### FluentHorizontalScroll — Removed
+## FluentHorizontalScroll
 
   `FluentHorizontalScroll` (horizontal scrolling container) has been removed.
 
@@ -47,7 +47,7 @@ hidden: true
 
 ---
 
-- ### FluentCollapsibleRegion — Removed
+## FluentCollapsibleRegion
 
   `FluentCollapsibleRegion` has been removed.
 
@@ -69,7 +69,7 @@ hidden: true
 
 ---
 
-- ### FluentAccessibility — Removed
+## FluentAccessibility
 
   `FluentAccessibility` (keyboard shortcut registration with notifications) has been removed.
 
@@ -77,7 +77,7 @@ hidden: true
 
 ---
 
-- ### FluentEditForm — Removed
+## FluentEditForm
 
   `FluentEditForm` (wrapper around Blazor's `EditForm`) has been removed.
   V5 extends standard Blazor `EditForm` directly with Fluent styling.
@@ -87,7 +87,7 @@ hidden: true
 
 ---
 
-- ### FluentProfileMenu — Removed
+## FluentProfileMenu
 
   `FluentProfileMenu` (user profile dropdown with avatar) has been removed.
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/MigrationVersion5.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/MigrationVersion5.md
@@ -11,9 +11,10 @@ hidden: true
 
 The following changes have been included in version 5.
 The categories these changes fall in are:
+
 - Coding changes
-- Component changes (marked with 🔃)
-- Breaking Changes (marked with 💥)
+- Component changes
+- Breaking Changes
 
 ## General
 
@@ -24,6 +25,7 @@ The categories these changes fall in are:
 {{ INCLUDE MigrationColor }}
 
 ## FluentAccordion
+
 {{ INCLUDE MigrationFluentAccordion }}
 
 ## FluentButton

--- a/tests/Core/Components/Dialog/FluentDialogTests.razor
+++ b/tests/Core/Components/Dialog/FluentDialogTests.razor
@@ -3,7 +3,7 @@
 @code
 {
     // A timeout can be set when you open a dialog box and do not close it.
-    private const int TEST_TIMEOUT = 13000;
+    private const int TEST_TIMEOUT = 3000;
 
     public FluentDialogTests()
     {

--- a/tests/Core/Components/Dialog/FluentDialogTests.razor
+++ b/tests/Core/Components/Dialog/FluentDialogTests.razor
@@ -3,7 +3,7 @@
 @code
 {
     // A timeout can be set when you open a dialog box and do not close it.
-    private const int TEST_TIMEOUT = 3000;
+    private const int TEST_TIMEOUT = 13000;
 
     public FluentDialogTests()
     {


### PR DESCRIPTION
Lots of quality of live improvements to the migration docs:
- Remove emojis from headers
- Remove broken link
- Formatting

## Before
<img width="936" height="583" alt="image" src="https://github.com/user-attachments/assets/693b1cac-23f6-4657-8d52-ba4242c3d9fb" />

## After
<img width="915" height="558" alt="image" src="https://github.com/user-attachments/assets/4f8a6d7a-828f-4fcd-b887-738fbafb4834" />

