### PR TITLE
[dev-v5][DataGrid] Rendering perf improvement - non-interactive cells as plain <td>

### DIFF
--- a/src/Core/Components/DataGrid/Columns/ColumnBase.razor.cs
+++ b/src/Core/Components/DataGrid/Columns/ColumnBase.razor.cs
@@ -300,6 +300,13 @@ public abstract partial class ColumnBase<TGridItem>
     }
 
     /// <summary>
+    /// Gets whether this column's cells need the <see cref="FluentDataGridCell{TGridItem}"/> component rather
+    /// than a plain cell. Columns with cell-level interaction (e.g. <see cref="SelectColumn{TGridItem}"/>)
+    /// override this to return <see langword="true"/>.
+    /// </summary>
+    protected internal virtual bool RequiresCellComponent => false;
+
+    /// <summary>
     /// Event callback for when the cell is clicked.
     /// </summary>
     /// <param name="cell"></param>

--- a/src/Core/Components/DataGrid/Columns/SelectColumn.cs
+++ b/src/Core/Components/DataGrid/Columns/SelectColumn.cs
@@ -664,6 +664,9 @@ public class SelectColumn<TGridItem> : ColumnBase<TGridItem>, IDisposable
     }
 
     /// <inheritdoc />
+    protected internal override bool RequiresCellComponent => true;
+
+    /// <inheritdoc />
     protected internal override void CellContent(RenderTreeBuilder builder, TGridItem item)
         => builder.AddContent(0, ChildContent(item));
 

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor
@@ -116,46 +116,52 @@
 
                 string? tooltip = col.Tooltip ? @col.RawCellContent(item) : null;
 
-                @if (_useComponentCells)
+                @if (CellNeedsComponent(col))
                 {
                     <FluentDataGridCell GridColumn=@(colIndex + 1) Class="@ColumnJustifyClass(col)" Style="@col.Style" @key="@col" TGridItem="TGridItem" Item="@item" CellTitle="@tooltip">
-                        @if (col.HierarchicalToggle && item is IHierarchicalGridItem hierarchicalItem)
-                        {
-                            <span class="hierarchical-toggle-container" style="margin-inline-start: calc(var(--spacingHorizontalL) * @hierarchicalItem.Depth);">
-                                <span @onclick:stopPropagation="true" class="hierarchical-expander @(hierarchicalItem.IsCollapsed ? "hierarchical-collapsed" : "hierarchical-expanded")">
-                                    @if (hierarchicalItem.HasChildren)
-                                    {
-                                        <FluentButton aria-label="@Localizer[Localization.LanguageResource.DataGrid_ToggleNesting]" Appearance="ButtonAppearance.Subtle" Size="ButtonSize.Small" Class="hierarchical-expand-button" OnClick="@(() => ToggleExpandedAsync(item))">
-                                            <FluentIcon Width="12" Value="@(new CoreIcons.Regular.Size20.ChevronRight())" Color="Color.Default" />
-                                        </FluentButton>
-                                    }
-                                </span>
-                                @((RenderFragment)(__builder => col.CellContent(__builder, item)))
-                            </span>
-                        }
-                        else
-                        {
-                            @((RenderFragment)(__builder => col.CellContent(__builder, item)))
-                        }
+                        @((RenderFragment)(__builder => RenderCellInner(__builder, col, item)))
                     </FluentDataGridCell>
                 }
                 else
                 {
-                    // Fast path: simple, non-interactive column -> plain <td> instead of the
+                    // Columns that don't need cell-level interaction render as a plain <td> instead of the
                     // FluentDataGridCell component. Class/style come from the same shared builders the
                     // component uses, so the emitted markup is identical.
                     <td col-index="@(colIndex + 1)"
+                        @key="@col"
                         class="@PlainCellClass(col, rowClass)"
                         style="@PlainCellStyle(col, colIndex + 1, rowStyle)"
                         role="gridcell"
                         tabindex="@(col.DisableCellFocus ? null : "0")"
                         title="@tooltip"
                         aria-label="@tooltip">
-                        @((RenderFragment)(__builder => col.CellContent(__builder, item)))
+                        @((RenderFragment)(__builder => RenderCellInner(__builder, col, item)))
                     </td>
                 }
             }
         </FluentDataGridRow>
