### PR TITLE
[dev-v5] MessageBar - Add ResultTiming

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/MessageBar/Examples/MessageBarServiceCustomized.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/MessageBar/Examples/MessageBarServiceCustomized.razor
@@ -27,6 +27,7 @@
             options.Intent = MessageBarIntent.Success;
             options.Title = "Hello from the NotificationService!";
             options.Lifetime = TimeSpan.FromSeconds(10);
+            options.ResultTiming = MessageBarResultTiming.Closed;
         });
 
         Console.WriteLine($"Message bar closed: {result.Reason}");
@@ -40,6 +41,7 @@
 
             options.Title = "Hello from the NotificationService!";
             options.Lifetime = TimeSpan.FromSeconds(5);
+            options.ResultTiming = MessageBarResultTiming.Closed;
         });
 
         Console.WriteLine($"Message bar closed: {result.Reason}");

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/MessageBar/Examples/MessageBarServiceOptions.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/MessageBar/Examples/MessageBarServiceOptions.razor
@@ -24,6 +24,7 @@
             options.Message = "Successfully deleted 'XYZ-blazor.pdf'";
             options.AllowDismiss = true;
             options.Lifetime = TimeSpan.FromSeconds(5);
+            options.ResultTiming = MessageBarResultTiming.Closed;
         });
 
         Console.WriteLine($"Message bar closed: {result.Reason}");

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/MessageBar/Examples/MessageBarServiceOptions.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/MessageBar/Examples/MessageBarServiceOptions.razor
@@ -25,6 +25,11 @@
             options.AllowDismiss = true;
             options.Lifetime = TimeSpan.FromSeconds(5);
             options.ResultTiming = MessageBarResultTiming.Closed;
+
+            options.OnStatusChange = (args) =>
+            {
+                Console.WriteLine($"Message bar status changed: {args.Status}");
+            };
         });
 
         Console.WriteLine($"Message bar closed: {result.Reason}");

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/MessageBar/FluentMessageBar.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/MessageBar/FluentMessageBar.md
@@ -76,6 +76,10 @@ and a local provider scoped to a specific panel or dialog), and to route each me
 
 The simplest way to display a message is to use one of the typed helpers, passing the target section and the message text:
 
+These four helper methods are non-blocking. Because they use `MessageBarResultTiming.Visible`, the awaited call completes 
+as soon as the bar is displayed; thus, the code following the `await` statement continues to execute immediately, without waiting for the bar 
+to be closed:
+
 - `NotificationService.ShowSuccessBarAsync("SECTION", "Title", "Message")`
 - `NotificationService.ShowWarningBarAsync("SECTION", "Title", "Message")`
 - `NotificationService.ShowErrorBarAsync("SECTION", "Title", "Message")`
@@ -89,6 +93,10 @@ For more control (title, intent, layout, lifetime, dismiss button, ...), use the
 an `Action<MessageBarOptions>`. The returned `MessageBarResult` indicates how the message bar was closed.
 
 {{ MessageBarServiceOptions }}
+
+**Notes**: 
+- By default, `ResultTiming = MessageBarResultTiming.Visible`. The code after `await` resumes as soon as the bar is visible. 
+- Set this property to `MessageBarResultTiming.Closed` to block execution until the bar is dismissed.
 
 **Using a custom component**
 

--- a/src/Core/Components/MessageBar/Services/INotificationService.cs
+++ b/src/Core/Components/MessageBar/Services/INotificationService.cs
@@ -49,19 +49,19 @@ public partial interface INotificationService : IFluentServiceBase<INotification
     Task<MessageBarResult> ShowInfoBarAsync(string section, string? title = null, string? message = null);
 
     /// <summary>
-    /// Shows a message bar using the supplied options and waits for the close result.
+    /// Shows a message bar using the supplied options.
     /// </summary>
     /// <param name="options">Options to configure the message bar.</param>
     Task<MessageBarResult> ShowMessageBarAsync(MessageBarOptions options);
 
     /// <summary>
-    /// Shows a message bar by configuring an options object and waits for the close result.
+    /// Shows a message bar by configuring an options object.
     /// </summary>
     /// <param name="options">Action used to configure the message bar.</param>
     Task<MessageBarResult> ShowMessageBarAsync(Action<MessageBarOptions> options);
 
     /// <summary>
