### PR TITLE
[dev-v5][DataGrid] Add lazy-loaded RowDetails example

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DataGrid/Examples/DataGridMasterDetailLazy.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DataGrid/Examples/DataGridMasterDetailLazy.razor
@@ -4,7 +4,7 @@
         background: var(--colorNeutralBackground2);
     }
 
-    .detail-spinner {
+    .lazy-loaded-detail .detail-spinner {
         margin: 1rem 0;
     }
 </style>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DataGrid/Examples/DataGridMasterDetailLazy.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DataGrid/Examples/DataGridMasterDetailLazy.razor
@@ -1,0 +1,64 @@
+<style>
+    .row-details-cell {
+        padding: 1rem 1rem 1rem 2.5rem;
+        background: var(--colorNeutralBackground2);
+    }
+</style>
+
+<FluentDataGrid TGridItem="Customer" Items="@customers" ShowHover="true" OnRowDetailsToggle="@OnRowDetailsToggleAsync">
+    <ChildContent>
+        <PropertyColumn Title="Customer" Property="@(c => c.Name)" Sortable="true" />
+        <PropertyColumn Title="City" Property="@(c => c.City)" Sortable="true" />
+    </ChildContent>
+    <RowDetails Context="customer">
+        @if (!ordersByCustomerId.TryGetValue(customer.Id, out var orders))
+        {
+            <FluentStack HorizontalAlignment="HorizontalAlignment.Center">
+                <FluentSpinner Size="SpinnerSize.Medium" />
+            </FluentStack>
+        }
+        else
+        {
+            <FluentDataGrid Items="@orders" ShowHover="true">
+                <PropertyColumn Title="Order #" Property="@(o => o.OrderNumber)" />
+                <PropertyColumn Title="Date" Property="@(o => o.OrderDate)" Format="yyyy-MM-dd" />
+                <PropertyColumn Title="Amount" Property="@(o => o.Amount)" Format="c" Align="DataGridCellAlignment.End" />
+            </FluentDataGrid>
+        }
+    </RowDetails>
+</FluentDataGrid>
+
+@code {
+    private record Customer(int Id, string Name, string City);
+    private record Order(string OrderNumber, DateTime OrderDate, decimal Amount);
+
+    // A missing entry means "not loaded yet" for that customer, so the RowDetails template shows the spinner
+    private readonly Dictionary<int, IQueryable<Order>> ordersByCustomerId = [];
+
+    private IQueryable<Customer> customers = new List<Customer>
+    {
+        new(1, "Contoso Ltd.", "Seattle"),
+        new(2, "Fabrikam, Inc.", "Paris"),
+        new(3, "Northwind Traders", "London"),
+    }.AsQueryable();
+
+    // OnRowDetailsToggle fires as soon as the row expands, so the grid can already render the RowDetails
+    // template (showing the spinner) while this handler is still fetching data in the background.
+    private async Task OnRowDetailsToggleAsync(Customer customer)
+    {
+        if (ordersByCustomerId.ContainsKey(customer.Id))
+        {
+            return;
+        }
+
+        // Simulates a network call to fetch this customer's orders
+        await Task.Delay(1500);
+
+        ordersByCustomerId[customer.Id] = customer.Id switch
+        {
+            1 => new List<Order> { new("ORD-1001", new DateTime(2026, 5, 12), 1250.00m), new("ORD-1002", new DateTime(2026, 6, 3), 480.50m) }.AsQueryable(),
+            2 => new List<Order> { new("ORD-2001", new DateTime(2026, 4, 21), 3200.00m) }.AsQueryable(),
+            _ => new List<Order> { new("ORD-3001", new DateTime(2026, 6, 10), 2100.00m) }.AsQueryable(),
+        };
+    }
+}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DataGrid/Examples/DataGridMasterDetailLazy.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DataGrid/Examples/DataGridMasterDetailLazy.razor
@@ -9,28 +9,30 @@
     }
 </style>
 
