### PR TITLE
[Dialog] Add DynamicDependency to prevent trimming

### DIFF
--- a/src/Core/Components/Dialog/ContentComponents/RenderFragmentDialog.razor.cs
+++ b/src/Core/Components/Dialog/ContentComponents/RenderFragmentDialog.razor.cs
@@ -1,0 +1,12 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+[method: DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(RenderFragmentDialog))]
+public partial class RenderFragmentDialog()
+{
+
+}


### PR DESCRIPTION
This pull request introduces a change to enhance compatibility with trimming tools by adding DynamicDependency attributes to a dialog component. This changes ensure that the public constructors of the component is preserved during trimming.

Enhancements for trimming compatibility:
* Added a new partial class `RenderFragmentDialog` with a `DynamicDependency` attribute to ensure its public constructors are preserved during build optimization. (`src/Core/Components/Dialog/ContentComponents/RenderFragmentDialog.razor.cs`)

Fix #5005 