### PR TITLE
[dev-v5][Mcp] Update ModelContextProtocol SDK to 2.0.0 (MCP 2026-07-28 spec)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,8 +21,8 @@
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.14.3" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="4.14.3" />
     <PackageVersion Include="LoxSmoke.DocXml" Version="3.9.0" />
-    <!-- For MCP Apps -->
-    <PackageVersion Include="ModelContextProtocol" Version="1.3.0" />
+    <!-- MCP SDK (aligned with the MCP 2026-07-28 specification) -->
+    <PackageVersion Include="ModelContextProtocol" Version="2.0.0" />
     <!-- Test dependencies -->
     <PackageVersion Include="bunit" Version="2.7.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Mcp/Prompts.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Mcp/Prompts.md
@@ -14,7 +14,7 @@ MCP Prompts are **pre-defined prompt templates** that help you accomplish common
 
 {{ MCP Type=prompts }}
 
-> [!NOTE] The Fluent UI Blazor MCP Server focuses primarily on **Tools** and **Resources** for documentation access. Prompt templates may be added in future versions based on community feedback.
+> [!NOTE] The prompts listed above are served directly by the MCP Server. Your MCP client (VS Code, Visual Studio, ...) exposes them, for example through the `/mcp.fluent-ui-blazor` prompt picker in GitHub Copilot Chat.
 
 ## Suggested Prompt Patterns
 
@@ -155,15 +155,6 @@ In your AI assistant chat:
 a grid for displaying customer orders with columns for OrderId,
 CustomerName, OrderDate, and TotalAmount. Enable sorting and pagination.
 ```
-
-## Future Prompt Support
-
-The MCP specification supports server-provided prompts. Future versions of the Fluent UI Blazor MCP Server may include:
-
-- **Component scaffold prompts** - Generate complete component templates
-- **Form builder prompts** - Create forms with validation
-- **Layout prompts** - Design page layouts with Fluent UI
-- **Theme customization prompts** - Apply custom theming
 
 ## Contributing Prompts
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Mcp/VersionCompatibility.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Mcp/VersionCompatibility.md
@@ -8,6 +8,13 @@ icon: ShieldCheckmark
 
 # Version Compatibility
 
+## MCP Protocol Version
+
+The server is built with the official [MCP C# SDK](https://github.com/modelcontextprotocol/csharp-sdk) **2.x**, which targets the MCP **2026-07-28** specification.
+The protocol version is **negotiated per connection**: clients using an earlier specification (2025-11-25 and before) automatically fall back to the legacy `initialize` handshake, so no specific MCP client version is required.
+
+## Component Library Version
+
 The MCP server and the `Microsoft.FluentUI.AspNetCore.Components` NuGet package are **published together with the same version number** (e.g. `5.0.0-rc.1-26049.2`).
 Because the documentation served by the MCP server is generated from a specific version of the component library, your project **must** reference the matching version to ensure the documentation is accurate.
 

--- a/src/Tools/McpServer/.mcp/server.json
+++ b/src/Tools/McpServer/.mcp/server.json
@@ -12,7 +12,7 @@
   "packages": [
     {
       "registryType": "nuget",
-      "registryBaseUrl": "https://api.nuget.org",
+      "registryBaseUrl": "https://api.nuget.org/v3/index.json",
       "identifier": "Microsoft.FluentUI.AspNetCore.McpServer",
       "version": "0.0.1",
       "runtimeHint": "dnx",

--- a/src/Tools/McpServer/.mcp/server.json
+++ b/src/Tools/McpServer/.mcp/server.json
@@ -1,11 +1,11 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "description": "MCP server for Fluent UI Blazor: 142+ components, parameters, events, methods, enums and examples.",
   "icons": [
     {
       "src": "https://www.fluentui-blazor.net/logo.svg",
       "sizes": [ "192x192" ],
-      "mimeType": "image/svg"
+      "mimeType": "image/svg+xml"
     }
   ],
   "name": "io.github.microsoft/fluentui-blazor-mcp",

--- a/src/Tools/McpServer/Microsoft.FluentUI.AspNetCore.McpServer.csproj
+++ b/src/Tools/McpServer/Microsoft.FluentUI.AspNetCore.McpServer.csproj
@@ -8,7 +8,6 @@
     <LangVersion>latest</LangVersion>
     <SignAssembly>False</SignAssembly>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <WarningsNotAsErrors>612,618</WarningsNotAsErrors>
     <RootNamespace>Microsoft.FluentUI.AspNetCore.McpServer</RootNamespace>
 
     <PackageId>Microsoft.FluentUI.AspNetCore.McpServer</PackageId>

--- a/src/Tools/McpServer/README.md
+++ b/src/Tools/McpServer/README.md
@@ -216,6 +216,12 @@ Resources provide static documentation that users can attach to conversations.
 
 ## Version Compatibility
 
+### MCP protocol version
+
+The server is built with the official [MCP C# SDK](https://github.com/modelcontextprotocol/csharp-sdk) **2.x**, which targets the MCP **2026-07-28** specification. The protocol version is negotiated per connection: clients using an earlier specification (2025-11-25 and before) automatically fall back to the legacy `initialize` handshake, so no specific client version is required.
+
+### Component library version
+
 The MCP server and the `Microsoft.FluentUI.AspNetCore.Components` NuGet package are published together with the **same version number** (e.g. `5.0.0-rc.1-26049.2`). Because the documentation served by the MCP is generated from a specific version of the library, it is important that the user's project references the matching version.
 
 Two tools are provided to automate this check:


### PR DESCRIPTION
# Pull Request

## 📖 Description

Chore: updates the MCP server to the `ModelContextProtocol` SDK **2.0.0** (released 2026-07-28), which aligns the C# SDK with the **MCP 2026-07-28 specification**, and removes what is no longer needed with the 2.x line.

- Bump `ModelContextProtocol` from 1.3.0 to **2.0.0** in `Directory.Packages.props`.
- Update `.mcp/server.json` to the latest registry schema (**2025-12-11**) and fix an invalid icon `mimeType` (`image/svg` → `image/svg+xml`).
- Remove the obsolete-warning suppression (`WarningsNotAsErrors 612,618`) from the McpServer csproj — no longer needed with the 2.x SDK (build is clean, 0 warnings).
- Document the targeted MCP protocol version and the per-connection backward compatibility (clients on 2025-11-25 and earlier fall back to the legacy `initialize` handshake) in the README and the demo `VersionCompatibility` page.
- Refresh the MCP Prompts demo page: server-provided prompts are available today, so the stale "Future Prompt Support" section is removed.

No code changes were required: the server is a pure STDIO server exposing tools/resources/prompts and does not use any of the APIs deprecated by the new specification (Roots, Sampling, MCP Logging).

### 🎫 Issues

N/A

## 👩‍💻 Reviewer Notes

- The SDK 2.0 breaking changes (stateless-by-default HTTP, OAuth hardening, Tasks extension split) do not affect this server since it is STDIO-only.
- Protocol version is negotiated per connection, so no minimum MCP client version is required.

## 📑 Test Plan

- `dotnet build src/Tools/McpServer` — succeeds with 0 warnings / 0 errors against SDK 2.0.0.
- `dotnet test tests/McpServer` — **639/639 tests pass**.

## ✅ Checklist

### General

- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### MCP Server

- [x] I have added or updated MCP Server tools/prompts/resources
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my MCP Server changes (existing suite covers the update; no new surface added)

## ⏭ Next Steps

None.