-    /// Shows a custom message bar component and waits for the close result.
+    /// Shows a custom message bar component.
     /// The component receives the current <see cref="IMessageBarInstance"/> through a cascading parameter.
     /// </summary>
     /// <typeparam name="TMessageBar">A Blazor component type used to render the message bar.</typeparam>
@@ -70,7 +70,7 @@ public partial interface INotificationService : IFluentServiceBase<INotification
         where TMessageBar : ComponentBase;
 
     /// <summary>
-    /// Shows a custom message bar component and waits for the close result.
+    /// Shows a custom message bar component.
     /// The component receives the current <see cref="IMessageBarInstance"/> through a cascading parameter.
     /// </summary>
     /// <typeparam name="TMessageBar">A Blazor component type used to render the message bar.</typeparam>

--- a/src/Core/Components/MessageBar/Services/MessageBarInstance.cs
+++ b/src/Core/Components/MessageBar/Services/MessageBarInstance.cs
@@ -98,6 +98,18 @@ public class MessageBarInstance : IMessageBarInstance, IDisposable
         }
     }
 
+    /// <summary>
+    /// Completes the <see cref="Result"/> task when the message bar becomes visible,
+    /// if <see cref="MessageBarOptions.ResultTiming"/> is set to <see cref="MessageBarResultTiming.Visible"/>.
+    /// </summary>
+    internal void TryCompleteResultOnVisible()
+    {
+        if (Options.ResultTiming == MessageBarResultTiming.Visible)
+        {
+            ResultCompletion.TrySetResult(MessageBarResult.OfVisible());
+        }
+    }
+
     /// <inheritdoc cref="IDisposable.Dispose()"/>
     public void Dispose()
     {

--- a/src/Core/Components/MessageBar/Services/MessageBarOptions.cs
+++ b/src/Core/Components/MessageBar/Services/MessageBarOptions.cs
@@ -147,6 +147,12 @@ public class MessageBarOptions : IFluentComponentBase
     public Action<MessageBarEventArgs>? OnStatusChange { get; set; }
 
     /// <summary>
+    /// Gets or sets when the <see cref="IMessageBarInstance.Result"/> task is completed.
+    /// The default is <see cref="MessageBarResultTiming.Closed"/>.
+    /// </summary>
+    public MessageBarResultTiming ResultTiming { get; set; } = MessageBarResultTiming.Closed;
+
+    /// <summary>
     /// Gets the class, including the optional <see cref="Margin"/> and <see cref="Padding"/> values.
     /// </summary>
     internal virtual string? ClassValue => new CssBuilder(Class)

--- a/src/Core/Components/MessageBar/Services/MessageBarOptions.cs
+++ b/src/Core/Components/MessageBar/Services/MessageBarOptions.cs
@@ -148,9 +148,9 @@ public class MessageBarOptions : IFluentComponentBase
 
     /// <summary>
     /// Gets or sets when the <see cref="IMessageBarInstance.Result"/> task is completed.
-    /// The default is <see cref="MessageBarResultTiming.Closed"/>.
+    /// The default is <see cref="MessageBarResultTiming.Visible"/>.
     /// </summary>
-    public MessageBarResultTiming ResultTiming { get; set; } = MessageBarResultTiming.Closed;
+    public MessageBarResultTiming ResultTiming { get; set; } = MessageBarResultTiming.Visible;
 
     /// <summary>
     /// Gets the class, including the optional <see cref="Margin"/> and <see cref="Padding"/> values.

--- a/src/Core/Components/MessageBar/Services/MessageBarResult.cs
+++ b/src/Core/Components/MessageBar/Services/MessageBarResult.cs
@@ -12,6 +12,7 @@ public class MessageBarResult
     internal static MessageBarResult OfDismissed(object? data = null) => new(MessageBarCloseReason.Dismissed, data);
     internal static MessageBarResult OfProgrammatic(object? data = null) => new(MessageBarCloseReason.Programmatic, data);
     internal static MessageBarResult OfTimedOut(object? data = null) => new(MessageBarCloseReason.TimedOut, data);
+    internal static MessageBarResult OfVisible(object? data = null) => new(MessageBarCloseReason.Programmatic, data);
 
     /// <summary />
     protected internal MessageBarResult(MessageBarCloseReason reason, object? data)

--- a/src/Core/Components/MessageBar/Services/NotificationService.cs
+++ b/src/Core/Components/MessageBar/Services/NotificationService.cs
@@ -18,6 +18,7 @@ public partial class NotificationService : FluentServiceBase<INotificationInstan
         return ShowMessageBarAsync(options =>
         {
             options.Section = section;
+            options.ResultTiming = MessageBarResultTiming.Visible;
             options.Intent = MessageBarIntent.Success;
             options.Title = title;
             options.Message = message;
@@ -30,6 +31,7 @@ public partial class NotificationService : FluentServiceBase<INotificationInstan
         return ShowMessageBarAsync(options =>
         {
             options.Section = section;
+            options.ResultTiming = MessageBarResultTiming.Visible;
             options.Intent = MessageBarIntent.Warning;
             options.Title = title;
             options.Message = message;
@@ -42,6 +44,7 @@ public partial class NotificationService : FluentServiceBase<INotificationInstan
         return ShowMessageBarAsync(options =>
         {
             options.Section = section;
+            options.ResultTiming = MessageBarResultTiming.Visible;
             options.Intent = MessageBarIntent.Error;
             options.Title = title;
             options.Message = message;
@@ -54,6 +57,7 @@ public partial class NotificationService : FluentServiceBase<INotificationInstan
         return ShowMessageBarAsync(options =>
         {
             options.Section = section;
+            options.ResultTiming = MessageBarResultTiming.Visible;
             options.Intent = MessageBarIntent.Info;
             options.Title = title;
             options.Message = message;

--- a/src/Core/Components/MessageBar/Services/NotificationService.cs
+++ b/src/Core/Components/MessageBar/Services/NotificationService.cs
@@ -163,6 +163,9 @@ public partial class NotificationService : FluentServiceBase<INotificationInstan
 
         options.OnStatusChange?.Invoke(new MessageBarEventArgs(instance, MessageBarLifecycleStatus.Visible));
 
+        // Complete the result now if the caller requested completion when the message bar becomes visible.
+        instance.TryCompleteResultOnVisible();
+
         // Schedule the auto-dismiss when a lifetime is configured.
         if (options.Lifetime is TimeSpan lifetime && lifetime > TimeSpan.Zero)
         {

--- a/src/Core/Enums/MessageBarResultTiming.cs
+++ b/src/Core/Enums/MessageBarResultTiming.cs
@@ -15,7 +15,8 @@ public enum MessageBarResultTiming
     Closed,
 
     /// <summary>
-    /// Complete the result when the message bar becomes visible.
+    /// Complete the result when the message bar is registered as visible.
+    /// In this mode, <see cref="MessageBarResult.Reason"/> will be <see cref="MessageBarCloseReason.Programmatic"/>.
     /// </summary>
     Visible,
 }

--- a/src/Core/Enums/MessageBarResultTiming.cs
+++ b/src/Core/Enums/MessageBarResultTiming.cs
@@ -1,0 +1,21 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// Controls when <see cref="IMessageBarInstance.Result"/> is completed.
+/// </summary>
+public enum MessageBarResultTiming
+{
+    /// <summary>
+    /// Complete the result when the message bar is dismissed or closed.
+    /// </summary>
+    Closed,
+
+    /// <summary>
+    /// Complete the result when the message bar becomes visible.
+    /// </summary>
+    Visible,
+}

--- a/tests/Core/Components/MessageBar/FluentMessageBarProviderTests.razor
+++ b/tests/Core/Components/MessageBar/FluentMessageBarProviderTests.razor
@@ -172,7 +172,13 @@
         // Arrange
         var cut = Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
 
-        var task = NotificationService.ShowInfoBarAsync(TEST_SECTION, "Dismiss me");
+        var task = NotificationService.ShowMessageBarAsync(o =>
+        {
+            o.Section = TEST_SECTION;
+            o.Intent = MessageBarIntent.Info;
+            o.Title = "Dismiss me";
+            o.ResultTiming = MessageBarResultTiming.Closed;
+        });
         cut.WaitForAssertion(() => Assert.Contains("Dismiss me", cut.Markup));
 
         // Act
@@ -197,6 +203,7 @@
             o.Section = TEST_SECTION;
             o.Id = "to-close";
             o.Title = "Close me";
+            o.ResultTiming = MessageBarResultTiming.Closed;
         });
         cut.WaitForAssertion(() => Assert.Contains("Close me", cut.Markup));
 
@@ -280,6 +287,7 @@
         {
             o.Section = TEST_SECTION;
             o.Title = "With result";
+            o.ResultTiming = MessageBarResultTiming.Closed;
             o.OnStatusChange = args =>
             {
                 if (args.Status == MessageBarLifecycleStatus.Visible)
@@ -378,12 +386,60 @@
             o.Section = TEST_SECTION;
             o.Title = "Auto";
             o.Lifetime = TimeSpan.FromMilliseconds(100);
+            o.ResultTiming = MessageBarResultTiming.Closed;
         });
 
         var result = await task;
 
         // Assert
         Assert.Equal(MessageBarCloseReason.TimedOut, result.Reason);
+    }
+
+    [Fact(Timeout = TEST_TIMEOUT)]
+    public async Task FluentMessageBarProvider_ResultTiming_Visible_CompletesBeforeClose()
+    {
+        // Arrange
+        var cut = Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
+
+        // Act: default ResultTiming is Visible, so the task completes as soon as the message is shown.
+        var result = await NotificationService.ShowMessageBarAsync(o =>
+        {
+            o.Section = TEST_SECTION;
+            o.Title = "Visible timing";
+        });
+
+        // Assert: result completed at visible time, and the message bar is still displayed.
+        Assert.Equal(MessageBarCloseReason.Programmatic, result.Reason);
+        Assert.Null(result.Data);
+        cut.WaitForAssertion(() => Assert.Contains("Visible timing", cut.Markup));
+
+        // Cleanup
+        await NotificationService.CloseAllMessageBarsAsync();
+    }
+
+    [Fact(Timeout = TEST_TIMEOUT)]
+    public async Task FluentMessageBarProvider_ResultTiming_Closed_WaitsUntilClose()
+    {
+        // Arrange
+        var cut = Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
+
+        var task = NotificationService.ShowMessageBarAsync(o =>
+        {
+            o.Section = TEST_SECTION;
+            o.Title = "Closed timing";
+            o.ResultTiming = MessageBarResultTiming.Closed;
+        });
+        cut.WaitForAssertion(() => Assert.Contains("Closed timing", cut.Markup));
+
+        // Assert: the result is not completed while the message bar is visible.
+        Assert.False(task.IsCompleted);
+
+        // Act
+        cut.Find("fluent-button[slot='dismiss']").Click();
+        var result = await task;
+
+        // Assert
+        Assert.Equal(MessageBarCloseReason.Dismissed, result.Reason);
     }
 
     [Fact(Timeout = TEST_TIMEOUT)]

--- a/tests/Core/Components/MessageBar/MessageBarInstanceTests.cs
+++ b/tests/Core/Components/MessageBar/MessageBarInstanceTests.cs
@@ -186,4 +186,57 @@ public class MessageBarInstanceTests : Bunit.BunitContext
         Assert.Null(exception);
         Assert.True(token.IsCancellationRequested);
     }
+
+    [Fact]
+    public async Task MessageBarInstance_TryCompleteResultOnVisible_TimingVisible_CompletesResult()
+    {
+        // Arrange
+        var service = (NotificationService)Services.GetRequiredService<INotificationService>();
+        var options = new MessageBarOptions { Section = "section", ResultTiming = MessageBarResultTiming.Visible };
+        var instance = new MessageBarInstance(service, options);
+
+        // Act
+        instance.TryCompleteResultOnVisible();
+        var result = await instance.Result;
+
+        // Assert
+        Assert.True(instance.Result.IsCompleted);
+        Assert.Equal(MessageBarCloseReason.Programmatic, result.Reason);
+        Assert.Null(result.Data);
+    }
+
+    [Fact]
+    public void MessageBarInstance_TryCompleteResultOnVisible_TimingClosed_DoesNotCompleteResult()
+    {
+        // Arrange
+        var service = (NotificationService)Services.GetRequiredService<INotificationService>();
+        var options = new MessageBarOptions { Section = "section", ResultTiming = MessageBarResultTiming.Closed };
+        var instance = new MessageBarInstance(service, options);
+
+        // Act
+        instance.TryCompleteResultOnVisible();
+
+        // Assert
+        Assert.False(instance.Result.IsCompleted);
+    }
+
+    [Fact]
+    public async Task MessageBarInstance_TryCompleteResultOnVisible_ThenClose_KeepsVisibleResult()
+    {
+        // Arrange
+        var service = (NotificationService)Services.GetRequiredService<INotificationService>();
+        var options = new MessageBarOptions { Section = "section", ResultTiming = MessageBarResultTiming.Visible };
+        var instance = new MessageBarInstance(service, options);
+        ((IFluentServiceBase<INotificationInstance>)service).Items.TryAdd(instance.Id, instance);
+        ((IFluentServiceBase<INotificationInstance>)service).ProviderId = "provider";
+
+        // Act
+        instance.TryCompleteResultOnVisible();
+        await instance.CloseAsync(MessageBarResult.OfDismissed("late"));
+        var result = await instance.Result;
+
+        // Assert: the result completed at visible time is not overwritten by the close.
+        Assert.Equal(MessageBarCloseReason.Programmatic, result.Reason);
+        Assert.Null(result.Data);
+    }
 }

--- a/tests/Core/Components/MessageBar/MessageBarOptionsTests.cs
+++ b/tests/Core/Components/MessageBar/MessageBarOptionsTests.cs
@@ -37,6 +37,20 @@ public class MessageBarOptionsTests
         Assert.Null(options.TimeStamp);
         Assert.Null(options.Lifetime);
         Assert.Null(options.OnStatusChange);
+        Assert.Equal(MessageBarResultTiming.Visible, options.ResultTiming);
+    }
+
+    [Fact]
+    public void MessageBarOptions_ResultTiming_CanBeChanged()
+    {
+        // Arrange
+        var options = new MessageBarOptions();
+
+        // Act
+        options.ResultTiming = MessageBarResultTiming.Closed;
+
+        // Assert
+        Assert.Equal(MessageBarResultTiming.Closed, options.ResultTiming);
     }
 
     [Fact]

--- a/tests/Core/Components/MessageBar/MessageBarResultTests.cs
+++ b/tests/Core/Components/MessageBar/MessageBarResultTests.cs
@@ -76,4 +76,26 @@ public class MessageBarResultTests
         Assert.Equal(MessageBarCloseReason.TimedOut, result.Reason);
         Assert.Equal(42, result.Data);
     }
+
+    [Fact]
+    public void MessageBarResult_OfVisible_NoData_SetsReason()
+    {
+        // Act
+        var result = MessageBarResult.OfVisible();
+
+        // Assert
+        Assert.Equal(MessageBarCloseReason.Programmatic, result.Reason);
+        Assert.Null(result.Data);
+    }
+
+    [Fact]
+    public void MessageBarResult_OfVisible_WithData_SetsData()
+    {
+        // Act
+        var result = MessageBarResult.OfVisible("shown");
+
+        // Assert
+        Assert.Equal(MessageBarCloseReason.Programmatic, result.Reason);
+        Assert.Equal("shown", result.Data);
+    }
 }


### PR DESCRIPTION
# [dev-v5] MessageBar - Add ResultTiming

Introduce a new `ResultTiming` option for the `MessageBar` to control when the result task is completed, either when the bar is visible or closed. 
This allows for greater flexibility in using the methods, but also ensures consistency with how Toasts work

Now, these four helper methods are non-blocking. Because they use `MessageBarResultTiming.Visible`, the awaited call completes 
as soon as the bar is displayed; thus, the code following the `await` statement continues to execute immediately, without waiting for the bar to be closed: `ShowSuccessBarAsync`, `ShowWarningBarAsync`, `ShowErrorBarAsync`, `ShowInfoBarAsync`

Update documentation. 

This change improves flexibility in handling message bar results.

Fix #4992

## Unit Tests

Added