-<FluentDataGrid TGridItem="Customer" Items="@customers" ShowHover="true" OnRowDetailsToggle="@OnRowDetailsToggleAsync">
-    <ChildContent>
-        <PropertyColumn Title="Customer" Property="@(c => c.Name)" Sortable="true" />
-        <PropertyColumn Title="City" Property="@(c => c.City)" Sortable="true" />
-    </ChildContent>
-    <RowDetails Context="customer">
-        @if (!ordersByCustomerId.TryGetValue(customer.Id, out var orders))
-        {
-            <FluentStack Class="detail-spinner" HorizontalAlignment="HorizontalAlignment.Center">
-                <FluentSpinner Size="SpinnerSize.Medium" />
-            </FluentStack>
-        }
-        else
-        {
-            <FluentDataGrid Items="@orders" ShowHover="true">
-                <PropertyColumn Title="Order #" Property="@(o => o.OrderNumber)" />
-                <PropertyColumn Title="Date" Property="@(o => o.OrderDate)" Format="yyyy-MM-dd" />
-                <PropertyColumn Title="Amount" Property="@(o => o.Amount)" Format="c" Align="DataGridCellAlignment.End" />
-            </FluentDataGrid>
-        }
-    </RowDetails>
-</FluentDataGrid>
+<div class="lazy-loaded-detail">
+    <FluentDataGrid TGridItem="Customer" Items="@customers" ShowHover="true" OnRowDetailsToggle="@OnRowDetailsToggleAsync">
+        <ChildContent>
+            <PropertyColumn Title="Customer" Property="@(c => c.Name)" Sortable="true" />
+            <PropertyColumn Title="City" Property="@(c => c.City)" Sortable="true" />
+        </ChildContent>
+        <RowDetails Context="customer">
+            @if (!ordersByCustomerId.TryGetValue(customer.Id, out var orders))
+            {
+                <FluentStack Class="detail-spinner" HorizontalAlignment="HorizontalAlignment.Center">
+                    <FluentSpinner Size="SpinnerSize.Medium" />
+                </FluentStack>
+            }
+            else
+            {
+                <FluentDataGrid Items="@orders" ShowHover="true">
+                    <PropertyColumn Title="Order #" Property="@(o => o.OrderNumber)" />
+                    <PropertyColumn Title="Date" Property="@(o => o.OrderDate)" Format="yyyy-MM-dd" />
+                    <PropertyColumn Title="Amount" Property="@(o => o.Amount)" Format="c" Align="DataGridCellAlignment.End" />
+                </FluentDataGrid>
+            }
+        </RowDetails>
+    </FluentDataGrid>
+</div>
 
 @code {
     private record Customer(int Id, string Name, string City);

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DataGrid/Examples/DataGridMasterDetailLazy.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DataGrid/Examples/DataGridMasterDetailLazy.razor
@@ -3,6 +3,10 @@
         padding: 1rem 1rem 1rem 2.5rem;
         background: var(--colorNeutralBackground2);
     }
+
+    .detail-spinner {
+        margin: 1rem 0;
+    }
 </style>
 
 <FluentDataGrid TGridItem="Customer" Items="@customers" ShowHover="true" OnRowDetailsToggle="@OnRowDetailsToggleAsync">
@@ -13,7 +17,7 @@
     <RowDetails Context="customer">
         @if (!ordersByCustomerId.TryGetValue(customer.Id, out var orders))
         {
-            <FluentStack HorizontalAlignment="HorizontalAlignment.Center">
+            <FluentStack Class="detail-spinner" HorizontalAlignment="HorizontalAlignment.Center">
                 <FluentSpinner Size="SpinnerSize.Medium" />
             </FluentStack>
         }

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DataGrid/Pages/DataGridMasterDetailPage.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DataGrid/Pages/DataGridMasterDetailPage.md
@@ -47,3 +47,15 @@ Each level filters its own child grid with its own row item (the `Context` of ea
 `customer`, then `order` — to avoid ambiguity between the nested templates).
 
 {{ DataGridMasterDetailTwoLevels Files=Code:DataGridMasterDetailTwoLevels.razor }}
