### PR TITLE
[dev-v5][Popover] Fix positioning for RTL mode

### DIFF
--- a/src/Core.Scripts/src/Components/Popover/FluentPopover.ts
+++ b/src/Core.Scripts/src/Components/Popover/FluentPopover.ts
@@ -155,6 +155,15 @@ export namespace Microsoft.FluentUI.Blazor.Components.Popover {
       return val !== null ? Number(val) : 0;
     }
 
+    private get isRtl(): boolean {
+      if (!this.anchorEl) {
+        return document.documentElement.dir === 'rtl';
+      }
+
+      const computedDirection = getComputedStyle(this.anchorEl).direction;
+      return computedDirection === 'rtl' || document.documentElement.dir === 'rtl';
+    }
+
     private get nested(): boolean {
       const val = this.getAttribute('nested');
       return val !== null && val !== 'false';
@@ -173,7 +182,9 @@ export namespace Microsoft.FluentUI.Blazor.Components.Popover {
 
       this.startAnchorPositionObserver();
       this.dialog.showPopover();
-      this.adjustDialogPosition();
+      requestAnimationFrame(() => {
+        this.adjustDialogPosition();
+      });
       setTimeout(() => this.addEventsAfterOpening(), 0);
 
       // Reflect opened property and attribute
@@ -313,27 +324,39 @@ export namespace Microsoft.FluentUI.Blazor.Components.Popover {
 
       const spaceAbove = rect.top - viewportTop;
       const spaceBelow = viewportBottom - rect.bottom;
-      const spaceLeft = rect.right - viewportLeft;
-      const spaceRight = viewportRight - rect.left;
+      const spaceLeft = rect.left - viewportLeft;
+      const spaceRight = viewportRight - rect.right;
 
       // Position dialog above the target
       const positionDialogAbove = () => {
         this.dialog.style.top = `${rect.top - dialogHeight + viewportTop}px`;
+        this.dialog.style.bottom = 'auto';
       }
 
       // Position dialog below the target
       const positionDialogBelow = () => {
         this.dialog.style.top = `${rect.bottom + this.offsetVertical + viewportTop}px`;
+        this.dialog.style.bottom = 'auto';
       }
 
-      // Position dialog aligned left with the target
-      const positionDialogLeft = () => {
-        this.dialog.style.left = `${rect.left + this.offsetHorizontal + viewportLeft}px`;
+      // Position dialog aligned to the start edge of the target (left in LTR, right in RTL)
+      const positionDialogStart = () => {
+        const left = this.isRtl
+          ? rect.right - dialogWidth + this.offsetHorizontal + viewportLeft
+          : rect.left + this.offsetHorizontal + viewportLeft;
+
+        this.dialog.style.left = `${left}px`;
+        this.dialog.style.right = 'auto';
       }
 
-      // Position dialog aligned right with the target
-      const positionDialogRight = () => {
-        this.dialog.style.left = `${rect.left + rect.width - dialogWidth - this.offsetHorizontal + viewportLeft}px`;
+      // Position dialog aligned to the end edge of the target (right in LTR, left in RTL)
+      const positionDialogEnd = () => {
+        const left = this.isRtl
+          ? rect.left + this.offsetHorizontal + viewportLeft
+          : rect.right - dialogWidth + this.offsetHorizontal + viewportLeft;
+
+        this.dialog.style.left = `${left}px`;
+        this.dialog.style.right = 'auto';
       }
 
       if (spaceBelow >= dialogHeight) {
@@ -346,14 +369,27 @@ export namespace Microsoft.FluentUI.Blazor.Components.Popover {
         positionDialogBelow();
       }
 
-      if (spaceRight >= dialogWidth) {
-        positionDialogLeft();
-      }
-      else if (spaceLeft >= dialogWidth) {
-        positionDialogRight();
+      if (this.isRtl) {
+        if (spaceRight >= dialogWidth) {
+          positionDialogStart();
+        }
+        else if (spaceLeft >= dialogWidth) {
+          positionDialogEnd();
+        }
+        else {
+          positionDialogStart();
+        }
       }
       else {
-        positionDialogLeft();
+        if (spaceRight >= dialogWidth) {
+          positionDialogStart();
+        }
+        else if (spaceLeft >= dialogWidth) {
+          positionDialogEnd();
+        }
+        else {
+          positionDialogStart();
+        }
       }
     };
   }

--- a/src/Core.Scripts/src/Components/Popover/FluentPopover.ts
+++ b/src/Core.Scripts/src/Components/Popover/FluentPopover.ts
@@ -156,12 +156,11 @@ export namespace Microsoft.FluentUI.Blazor.Components.Popover {
     }
 
     private get isRtl(): boolean {
-      if (!this.anchorEl) {
+      const anchorEl = this.anchorEl;
+      if (!anchorEl) {
         return document.documentElement.dir === 'rtl';
       }
-
-      const computedDirection = getComputedStyle(this.anchorEl).direction;
-      return computedDirection === 'rtl' || document.documentElement.dir === 'rtl';
+      return getComputedStyle(anchorEl).direction === 'rtl';
     }
 
     private get nested(): boolean {
@@ -342,7 +341,7 @@ export namespace Microsoft.FluentUI.Blazor.Components.Popover {
       // Position dialog aligned to the start edge of the target (left in LTR, right in RTL)
       const positionDialogStart = () => {
         const left = this.isRtl
-          ? rect.right - dialogWidth + this.offsetHorizontal + viewportLeft
+          ? rect.right - this.dialog.offsetWidth + this.offsetHorizontal + viewportLeft
           : rect.left + this.offsetHorizontal + viewportLeft;
 
         this.dialog.style.left = `${left}px`;
@@ -353,7 +352,7 @@ export namespace Microsoft.FluentUI.Blazor.Components.Popover {
       const positionDialogEnd = () => {
         const left = this.isRtl
           ? rect.left + this.offsetHorizontal + viewportLeft
-          : rect.right - dialogWidth + this.offsetHorizontal + viewportLeft;
+          : rect.right - this.dialog.offsetWidth + this.offsetHorizontal + viewportLeft;
 
         this.dialog.style.left = `${left}px`;
         this.dialog.style.right = 'auto';
@@ -370,10 +369,10 @@ export namespace Microsoft.FluentUI.Blazor.Components.Popover {
       }
 
       if (this.isRtl) {
-        if (spaceRight >= dialogWidth) {
+        if (spaceLeft >= dialogWidth) {
           positionDialogStart();
         }
-        else if (spaceLeft >= dialogWidth) {
+        else if (spaceRight >= dialogWidth) {
           positionDialogEnd();
         }
         else {
@@ -381,10 +380,10 @@ export namespace Microsoft.FluentUI.Blazor.Components.Popover {
         }
       }
       else {
-        if (spaceRight >= dialogWidth) {
+        if (spaceLeft >= dialogWidth) {
           positionDialogStart();
         }
-        else if (spaceLeft >= dialogWidth) {
+        else if (spaceRight >= dialogWidth) {
           positionDialogEnd();
         }
         else {


### PR DESCRIPTION
Fix #5013 

The popover was not taking the correct RTL calculations for positioning the popover into account. This PR fixes that.

### Before
<img width="867" height="365" alt="image" src="https://github.com/user-attachments/assets/8a64e5db-0262-40d5-b1f5-12e0c0d5165b" />

### After
<img width="789" height="504" alt="image" src="https://github.com/user-attachments/assets/db2c1955-9382-417b-a228-3a134aad6da7" />
