### PR TITLE
[dev-v5][DataGrid] Add HasRowDetails to hide the toggle for rows without data

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DataGrid/Examples/DataGridMasterDetail.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DataGrid/Examples/DataGridMasterDetail.razor
@@ -9,7 +9,9 @@
     }
 </style>
 
-<FluentDataGrid Items="@customers" ShowHover="true" HasRowDetails="@(c => OrdersOf(c.Id).Any())">
+<FluentSwitch @bind-Value="@showOnlyRowsWithDetails" Label="Show toggle only on rows with details" />
+
+<FluentDataGrid Items="@customers" ShowHover="true" HasRowDetails="@CurrentHasRowDetails">
     <ChildContent>
         <PropertyColumn Title="Customer" Property="@(c => c.Name)" Sortable="true" />
         <PropertyColumn Title="City" Property="@(c => c.City)" Sortable="true" />
@@ -19,14 +21,19 @@
     <RowDetails Context="customer">
         <h5 class="detail-heading">Orders of @customer.Name</h5>
         <FluentDataGrid Items="@OrdersOf(customer.Id)" ShowHover="true">
-            <PropertyColumn Title="Order #" Property="@(o => o.OrderNumber)" />
-            <PropertyColumn Title="Date" Property="@(o => o.OrderDate)" Format="yyyy-MM-dd" Sortable="true" InitialSortDirection="DataGridSortDirection.Descending" IsDefaultSortColumn="true" />
-            <PropertyColumn Title="Amount" Property="@(o => o.Amount)" Format="c" Align="DataGridCellAlignment.End" Sortable="true" />
-            <TemplateColumn Title="Status">
-                <FluentBadge Color="@(context.Status == "Delivered" ? BadgeColor.Success : BadgeColor.Subtle)">
-                    @context.Status
-                </FluentBadge>
-            </TemplateColumn>
+            <ChildContent>
+                <PropertyColumn Title="Order #" Property="@(o => o.OrderNumber)" />
+                <PropertyColumn Title="Date" Property="@(o => o.OrderDate)" Format="yyyy-MM-dd" Sortable="true" InitialSortDirection="DataGridSortDirection.Descending" IsDefaultSortColumn="true" />
+                <PropertyColumn Title="Amount" Property="@(o => o.Amount)" Format="c" Align="DataGridCellAlignment.End" Sortable="true" />
+                <TemplateColumn Title="Status">
+                    <FluentBadge Color="@(context.Status == "Delivered" ? BadgeColor.Success : BadgeColor.Subtle)">
+                        @context.Status
+                    </FluentBadge>
+                </TemplateColumn>
+            </ChildContent>
+            <EmptyContent>
+                <p>No orders yet.</p>
+            </EmptyContent>
         </FluentDataGrid>
     </RowDetails>
 </FluentDataGrid>
@@ -35,7 +42,11 @@
     private record Customer(int Id, string Name, string City);
     private record Order(string OrderNumber, int CustomerId, DateTime OrderDate, decimal Amount, string Status);
 
-    // Tailspin Toys has no orders yet, so HasRowDetails hides its toggle button entirely
+    private bool showOnlyRowsWithDetails = true;
+
+    private Func<Customer, bool>? CurrentHasRowDetails => showOnlyRowsWithDetails ? CustomerHasOrders : null;
+
+    // Tailspin Toys has no orders yet, so HasRowDetails can hide its toggle button when enabled
     private IQueryable<Customer> customers = new List<Customer>
     {
         new(1, "Contoso Ltd.", "Seattle"),
@@ -57,6 +68,9 @@
         new("ORD-1008", 3, new DateTime(2026, 7, 1), 55.99m, "Pending"),
         new("ORD-1009", 4, new DateTime(2026, 6, 22), 640.00m, "Shipped"),
     };
+
+    private bool CustomerHasOrders(Customer customer)
+        => OrdersOf(customer.Id).Any();
 
     // The child grid is filtered with the master row's item (the customer)
     private IQueryable<Order> OrdersOf(int customerId)

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DataGrid/Examples/DataGridMasterDetail.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DataGrid/Examples/DataGridMasterDetail.razor
@@ -9,7 +9,7 @@
     }
 </style>
 