+
+## Lazy-loaded detail
+
+The examples above keep every row's detail data in memory up front. For data that's expensive to fetch, use
+`OnRowDetailsToggle` to load it on demand instead: the grid renders the `RowDetails` template as soon as a row
+expands — showing a spinner while the item isn't loaded yet — and re-renders it once the callback populates the
+data, without blocking the row from expanding while the load is in progress.
+
+In this example, expanding a customer for the first time shows a spinner for 1.5 seconds (simulating a network
+call) before its orders appear. Expanding it again afterwards shows the cached orders immediately.
+
+{{ DataGridMasterDetailLazy Files=Code:DataGridMasterDetailLazy.razor }}

--- a/tests/Core/Components/DataGrid/FluentDataGridRowDetailsTests.razor
+++ b/tests/Core/Components/DataGrid/FluentDataGridRowDetailsTests.razor
@@ -170,6 +170,86 @@
     }
 
     [Fact]
+    public async Task FluentDataGrid_RowDetails_Row_Appears_Before_Async_OnRowDetailsToggle_CompletesAsync()
+    {
+        // Arrange: an OnRowDetailsToggle handler that suspends on an incomplete Task, simulating a lazy load
+        var tcs = new TaskCompletionSource();
+        var cut = Render<FluentDataGrid<Customer>>(
+            @<FluentDataGrid Items="@GetCustomers().AsQueryable()" ItemKey="@(c => c.Id)" OnRowDetailsToggle="@((Customer c) => tcs.Task)">
+                <ChildContent>
+                    <PropertyColumn Property="@(x => x.Name)" />
+                </ChildContent>
+                <RowDetails>
+                    <p>details of @context.Name</p>
+                </RowDetails>
+            </FluentDataGrid>);
+
+        // Act: click the toggle; the handler suspends immediately on the incomplete task
+        await cut.InvokeAsync(() => cut.Find(".row-expand-button").Click());
+
+        // Assert: the details row (and whatever placeholder RowDetails renders while data is loading)
+        // must already be visible while the handler is still pending, not only once it completes.
+        Assert.NotEmpty(cut.FindAll("tr.row-details-row"));
+
+        // Cleanup: let the pending handler complete
+        tcs.SetResult();
+        await cut.InvokeAsync(() => Task.CompletedTask);
+    }
+
+    [Fact]
+    public async Task FluentDataGrid_RowDetails_Supports_Lazy_Loading_With_Spinner_PlaceholderAsync()
+    {
+        // Arrange: RowDetails shows a spinner until OnRowDetailsToggle populates the per-item cache,
+        // matching the lazy-loading pattern from the feature request.
+        var tcs = new TaskCompletionSource();
+        Dictionary<int, string?> loadedDetails = [];
+
+        async Task OnToggleAsync(Customer c)
+        {
+            if (!loadedDetails.ContainsKey(c.Id))
+            {
+                loadedDetails[c.Id] = null; // triggers the spinner branch on the next render
+                await tcs.Task;
+                loadedDetails[c.Id] = $"loaded details of {c.Name}";
+            }
+        }
+
+        var cut = Render<FluentDataGrid<Customer>>(
+            @<FluentDataGrid Items="@GetCustomers().AsQueryable()" ItemKey="@(c => c.Id)" OnRowDetailsToggle="@((Customer c) => OnToggleAsync(c))">
+                <ChildContent>
+                    <PropertyColumn Property="@(x => x.Name)" />
+                </ChildContent>
+                <RowDetails Context="customer">
+                    @if (loadedDetails.TryGetValue(customer.Id, out var loaded) && loaded is not null)
+                    {
+                        <p class="loaded">@loaded</p>
+                    }
+                    else
+                    {
+                        <p class="spinner">loading...</p>
+                    }
+                </RowDetails>
+            </FluentDataGrid>);
+
+        // Act: expand the row; the handler suspends on the incomplete task
+        await cut.InvokeAsync(() => cut.Find(".row-expand-button").Click());
+
+        // Assert: the spinner placeholder shows first, before the async load completes
+        Assert.NotEmpty(cut.FindAll("p.spinner"));
+        Assert.Empty(cut.FindAll("p.loaded"));
+
+        // Act: complete the pending load
+        tcs.SetResult();
+
+        // Assert: the row now shows the loaded content instead of the spinner
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Empty(cut.FindAll("p.spinner"));
+            Assert.Contains("loaded details of Denis Voituron", cut.Find("p.loaded").TextContent);
+        });
+    }
+
+    [Fact]
     public void FluentDataGrid_RowDetails_With_Virtualize_Throws()
     {
         // Arrange && Act && Assert

--- a/tests/Core/Components/DataGrid/FluentDataGridRowDetailsTests.razor
+++ b/tests/Core/Components/DataGrid/FluentDataGridRowDetailsTests.razor
@@ -185,7 +185,7 @@
             </FluentDataGrid>);
 
         // Act: click the toggle; the handler suspends immediately on the incomplete task
