### PR TITLE
[Menu] Unregister disposed menu instances

### DIFF
--- a/src/Core/Components/Menu/FluentMenu.razor.cs
+++ b/src/Core/Components/Menu/FluentMenu.razor.cs
@@ -23,6 +23,7 @@ public partial class FluentMenu : FluentComponentBase, IAsyncDisposable
     private bool _contextMenu = false;
     private readonly Dictionary<string, FluentMenuItem> items = [];
     private IMenuService? _menuService = null;
+    private IMenuService? _registeredMenuService;
     private IJSObjectReference _jsModule = default!;
     private IJSObjectReference _anchoredRegionModule = default!;
     private bool _disposed;
@@ -200,14 +201,16 @@ public partial class FluentMenu : FluentComponentBase, IAsyncDisposable
         }
 
         _menuService = ServiceProvider?.GetService<IMenuService>();
-        if (MenuService != null && DrawMenuWithService)
+        var menuService = MenuService;
+        if (menuService != null && DrawMenuWithService)
         {
-            if (string.IsNullOrEmpty(MenuService.ProviderId))
+            if (string.IsNullOrEmpty(menuService.ProviderId))
             {
                 throw new ArgumentNullException(nameof(UseMenuService), "<FluentMenuProvider /> needs to be added to the main layout of your application/site.");
             }
 
-            MenuService.Add(this);
+            menuService.Add(this);
+            _registeredMenuService = menuService;
         }
 
         base.OnInitialized();
@@ -398,6 +401,13 @@ public partial class FluentMenu : FluentComponentBase, IAsyncDisposable
     /// </summary>
     public async ValueTask DisposeAsync()
     {
+        if (_registeredMenuService is not null)
+        {
+            var menuService = _registeredMenuService;
+            _registeredMenuService = null;
+            menuService.Remove(this);
+        }
+
         if (_disposed)
         {
             return;

--- a/src/Core/Components/Menu/Services/MenuService.cs
+++ b/src/Core/Components/Menu/Services/MenuService.cs
@@ -60,18 +60,21 @@ public class MenuService : IMenuService, IDisposable
     /// </summary>
     public void Remove(FluentMenu menu)
     {
+        bool removed;
+
         MenuLock.EnterWriteLock();
         try
         {
-            var item = MenuList.FirstOrDefault(i => i.Id == menu.Id);
-            if (item != null)
-            {
-                MenuList.Remove(item);
-            }
+            removed = MenuList.Remove(menu);
         }
         finally
         {
             MenuLock.ExitWriteLock();
+        }
+
+        if (removed)
+        {
+            OnMenuUpdated.Invoke();
         }
     }
 

--- a/tests/Core/_ToDo/Menu/FluentMenuTests.razor.cs
+++ b/tests/Core/_ToDo/Menu/FluentMenuTests.razor.cs
@@ -69,5 +69,96 @@ public partial class FluentMenuTests : TestContext
         var menuInProvider = menuProviderCut.FindComponent<FluentMenu>();
         Assert.Equal(className, menuInProvider.Instance.Class, StringComparer.Ordinal);
     }
-}
 
+    [Fact]
+    public async Task FluentMenu_DisposeAsync_UnregistersMenuAndNotifiesProvider()
+    {
+        // Arrange
+        var menuService = Services.GetRequiredService<IMenuService>();
+        var updateCount = 0;
+        menuService.ProviderId = "menu-provider";
+        menuService.OnMenuUpdated = () => updateCount++;
+        var menu = new TestFluentMenu
+        {
+            ServiceProvider = Services,
+            Anchor = "menu-anchor",
+            Anchored = true
+        };
+        menu.Initialize();
+
+        Assert.Same(menu, Assert.Single(menuService.Menus));
+
+        // Act
+        await menu.DisposeAsync();
+
+        // Assert
+        Assert.Empty(menuService.Menus);
+        Assert.Equal(1, updateCount);
+    }
+
+    [Fact]
+    public async Task FluentMenu_DisposeAsync_WhenAlreadyDisposed_DoesNotNotifyProviderAgain()
+    {
+        // Arrange
+        var menuService = Services.GetRequiredService<IMenuService>();
+        var updateCount = 0;
+        menuService.ProviderId = "menu-provider";
+        menuService.OnMenuUpdated = () => updateCount++;
+        var menu = new TestFluentMenu
+        {
+            ServiceProvider = Services,
+            Anchor = "menu-anchor",
+            Anchored = true
+        };
+        menu.Initialize();
+        await menu.DisposeAsync();
+
+        // Act
+        await menu.DisposeAsync();
+
+        // Assert
+        Assert.Empty(menuService.Menus);
+        Assert.Equal(1, updateCount);
+    }
+
+    [Fact]
+    public async Task FluentMenu_DisposeAsync_DoesNotUnregisterDifferentMenuWithSameId()
+    {
+        // Arrange
+        var menuService = Services.GetRequiredService<IMenuService>();
+        menuService.ProviderId = "menu-provider";
+        var registeredMenu = new TestFluentMenu
+        {
+            ServiceProvider = Services,
+            Id = "shared-menu-id",
+            Anchor = "registered-menu-anchor",
+            Anchored = true
+        };
+        var unregisteredMenu = new TestFluentMenu
+        {
+            ServiceProvider = Services,
+            Id = "shared-menu-id",
+            Anchor = "unregistered-menu-anchor",
+            Anchored = true,
+            UseMenuService = false
+        };
+        registeredMenu.Initialize();
+        unregisteredMenu.Initialize();
+
+        Assert.Same(registeredMenu, Assert.Single(menuService.Menus));
+
+        // Act
+        await unregisteredMenu.DisposeAsync();
+
+        // Assert
+        Assert.Same(registeredMenu, Assert.Single(menuService.Menus));
+    }
+
+    private sealed class TestFluentMenu : FluentMenu
+    {
+        public void Initialize()
+        {
+            base.OnInitialized();
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## 📖 Description

`FluentMenu` registered service-backed instances during initialization but never called the existing `IMenuService.Remove` operation during disposal. The scoped service therefore retained disposed menus, including their render fragments, callbacks, and parent component state, for the circuit lifetime.

This change tracks the exact service instance that accepted each registration and unregisters the menu before disposing JavaScript resources. `MenuService.Remove` now removes the exact component instance and notifies the provider only when removal succeeds, keeping repeated disposal idempotent and allowing provider render state to release the menu.

### 🎫 Issues

Fixes #5032

## 👩‍💻 Reviewer Notes

Please focus on the service-backed menu lifecycle in `FluentMenu.DisposeAsync` and the successful-removal notification in `MenuService.Remove`.

No smoke test is required; the regression is covered at the component/service lifecycle boundary.

## 📑 Test Plan

- `dotnet test tests\Core\Microsoft.FluentUI.AspNetCore.Components.Tests.csproj --no-restore --filter "FullyQualifiedName~Microsoft.FluentUI.AspNetCore.Components.Tests.Menu.FluentMenuTests" --verbosity minimal`
- 6 FluentMenu tests passed, including registration/unregistration, provider notification, repeated disposal, and duplicate-ID isolation.

## ✅ Checklist

### General

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

None.