### PR TITLE
[dev-v5][TextInput] Added parameter to hide Show Password toggle in Microsoft Edge

### DIFF
--- a/src/Core.Scripts/src/Components/TextInput/TextInput.ts
+++ b/src/Core.Scripts/src/Components/TextInput/TextInput.ts
@@ -36,6 +36,29 @@ export namespace Microsoft.FluentUI.Blazor.Components.TextInput {
     }
   };
 
+  export function setEdgePasswordRevealToggle(id: string, hide: boolean) {
+    const fieldElement = document.getElementById(id);
+    const shadowRoot = fieldElement?.shadowRoot;
+
+    if (!shadowRoot) {
+        return;
+    }
+
+    const styleElement = shadowRoot.querySelector("style[data-fluent-text-field-edge-password-toggle]");
+
+    if (hide) {
+        if (!styleElement) {
+            const newStyleElement = document.createElement("style");
+            newStyleElement.setAttribute("data-fluent-text-field-edge-password-toggle", "true");
+            newStyleElement.textContent = "#control::-ms-reveal { display: none !important; }";
+            shadowRoot.appendChild(newStyleElement);
+        }
+    }
+    else if (styleElement) {
+        styleElement.remove();
+    }
+  }
+
   /**
    * Type for elements that support delayed 'immediate' input events
    */

--- a/src/Core.Scripts/src/Components/TextInput/TextInput.ts
+++ b/src/Core.Scripts/src/Components/TextInput/TextInput.ts
@@ -36,27 +36,28 @@ export namespace Microsoft.FluentUI.Blazor.Components.TextInput {
     }
   };
 
