### PR TITLE
Fix FluentDataGrid column width popup focus on tab navigation

### DIFF
--- a/src/Core/Components/AnchoredRegion/FluentAnchoredRegion.razor.js
+++ b/src/Core/Components/AnchoredRegion/FluentAnchoredRegion.razor.js
@@ -44,6 +44,50 @@ export function goToNextFocusableElement(forContainer, toOriginal, delay) {
 // ---------------------------------------------------------------------------
 
 const keyboardNavigationState = new Map();
+const focusableSelectors = "input, select, textarea, button, object, a[href], area[href], [tabindex]";
+
+function getAnchorFocusTarget(anchorElement) {
+    if (isFocusableElement(anchorElement)) {
+        return anchorElement;
+    }
+
+    return new FocusableElement(anchorElement).findNextFocusableElement() ?? anchorElement;
+}
+
+function getAnchorTraversalStart(anchorElement) {
+    const focusTarget = getAnchorFocusTarget(anchorElement);
+    return getFluentShadowFocusTarget(focusTarget) ?? focusTarget;
+}
+
+function getFluentShadowFocusTarget(element) {
+    if (!element?.tagName?.startsWith("FLUENT-")) {
+        return null;
+    }
+
+    return Array.from(element.shadowRoot?.children ?? [])
+        .find(child => child.tabIndex !== -1 && child.checkVisibility()) ?? null;
+}
+
+function findNextFocusableElementAfterAnchor(anchorElement, popupElement) {
+    const startFrom = getAnchorTraversalStart(anchorElement);
+    const focusableElements = new FocusableElement(anchorElement.getRootNode())
+        .getFocusableElements()
+        .filter(element => !popupElement.contains(element));
+    const currentIndex = focusableElements.indexOf(startFrom);
+
+    return currentIndex === -1 ? null : focusableElements[currentIndex + 1] ?? null;
+}
+
+function isFocusableElement(element) {
+    if (!element) {
+        return false;
+    }
+
+    const isFocusableCandidate = element.matches(focusableSelectors)
+        || element.tagName.toLowerCase().startsWith("fluent-");
+
+    return isFocusableCandidate && element.tabIndex !== -1 && element.checkVisibility();
+}
 
 /**
  * Attaches keyboard navigation listeners to an anchor+popup pair.
@@ -85,16 +129,10 @@ export function initializeKeyboardNavigation(anchorId, popupId, dotNetHelper, cl
             ev.stopPropagation();
             if (!ev.shiftKey) {
                 // Case 3: move to element after anchor in page
-                let startFrom;
-                if (anchorElement.tagName.startsWith("FLUENT-") && anchorElement.shadowRoot?.children.length > 0) {
-                    startFrom = anchorElement.shadowRoot.children[0];
-                } else {
-                    startFrom = anchorElement;
-                }
-                new FocusableElement(anchorElement.getRootNode()).findNextFocusableElement(startFrom)?.focus();
+                findNextFocusableElementAfterAnchor(anchorElement, popupElement)?.focus();
             } else {
                 // Case 2: Shift+Tab → focus anchor
-                anchorElement.focus();
+                getAnchorFocusTarget(anchorElement).focus();
             }
             dotNetHelper.invokeMethodAsync('CloseAsync');
         } else {
@@ -107,19 +145,13 @@ export function initializeKeyboardNavigation(anchorId, popupId, dotNetHelper, cl
                 // Case 3: Tab on last element → next page element after anchor, close
                 ev.preventDefault();
                 ev.stopPropagation();
-                let startFrom;
-                if (anchorElement.tagName.startsWith("FLUENT-") && anchorElement.shadowRoot?.children.length > 0) {
-                    startFrom = anchorElement.shadowRoot.children[0];
-                } else {
-                    startFrom = anchorElement;
-                }
-                new FocusableElement(anchorElement.getRootNode()).findNextFocusableElement(startFrom)?.focus();
+                findNextFocusableElementAfterAnchor(anchorElement, popupElement)?.focus();
                 dotNetHelper.invokeMethodAsync('CloseAsync');
             } else if (ev.shiftKey && (focusables.length === 0 || activeIndex === 0)) {
                 // Case 2: Shift+Tab on first element → focus anchor, close
                 ev.preventDefault();
                 ev.stopPropagation();
-                anchorElement.focus();
+                getAnchorFocusTarget(anchorElement).focus();
                 dotNetHelper.invokeMethodAsync('CloseAsync');
             }
             // Otherwise: middle element — let browser handle Tab/Shift+Tab naturally
@@ -174,7 +206,7 @@ export function disposeKeyboardNavigation(anchorId) {
  * Focusable Element
  */
 export class FocusableElement {
-    FOCUSABLE_SELECTORS = "input, select, textarea, button, object, a[href], area[href], [tabindex]";
+    FOCUSABLE_SELECTORS = focusableSelectors;
     _originalActiveElement;
     _container;
 

--- a/src/Core/Components/AnchoredRegion/FluentAnchoredRegion.razor.js
+++ b/src/Core/Components/AnchoredRegion/FluentAnchoredRegion.razor.js
@@ -60,7 +60,7 @@ function getAnchorTraversalStart(anchorElement) {
 }
 
 function getFluentShadowFocusTarget(element) {
-    if (!element?.tagName?.startsWith("FLUENT-")) {
+    if (!element?.tagName?.startsWith("FLUENT-") || element.tabIndex !== -1) {
         return null;
     }
 
@@ -68,11 +68,26 @@ function getFluentShadowFocusTarget(element) {
         .find(child => child.tabIndex !== -1 && child.checkVisibility()) ?? null;
 }
 
+function isInComposedTree(element, ancestor) {
+    let current = element;
+
+    while (current) {
+        if (ancestor.contains(current)) {
+            return true;
+        }
+
+        const root = current.getRootNode();
+        current = root instanceof ShadowRoot ? root.host : null;
+    }
+
+    return false;
+}
+
 function findNextFocusableElementAfterAnchor(anchorElement, popupElement) {
     const startFrom = getAnchorTraversalStart(anchorElement);
     const focusableElements = new FocusableElement(anchorElement.getRootNode())
         .getFocusableElements()
-        .filter(element => !popupElement.contains(element));
+        .filter(element => !isInComposedTree(element, popupElement));
     const currentIndex = focusableElements.indexOf(startFrom);
 
     return currentIndex === -1 ? null : focusableElements[currentIndex + 1] ?? null;
@@ -117,7 +132,7 @@ export function initializeKeyboardNavigation(anchorId, popupId, dotNetHelper, cl
             // Case 4: close key → return focus to anchor, close
             ev.preventDefault();
             ev.stopPropagation();
-            anchorElement.focus();
+            getAnchorFocusTarget(anchorElement).focus();
             dotNetHelper.invokeMethodAsync('CloseAsync');
             return;
         }

--- a/src/Core/Components/AnchoredRegion/FluentAnchoredRegion.razor.js
+++ b/src/Core/Components/AnchoredRegion/FluentAnchoredRegion.razor.js
@@ -44,65 +44,6 @@ export function goToNextFocusableElement(forContainer, toOriginal, delay) {
 // ---------------------------------------------------------------------------
 
 const keyboardNavigationState = new Map();
-const focusableSelectors = "input, select, textarea, button, object, a[href], area[href], [tabindex]";
-
-function getAnchorFocusTarget(anchorElement) {
-    if (isFocusableElement(anchorElement)) {
-        return anchorElement;
-    }
-
-    return new FocusableElement(anchorElement).findNextFocusableElement() ?? anchorElement;
-}
-
-function getAnchorTraversalStart(anchorElement) {
-    const focusTarget = getAnchorFocusTarget(anchorElement);
-    return getFluentShadowFocusTarget(focusTarget) ?? focusTarget;
-}
-
-function getFluentShadowFocusTarget(element) {
-    if (!element?.tagName?.startsWith("FLUENT-") || element.tabIndex !== -1) {
-        return null;
-    }
-
-    return Array.from(element.shadowRoot?.children ?? [])
-        .find(child => child.tabIndex !== -1 && child.checkVisibility()) ?? null;
-}
-
-function isInComposedTree(element, ancestor) {
-    let current = element;
-
-    while (current) {
-        if (ancestor.contains(current)) {
-            return true;
-        }
-
-        const root = current.getRootNode();
-        current = root instanceof ShadowRoot ? root.host : null;
-    }
-
-    return false;
-}
-
-function findNextFocusableElementAfterAnchor(anchorElement, popupElement) {
-    const startFrom = getAnchorTraversalStart(anchorElement);
-    const focusableElements = new FocusableElement(anchorElement.getRootNode())
-        .getFocusableElements()
-        .filter(element => !isInComposedTree(element, popupElement));
-    const currentIndex = focusableElements.indexOf(startFrom);
-
-    return currentIndex === -1 ? null : focusableElements[currentIndex + 1] ?? null;
-}
-
-function isFocusableElement(element) {
-    if (!element) {
-        return false;
-    }
-
-    const isFocusableCandidate = element.matches(focusableSelectors)
-        || element.tagName.toLowerCase().startsWith("fluent-");
-
-    return isFocusableCandidate && element.tabIndex !== -1 && element.checkVisibility();
-}
 
 /**
  * Attaches keyboard navigation listeners to an anchor+popup pair.
@@ -132,7 +73,7 @@ export function initializeKeyboardNavigation(anchorId, popupId, dotNetHelper, cl
             // Case 4: close key → return focus to anchor, close
             ev.preventDefault();
             ev.stopPropagation();
-            getAnchorFocusTarget(anchorElement).focus();
+            anchorElement.focus();
             dotNetHelper.invokeMethodAsync('CloseAsync');
             return;
         }
@@ -144,10 +85,16 @@ export function initializeKeyboardNavigation(anchorId, popupId, dotNetHelper, cl
             ev.stopPropagation();
             if (!ev.shiftKey) {
                 // Case 3: move to element after anchor in page
-                findNextFocusableElementAfterAnchor(anchorElement, popupElement)?.focus();
+                let startFrom;
+                if (anchorElement.tagName.startsWith("FLUENT-") && anchorElement.shadowRoot?.children.length > 0) {
+                    startFrom = anchorElement.shadowRoot.children[0];
+                } else {
+                    startFrom = anchorElement;
+                }
+                new FocusableElement(anchorElement.getRootNode()).findNextFocusableElement(startFrom)?.focus();
             } else {
                 // Case 2: Shift+Tab → focus anchor
-                getAnchorFocusTarget(anchorElement).focus();
+                anchorElement.focus();
             }
             dotNetHelper.invokeMethodAsync('CloseAsync');
         } else {
@@ -160,13 +107,19 @@ export function initializeKeyboardNavigation(anchorId, popupId, dotNetHelper, cl
                 // Case 3: Tab on last element → next page element after anchor, close
                 ev.preventDefault();
                 ev.stopPropagation();
-                findNextFocusableElementAfterAnchor(anchorElement, popupElement)?.focus();
+                let startFrom;
+                if (anchorElement.tagName.startsWith("FLUENT-") && anchorElement.shadowRoot?.children.length > 0) {
+                    startFrom = anchorElement.shadowRoot.children[0];
+                } else {
+                    startFrom = anchorElement;
+                }
+                new FocusableElement(anchorElement.getRootNode()).findNextFocusableElement(startFrom)?.focus();
                 dotNetHelper.invokeMethodAsync('CloseAsync');
             } else if (ev.shiftKey && (focusables.length === 0 || activeIndex === 0)) {
                 // Case 2: Shift+Tab on first element → focus anchor, close
                 ev.preventDefault();
                 ev.stopPropagation();
-                getAnchorFocusTarget(anchorElement).focus();
+                anchorElement.focus();
                 dotNetHelper.invokeMethodAsync('CloseAsync');
             }
             // Otherwise: middle element — let browser handle Tab/Shift+Tab naturally
@@ -221,7 +174,7 @@ export function disposeKeyboardNavigation(anchorId) {
  * Focusable Element
  */
 export class FocusableElement {
-    FOCUSABLE_SELECTORS = focusableSelectors;
+    FOCUSABLE_SELECTORS = "input, select, textarea, button, object, a[href], area[href], [tabindex]";
     _originalActiveElement;
     _container;
 

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.js
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.js
@@ -10,7 +10,10 @@ function getFocusableElements(container) {
     const focusableElements = [];
     queriedElements.forEach(el => {
         if (el.tagName.toLowerCase().startsWith("fluent-") && el.tabIndex === -1 && !!el.shadowRoot) {
-            Array.from(el.shadowRoot.children).forEach(child => {
+            // The host itself is not focusable, so collect what it renders in its shadow root instead.
+            // Those elements are not always direct children of the shadow root (a text field renders
+            // its input inside a wrapper), so the whole shadow tree has to be queried.
+            el.shadowRoot.querySelectorAll(focusableSelectors).forEach(child => {
                 if (child.tabIndex !== -1 && child.checkVisibility()) {
                     focusableElements.push(child);
                 }

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.js
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.js
@@ -23,9 +23,25 @@ function getFocusableElements(container) {
     return focusableElements.filter(el => !!el && el.tabIndex !== -1 && el.checkVisibility());
 }
 
+function indexOfFocusableElement(focusableElements, element) {
+    // Fluent web components delegate focus into their shadow root, so the event origin is often a
+    // shadow descendant of the element that was collected. Walk up the composed tree to find it.
+    let node = element;
+    while (node) {
+        const index = focusableElements.indexOf(node);
+        if (index !== -1) {
+            return index;
+        }
+
+        node = node.parentNode ?? node.host;
+    }
+
+    return -1;
+}
+
 function findAdjacentFocusableElement(currentElement, reverse = false) {
     const focusableElements = getFocusableElements(document.body);
-    const currentIndex = focusableElements.indexOf(currentElement);
+    const currentIndex = indexOfFocusableElement(focusableElements, currentElement);
     if (currentIndex === -1) {
         return null;
     }
@@ -106,9 +122,9 @@ export function init(gridElement, autoFocus) {
             if (event.key === "Tab") {
                 const activeElement = event.composedPath()[0];
                 const resizeFocusables = getFocusableElements(columnResizeElement);
-                const activeIndex = resizeFocusables.indexOf(activeElement);
+                const activeIndex = indexOfFocusableElement(resizeFocusables, activeElement);
                 const isFirstElement = activeIndex === 0;
-                const isLastElement = activeIndex === resizeFocusables.length - 1;
+                const isLastElement = activeIndex !== -1 && activeIndex === resizeFocusables.length - 1;
 
                 if ((event.shiftKey && isFirstElement) || (!event.shiftKey && isLastElement)) {
                     const focusTarget = findAdjacentFocusableElement(activeElement, event.shiftKey);

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.js
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.js
@@ -1,5 +1,45 @@
 let grids = [];
 
+const focusableSelectors = "input, select, textarea, button, object, a[href], area[href], [tabindex]";
+
+function getFocusableElements(container) {
+    const queriedElements = Array.from(container.querySelectorAll("*")).filter(el => {
+        return el.matches(focusableSelectors) || el.tagName.toLowerCase().startsWith("fluent-");
+    });
+
+    const focusableElements = [];
+    queriedElements.forEach(el => {
+        if (el.tagName.toLowerCase().startsWith("fluent-") && el.tabIndex === -1 && !!el.shadowRoot) {
+            Array.from(el.shadowRoot.children).forEach(child => {
+                if (child.tabIndex !== -1 && child.checkVisibility()) {
+                    focusableElements.push(child);
+                }
+            });
+        } else {
+            focusableElements.push(el);
+        }
+    });
+
+    return focusableElements.filter(el => !!el && el.tabIndex !== -1 && el.checkVisibility());
+}
+
+function findAdjacentFocusableElement(currentElement, reverse = false) {
+    const focusableElements = getFocusableElements(document.body);
+    const currentIndex = focusableElements.indexOf(currentElement);
+    if (currentIndex === -1) {
+        return null;
+    }
+
+    return focusableElements[currentIndex + (reverse ? -1 : 1)] ?? null;
+}
+
+function closeColumnResizeAndFocus(gridElement, columnResizeElement, focusTarget) {
+    gridElement.dispatchEvent(new CustomEvent('closecolumnresize', { bubbles: true }));
+
+    const columnHeaderButton = columnResizeElement.closest('.column-header')?.querySelector('.col-sort-button');
+    (focusTarget ?? columnHeaderButton ?? gridElement).focus();
+}
+
 export function init(gridElement, autoFocus) {
     if (gridElement === undefined || gridElement === null) {
         return;
@@ -60,6 +100,22 @@ export function init(gridElement, autoFocus) {
         if (columnResizeElement && columnResizeElement.contains(event.target)) {
             if (event.key === "ArrowRight" || event.key === "ArrowLeft" || event.key === "ArrowDown" || event.key === "ArrowUp") {
                 event.stopPropagation();
+                return;
+            }
+
+            if (event.key === "Tab") {
+                const resizeFocusables = getFocusableElements(columnResizeElement);
+                const activeIndex = resizeFocusables.indexOf(document.activeElement);
+                const isFirstElement = activeIndex === 0;
+                const isLastElement = activeIndex === resizeFocusables.length - 1;
+
+                if ((event.shiftKey && isFirstElement) || (!event.shiftKey && isLastElement)) {
+                    const focusTarget = findAdjacentFocusableElement(document.activeElement, event.shiftKey);
+                    event.preventDefault();
+                    event.stopPropagation();
+                    closeColumnResizeAndFocus(gridElement, columnResizeElement, focusTarget);
+                }
+
                 return;
             }
         }

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.js
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.js
@@ -104,13 +104,14 @@ export function init(gridElement, autoFocus) {
             }
 
             if (event.key === "Tab") {
+                const activeElement = event.composedPath()[0];
                 const resizeFocusables = getFocusableElements(columnResizeElement);
-                const activeIndex = resizeFocusables.indexOf(document.activeElement);
+                const activeIndex = resizeFocusables.indexOf(activeElement);
                 const isFirstElement = activeIndex === 0;
                 const isLastElement = activeIndex === resizeFocusables.length - 1;
 
                 if ((event.shiftKey && isFirstElement) || (!event.shiftKey && isLastElement)) {
-                    const focusTarget = findAdjacentFocusableElement(document.activeElement, event.shiftKey);
+                    const focusTarget = findAdjacentFocusableElement(activeElement, event.shiftKey);
                     event.preventDefault();
                     event.stopPropagation();
                     closeColumnResizeAndFocus(gridElement, columnResizeElement, focusTarget);


### PR DESCRIPTION
## Summary

Closes the `FluentDataGrid` column width popup when focus leaves it via `Tab` / `Shift+Tab`, preserving the expected previous/next focus target.

Fixes #5002

## Scope change

This PR originally also changed `FluentAnchoredRegion.razor.js` to fix #5001. Those changes have been dropped — #5041 rewrites the same focus traversal and covers everything this branch did there, so keeping both would only produce a conflict. #5041 now closes #5001.

What remains here is a single file, `FluentDataGrid.razor.js`, which is self-contained and imports nothing from the anchored region module.

## Two defects, both in how focusable elements are matched across shadow boundaries

`getFocusableElements()` returns the `fluent-*` **host** whenever that host is itself focusable, and substitutes the host's shadow descendants only when the host has `tabIndex === -1`. Both halves of that were wrong in a different way.

**1. The host was collected, but the event origin is never the host.** The resize buttons in `ColumnResizeOptions.razor` set `tabindex="0"` explicitly, so the collected list holds hosts. `fluent-button` uses `delegatesFocus`, so `event.composedPath()[0]` is the inner `button.control` inside the shadow root — never the host. `indexOf()` returned `-1`, neither boundary matched, and the popup stayed open after focus had already left it.

`indexOfFocusableElement()` now walks up the composed tree from the event origin until it finds an element that is actually in the list, which works whichever side of the shadow boundary the collected element sits on. The last-element check is also guarded against `-1` so an empty list can no longer look like a boundary.

**2. Nested shadow descendants were dropped entirely.** When descending into a host's shadow root, only its **direct** children were considered. `fluent-button` happens to render `<button class="control">` at the top of its shadow root, so it survived — but `fluent-text-field` renders `<label>` and `<div class="root">`, both `tabindex="-1"`, with its real `input.control` one level further down inside that wrapper. The text field the popup renders in `Exact` resize mode was therefore never in the list at all, which produced two visible bugs:

- `Shift+Tab` out of the text field (the genuine first element) left the popup **open** with focus outside it — the exact symptom this PR is meant to fix.
- `Shift+Tab` on the *Set column widths* button closed the popup and jumped past the text field, because that button looked like the first element. The text field was unreachable going backwards.

The shadow root is now queried with the focusable selectors instead of only its direct children.

## 📑 Test Plan

```shell
node --check src/Core/Components/DataGrid/FluentDataGrid.razor.js
dotnet test tests/Core/Microsoft.FluentUI.AspNetCore.Components.Tests.csproj --filter FullyQualifiedName~DataGrid
```

The filtered test run passed: 52 tests, 0 failures.

No automated test covers the new behavior. The change is entirely in JS, the DataGrid bUnit tests run with mocked JS interop and never execute the module, and the repository has no JS test runner — so a test there would pass identically with and without this fix.

Verified instead by driving the real demo site in a browser and asserting on the **composed** active element (`document.activeElement` reports the host under `delegatesFocus`, so it has to be resolved through `shadowRoot.activeElement`).

`Discrete` mode, `/datagrid-typical`, **Bronze** column:

| Action | Popup | Composed focus |
| --- | --- | --- |
| Open resize | open | Shrink column width |
| `Tab` | open | Grow column width |
| `Tab` | open | Restore |
| `Tab` (last element) | **closed** | next column header button |
| `Shift+Tab` (first element) | **closed** | originating column header button |

`Exact` mode, `/datagrid-menu-header`, **Name** column:

| Action | Popup | Composed focus |
| --- | --- | --- |
| Open resize | open | Column width text field |
| `Tab` | open | Set column widths |
| `Tab` | open | Reset column widths |
| `Tab` (last element) | **closed** | next column header button |
| `Shift+Tab` from *Set column widths* | open | Column width text field |
| `Shift+Tab` (first element) | **closed** | originating column header button |

Before this change every one of those `Tab` presses left the popup open, except the `Shift+Tab` on *Set column widths*, which closed it and skipped the text field.

## Manual repro

Run the demo server with the **Run Demo Server** VS Code launch profile, or:

```bash
dotnet run --project examples/Demo/Server/FluentUI.Demo.Server.csproj --framework net9.0 --launch-profile FluentUI.Demo.Server
```

### Discrete resize

1. Open `http://localhost:5062/datagrid-typical`. This grid sets `ResizableColumns="true"`, `ResizeType="DataGridResizeType.Discrete"` and `HeaderCellAsButtonWithMenu="true"`.
2. `Tab` to the **Bronze** column header button and press `Enter` — it opens the `.col-resize` popup directly. (On the other columns, press `Enter` to open the menu and choose **Resize**.)
3. Press `Tab` three times to walk Shrink → Grow → Restore, then once more. Expected: the popup closes and focus advances to the next column header.
4. Reopen it and press `Shift+Tab` on the first button. Expected: the popup closes and focus returns to the originating header.

### Exact resize

5. Open `http://localhost:5062/datagrid-menu-header`, which sets `ResizeType="DataGridResizeType.Exact"`.
6. Open the **Name** column menu and choose **Resize**. Focus lands in the width text field.
7. Press `Shift+Tab`. Expected: the popup closes and focus returns to the header.
8. Reopen it, press `Tab` once to reach *Set column widths*, then `Shift+Tab`. Expected: focus returns to the text field and the popup stays open.

Before this change, steps 3, 4 and 7 left the popup open, and step 8 closed the popup and skipped the text field.

## Follow-up

`FluentDataGrid.razor.js` now carries its own copy of `getFocusableElements` / focusable-selector logic that duplicates the equivalent helpers in `FluentAnchoredRegion.razor.js`. Factoring out a shared module is a larger change than either bugfix warrants and is better handled as its own issue.
