### PR TITLE
[dev-v5][Chore] Exclude Tests.Tools from coverage

### DIFF
--- a/.github/workflows/build-core-lib.yml
+++ b/.github/workflows/build-core-lib.yml
@@ -83,7 +83,7 @@ jobs:
        run: |
          TESTS="${{ env.TESTS }}"
          for test in $TESTS; do
-           dotnet test "$test" --logger:trx --results-directory ./TestResults --verbosity normal --configuration Release /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:DebugType=Full
+           dotnet test "$test" --logger:trx --results-directory ./TestResults --verbosity normal --configuration Release /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:DebugType=Full /p:Exclude="[Microsoft.FluentUI.AspNetCore.Components.Tests.Tools]*"
          done
        working-directory: ${{ github.workspace }}
 
@@ -150,6 +150,7 @@ jobs:
          reports: '**/coverage.cobertura.xml;**/coverage.net10.0.cobertura.xml'
          targetdir: 'CoverageReports'
          title: 'Unit Tests Code Coverage'
+         assemblyfilters: '+Microsoft.FluentUI.AspNetCore.Components*;+Microsoft.FluentUI.AspNetCore.Components.Charts*;-Microsoft.FluentUI.AspNetCore.Components.Tests.Tools'
          classfilters: '-Microsoft.FluentUI.AspNetCore.Components.DesignTokens.*'
          filefilters: '-*RegexGenerator.g.cs'
          customSettings: 'minimumCoverageThresholds:lineCoverage=${{ env.MIN_COVERAGE }};riskHotspotsAnalysisThresholds:metricThresholdForCrapScore=30;riskHotspotsAnalysisThresholds:metricThresholdForCyclomaticComplexity=30'

--- a/eng/pipelines/build-all-lib.yml
+++ b/eng/pipelines/build-all-lib.yml
@@ -186,7 +186,7 @@ extends:
           inputs:
             command: test
             projects: ${{ parameters.Tests }}
-            arguments: '--configuration Release /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:DebugType=Full'
+            arguments: '--configuration Release /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:DebugType=Full /p:Exclude="[Microsoft.FluentUI.AspNetCore.Components.Tests.Tools]*"'
             publishTestResults: true
 
         # Coverage Generation
@@ -197,6 +197,7 @@ extends:
             reports: '**/*.cobertura.xml'
             targetdir: 'CoverageFolder'
             reporttypes: 'HtmlInline_AzurePipelines'
+            assemblyfilters: '+Microsoft.FluentUI.AspNetCore.Components*;+Microsoft.FluentUI.AspNetCore.Components.Charts*;-Microsoft.FluentUI.AspNetCore.Components.Tests.Tools'
 
         # Publish code coverage
         - task: PublishCodeCoverageResults@2

--- a/eng/pipelines/build-core-lib.yml
+++ b/eng/pipelines/build-core-lib.yml
@@ -209,7 +209,7 @@ extends:
           inputs:
             command: test
             projects: ${{ parameters.Tests }}
-            arguments: '--configuration Release /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:DebugType=Full'
+            arguments: '--configuration Release /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:DebugType=Full /p:Exclude="[Microsoft.FluentUI.AspNetCore.Components.Tests.Tools]*"'
             publishTestResults: true
 
         # Coverage Generation
@@ -220,6 +220,7 @@ extends:
             reports: '**/*.cobertura.xml'
             targetdir: 'CoverageFolder'
             reporttypes: 'HtmlInline_AzurePipelines'
+            assemblyfilters: '+Microsoft.FluentUI.AspNetCore.Components*;+Microsoft.FluentUI.AspNetCore.Components.Charts*;-Microsoft.FluentUI.AspNetCore.Components.Tests.Tools'
 
         # Publish code coverage
         - task: PublishCodeCoverageResults@2

--- a/tests/_StartCodeCoverage.ps1
+++ b/tests/_StartCodeCoverage.ps1
@@ -136,7 +136,7 @@ else {
         & dotnet test (Join-Path $scriptDir 'Core\Components.Tests.csproj') `
             '--collect:XPlat Code Coverage' `
             '--results-directory' $coreResults `
-            '--' 'DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Include=[Microsoft.FluentUI.AspNetCore.Components]*'
+            '--' 'DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Include=[Microsoft.FluentUI.AspNetCore.Components]*' 'DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude=[Microsoft.FluentUI.AspNetCore.Components.Tests.Tools]*'
 
         if ($LASTEXITCODE -eq 0) {
             New-Item -ItemType File -Path $coreStamp -Force | Out-Null
@@ -170,7 +170,7 @@ Write-Host '=== Merging coverage reports ==='
     "-reports:$resultsDir\**\coverage.cobertura.xml" `
     "-targetdir:$resultsDir\Report" `
     '-reporttypes:HtmlInline_AzurePipelines' `
-    '-assemblyfilters:+Microsoft.FluentUI.AspNetCore.Components;+Microsoft.FluentUI.AspNetCore.Components.Charts' `
+    '-assemblyfilters:+Microsoft.FluentUI.AspNetCore.Components;+Microsoft.FluentUI.AspNetCore.Components.Charts;-Microsoft.FluentUI.AspNetCore.Components.Tests.Tools' `
     '-classfilters:-Microsoft.FluentUI.AspNetCore.Components.DesignTokens.*' `
     '-filefilters:-*RegexGenerator.g.cs' `
     'riskHotspotsAnalysisThresholds:metricThresholdForCrapScore=30' `


### PR DESCRIPTION
The recently added `Microsoft.FluentUI.AspNetCore.Components.Tests.Tools` is included in coverage and reporting. This PR fixes that.


## Before
<img width="914" height="238" alt="image" src="https://github.com/user-attachments/assets/b4da54f3-d17c-4fcf-aae0-a20101cfa120" />

## After

<img width="674" height="206" alt="image" src="https://github.com/user-attachments/assets/4644210b-7061-41eb-b0d4-d7275eddc7d6" />