-<FluentDataGrid Items="@customers" ShowHover="true">
+<FluentDataGrid Items="@customers" ShowHover="true" HasRowDetails="@(c => OrdersOf(c.Id).Any())">
     <ChildContent>
         <PropertyColumn Title="Customer" Property="@(c => c.Name)" Sortable="true" />
         <PropertyColumn Title="City" Property="@(c => c.City)" Sortable="true" />
@@ -19,19 +19,14 @@
     <RowDetails Context="customer">
         <h5 class="detail-heading">Orders of @customer.Name</h5>
         <FluentDataGrid Items="@OrdersOf(customer.Id)" ShowHover="true">
-            <ChildContent>
-                <PropertyColumn Title="Order #" Property="@(o => o.OrderNumber)" />
-                <PropertyColumn Title="Date" Property="@(o => o.OrderDate)" Format="yyyy-MM-dd" Sortable="true" InitialSortDirection="DataGridSortDirection.Descending" IsDefaultSortColumn="true" />
-                <PropertyColumn Title="Amount" Property="@(o => o.Amount)" Format="c" Align="DataGridCellAlignment.End" Sortable="true" />
-                <TemplateColumn Title="Status">
-                    <FluentBadge Color="@(context.Status == "Delivered" ? BadgeColor.Success : BadgeColor.Subtle)">
-                        @context.Status
-                    </FluentBadge>
-                </TemplateColumn>
-            </ChildContent>
-            <EmptyContent>
-                <p>No orders yet.</p>
-            </EmptyContent>
+            <PropertyColumn Title="Order #" Property="@(o => o.OrderNumber)" />
+            <PropertyColumn Title="Date" Property="@(o => o.OrderDate)" Format="yyyy-MM-dd" Sortable="true" InitialSortDirection="DataGridSortDirection.Descending" IsDefaultSortColumn="true" />
+            <PropertyColumn Title="Amount" Property="@(o => o.Amount)" Format="c" Align="DataGridCellAlignment.End" Sortable="true" />
+            <TemplateColumn Title="Status">
+                <FluentBadge Color="@(context.Status == "Delivered" ? BadgeColor.Success : BadgeColor.Subtle)">
+                    @context.Status
+                </FluentBadge>
+            </TemplateColumn>
         </FluentDataGrid>
     </RowDetails>
 </FluentDataGrid>
@@ -40,7 +35,7 @@
     private record Customer(int Id, string Name, string City);
     private record Order(string OrderNumber, int CustomerId, DateTime OrderDate, decimal Amount, string Status);
 
