### PR TITLE
[NavItem] Remove Href when item is disabled

### DIFF
--- a/src/Core/Components/Nav/FluentNavItem.razor
+++ b/src/Core/Components/Nav/FluentNavItem.razor
@@ -32,6 +32,7 @@ else
             title="@Tooltip"
             target="@Target.ToAttributeValue()"
             rel="@(Target is not null ? RelNoOpenerNoReferrer : string.Empty)"
+            disabled="@Disabled"
             @onclick="OnClickHandlerAsync"
             @attributes="@AdditionalAttributes">
         @RenderIcon

--- a/src/Core/Components/Nav/FluentNavItem.razor
+++ b/src/Core/Components/Nav/FluentNavItem.razor
@@ -2,7 +2,7 @@
 @using Microsoft.FluentUI.AspNetCore.Components.Extensions
 @inherits FluentNavBase
 
-@if (!string.IsNullOrEmpty(Href))
+@if (!string.IsNullOrEmpty(Href) && !Disabled)
 {
     <NavLink fuib
              id="@Id"

--- a/tests/Core/Components/Nav/FluentNavItemTests.FluentNavItem_Disabled_Rendering.verified.razor.html
+++ b/tests/Core/Components/Nav/FluentNavItemTests.FluentNavItem_Disabled_Rendering.verified.razor.html
@@ -1,0 +1,16 @@
+<html>
+	<head></head>
+	<body>
+		<nav id="xxx" role="navigation" class="fluent-nav">
+			<a fuib="" id="xxx" tabindex="-1" href="#" rel="" blazor:onclick="x" class="fluent-navitem">
+				<span style="width: 20px;"></span>
+				Test Item 1</a>
+			<button fuib="" id="xxx" tabindex="-1" class="fluent-navitem disabled" href="#" rel="" disabled="" blazor:onclick="x">
+				<span style="width: 20px;"></span>
+				Test Item 2</button>
+			<button fuib="" id="xxx" tabindex="-1" class="fluent-navitem" rel="" blazor:onclick="x">
+				<span style="width: 20px;"></span>
+				Test Item 3</button>
+		</nav>
+	</body>
+</html>

--- a/tests/Core/Components/Nav/FluentNavItemTests.razor
+++ b/tests/Core/Components/Nav/FluentNavItemTests.razor
@@ -839,4 +839,20 @@
 		Assert.NotNull(clickedItem);
 		Assert.Equal("sub-item", clickedItem.Id);
 	}
+
+    [Fact]
+	public void FluentNavItem_Disabled_Rendering()
+	{
+        // Act
+		var cut = Render(@<FluentNav>
+                <FluentNavItem Href="#">Test Item 1</FluentNavItem>
+				<FluentNavItem Href="#" Disabled="true">Test Item 2</FluentNavItem>
+                <FluentNavItem>Test Item 3</FluentNavItem>
+			</FluentNav>);
+
+		// Assert
+		Assert.NotNull(cut);
+
+		cut.Verify();
+	}
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR removes the rendering of anchor tags when the `Disabled` parameter is set in `FluentNavItem`. Now the UI will render the button approach without any active `href` instead.

### 🎫 Issues

Fixes #5020 

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