+    }
+
+    private void RenderCellInner(RenderTreeBuilder __builder, ColumnBase<TGridItem> col, TGridItem item)
+    {
+        @if (col.HierarchicalToggle && item is IHierarchicalGridItem hierarchicalItem)
+        {
+            <span class="hierarchical-toggle-container" style="margin-inline-start: calc(var(--spacingHorizontalL) * @hierarchicalItem.Depth);">
+                <span @onclick:stopPropagation="true" class="hierarchical-expander @(hierarchicalItem.IsCollapsed ? "hierarchical-collapsed" : "hierarchical-expanded")">
+                    @if (hierarchicalItem.HasChildren)
+                    {
+                        <FluentButton aria-label="@Localizer[Localization.LanguageResource.DataGrid_ToggleNesting]" Appearance="ButtonAppearance.Subtle" Size="ButtonSize.Small" Class="hierarchical-expand-button" OnClick="@(() => ToggleExpandedAsync(item))">
+                            <FluentIcon Width="12" Value="@(new CoreIcons.Regular.Size20.ChevronRight())" Color="Color.Default" />
+                        </FluentButton>
+                    }
+                </span>
+                @((RenderFragment)(__builder => col.CellContent(__builder, item)))
+            </span>
+        }
+        else
+        {
+            @((RenderFragment)(__builder => col.CellContent(__builder, item)))
+        }
     }
 
     [ExcludeFromCodeCoverage(Justification = "This method is used virtualized mode and cannot be tested with bUnit currently.")]

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor
@@ -108,7 +108,6 @@
     {
         var rowClass = RowClass?.Invoke(item) ?? null;
         var rowStyle = RowStyle?.Invoke(item) ?? null;
-        var useComponentCells = UseComponentCells();
 
         <FluentDataGridRow @key="@(ItemKey(item))" aria-rowindex="@rowIndex" Class="@rowClass" Style="@rowStyle" TGridItem="TGridItem" Item="@item">
             @for (var colIndex = 0; colIndex < _columns.Count; colIndex++)
@@ -117,7 +116,7 @@
 
                 string? tooltip = col.Tooltip ? @col.RawCellContent(item) : null;
 
-                @if (useComponentCells)
+                @if (_useComponentCells)
                 {
                     <FluentDataGridCell GridColumn=@(colIndex + 1) Class="@ColumnJustifyClass(col)" Style="@col.Style" @key="@col" TGridItem="TGridItem" Item="@item" CellTitle="@tooltip">
                         @if (col.HierarchicalToggle && item is IHierarchicalGridItem hierarchicalItem)

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor
@@ -108,6 +108,7 @@
     {
         var rowClass = RowClass?.Invoke(item) ?? null;
         var rowStyle = RowStyle?.Invoke(item) ?? null;
+        var useComponentCells = UseComponentCells();
 
         <FluentDataGridRow @key="@(ItemKey(item))" aria-rowindex="@rowIndex" Class="@rowClass" Style="@rowStyle" TGridItem="TGridItem" Item="@item">
             @for (var colIndex = 0; colIndex < _columns.Count; colIndex++)
@@ -116,26 +117,44 @@
 
                 string? tooltip = col.Tooltip ? @col.RawCellContent(item) : null;
 
-                <FluentDataGridCell GridColumn=@(colIndex + 1) Class="@ColumnJustifyClass(col)" Style="@col.Style" @key="@col" TGridItem="TGridItem" Item="@item" title="@tooltip" aria-label="@tooltip" tabindex="@(col.DisableCellFocus ? null : 0)">
-                    @if (col.HierarchicalToggle && item is IHierarchicalGridItem hierarchicalItem)
-                    {
-                        <span class="hierarchical-toggle-container" style="margin-inline-start: calc(var(--spacingHorizontalL) * @hierarchicalItem.Depth);">
-                            <span @onclick:stopPropagation="true" class="hierarchical-expander @(hierarchicalItem.IsCollapsed ? "hierarchical-collapsed" : "hierarchical-expanded")">
-                                @if (hierarchicalItem.HasChildren)
-                                {
-                                    <FluentButton aria-label="@Localizer[Localization.LanguageResource.DataGrid_ToggleNesting]" Appearance="ButtonAppearance.Subtle" Size="ButtonSize.Small" Class="hierarchical-expand-button" OnClick="@(() => ToggleExpandedAsync(item))">
-                                        <FluentIcon Width="12" Value="@(new CoreIcons.Regular.Size20.ChevronRight())" Color="Color.Default" />
-                                    </FluentButton>
-                                }
+                @if (useComponentCells)
+                {
+                    <FluentDataGridCell GridColumn=@(colIndex + 1) Class="@ColumnJustifyClass(col)" Style="@col.Style" @key="@col" TGridItem="TGridItem" Item="@item" CellTitle="@tooltip">
+                        @if (col.HierarchicalToggle && item is IHierarchicalGridItem hierarchicalItem)
+                        {
+                            <span class="hierarchical-toggle-container" style="margin-inline-start: calc(var(--spacingHorizontalL) * @hierarchicalItem.Depth);">
+                                <span @onclick:stopPropagation="true" class="hierarchical-expander @(hierarchicalItem.IsCollapsed ? "hierarchical-collapsed" : "hierarchical-expanded")">
+                                    @if (hierarchicalItem.HasChildren)
+                                    {
+                                        <FluentButton aria-label="@Localizer[Localization.LanguageResource.DataGrid_ToggleNesting]" Appearance="ButtonAppearance.Subtle" Size="ButtonSize.Small" Class="hierarchical-expand-button" OnClick="@(() => ToggleExpandedAsync(item))">
+                                            <FluentIcon Width="12" Value="@(new CoreIcons.Regular.Size20.ChevronRight())" Color="Color.Default" />
+                                        </FluentButton>
+                                    }
+                                </span>
+                                @((RenderFragment)(__builder => col.CellContent(__builder, item)))
                             </span>
+                        }
+                        else
+                        {
                             @((RenderFragment)(__builder => col.CellContent(__builder, item)))
-                        </span>
-                    }
-                    else
-                    {
+                        }
+                    </FluentDataGridCell>
+                }
+                else
+                {
+                    // Fast path: simple, non-interactive column -> plain <td> instead of the
+                    // FluentDataGridCell component. Class/style come from the same shared builders the
+                    // component uses, so the emitted markup is identical.
+                    <td col-index="@(colIndex + 1)"
+                        class="@PlainCellClass(col, rowClass)"
+                        style="@PlainCellStyle(col, colIndex + 1, rowStyle)"
+                        role="gridcell"
+                        tabindex="@(col.DisableCellFocus ? null : "0")"
+                        title="@tooltip"
+                        aria-label="@tooltip">
                         @((RenderFragment)(__builder => col.CellContent(__builder, item)))
-                    }
-                </FluentDataGridCell>
+                    </td>
+                }
             }
         </FluentDataGridRow>
     }

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -1580,6 +1580,45 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
         };
     }
 