-    // Tailspin Toys has no orders yet, to show what RowDetails looks like for a row without detail data
+    // Tailspin Toys has no orders yet, so HasRowDetails hides its toggle button entirely
     private IQueryable<Customer> customers = new List<Customer>
     {
         new(1, "Contoso Ltd.", "Seattle"),

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DataGrid/Pages/DataGridMasterDetailPage.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DataGrid/Pages/DataGridMasterDetailPage.md
@@ -11,8 +11,13 @@ spanning all columns, directly below the expanded row.
 
 The template's `context` is the master row's item, so you can place a child `FluentDataGrid` inside it and filter
 its items based on the master row. In this example, expanding a customer shows a child grid with that customer's
-orders. Not every row needs to have detail data: Tailspin Toys has no orders yet, so expanding it shows the child
-grid's `EmptyContent` instead.
+orders.
+
+Not every row needs to have detail data. Set `HasRowDetails` to a function that returns whether a given row has
+anything to show — rows for which it returns `false` keep their indentation but get no toggle button at all, so
+they can't be expanded from the UI. In this example, Tailspin Toys has no orders yet, so it gets no toggle button.
+`HasRowDetails` only affects the button: `ToggleRowDetailsAsync` and the other programmatic methods still work
+regardless.
 
 Unlike the [hierarchical view](/DataGrid/Hierarchical) — where parent and child rows share the same item type and
 the same columns within a single grid — the master/detail view displays data of a completely different structure:

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DataGrid/Pages/DataGridMasterDetailPage.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DataGrid/Pages/DataGridMasterDetailPage.md
@@ -15,9 +15,12 @@ orders.
 
 Not every row needs to have detail data. Set `HasRowDetails` to a function that returns whether a given row has
 anything to show — rows for which it returns `false` keep their indentation but get no toggle button at all, so
-they can't be expanded from the UI. In this example, Tailspin Toys has no orders yet, so it gets no toggle button.
-`HasRowDetails` only affects the button: `ToggleRowDetailsAsync` and the other programmatic methods still work
-regardless.
+they can't be expanded from the UI. `HasRowDetails` only affects the button: `ToggleRowDetailsAsync` and the other
+programmatic methods still work regardless.
+
+In this example, Tailspin Toys has no orders yet. Use the switch to compare both ways of handling that: with the
+switch on, `HasRowDetails` hides its toggle button entirely; with it off, `HasRowDetails` is `null` (the default),
+so every row gets a toggle button, and expanding Tailspin Toys shows the child grid's `EmptyContent` instead.
 
 Unlike the [hierarchical view](/DataGrid/Hierarchical) — where parent and child rows share the same item type and
 the same columns within a single grid — the master/detail view displays data of a completely different structure:

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor
@@ -167,11 +167,15 @@
         @if (RowDetails is not null && col.Index == 1)
         {
             var rowDetailsExpanded = IsRowDetailsExpanded(item);
+            var hasRowDetails = HasRowDetails is null || HasRowDetails(item);
             <span class="row-toggle-container row-details-toggle-container">
                 <span @onclick:stopPropagation="true" class="row-expander @(rowDetailsExpanded ? "row-expanded" : "row-collapsed")">
-                    <FluentButton aria-label="@Localizer[Localization.LanguageResource.DataGrid_ToggleRowDetails]" aria-expanded="@(rowDetailsExpanded ? "true" : "false")" Appearance="ButtonAppearance.Subtle" Size="ButtonSize.Small" Class="row-expand-button" OnClick="@(() => ToggleRowDetailsAsync(item))">
-                        <FluentIcon Width="12px" Value="@(new CoreIcons.Regular.Size20.ChevronRight())" Color="Color.Default" />
-                    </FluentButton>
+                    @if (hasRowDetails)
+                    {
+                        <FluentButton aria-label="@Localizer[Localization.LanguageResource.DataGrid_ToggleRowDetails]" aria-expanded="@(rowDetailsExpanded ? "true" : "false")" Appearance="ButtonAppearance.Subtle" Size="ButtonSize.Small" Class="row-expand-button" OnClick="@(() => ToggleRowDetailsAsync(item))">
+                            <FluentIcon Width="12px" Value="@(new CoreIcons.Regular.Size20.ChevronRight())" Color="Color.Default" />
+                        </FluentButton>
+                    }
                 </span>
             </span>
         }

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -365,6 +365,18 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     public RenderFragment<TGridItem>? RowDetails { get; set; }
 
     /// <summary>
+    /// Optionally determines, per row, whether that row has <see cref="RowDetails"/> content to show.
+    /// When set, the expand/collapse toggle button is only rendered for rows where this returns
+    /// <see langword="true"/> — other rows keep the same indentation but show no button, so their
+    /// content can't be expanded via the UI. If not set, every row gets the toggle button.
+    ///
+    /// This only controls the toggle button; it doesn't affect <see cref="ToggleRowDetailsAsync"/> and the
+    /// other programmatic expand/collapse methods, which work regardless.
+    /// </summary>
+    [Parameter]
+    public Func<TGridItem, bool>? HasRowDetails { get; set; }
+
+    /// <summary>
     /// Event callback for when a row's <see cref="RowDetails"/> content is expanded or collapsed.
     /// </summary>
     [Parameter]

--- a/tests/Core/Components/DataGrid/FluentDataGridRowDetailsTests.razor
+++ b/tests/Core/Components/DataGrid/FluentDataGridRowDetailsTests.razor
@@ -250,6 +250,49 @@
     }
 
     [Fact]
