### PR TITLE
[dev-v5] KeyCode - Enhance event handling with SafeKeyboardEvent

### DIFF
--- a/src/Core/Components/KeyCode/FluentKeyCode.razor.ts
+++ b/src/Core/Components/KeyCode/FluentKeyCode.razor.ts
@@ -142,7 +142,7 @@ export namespace Microsoft.FluentUI.Blazor.KeyCode {
     constructor(event: KeyboardEvent) {
       const ev = event as any;
       this.source = event;
-      this.keyCode = SafeKeyboardEvent.toSafeInt(ev.which || ev.keyCode || ev.charCode);
+      this.keyCode = SafeKeyboardEvent.toSafeInt(ev.which ?? ev.keyCode ?? ev.charCode);
       this.key = SafeKeyboardEvent.toSafeString(ev.key);
       this.ctrlKey = SafeKeyboardEvent.toSafeBool(ev.ctrlKey);
       this.shiftKey = SafeKeyboardEvent.toSafeBool(ev.shiftKey);

--- a/src/Core/Components/KeyCode/FluentKeyCode.razor.ts
+++ b/src/Core/Components/KeyCode/FluentKeyCode.razor.ts
@@ -57,17 +57,16 @@ export namespace Microsoft.FluentUI.Blazor.KeyCode {
         return handler(e, "OnKeyUpRaisedAsync");
       }
 
-      const handler = function (e: KeyboardEvent, netMethod: string) {
-        const ev = e as any;
-        const keyCode = ev.which || ev.keyCode || ev.charCode;
+      const handler = function (event: KeyboardEvent, netMethod: string) {
+        const e = new SafeKeyboardEvent(event);
+        const keyCode = e.keyCode;
 
         if (stopRepeat && e.repeat) {
           return;
         }
 
         if (!!dotNetHelper && !!dotNetHelper.invokeMethodAsync) {
-
-          const targetId = ev.currentTarget?.id ?? "";
+          const targetId = e.targetId;
           const isPreventDefault = preventDefault || (preventDefaultOnly.length > 0 && preventDefaultOnly.includes(keyCode));
           const isStopPropagation = stopPropagation;
 
@@ -129,6 +128,60 @@ export namespace Microsoft.FluentUI.Blazor.KeyCode {
       }
 
       delete (document as any)._fluentKeyCodeEvents[eventId];
+    }
+  }
+
+  /**
+   * A safe, read-only snapshot of the fields needed from a keyboard event, guaranteed
+   * to have valid types even when the source event is missing properties (e.g. a
+   * synthetic or malformed event dispatched instead of a real KeyboardEvent).
+   */
+  class SafeKeyboardEvent {
+    private readonly source: KeyboardEvent;
+
+    constructor(event: KeyboardEvent) {
+      const ev = event as any;
+      this.source = event;
+      this.keyCode = SafeKeyboardEvent.toSafeInt(ev.which || ev.keyCode || ev.charCode);
+      this.key = SafeKeyboardEvent.toSafeString(ev.key);
+      this.ctrlKey = SafeKeyboardEvent.toSafeBool(ev.ctrlKey);
+      this.shiftKey = SafeKeyboardEvent.toSafeBool(ev.shiftKey);
+      this.altKey = SafeKeyboardEvent.toSafeBool(ev.altKey);
+      this.metaKey = SafeKeyboardEvent.toSafeBool(ev.metaKey);
+      this.location = SafeKeyboardEvent.toSafeInt(ev.location);
+      this.repeat = SafeKeyboardEvent.toSafeBool(ev.repeat);
+      this.targetId = SafeKeyboardEvent.toSafeString(ev.currentTarget?.id);
+    }
+
+    readonly keyCode: number;
+    readonly key: string;
+    readonly ctrlKey: boolean;
+    readonly shiftKey: boolean;
+    readonly altKey: boolean;
+    readonly metaKey: boolean;
+    readonly location: number;
+    readonly repeat: boolean;
+    readonly targetId: string;
+
+    preventDefault(): void {
+      this.source.preventDefault();
+    }
+
+    stopPropagation(): void {
+      this.source.stopPropagation();
+    }
+
+    private static toSafeString(value: unknown): string {
+      return typeof value === "string" ? value : "";
+    }
+
+    private static toSafeInt(value: unknown): number {
+      const result = Number(value);
+      return Number.isInteger(result) ? result : 0;
+    }
+
+    private static toSafeBool(value: unknown): boolean {
+      return typeof value === "boolean" ? value : false;
     }
   }
 }


### PR DESCRIPTION
# [dev-v5] KeyCode - Enhance event handling with SafeKeyboardEvent

## Problem

Some events reaching `FluentKeyCode`'s handler aren't fully-formed `KeyboardEvent` objects — e.g. browser autofill/autocomplete or synthetic `Event('keydown')` dispatches leave fields like `ctrlKey`, `location`, or `key` as `undefined`. These `undefined` values get serialized to `null` in the JS interop JSON payload, causing `System.Text.Json` to throw when binding them to non-nullable C# parameters and crashing the component.

```
Uncaught (in promise) Error: System.Text.Json.JsonException: The JSON value could not be converted to System.Int32. Path: $ | LineNumber: 0 | BytePositionInLine: 4.
 ---> System.InvalidOperationException: Cannot get the value of a token type 'Null' as a number.
   at System.Text.Json.ThrowHelper.ThrowInvalidOperationException_ExpectedNumber(JsonTokenType tokenType)
   at System.Text.Json.Utf8JsonReader.TryGetInt32(Int32& value)
   ...
```

## Solution

Added a `SafeKeyboardEvent` class that wraps the raw event and produces a fully-typed, read-only snapshot (`keyCode`, `key`, `ctrlKey`, `shiftKey`, `altKey`, `metaKey`, `location`, `repeat`, `targetId`), falling back to safe defaults (`0`/`false`/`""`) via `toSafeInt`/`toSafeBool`/`toSafeString` whenever a value is missing or of the wrong type. `handler()` now builds one `SafeKeyboardEvent` per event and uses it exclusively (including `preventDefault()`/`stopPropagation()`), guaranteeing only valid, non-nullable values are ever sent to .NET.

## Manual Test

To test:
1. Create a page with this code
```razor
<FluentKeyCode OnKeyDown="@HandleKeyDown">
    <input id="my-target" />
</FluentKeyCode>

@code {
    void HandleKeyDown(FluentKeyCodeEventArgs args)
    {
        Console.WriteLine($"KeyDown: {args.Key} ({args.KeyCode})");
    }
}
```
2. Display this page and run this JS code from the DevTools
```js
document.getElementById('my-target').dispatchEvent(new Event('keydown', { bubbles: true }))
```