-        await cut.InvokeAsync(() => cut.Find(".row-expand-button").Click());
+        var clickTask = cut.InvokeAsync(() => cut.Find(".row-expand-button").Click());
 
         // Assert: the details row (and whatever placeholder RowDetails renders while data is loading)
         // must already be visible while the handler is still pending, not only once it completes.
@@ -193,7 +193,7 @@
 
         // Cleanup: let the pending handler complete
         tcs.SetResult();
-        await cut.InvokeAsync(() => Task.CompletedTask);
+        await clickTask;
     }
 
     [Fact]


### PR DESCRIPTION
# Pull Request

## 📖 Description

Addresses the feature request asking for a way to trigger a function on row expand/collapse so detail data can be loaded lazily (showing a spinner in the meantime) instead of requiring all detail data to be in memory up front.

No library code change is needed: `FluentDataGrid` doesn't override `IHandleEvent.HandleEventAsync`, so it uses `ComponentBase`'s default implementation, which renders once immediately after invoking an event callback and again after that callback's task completes. That means `RowDetails` already re-renders as soon as a row expands — before an async `OnRowDetailsToggle` handler finishes — so a template that branches on a "loaded yet?" flag already shows its "loading" branch immediately and its "loaded" branch once the handler populates the data.

This PR adds:
- Two bUnit tests (using a `TaskCompletionSource` to hold an `OnRowDetailsToggle` handler mid-flight) proving this works: the details row appears while the handler is still pending, and a full spinner→loaded-content scenario matching the feature request's own example.
- A new **"Lazy-loaded detail"** example and docs section on `/DataGrid/MasterDetail`: expanding a customer for the first time shows a `FluentSpinner` for 1.5s (simulating a network call), then its orders; expanding it again shows the cached orders immediately.

### 🎫 Issues

* Addresses the feature request for lazy-loading `RowDetails` content (no issue number handy — link it here if you have it).

## 👩‍💻 Reviewer Notes

Nothing in `src/Core` changed — this is tests + docs only, confirming existing behavior rather than adding new API surface. Worth double-checking the reasoning about `ComponentBase`'s default `IHandleEvent.HandleEventAsync` if you want a second opinion, since that's the crux of why this already works.

Suggested smoke test: open `/DataGrid/MasterDetail`, scroll to "Lazy-loaded detail", expand a customer and confirm the spinner shows before the orders appear, then collapse and re-expand to confirm the cached orders show immediately (no spinner the second time).

## 📑 Test Plan

Added to `tests/Core/Components/DataGrid/FluentDataGridRowDetailsTests.razor`:
- `FluentDataGrid_RowDetails_Row_Appears_Before_Async_OnRowDetailsToggle_CompletesAsync` — the details row is present while an `OnRowDetailsToggle` handler is still suspended on an incomplete `Task`.
- `FluentDataGrid_RowDetails_Supports_Lazy_Loading_With_Spinner_PlaceholderAsync` — a `RowDetails` template that branches on a per-item cache shows the spinner branch first, then the loaded branch once the handler's task completes.

Full suite run locally: 3760 passed, 1 failed, 0 skipped — the one failure (`FluentNumberTests.FluentNumber_Culture_FR`) is pre-existing/unrelated (culture/environment-dependent).

Also manually verified in the running demo app: captured the spinner state right after expanding, and the loaded-orders state ~2s later, confirming the transition happens as designed.

## ✅ Checklist

### General

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

- If the requester's exact scenario (per-row cache invalidation, retry-on-error, etc.) needs more built-in support later, happy to discuss further — but the core "lazy load + spinner" ask is covered by the existing `OnRowDetailsToggle` callback.