+    public void FluentDataGrid_HasRowDetails_Hides_Toggle_Button_But_Keeps_Container()
+    {
+        // Arrange && Act: Vincent Baaij (index 1) is the only one without row details
+        var cut = Render<FluentDataGrid<Customer>>(
+            @<FluentDataGrid Items="@GetCustomers().AsQueryable()" ItemKey="@(c => c.Id)" HasRowDetails="@(c => c.Name != "Vincent Baaij")">
+                <ChildContent>
+                    <PropertyColumn Property="@(x => x.Name)" />
+                </ChildContent>
+                <RowDetails>
+                    <p>details of @context.Name</p>
+                </RowDetails>
+            </FluentDataGrid>);
+
+        // Assert: every row still reserves the same toggle space (alignment stays consistent)...
+        Assert.Equal(3, cut.FindAll(".row-details-toggle-container").Count);
+        // ...but only two rows actually get a clickable button
+        Assert.Equal(2, cut.FindAll(".row-expand-button").Count);
+    }
+
+    [Fact]
+    public async Task FluentDataGrid_HasRowDetails_Does_Not_Block_Programmatic_ExpandAsync()
+    {
+        // Arrange
+        var cut = Render<FluentDataGrid<Customer>>(
+            @<FluentDataGrid Items="@GetCustomers().AsQueryable()" ItemKey="@(c => c.Id)" HasRowDetails="@(c => c.Name != "Vincent Baaij")">
+                <ChildContent>
+                    <PropertyColumn Property="@(x => x.Name)" />
+                </ChildContent>
+                <RowDetails>
+                    <p>details of @context.Name</p>
+                </RowDetails>
+            </FluentDataGrid>);
+        var vincent = GetCustomers().Single(c => c.Name == "Vincent Baaij");
+
+        // Act: HasRowDetails only hides the button, so the programmatic API still works
+        await cut.InvokeAsync(() => cut.Instance.ExpandRowDetailsAsync(vincent));
+
+        // Assert
+        Assert.True(cut.Instance.IsRowDetailsExpanded(vincent));
+        Assert.Contains("details of Vincent Baaij", cut.Find("tr.row-details-row").TextContent);
+    }
+
+    [Fact]
     public void FluentDataGrid_RowDetails_With_Virtualize_Throws()
     {
         // Arrange && Act && Assert


### PR DESCRIPTION
# Pull Request

## 📖 Description

Follow-up to #5011 / #5033. When #5011 was reviewed, the Tailspin Toys example (a row with no orders) was added to show what `RowDetails` looks like for a row without data — it expanded into the child grid's `EmptyContent`. The reviewer's follow-up: that row shouldn't get an expand/collapse button at all.

Adds `HasRowDetails` — a `Func<TGridItem, bool>?` parameter (not a plain bool, since whether a row "has details" is data-dependent per row, not a grid-wide setting). Rows for which it returns `false` get no toggle button, but the toggle *container* still renders (same as how `HierarchicalToggle` already handles leaf nodes with no children), so column alignment stays consistent — no button, but no misaligned text either.

`HasRowDetails` only affects the button. `ToggleRowDetailsAsync`/`ExpandRowDetailsAsync`/`CollapseRowDetailsAsync`/`ExpandAllRowDetailsAsync`/`CollapseAllRowDetailsAsync` still work regardless, in case a caller wants to force-expand a row anyway.

Updated the Tailspin Toys example to use `HasRowDetails="@(c => OrdersOf(c.Id).Any())"` instead of expanding into `EmptyContent`.

### 🎫 Issues

* Follow-up to #5011/#5033 (review comment asking for this).

## 👩‍💻 Reviewer Notes

Suggested smoke test: open `/DataGrid/MasterDetail`, confirm "Tailspin Toys" (no orders) has no chevron while its "Customer" text stays aligned with the other rows, and that the other customers still expand/collapse normally.

Areas to focus review on:
- `FluentDataGrid.razor` — `RenderCellInner` now computes `hasRowDetails` and only renders the `FluentButton` when true, keeping the surrounding `row-toggle-container`/`row-expander` spans either way.
- `FluentDataGrid.razor.cs` — new `HasRowDetails` parameter, documented as button-only (doesn't gate the programmatic API).

## 📑 Test Plan

Added to `tests/Core/Components/DataGrid/FluentDataGridRowDetailsTests.razor`:
- `FluentDataGrid_HasRowDetails_Hides_Toggle_Button_But_Keeps_Container` — every row still reserves the toggle space, but only rows where `HasRowDetails` returns true get a clickable button.
- `FluentDataGrid_HasRowDetails_Does_Not_Block_Programmatic_ExpandAsync` — `ExpandRowDetailsAsync` still works for a row whose `HasRowDetails` returns false.

Full suite run locally: 3760 passed, 1 failed, 0 skipped — the one failure (`FluentNumberTests.FluentNumber_Culture_FR`) is pre-existing/unrelated (culture/environment-dependent).

Also manually verified in the running demo app: Tailspin Toys shows no chevron and stays aligned with the other rows.

## ✅ Checklist

### General

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

None anticipated.
