### PR TITLE
[dev-v5] Extend DefaultValues with option to set default value on a base class

### DIFF
--- a/src/Core/Infrastructure/DefaultValues.cs
+++ b/src/Core/Infrastructure/DefaultValues.cs
@@ -117,20 +117,21 @@ public class DefaultValues
             }
         }
 
-        var mergedProperties = new ConcurrentDictionary<string, object?>(StringComparer.Ordinal);
+        ConcurrentDictionary<string, object?>? mergedProperties = null;
 
         for (var i = inheritanceChain.Count - 1; i >= 0; i--)
         {
             if (TryGetRegisteredProperties(inheritanceChain[i], out var properties))
             {
+                mergedProperties ??= new ConcurrentDictionary<string, object?>(StringComparer.Ordinal);
                 foreach (var property in properties)
                 {
-                    mergedProperties.AddOrUpdate(property.Key, property.Value, (_, _) => property.Value);
+                    mergedProperties[property.Key] = property.Value;
                 }
             }
         }
 
-        return !mergedProperties.IsEmpty ? mergedProperties : null;
+        return mergedProperties;
     }
 
     private bool TryGetRegisteredProperties(Type componentType, [NotNullWhen(true)] out ConcurrentDictionary<string, object?>? properties)

--- a/src/Core/Infrastructure/DefaultValues.cs
+++ b/src/Core/Infrastructure/DefaultValues.cs
@@ -105,16 +105,47 @@ public class DefaultValues
             return null;
         }
 
-        // Try exact type first
-        if (!_componentCache.TryGetValue(componentType, out var properties))
+        var inheritanceChain = new List<Type>();
+
+        for (var currentType = componentType; currentType is not null && currentType != typeof(object); currentType = currentType.BaseType)
         {
-            // Fallback: check open generic type definition
-            if (componentType.IsGenericType)
+            inheritanceChain.Add(currentType);
+
+            if (currentType == typeof(FluentComponentBase))
             {
-                _componentCache.TryGetValue(componentType.GetGenericTypeDefinition(), out properties);
+                break;
             }
         }
 
-        return properties;
+        var mergedProperties = new ConcurrentDictionary<string, object?>(StringComparer.Ordinal);
+
+        for (var i = inheritanceChain.Count - 1; i >= 0; i--)
+        {
+            if (TryGetRegisteredProperties(inheritanceChain[i], out var properties))
+            {
+                foreach (var property in properties)
+                {
+                    mergedProperties.AddOrUpdate(property.Key, property.Value, (_, _) => property.Value);
+                }
+            }
+        }
+
+        return !mergedProperties.IsEmpty ? mergedProperties : null;
+    }
+
+    private bool TryGetRegisteredProperties(Type componentType, [NotNullWhen(true)] out ConcurrentDictionary<string, object?>? properties)
+    {
+        if (_componentCache.TryGetValue(componentType, out properties))
+        {
+            return true;
+        }
+
+        if (componentType.IsGenericType)
+        {
+            return _componentCache.TryGetValue(componentType.GetGenericTypeDefinition(), out properties);
+        }
+
+        properties = null;
+        return false;
     }
 }

--- a/src/Core/Infrastructure/DefaultValuesComponentBuilder.cs
+++ b/src/Core/Infrastructure/DefaultValuesComponentBuilder.cs
@@ -50,6 +50,13 @@ public class DefaultValuesComponentBuilder<[DynamicallyAccessedMembers(Dynamical
         var propertyName = propertyInfo?.Name
                         ?? throw new ArgumentException($"The parameter selector '{parameterSelector}' does not resolve to a public property on the component '{typeof(TComponent)}'.", nameof(parameterSelector));
 
+        if (!propertyInfo.CanWrite)
+        {
+            throw new ArgumentException($"The property '{propertyName}' on component '{typeof(TComponent)}' is read-only and cannot be used for default values.", nameof(parameterSelector));
+        }
+
+        ValidateValueCompatibility(propertyInfo, value, propertyName);
+
         // Add the value to the dictionary, using the property name as the key.
         _values.AddOrUpdate(propertyName, AddFunction, UpdateFunction);
 
@@ -66,6 +73,28 @@ public class DefaultValuesComponentBuilder<[DynamicallyAccessedMembers(Dynamical
             }
 
             return value;
+        }
+    }
+
+    private static void ValidateValueCompatibility(PropertyInfo propertyInfo, object? value, string propertyName)
+    {
+        var propertyType = propertyInfo.PropertyType;
+        var nullableUnderlyingType = Nullable.GetUnderlyingType(propertyType);
+        var targetType = nullableUnderlyingType ?? propertyType;
+
+        if (value is null)
+        {
+            if (propertyType.IsValueType && nullableUnderlyingType is null)
+            {
+                throw new ArgumentException($"Default value for '{propertyName}' on component '{typeof(TComponent)}' cannot be null because the property type '{propertyType}' is non-nullable.", nameof(value));
+            }
+
+            return;
+        }
+
+        if (!targetType.IsInstanceOfType(value))
+        {
+            throw new ArgumentException($"Default value for '{propertyName}' on component '{typeof(TComponent)}' must be assignable to '{targetType}', but was '{value.GetType()}'.", nameof(value));
         }
     }
 }

--- a/src/Core/Infrastructure/DefaultValuesComponentBuilder.cs
+++ b/src/Core/Infrastructure/DefaultValuesComponentBuilder.cs
@@ -89,6 +89,12 @@ public class DefaultValuesComponentBuilder<[DynamicallyAccessedMembers(Dynamical
                 throw new ArgumentException($"Default value for '{propertyName}' on component '{typeof(TComponent)}' cannot be null because the property type '{propertyType}' is non-nullable.", nameof(value));
             }
 
+            var nullabilityInfo = new NullabilityInfoContext().Create(propertyInfo);
+            if (nullabilityInfo.WriteState == NullabilityState.NotNull)
+            {
+                throw new ArgumentException($"Default value for '{propertyName}' on component '{typeof(TComponent)}' cannot be null because the property is non-nullable.", nameof(value));
+            }
+
             return;
         }
 


### PR DESCRIPTION
This pull request expands and improves the robustness and correctness of setting and retrieving default values for component properties. 

The main changes include 
- Allow setting a default value on a base class so to set it for all derived components. This default can be overridden in a derived class. So now this works:
```
// Add FluentUI services
builder.Services.AddFluentUIComponents(config =>
{
    // Set default values for all charts 
    config.DefaultValues.For<FluentChartBase>().Set(p => p.RoundedCorners, true);

    // But not for DonutCharts
    config.DefaultValues.For<FluentDonutChart>().Set(p => p.RoundedCorners, false);
});
```
Of course, setting a value on a component itself still takes precedence.

- enhancing type safety and validation when assigning default values, and updating the logic for property inheritance and merging in the `DefaultValues` class.

**Default value assignment improvements:**

- Added a check to ensure that only writable properties can be assigned default values, throwing an exception for read-only properties.
- Introduced strict validation to ensure that assigned default values are compatible with the property type, including nullability and type assignability checks.