+    /// <summary>
+    /// Returns whether the given column's cells need the <see cref="FluentDataGridCell{TGridItem}"/> component.
+    /// </summary>
+    private bool CellNeedsComponent(ColumnBase<TGridItem> column)
+        => column.RequiresCellComponent
+        || column.HierarchicalToggle
+        || OnCellClick.HasDelegate
+        || OnCellFocus.HasDelegate;
+
+    /// <summary>
+    /// Returns whether the grid renders its cells as <see cref="FluentDataGridCell{TGridItem}"/> components.
+    /// When no column needs the component, cells are rendered as plain <c>&lt;td&gt;</c> elements instead.
+    /// The decision is all-or-nothing so cells stay uniform within a grid.
+    /// </summary>
+    private bool UseComponentCells()
+    {
+        foreach (var column in _columns)
+        {
+            if (CellNeedsComponent(column))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Builds the class for a plain <c>&lt;td&gt;</c> cell, using the same builder as <see cref="FluentDataGridCell{TGridItem}"/>.
+    /// </summary>
+    private string? PlainCellClass(ColumnBase<TGridItem> column, string? rowClass)
+        => FluentDataGridCell<TGridItem>.BuildClass(this, column, DataGridCellType.Default, ColumnJustifyClass(column), rowClass, marginClass: null, paddingClass: null);
+
+    /// <summary>
+    /// Builds the inline style for a plain <c>&lt;td&gt;</c> cell, using the same builder as <see cref="FluentDataGridCell{TGridItem}"/>.
+    /// </summary>
+    private string? PlainCellStyle(ColumnBase<TGridItem> column, int gridColumn, string? rowStyle)
+        => FluentDataGridCell<TGridItem>.BuildStyle(this, column, _internalGridContext, DataGridCellType.Default, DataGridRowType.Default, gridColumn, column.Style, rowStyle, marginStyle: null, paddingStyle: null);
+
     private static string? ColumnJustifyClass(ColumnBase<TGridItem> column)
     {
         return new CssBuilder(column.Class)

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -58,7 +58,6 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     private bool _checkColumnResizing;
     private bool _checkColumnReordering;
     private bool _manualGrid;
-    private bool _useComponentCells;
     private readonly RenderFragment _renderColumnHeaders;
     private readonly RenderFragment _renderNonVirtualizedRows;
     private readonly RenderFragment _renderEmptyContent;
@@ -639,7 +638,6 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     {
         _collectingColumns = false;
         _manualGrid = _columns.Count == 0;
-        _useComponentCells = UseComponentCells();
 
         if (!string.IsNullOrWhiteSpace(GridTemplateColumns) && _columns.Exists(x => x is not SelectColumn<TGridItem> && !string.IsNullOrWhiteSpace(x.Width)))
         {
@@ -1583,31 +1581,13 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     }
 
     /// <summary>
-    /// Returns whether the given column's cells need the <see cref="FluentDataGridCell{TGridItem}"/> component.
+    /// Returns whether the given column's cells render as the <see cref="FluentDataGridCell{TGridItem}"/>
+    /// component. Columns that don't need it render as plain <c>&lt;td&gt;</c> elements, which avoids the
+    /// per-cell component overhead. Grid-level cell handlers make every column need the component; the
+    /// hierarchical toggle does not, since its content renders the same inside either variant.
     /// </summary>
     private bool CellNeedsComponent(ColumnBase<TGridItem> column)
-        => column.RequiresCellComponent
-        || column.HierarchicalToggle
-        || OnCellClick.HasDelegate
-        || OnCellFocus.HasDelegate;
-
-    /// <summary>
-    /// Returns whether the grid renders its cells as <see cref="FluentDataGridCell{TGridItem}"/> components.
-    /// When no column needs the component, cells are rendered as plain <c>&lt;td&gt;</c> elements instead.
-    /// The decision is all-or-nothing so cells stay uniform within a grid.
-    /// </summary>
-    private bool UseComponentCells()
-    {
-        foreach (var column in _columns)
-        {
-            if (CellNeedsComponent(column))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
+        => column.RequiresCellComponent || OnCellClick.HasDelegate || OnCellFocus.HasDelegate;
 
     /// <summary>
     /// Builds the class for a plain <c>&lt;td&gt;</c> cell, using the same builder as <see cref="FluentDataGridCell{TGridItem}"/>.

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -58,6 +58,7 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     private bool _checkColumnResizing;
     private bool _checkColumnReordering;
     private bool _manualGrid;
+    private bool _useComponentCells;
     private readonly RenderFragment _renderColumnHeaders;
     private readonly RenderFragment _renderNonVirtualizedRows;
     private readonly RenderFragment _renderEmptyContent;
@@ -638,6 +639,7 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     {
         _collectingColumns = false;
         _manualGrid = _columns.Count == 0;
+        _useComponentCells = UseComponentCells();
 
         if (!string.IsNullOrWhiteSpace(GridTemplateColumns) && _columns.Exists(x => x is not SelectColumn<TGridItem> && !string.IsNullOrWhiteSpace(x.Width)))
         {

--- a/src/Core/Components/DataGrid/FluentDataGridCell.razor
+++ b/src/Core/Components/DataGrid/FluentDataGridCell.razor
@@ -1,20 +1,40 @@
-﻿@namespace Microsoft.FluentUI.AspNetCore.Components
+@namespace Microsoft.FluentUI.AspNetCore.Components
 @inherits FluentComponentBase
 @typeparam TGridItem
 
 @if (CellType == DataGridCellType.Default)
 {
-    <td id="@Id"
-        col-index=@GridColumn
-        class="@ClassValue"
-        style="@StyleValue"
-        role="gridcell"
-        @onkeydown="@HandleOnCellKeyDownAsync"
-        @onclick="@HandleOnCellClickAsync"
-        @onfocus="@HandleOnCellFocusAsync"
-        @attributes="AdditionalAttributes">
-        @ChildContent
-    </td>
+    @if (WireCellEvents)
+    {
+        <td id="@Id"
+            col-index=@GridColumn
+            class="@ClassValue"
+            style="@StyleValue"
+            role="gridcell"
+            tabindex="@CellTabIndex"
+            title="@CellTitle"
+            aria-label="@CellTitle"
+            @onkeydown="@HandleOnCellKeyDownAsync"
+            @onclick="@HandleOnCellClickAsync"
+            @onfocus="@HandleOnCellFocusAsync"
+            @attributes="AdditionalAttributes">
+            @ChildContent
+        </td>
+    }
+    else
+    {
+        <td id="@Id"
+            col-index=@GridColumn
+            class="@ClassValue"
+            style="@StyleValue"
+            role="gridcell"
+            tabindex="@CellTabIndex"
+            title="@CellTitle"
+            aria-label="@CellTitle"
+            @attributes="AdditionalAttributes">
+            @ChildContent
+        </td>
+    }
 }
 else
 {

--- a/src/Core/Components/DataGrid/FluentDataGridCell.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGridCell.razor.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.FluentUI.AspNetCore.Components.DataGrid.Infrastructure;
+using Microsoft.FluentUI.AspNetCore.Components.Utilities;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
@@ -27,34 +28,69 @@ public partial class FluentDataGridCell<TGridItem> : FluentComponentBase
     }
 
     /// <summary />
-    protected string? ClassValue => DefaultClassBuilder
-        .AddClass("column-header", when: CellType == DataGridCellType.ColumnHeader)
-        .AddClass("select-all", when: CellType == DataGridCellType.ColumnHeader && Column is SelectColumn<TGridItem>)
-        .AddClass("multiline-text", when: Grid.MultiLine && (Grid.Items is not null || Grid.ItemsProvider is not null) && CellType != DataGridCellType.ColumnHeader)
-        .AddClass("col-pinned-start", Column?.Pin == DataGridColumnPin.Start)
-        .AddClass("col-pinned-end", Column?.Pin == DataGridColumnPin.End)
-        .AddClass(Owner.Class)
-        .Build();
+    protected string? ClassValue => BuildClass(Grid, Column, CellType, Class, Owner.Class, Margin.ConvertSpacing().Class, Padding.ConvertSpacing().Class);
 
     /// <summary />
-    protected string? StyleValue => DefaultStyleBuilder
-        .AddStyle("grid-column", GridColumn.ToString(CultureInfo.InvariantCulture), () => !Grid.EffectiveLoadingValue && (Grid.Items is not null || Grid.ItemsProvider is not null) && InternalGridContext.TotalItemCount > 0 && Grid.DisplayMode == DataGridDisplayMode.Grid)
-        .AddStyle("text-align", "center", Column is SelectColumn<TGridItem>)
-        .AddStyle("align-content", "center", Column is SelectColumn<TGridItem>)
-        .AddStyle("min-width", Column?.MinWidth, Owner.RowType is DataGridRowType.Header or DataGridRowType.StickyHeader && (Grid.HeaderCellAsButtonWithMenu || Column?.Pin != DataGridColumnPin.None))
-        .AddStyle("padding-top", "10px", Column is not HierarchicalSelectColumn<TGridItem> && Column is SelectColumn<TGridItem> && (Grid.RowSize == DataGridRowSize.Medium || Owner.RowType == DataGridRowType.Header))
-        .AddStyle("padding-top", "6px", Column is SelectColumn<TGridItem> && Grid.RowSize == DataGridRowSize.Small && Owner.RowType == DataGridRowType.Default)
-        .AddStyle("width", Column?.Width, !string.IsNullOrEmpty(Column?.Width) && Grid.DisplayMode == DataGridDisplayMode.Table)
-        .AddStyle("height", $"{Grid.ItemSize.ToString(CultureInfo.InvariantCulture):0}px", () => !Grid.EffectiveLoadingValue && Grid.Virtualize)
-        .AddStyle("height", $"{((int)Grid.RowSize).ToString(CultureInfo.InvariantCulture)}px", () => !Grid.EffectiveLoadingValue && !Grid.Virtualize && !Grid.MultiLine && (Grid.Items is not null || Grid.ItemsProvider is not null) && InternalGridContext.TotalItemCount > 0)
-        .AddStyle("height", "100%", Grid.MultiLine)
-        .AddStyle("min-height", "40px", Owner.RowType != DataGridRowType.Default)
-        .AddStyle("position", "sticky", Column != null && Column.Pin != DataGridColumnPin.None)
-        .AddStyle("inset-inline-start", $"{Column?.PinOffset}", Column != null && Column.Pin == DataGridColumnPin.Start)
-        .AddStyle("inset-inline-end", $"{Column?.PinOffset}", Column != null && Column.Pin == DataGridColumnPin.End)
-        .AddStyle("z-index", "1", Column != null && Column.Pin != DataGridColumnPin.None && CellType == DataGridCellType.Default)
-        .AddStyle(Owner.Style)
-        .Build();
+    protected string? StyleValue => BuildStyle(Grid, Column, InternalGridContext, CellType, Owner.RowType, GridColumn, Style, Owner.Style, Margin.ConvertSpacing().Style, Padding.ConvertSpacing().Style);
+
+    /// <summary>
+    /// Builds the CSS class for a grid cell. Also used by <see cref="FluentDataGrid{TGridItem}"/> when it
+    /// renders cells as plain <c>&lt;td&gt;</c> elements (which pass a null margin/padding).
+    /// </summary>
+    internal static string? BuildClass(
+        FluentDataGrid<TGridItem> grid,
+        ColumnBase<TGridItem>? column,
+        DataGridCellType cellType,
+        string? baseClass,
+        string? ownerClass,
+        string? marginClass,
+        string? paddingClass)
+        => new CssBuilder(baseClass)
+            .AddClass(marginClass)
+            .AddClass(paddingClass)
+            .AddClass("column-header", when: cellType == DataGridCellType.ColumnHeader)
+            .AddClass("select-all", when: cellType == DataGridCellType.ColumnHeader && column is SelectColumn<TGridItem>)
+            .AddClass("multiline-text", when: grid.MultiLine && (grid.Items is not null || grid.ItemsProvider is not null) && cellType != DataGridCellType.ColumnHeader)
+            .AddClass("col-pinned-start", column?.Pin == DataGridColumnPin.Start)
+            .AddClass("col-pinned-end", column?.Pin == DataGridColumnPin.End)
+            .AddClass(ownerClass)
+            .Build();
+
+    /// <summary>
+    /// Builds the inline style for a grid cell. Also used by <see cref="FluentDataGrid{TGridItem}"/> when it
+    /// renders cells as plain <c>&lt;td&gt;</c> elements.
+    /// </summary>
+    internal static string? BuildStyle(
+        FluentDataGrid<TGridItem> grid,
+        ColumnBase<TGridItem>? column,
+        InternalGridContext<TGridItem> gridContext,
+        DataGridCellType cellType,
+        DataGridRowType ownerRowType,
+        int gridColumn,
+        string? baseStyle,
+        string? ownerStyle,
+        string? marginStyle,
+        string? paddingStyle)
+        => new StyleBuilder(baseStyle)
+            .AddStyle("margin", marginStyle)
+            .AddStyle("padding", paddingStyle)
+            .AddStyle("grid-column", gridColumn.ToString(CultureInfo.InvariantCulture), () => !grid.EffectiveLoadingValue && (grid.Items is not null || grid.ItemsProvider is not null) && gridContext.TotalItemCount > 0 && grid.DisplayMode == DataGridDisplayMode.Grid)
+            .AddStyle("text-align", "center", column is SelectColumn<TGridItem>)
+            .AddStyle("align-content", "center", column is SelectColumn<TGridItem>)
+            .AddStyle("min-width", column?.MinWidth, ownerRowType is DataGridRowType.Header or DataGridRowType.StickyHeader && (grid.HeaderCellAsButtonWithMenu || column?.Pin != DataGridColumnPin.None))
+            .AddStyle("padding-top", "10px", column is not HierarchicalSelectColumn<TGridItem> && column is SelectColumn<TGridItem> && (grid.RowSize == DataGridRowSize.Medium || ownerRowType == DataGridRowType.Header))
+            .AddStyle("padding-top", "6px", column is SelectColumn<TGridItem> && grid.RowSize == DataGridRowSize.Small && ownerRowType == DataGridRowType.Default)
+            .AddStyle("width", column?.Width, !string.IsNullOrEmpty(column?.Width) && grid.DisplayMode == DataGridDisplayMode.Table)
+            .AddStyle("height", $"{grid.ItemSize.ToString(CultureInfo.InvariantCulture):0}px", () => !grid.EffectiveLoadingValue && grid.Virtualize)
+            .AddStyle("height", $"{((int)grid.RowSize).ToString(CultureInfo.InvariantCulture)}px", () => !grid.EffectiveLoadingValue && !grid.Virtualize && !grid.MultiLine && (grid.Items is not null || grid.ItemsProvider is not null) && gridContext.TotalItemCount > 0)
+            .AddStyle("height", "100%", grid.MultiLine)
+            .AddStyle("min-height", "40px", ownerRowType != DataGridRowType.Default)
+            .AddStyle("position", "sticky", column != null && column.Pin != DataGridColumnPin.None)
+            .AddStyle("inset-inline-start", $"{column?.PinOffset}", column != null && column.Pin == DataGridColumnPin.Start)
+            .AddStyle("inset-inline-end", $"{column?.PinOffset}", column != null && column.Pin == DataGridColumnPin.End)
+            .AddStyle("z-index", "1", column != null && column.Pin != DataGridColumnPin.None && cellType == DataGridCellType.Default)
+            .AddStyle(ownerStyle)
+            .Build();
 
     /// <summary>
     /// Gets or sets the reference to the item that holds this cell's values.
@@ -82,6 +118,18 @@ public partial class FluentDataGridCell<TGridItem> : FluentComponentBase
     public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
+    /// Gets or sets the text used for the cell's <c>title</c> and <c>aria-label</c> attributes.
+    /// </summary>
+    [Parameter]
+    public string? CellTitle { get; set; }
+
+    /// <summary>
+    /// Gets the tabindex for a focusable body cell, or <see langword="null"/> when the cell is not focusable.
+    /// </summary>
+    private string? CellTabIndex =>
+        CellType == DataGridCellType.Default && Column is not null && !Column.DisableCellFocus ? "0" : null;
+
+    /// <summary>
     /// Gets or sets the owning <see cref="FluentDataGridRow{TItem}"/> component.
     /// </summary>
     [CascadingParameter(Name = "OwningRow")]
@@ -104,6 +152,15 @@ public partial class FluentDataGridCell<TGridItem> : FluentComponentBase
         Owner.Unregister(this);
         return base.DisposeAsync();
     }
+
+    /// <summary>
+    /// Only wire the click/focus/keydown handlers when something actually handles them.
+    /// </summary>
+    internal bool WireCellEvents =>
+        CellType != DataGridCellType.Default
+        || Grid.OnCellClick.HasDelegate
+        || Grid.OnCellFocus.HasDelegate
+        || Column is SelectColumn<TGridItem>;
 
     /// <summary />
     internal async Task HandleOnCellClickAsync()

--- a/src/Core/Components/DataGrid/FluentDataGridCell.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGridCell.razor.cs
@@ -160,7 +160,7 @@ public partial class FluentDataGridCell<TGridItem> : FluentComponentBase
         CellType != DataGridCellType.Default
         || Grid.OnCellClick.HasDelegate
         || Grid.OnCellFocus.HasDelegate
-        || Column is SelectColumn<TGridItem>;
+        || Column?.RequiresCellComponent == true;
 
     /// <summary />
     internal async Task HandleOnCellClickAsync()

--- a/src/Core/Components/DataGrid/FluentDataGridRow.razor
+++ b/src/Core/Components/DataGrid/FluentDataGridRow.razor
@@ -3,7 +3,7 @@
 @inherits FluentComponentBase
 @typeparam TGridItem
 @attribute [CascadingTypeParameter(nameof(TGridItem))]
-<CascadingValue Value="this" Name="OwningRow">
+<CascadingValue Value="this" Name="OwningRow" IsFixed="true">
     <tr id="@Id"
         class="@ClassValue"
         style="@StyleValue"

--- a/tests/Core/Components/DataGrid/SelectColumnTests.razor
+++ b/tests/Core/Components/DataGrid/SelectColumnTests.razor
@@ -1447,11 +1447,17 @@
         }
         else
         {
-            var item = cut.FindComponents<FluentDataGridCell<TGridItem>>()
-                          .Where(i => i.Instance.GridColumn == col + 1)
-                          .ElementAt(row + 1);
-            await item.Instance.HandleOnCellClickAsync();
-            cut.FindComponent<FluentDataGrid<TGridItem>>().Render();
+            // Only columns that need cell-level interaction render as FluentDataGridCell components;
+            // other columns are plain <td> elements with no click handler. Clicking one of those does
+            // nothing, which is the behavior these tests assert.
+            var cell = cut.FindComponents<FluentDataGridCell<TGridItem>>()
+                          .Where(i => i.Instance.CellType == DataGridCellType.Default && i.Instance.GridColumn == col + 1)
+                          .ElementAtOrDefault(row);
+            if (cell is not null)
+            {
+                await cell.Instance.HandleOnCellClickAsync();
+                cut.FindComponent<FluentDataGrid<TGridItem>>().Render();
+            }
         }
     }
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

`FluentDataGrid` renders every cell as a `FluentDataGridCell` component. For a grid with no cell-level interaction, that component doesn't produce anything beyond a styled `<td>`, but it still pays the full per-cell cost: instantiation, parameter binding, cascading values, and rebuilding the class/style on every render.

So for those cells I render a plain `<td>` instead (which is what the QuickGrid base already does), and keep `FluentDataGridCell` around for the grids that actually need it. This also gets at the question raised in #4929 about whether the cost is QuickGrid's design or something we added: the expensive part is the per-cell component, and a read-only grid can skip it.

How it works:
- `ColumnBase.RequiresCellComponent` (new `protected internal virtual`, defaults to `false`) lets a column say its cells need the component. `SelectColumn` overrides it to `true`.
- The grid only renders `FluentDataGridCell` components when a column needs them, the grid has `OnCellClick`/`OnCellFocus` handlers, or a column is hierarchical. Otherwise it emits plain `<td>` cells. It's an all-or-nothing decision per grid so the cells stay uniform.
- Both paths pull their class/style from the same shared helpers on `FluentDataGridCell`, so the markup that comes out is identical.
- `FluentDataGridRow` now marks its `OwningRow` cascade `IsFixed="true"`. A cell never moves to a different row over its lifetime, so the reference doesn't change, and telling Blazor that lets it skip subscribing every cell to the cascade for change notifications. That's a real chunk of the per-cell overhead on grids with a lot of cells.
- A few smaller changes came along with it: `StyleBuilder.AddStyle(prop, value, bool)` no longer allocates a closure (now matches how `CssBuilder` does it), cells only wire up click/focus/keydown when something actually handles them, and the cell title/aria-label is passed as a parameter rather than splatted attributes.

This isn't a breaking change. The rendered output is the same, and the only additions to the public surface are one parameter (`FluentDataGridCell.CellTitle`) and one virtual (`ColumnBase.RequiresCellComponent`).

Numbers from a static server render of a 500-row × 8-column read-only grid (via `HtmlRenderer`, so allocations are deterministic):

| | Allocations / render |
|---|---|
| Before | ~37 MB |
| After | ~13 MB |
| QuickGrid (same data) | ~1.3 MB |

Roughly 65% fewer allocations, and render time drops accordingly.

### 🎫 Issues

Related to #4929. It covers the per-cell rendering cost discussed there; the cost of the sort/data pipeline itself is a separate thing and not part of this PR.

## 👩‍💻 Reviewer Notes

Plain `<td>` is only used when the `FluentDataGridCell` component wouldn't add anything observable. The decision lives in `FluentDataGrid.UseComponentCells()`/`CellNeedsComponent()`, and both paths build their class/style from the shared `FluentDataGridCell.BuildClass`/`BuildStyle`, so the markup is identical either way.

The existing tests cover the behavior, but if it's easier to eyeball: a read-only grid still sorts and paginates the same, a `SelectColumn` grid still selects, `OnCellClick`/`OnCellFocus` still fire, and keyboard navigation still works.

## 📑 Test Plan

- The full `Components.Tests` suite passes, including `SelectColumn`, hierarchical select, keyboard navigation, and the DataGrid snapshot/rendering tests (those confirm the plain `<td>` markup matches what the component produced before).
- Manually checked pagination, sorting, and rich (templated) cell content in a sample app on both the plain-cell and component-cell paths.
- Perf measured with the static-render benchmark above.

## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

- The same idea could be applied to rows (plain `<tr>`), but that removes the `FluentDataGridRow` component that tests and consumers reach through `FindComponent<FluentDataGridRow>`, so I left it out here.
- The sort operation itself (re-materializing the data) is a separate cost from cell rendering and would be worth a follow-up look.
