### PR TITLE
[dev-v5][Input] Make sure label is created at the right location

### DIFF
--- a/src/Core/Components/Field/FluentField.razor.cs
+++ b/src/Core/Components/Field/FluentField.razor.cs
@@ -223,9 +223,25 @@ public partial class FluentField : FluentComponentBase, IFluentField
     }
 
     private bool HasLabel
-        => !string.IsNullOrWhiteSpace(Parameters.Label)
-        || Parameters.LabelTemplate is not null
-        || Parameters.HasLabelInfo;
+    {
+        get
+        {
+            var hasLabelContent = !string.IsNullOrWhiteSpace(Parameters.Label)
+                || Parameters.LabelTemplate is not null
+                || Parameters.HasLabelInfo;
+
+            // Only show label if the InputComponent is FluentCheckbox or FluentSwitch
+            if (InputComponent is not null)
+            {
+                return IsCheckboxOrSwitch() && hasLabelContent;
+            }
+
+            return hasLabelContent;
+        }
+    }
+
+    private bool IsCheckboxOrSwitch()
+        => InputComponent?.GetType() is { Name: "FluentCheckbox" or "FluentSwitch" };
 
     private bool HasMessage
         => !string.IsNullOrWhiteSpace(Parameters.Message)

--- a/src/Core/Components/NumberInput/FluentNumberInput.razor
+++ b/src/Core/Components/NumberInput/FluentNumberInput.razor
@@ -1,4 +1,4 @@
-@namespace Microsoft.FluentUI.AspNetCore.Components
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 @using Microsoft.FluentUI.AspNetCore.Components.Extensions
 @typeparam TValue
 @inherits FluentInputImmediateBase<TValue>
@@ -55,5 +55,6 @@
                 </div>
             }
         </div>
+        @Label@LabelTemplate
     </fluent-text-input>
 </FluentField>

--- a/src/Core/Components/TextArea/FluentTextArea.razor
+++ b/src/Core/Components/TextArea/FluentTextArea.razor
@@ -28,5 +28,8 @@
                      @onchange="@ChangeHandlerAsync"
                      @ontextimmediate="@InputHandlerAsync"
                      @attributes="AdditionalAttributes">
+        <FluentLabel slot="@FluentSlot.FieldLabel">
+            @Label@LabelTemplate
+        </FluentLabel>
     </fluent-textarea>
 </FluentField>

--- a/src/Core/Components/TextInput/FluentTextInput.razor
+++ b/src/Core/Components/TextInput/FluentTextInput.razor
@@ -43,6 +43,6 @@
                 @EndTemplate
             </div>
         }
-        @Label
+        @Label@LabelTemplate
     </fluent-text-input>
 </FluentField>

--- a/src/Core/Components/TextInput/FluentTextInput.razor
+++ b/src/Core/Components/TextInput/FluentTextInput.razor
@@ -43,6 +43,6 @@
                 @EndTemplate
             </div>
         }
-
+        @Label
     </fluent-text-input>
 </FluentField>


### PR DESCRIPTION
Fix #4980 

We need to re-evaluate how to render the label on input components. We are deviating from how it is done in the standard web components and that's causing a11y issues.

This is only a first stab at solving this. It is not complete and unit tests have not been created/altered.

We can use https://stackblitz.com/edit/typescript-juzjvyeg?file=index.html for seeing how it works on the WC side

**This must be released before go-live**