-  export function setEdgePasswordRevealToggle(id: string, hide: boolean) {
+  export function setEdgePasswordRevealToggle(id: string, hide: boolean): void {
     const fieldElement = document.getElementById(id);
     const shadowRoot = fieldElement?.shadowRoot;
 
     if (!shadowRoot) {
-        return;
+      return;
     }
 
     const styleElement = shadowRoot.querySelector("style[data-fluent-text-field-edge-password-toggle]");
 
     if (hide) {
-        if (!styleElement) {
-            const newStyleElement = document.createElement("style");
-            newStyleElement.setAttribute("data-fluent-text-field-edge-password-toggle", "true");
-            newStyleElement.textContent = "#control::-ms-reveal { display: none !important; }";
-            shadowRoot.appendChild(newStyleElement);
-        }
+      if (!styleElement) {
+        const newStyleElement = document.createElement("style");
+        newStyleElement.setAttribute("data-fluent-text-field-edge-password-toggle", "true");
+        newStyleElement.textContent = "#control::-ms-reveal { display: none !important; }";
+        shadowRoot.appendChild(newStyleElement);
+      }
+
+      return;
     }
-    else if (styleElement) {
-        styleElement.remove();
-    }
+    
+    styleElement?.remove();
   }
 
   /**

--- a/src/Core/Components/TextInput/FluentTextInput.razor.cs
+++ b/src/Core/Components/TextInput/FluentTextInput.razor.cs
@@ -156,7 +156,13 @@ public partial class FluentTextInput : FluentInputImmediateBase<string?>, IFluen
     /// Gets or sets a value indicating whether spellcheck should be used.
     /// </summary>
     [Parameter]
-    public bool? Spellcheck { get; set; }           // TODO: To verify if this is supported by the component
+    public bool? Spellcheck { get; set; } // TODO: To verify if this is supported by the component
+    
+    /// <summary>
+    /// Gets or sets a value indicating whether the Microsoft Edge password toggle should be hidden for password fields.
+    /// </summary>
+    [Parameter]
+    public bool HideEdgePasswordToggle { get; set; }
 
     /// <summary>
     /// Gets or sets the type of data that can be entered by the user when editing the element or its content.
@@ -222,6 +228,14 @@ public partial class FluentTextInput : FluentInputImmediateBase<string?>, IFluen
 
                 await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Components.TextMasked.applyPatternMask", Id, MaskPattern, MaskLazy, placeholder);
             }
+        }
+
+        if (TextInputType == Components.TextInputType.Password && HideEdgePasswordToggle)
+        {
+            await JSRuntime.InvokeVoidAsync(
+                "Microsoft.FluentUI.Blazor.Components.TextInput.setEdgePasswordRevealToggle",
+                Id, HideEdgePasswordToggle
+            );
         }
     }
 

--- a/src/Core/Components/TextInput/FluentTextInput.razor.cs
+++ b/src/Core/Components/TextInput/FluentTextInput.razor.cs
@@ -208,6 +208,9 @@ public partial class FluentTextInput : FluentInputImmediateBase<string?>, IFluen
         await base.RenderTooltipAsync(Tooltip);
     }
 
+    /// <summary />
+    private bool _isEdgePasswordToggleHidden;
+
     /// <inheritdoc cref="ComponentBase.OnAfterRenderAsync(bool)" />
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -230,11 +233,19 @@ public partial class FluentTextInput : FluentInputImmediateBase<string?>, IFluen
             }
         }
 
-        if (TextInputType == Components.TextInputType.Password && HideEdgePasswordToggle)
+        if (TextInputType == Components.TextInputType.Password)
         {
             await JSRuntime.InvokeVoidAsync(
                 "Microsoft.FluentUI.Blazor.Components.TextInput.setEdgePasswordRevealToggle",
                 Id, HideEdgePasswordToggle
+            );
+        }
+        else if (_isEdgePasswordToggleHidden)
+        {
+            _isEdgePasswordToggleHidden = false;
+            await JSRuntime.InvokeVoidAsync(
+                "Microsoft.FluentUI.Blazor.Components.TextInput.setEdgePasswordRevealToggle",
+                Id, false
             );
         }
     }

--- a/tests/Core/Components/TextInput/FluentTextInputTests.razor
+++ b/tests/Core/Components/TextInput/FluentTextInputTests.razor
@@ -88,27 +88,41 @@
     }
 
     [Fact]
-    public void FluentInputText_HidePasswordReveal_DoesNotAffectMarkup()
+    public void FluentInputText_HideEdgePasswordToggle_DoesNotAffectMarkup()
     {
-        // Arrange && Act
+        // Arrange
         using var context = new IdentifierContext(i => "myId");
-        var cut = Render(@<FluentTextInput TextInputType="@TextInputType.Password" HideEdgePasswordToggle="true" />);
+        var invocation = JSInterop.SetupVoid(
+    "Microsoft.FluentUI.Blazor.Components.TextInput.setEdgePasswordRevealToggle",
+    _ => true);
 
-        // Assert
+        // Act
+        var cut = Render(@<FluentTextInput TextInputType="@TextInputType.Password" HideEdgePasswordToggle="true" />);
         cut.Find("fluent-text-input")
-        .MarkupMatches("<fluent-text-input id=\"myId\" slot=\"input\" appearance=\"outline\" type=\"password\" />");
+           .MarkupMatches("<fluent-text-input id=\"myId\" slot=\"input\" appearance=\"outline\" type=\"password\" />");
+
+        var call = Assert.Single(invocation.Invocations);
+        Assert.Equal("myId", call.Arguments[0]);
+        Assert.Equal(true, call.Arguments[1]);
     }
 
     [Fact]
-    public void FluentInputText_HidePasswordReveal_OnNonPasswordField_DoesNotAffectMarkup()
+    public void FluentInputText_HideEdgePasswordToggle_OnNonPasswordField_DoesNotAffectMarkup()
     {
-        // Arrange && Act
+        // Arrange
         using var context = new IdentifierContext(i => "myId");
+        var invocation = JSInterop.SetupVoid(
+    "Microsoft.FluentUI.Blazor.Components.TextInput.setEdgePasswordRevealToggle",
+    _ => true);
+
+         // Act
         var cut = Render(@<FluentTextInput TextInputType="@TextInputType.Text" HideEdgePasswordToggle="true" />);
 
         // Assert
         cut.Find("fluent-text-input")
-        .MarkupMatches("<fluent-text-input id=\"myId\" slot=\"input\" appearance=\"outline\" type=\"text\" />");
+            .MarkupMatches("<fluent-text-input id=\"myId\" slot=\"input\" appearance=\"outline\" type=\"text\" />");
+        
+        Assert.Empty(invocation.Invocations);
     }
 
     [Theory]

--- a/tests/Core/Components/TextInput/FluentTextInputTests.razor
+++ b/tests/Core/Components/TextInput/FluentTextInputTests.razor
@@ -87,6 +87,30 @@
            .MarkupMatches($"<fluent-text-input id=\"myId\" slot=\"input\" appearance=\"outline\" type=\"{expectedAttribute}\" />");
     }
 
+    [Fact]
+    public void FluentInputText_HidePasswordReveal_DoesNotAffectMarkup()
+    {
+        // Arrange && Act
+        using var context = new IdentifierContext(i => "myId");
+        var cut = Render(@<FluentTextInput TextInputType="@TextInputType.Password" HideEdgePasswordToggle="true" />);
+
+        // Assert
+        cut.Find("fluent-text-input")
+        .MarkupMatches("<fluent-text-input id=\"myId\" slot=\"input\" appearance=\"outline\" type=\"password\" />");
+    }
+
+    [Fact]
+    public void FluentInputText_HidePasswordReveal_OnNonPasswordField_DoesNotAffectMarkup()
+    {
+        // Arrange && Act
+        using var context = new IdentifierContext(i => "myId");
+        var cut = Render(@<FluentTextInput TextInputType="@TextInputType.Text" HideEdgePasswordToggle="true" />);
+
+        // Assert
+        cut.Find("fluent-text-input")
+        .MarkupMatches("<fluent-text-input id=\"myId\" slot=\"input\" appearance=\"outline\" type=\"text\" />");
+    }
+
     [Theory]
     [InlineData(TextInputSize.Small)]
     [InlineData(TextInputSize.Medium)]


### PR DESCRIPTION
# Pull Request

## 📖 Description

This is a new feature that allows developers to disable the [password reveal button](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/password-reveal) in Microsoft Edge via a new HideEdgePasswordToggle boolean parameter, using the [::ms-reveal CSS control](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/password-reveal) under-the-hood. Because the <fluent-text-input> component is rendered in the Shadow DOM, setting the style in CSS does not work. Currently, developers using this library would have to write custom JavaScript to get this functionality to work without this change.

### 🎫 Issues

I could not find any related issues, however there was a [prior discussion](https://github.com/microsoft/fluentui-blazor/discussions/3561) related to this feature.

## 👩‍💻 Reviewer Notes

This PR adds a HideEdgePasswordToggle parameter to FluentTextField that hides the Microsoft Edge native password reveal button on password fields. The button is injected into the shadow DOM via a :-ms-reveal pseudo-element, so it requires a small style injection into the shadow root via JS. I am not opposed to changing the name of this parameter. I did feel that "HideEdgePasswordReveal" would be a bit confusing with "Hide" and "Reveal" in the same parameter name.

I am relatively new to open source contributions and willing to change whatever is needed.

Smoke test:
- Add a <FluentTextInput TextInputType="TextInputType.Password" HideEdgePasswordToggle="true" /> to a page
- Open in Microsoft Edge
- Type into the field - the native reveal button should not appear
- Ensure FluentTextField still works in other browsers

## 📑 Test Plan

Unit tests in FluentTextInputTests.razor cover the new parameter. Manual testing performed in Edge to verify the password reveal button is hidden when HideEdgePasswordToggle="true" and visible when false.

## ✅ Checklist

### General

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
**The above "standards" link (https://www.fast.design/docs/community/code-of-conduct/#our-standards) results in a 404, so I cannot say that I have read that page. However, I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation.**

### Component-specific

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

This would be a bigger change, but potentially better ways to interact with these types of controls in the Shadow DOM in general. Though that change would only be tangentially related to this PR.