### PR TITLE
[dev-v5][ValidationMessage] Fix displaying multiple messages on top of each other

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Forms/Forms.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Forms/Forms.md
@@ -19,7 +19,7 @@ By default the Fluent UI components render validation feedback using the library
 builder.Services.AddFluentUIComponents(config =>
 {
     // Default is false. Set to true to enable the browser's native constraint validation UI.
-    config.UseNativeConstraintValidationUi = true;
+    config.UseNativeConstraintValidationUI = true;
 });
 ```
 

--- a/src/Core/Components/Forms/FluentValidationMessage.razor
+++ b/src/Core/Components/Forms/FluentValidationMessage.razor
@@ -9,7 +9,7 @@
             Color="@Color.Error"
             @attributes="AdditionalAttributes">
     @foreach (var message in ValidationMessages)
-    {   <div class="fluent-validation-message-part" >
+    {   <div class="message" >
             @CreateIcon(Icon)
             @message
         </div>

--- a/src/Core/Components/Forms/FluentValidationMessage.razor
+++ b/src/Core/Components/Forms/FluentValidationMessage.razor
@@ -9,12 +9,10 @@
             Color="@Color.Error"
             @attributes="AdditionalAttributes">
     @foreach (var message in ValidationMessages)
-    {
-        @CreateIcon(Icon)
-        @message
-        @if (message != ValidationMessages.Last())
-        {
-            <br />
-        }
+    {   <div class="fluent-validation-message-part" >
+            @CreateIcon(Icon)
+            @message
+        </div>
+
     }
 </FluentText>

--- a/src/Core/Components/Forms/FluentValidationMessage.razor
+++ b/src/Core/Components/Forms/FluentValidationMessage.razor
@@ -9,7 +9,7 @@
             Color="@Color.Error"
             @attributes="AdditionalAttributes">
     @foreach (var message in ValidationMessages)
-    {   <div class="message" >
+    {   <div message >
             @CreateIcon(Icon)
             @message
         </div>

--- a/src/Core/Components/Forms/FluentValidationMessage.razor
+++ b/src/Core/Components/Forms/FluentValidationMessage.razor
@@ -2,15 +2,19 @@
 @inherits FluentComponentBase
 @typeparam TValue
 
-@foreach (var message in ValidationMessages)
-{
-    <FluentText slot="@FluentSlot.FieldMessage"
-                Class="@ClassValue"
-                Style="@StyleValue"
-                Size="@TextSize.Size200"
-                Color="@Color.Error"
-                @attributes="AdditionalAttributes">
+<FluentText slot="@FluentSlot.FieldMessage"
+            Class="@ClassValue"
+            Style="@StyleValue"
+            Size="@TextSize.Size200"
+            Color="@Color.Error"
+            @attributes="AdditionalAttributes">
+    @foreach (var message in ValidationMessages)
+    {
         @CreateIcon(Icon)
         @message
-    </FluentText>
-}
+        @if (message != ValidationMessages.Last())
+        {
+            <br />
+        }
+    }
+</FluentText>

--- a/src/Core/Components/Forms/FluentValidationMessage.razor.cs
+++ b/src/Core/Components/Forms/FluentValidationMessage.razor.cs
@@ -56,6 +56,7 @@ public partial class FluentValidationMessage<TValue> : FluentComponentBase
 
     /// <summary />
     protected string? StyleValue => DefaultStyleBuilder
+        .AddStyle("display", "inline-block")
         .Build();
 
     private IEnumerable<string> ValidationMessages => _hasFieldIdentifier

--- a/src/Core/Components/Forms/FluentValidationMessage.razor.cs
+++ b/src/Core/Components/Forms/FluentValidationMessage.razor.cs
@@ -56,7 +56,6 @@ public partial class FluentValidationMessage<TValue> : FluentComponentBase
 
     /// <summary />
     protected string? StyleValue => DefaultStyleBuilder
-        .AddStyle("display", "inline-block")
         .Build();
 
     private IEnumerable<string> ValidationMessages => _hasFieldIdentifier

--- a/src/Core/Components/Forms/FluentValidationMessage.razor.css
+++ b/src/Core/Components/Forms/FluentValidationMessage.razor.css
@@ -1,9 +1,4 @@
-.fluent-validation-message {
-  display: inline-block;
-  align-items: center;
-}
-
-.fluent-validation-message-part {
+.fluent-validation-message > .message {
   display: flex;
   align-items: center;
 }

--- a/src/Core/Components/Forms/FluentValidationMessage.razor.css
+++ b/src/Core/Components/Forms/FluentValidationMessage.razor.css
@@ -1,4 +1,9 @@
 .fluent-validation-message {
+  display: inline-block;
+  align-items: center;
+}
+
+.fluent-validation-message-part {
   display: flex;
   align-items: center;
 }

--- a/src/Core/Components/Forms/FluentValidationMessage.razor.css
+++ b/src/Core/Components/Forms/FluentValidationMessage.razor.css
@@ -1,4 +1,5 @@
-.fluent-validation-message > .message {
+.fluent-validation-message > div[message] {
   display: flex;
   align-items: center;
+  border: 1px dotted green;
 }


### PR DESCRIPTION
Fix #5008 by rendering the messages in a loop within a `fluent-text` instead of rendering a `fluent-text` per message in a loop

## Before
<img width="270" height="119" alt="image" src="https://github.com/user-attachments/assets/7f559f09-8bf7-40db-a042-4a898411d3f1" />


## After
<img width="409" height="253" alt="image" src="https://github.com/user-attachments/assets/56e40467-8f16-4805-9c58-851f0e52b12a" />
