### PR TITLE
[dev-v5] Extend DefaultValues to set value on a base class

### DIFF
--- a/src/Core/Infrastructure/DefaultValues.cs
+++ b/src/Core/Infrastructure/DefaultValues.cs
@@ -14,6 +14,9 @@ public class DefaultValues
     // List of components and their Property/Default values.
     private readonly ConcurrentDictionary<Type, ConcurrentDictionary<string, object?>> _componentCache = new ConcurrentDictionary<Type, ConcurrentDictionary<string, object?>>();
 
+    // Per-type cache of the properties merged across the inheritance chain, computed once and reused across every ApplyDefaults/SetInitialValues call.
+    private readonly ConcurrentDictionary<Type, ConcurrentDictionary<string, object?>?> _mergedCache = new ConcurrentDictionary<Type, ConcurrentDictionary<string, object?>?>();
+
     private bool _isInitialized;
 
     /// <summary>
@@ -104,22 +107,54 @@ public class DefaultValues
             return null;
         }
 
-        // Walk up the type hierarchy (exact type, then its open generic definition) until "root" object is reached.
+        // Get the merged properties for the component type, computing them if they haven't been cached yet.
+        return _mergedCache.GetOrAdd(componentType, BuildMergedProperties);
+    }
+
+    /// <summary>
+    /// Walks up the type hierarchy (exact type, then its open generic definition) until "root" object is reached,
+    /// merging defaults from base classes so that values registered on a more derived type take precedence.
+    /// The result is cached per exact component type by <see cref="GetCachedProperties"/>.
+    /// </summary>
+    private ConcurrentDictionary<string, object?>? BuildMergedProperties(Type componentType)
+    {
+        ConcurrentDictionary<string, object?>? merged = null;
+
         for (var currentType = componentType; currentType is not null && currentType != typeof(object); currentType = currentType.BaseType)
         {
-            // Try exact type first
-            if (_componentCache.TryGetValue(currentType, out var properties))
+            if (TryGetRegisteredProperties(currentType, out var properties))
             {
-                return properties;
-            }
-
-            // Fallback: check open generic type definition
-            if (currentType.IsGenericType && _componentCache.TryGetValue(currentType.GetGenericTypeDefinition(), out properties))
-            {
-                return properties;
+                merged ??= new ConcurrentDictionary<string, object?>(StringComparer.Ordinal);
+                foreach (var property in properties)
+                {
+                    // The more specific type's values take precedence, so only add if not already present in the merged dictionary.
+                    if (!merged.ContainsKey(property.Key))
+                    {
+                        merged[property.Key] = property.Value;
+                    }
+                }
             }
         }
 
-        return null;
+        return merged;
+    }
+
+    /// <summary>
+    /// Tries to retrieve the registered properties for a given component type, checking both the exact type and its open generic definition if applicable.
+    /// </summary>
+    private bool TryGetRegisteredProperties(Type componentType, [NotNullWhen(true)] out ConcurrentDictionary<string, object?>? properties)
+    {
+        if (_componentCache.TryGetValue(componentType, out properties))
+        {
+            return true;
+        }
+
+        if (componentType.IsGenericType)
+        {
+            return _componentCache.TryGetValue(componentType.GetGenericTypeDefinition(), out properties);
+        }
+
+        properties = null;
+        return false;
     }
 }

--- a/src/Core/Infrastructure/DefaultValues.cs
+++ b/src/Core/Infrastructure/DefaultValues.cs
@@ -14,10 +14,17 @@ public class DefaultValues
     // List of components and their Property/Default values.
     private readonly ConcurrentDictionary<Type, ConcurrentDictionary<string, object?>> _componentCache = new ConcurrentDictionary<Type, ConcurrentDictionary<string, object?>>();
 
-    // Per-type cache of the properties merged across the inheritance chain, computed once and reused across every ApplyDefaults/SetInitialValues call.
-    private readonly ConcurrentDictionary<Type, IReadOnlyDictionary<string, object?>?> _mergedCache = new ConcurrentDictionary<Type, IReadOnlyDictionary<string, object?>?>();
+    // Per-type cache of the properties merged across the inheritance chain, with PropertyInfo resolved once and reused
+    // across every ApplyDefaults/SetInitialValues call, avoiding reflection lookups on every component instantiation.
+    private readonly ConcurrentDictionary<Type, CachedDefault[]?> _mergedCache = new ConcurrentDictionary<Type, CachedDefault[]?>();
 
     private bool _isInitialized;
+
+    /// <summary>
+    /// A default value with its <see cref="PropertyInfo"/> already resolved, so <see cref="ApplyDefaults{TComponent}(TComponent)"/>
+    /// never needs to perform a reflection lookup by name.
+    /// </summary>
+    private readonly record struct CachedDefault(PropertyInfo Property, object? Value);
 
     /// <summary>
     /// Registers default values for a specific component type.
@@ -65,11 +72,7 @@ public class DefaultValues
         {
             foreach (var property in properties)
             {
-                var propInfo = componentType.GetProperty(property.Key, BindingFlags.Public | BindingFlags.Instance);
-                if (propInfo != null && propInfo.CanWrite)
-                {
-                    propInfo.SetValue(component, property.Value);
-                }
+                property.Property.SetValue(component, property.Value);
             }
         }
     }
@@ -87,7 +90,7 @@ public class DefaultValues
         {
             foreach (var kvp in initialValues)
             {
-                if (!properties.ContainsKey(kvp.Name))
+                if (!ContainsProperty(properties, kvp.Name))
                 {
                     var propInfo = componentType.GetProperty(kvp.Name, BindingFlags.Public | BindingFlags.Instance);
                     if (propInfo != null && propInfo.CanWrite)
@@ -100,7 +103,7 @@ public class DefaultValues
     }
 
     /// <summary />
-    private IReadOnlyDictionary<string, object?>? GetCachedProperties(Type componentType)
+    private CachedDefault[]? GetCachedProperties(Type componentType)
     {
         if (!_isInitialized || componentType is null)
         {
@@ -112,42 +115,53 @@ public class DefaultValues
     }
 
     /// <summary>
-    /// Walks up the type hierarchy (exact type, then its open generic definition) until "root" object is reached,
-    /// merging defaults from base classes so that values registered on a more derived type take precedence.
-    /// The result is cached per exact component type by <see cref="GetCachedProperties"/>.
+    /// Walks up the type hierarchy, merging defaults from base classes so that values registered on a more derived type
+    /// take precedence, then resolves each property's <see cref="PropertyInfo"/> once. The result is cached per exact
+    /// component type by <see cref="GetCachedProperties"/> so no reflection lookup is repeated on later calls.
     /// </summary>
-    private IReadOnlyDictionary<string, object?>? BuildMergedProperties(Type componentType)
+    private CachedDefault[]? BuildMergedProperties(Type componentType)
     {
-        IReadOnlyDictionary<string, object?>? merged = null;
-        Dictionary<string, object?>? combined = null;
+        Dictionary<string, object?>? merged = null;
 
-        // Walk up the type hierarchy, merging defaults from base classes so that values registered on a more derived type take precedence.
         for (var currentType = componentType; currentType is not null && currentType != typeof(object); currentType = currentType.BaseType)
         {
-            // Check if the current type has registered properties in the cache
             if (!TryGetRegisteredProperties(currentType, out var properties))
             {
                 continue;
             }
 
-            // Common case: only one type in the chain has registrations, so reuse it without allocating.
             if (merged is null)
             {
-                merged = properties;
+                merged = new Dictionary<string, object?>(properties, StringComparer.Ordinal);
                 continue;
             }
 
-            // A base class also has defaults: copy once, then let more derived values (already in combined) win.
-            combined ??= new Dictionary<string, object?>(merged, StringComparer.Ordinal);
+            // A base class also has defaults: only add names not already set by a more derived type.
             foreach (var property in properties)
             {
-                combined.TryAdd(property.Key, property.Value);
+                merged.TryAdd(property.Key, property.Value);
             }
-
-            merged = combined;
         }
 
-        return merged;
+        if (merged is null)
+        {
+            return null;
+        }
+
+        // Resolve PropertyInfo for each property name once, so ApplyDefaults never needs to perform a reflection lookup by name.
+        var resolved = new CachedDefault[merged.Count];
+        var count = 0;
+
+        foreach (var (name, value) in merged)
+        {
+            var propInfo = componentType.GetProperty(name, BindingFlags.Public | BindingFlags.Instance);
+            if (propInfo != null && propInfo.CanWrite)
+            {
+                resolved[count++] = new CachedDefault(propInfo, value);
+            }
+        }
+
+        return count == resolved.Length ? resolved : resolved[..count];
     }
 
     /// <summary>
@@ -166,6 +180,23 @@ public class DefaultValues
         }
 
         properties = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Checks if the provided property name exists in the cached properties array.
+    /// Using a foreach loop instead of LINQ to avoid allocations and improve performance.
+    /// </summary>
+    private static bool ContainsProperty(CachedDefault[] properties, string name)
+    {
+        foreach (var property in properties)
+        {
+            if (string.Equals(property.Property.Name, name, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
         return false;
     }
 }

--- a/src/Core/Infrastructure/DefaultValues.cs
+++ b/src/Core/Infrastructure/DefaultValues.cs
@@ -9,7 +9,6 @@ using System.Reflection;
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 /// <summary />
-[ExcludeFromCodeCoverage(Justification = "Test will be added later")]
 public class DefaultValues
 {
     // List of components and their Property/Default values.

--- a/src/Core/Infrastructure/DefaultValues.cs
+++ b/src/Core/Infrastructure/DefaultValues.cs
@@ -15,7 +15,7 @@ public class DefaultValues
     private readonly ConcurrentDictionary<Type, ConcurrentDictionary<string, object?>> _componentCache = new ConcurrentDictionary<Type, ConcurrentDictionary<string, object?>>();
 
     // Per-type cache of the properties merged across the inheritance chain, computed once and reused across every ApplyDefaults/SetInitialValues call.
-    private readonly ConcurrentDictionary<Type, ConcurrentDictionary<string, object?>?> _mergedCache = new ConcurrentDictionary<Type, ConcurrentDictionary<string, object?>?>();
+    private readonly ConcurrentDictionary<Type, IReadOnlyDictionary<string, object?>?> _mergedCache = new ConcurrentDictionary<Type, IReadOnlyDictionary<string, object?>?>();
 
     private bool _isInitialized;
 
@@ -100,7 +100,7 @@ public class DefaultValues
     }
 
     /// <summary />
-    private ConcurrentDictionary<string, object?>? GetCachedProperties(Type componentType)
+    private IReadOnlyDictionary<string, object?>? GetCachedProperties(Type componentType)
     {
         if (!_isInitialized || componentType is null)
         {
@@ -116,24 +116,35 @@ public class DefaultValues
     /// merging defaults from base classes so that values registered on a more derived type take precedence.
     /// The result is cached per exact component type by <see cref="GetCachedProperties"/>.
     /// </summary>
-    private ConcurrentDictionary<string, object?>? BuildMergedProperties(Type componentType)
+    private IReadOnlyDictionary<string, object?>? BuildMergedProperties(Type componentType)
     {
-        ConcurrentDictionary<string, object?>? merged = null;
+        IReadOnlyDictionary<string, object?>? merged = null;
+        Dictionary<string, object?>? combined = null;
 
+        // Walk up the type hierarchy, merging defaults from base classes so that values registered on a more derived type take precedence.
         for (var currentType = componentType; currentType is not null && currentType != typeof(object); currentType = currentType.BaseType)
         {
-            if (TryGetRegisteredProperties(currentType, out var properties))
+            // Check if the current type has registered properties in the cache
+            if (!TryGetRegisteredProperties(currentType, out var properties))
             {
-                merged ??= new ConcurrentDictionary<string, object?>(StringComparer.Ordinal);
-                foreach (var property in properties)
-                {
-                    // The more specific type's values take precedence, so only add if not already present in the merged dictionary.
-                    if (!merged.ContainsKey(property.Key))
-                    {
-                        merged[property.Key] = property.Value;
-                    }
-                }
+                continue;
             }
+
+            // Common case: only one type in the chain has registrations, so reuse it without allocating.
+            if (merged is null)
+            {
+                merged = properties;
+                continue;
+            }
+
+            // A base class also has defaults: copy once, then let more derived values (already in combined) win.
+            combined ??= new Dictionary<string, object?>(merged, StringComparer.Ordinal);
+            foreach (var property in properties)
+            {
+                combined.TryAdd(property.Key, property.Value);
+            }
+
+            merged = combined;
         }
 
         return merged;

--- a/src/Core/Infrastructure/DefaultValues.cs
+++ b/src/Core/Infrastructure/DefaultValues.cs
@@ -105,16 +105,22 @@ public class DefaultValues
             return null;
         }
 
-        // Try exact type first
-        if (!_componentCache.TryGetValue(componentType, out var properties))
+        // Walk up the type hierarchy (exact type, then its open generic definition) until "root" object is reached.
+        for (var currentType = componentType; currentType is not null && currentType != typeof(object); currentType = currentType.BaseType)
         {
-            // Fallback: check open generic type definition
-            if (componentType.IsGenericType)
+            // Try exact type first
+            if (_componentCache.TryGetValue(currentType, out var properties))
             {
-                _componentCache.TryGetValue(componentType.GetGenericTypeDefinition(), out properties);
+                return properties;
+            }
+
+            // Fallback: check open generic type definition
+            if (currentType.IsGenericType && _componentCache.TryGetValue(currentType.GetGenericTypeDefinition(), out properties))
+            {
+                return properties;
             }
         }
 
-        return properties;
+        return null;
     }
 }

--- a/src/Core/Infrastructure/DefaultValuesComponentBuilder.cs
+++ b/src/Core/Infrastructure/DefaultValuesComponentBuilder.cs
@@ -79,7 +79,7 @@ public class DefaultValuesComponentBuilder<[DynamicallyAccessedMembers(Dynamical
     /// <summary>
     /// Validates that the provided value is compatible with the specified property type. Throws an exception if the value is not compatible.
     /// </summary>
-    private static void ValidateValueCompatibility(PropertyInfo propertyInfo, object? value, string propertyName)
+    internal static void ValidateValueCompatibility(PropertyInfo propertyInfo, object? value, string propertyName)
     {
         var propertyType = propertyInfo.PropertyType;
         var nullableUnderlyingType = Nullable.GetUnderlyingType(propertyType);

--- a/src/Core/Infrastructure/DefaultValuesComponentBuilder.cs
+++ b/src/Core/Infrastructure/DefaultValuesComponentBuilder.cs
@@ -23,7 +23,7 @@ public class DefaultValuesComponentBuilder<[DynamicallyAccessedMembers(Dynamical
     /// Initializes a new instance of the <see cref="DefaultValuesComponentBuilder{TComponent}"/> class with the specified default
     /// values.
     /// </summary>
-    /// <param name="values">A thread-safe dictionary containing the default values to be used by the component.  Keys represent the names of
+    /// <param name="values">A thrad-safe dictionary containing the default values to be used by the component.  Keys represent the names of
     /// the values, and values represent their corresponding default values.  Cannot be <see langword="null"/>.</param>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="values"/> is <see langword="null"/>.</exception>
     internal DefaultValuesComponentBuilder(ConcurrentDictionary<string, object?> values)

--- a/src/Core/Infrastructure/DefaultValuesComponentBuilder.cs
+++ b/src/Core/Infrastructure/DefaultValuesComponentBuilder.cs
@@ -12,7 +12,6 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// <summary>
 /// Provides functionality to configure default values for component parameters of type <typeparamref name="TComponent" />.
 /// </summary>
-[ExcludeFromCodeCoverage(Justification = "Test will be added later")]
 public class DefaultValuesComponentBuilder<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TComponent>
 {
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]

--- a/src/Core/Infrastructure/DefaultValuesComponentBuilder.cs
+++ b/src/Core/Infrastructure/DefaultValuesComponentBuilder.cs
@@ -16,13 +16,14 @@ public class DefaultValuesComponentBuilder<[DynamicallyAccessedMembers(Dynamical
 {
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
     private static readonly Type TComponentType = typeof(TComponent);
+    private static readonly NullabilityInfoContext NullabilityContext = new();
     private readonly ConcurrentDictionary<string, object?> _values;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DefaultValuesComponentBuilder{TComponent}"/> class with the specified default
     /// values.
     /// </summary>
-    /// <param name="values">A thrad-safe dictionary containing the default values to be used by the component.  Keys represent the names of
+    /// <param name="values">A thread-safe dictionary containing the default values to be used by the component.  Keys represent the names of
     /// the values, and values represent their corresponding default values.  Cannot be <see langword="null"/>.</param>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="values"/> is <see langword="null"/>.</exception>
     internal DefaultValuesComponentBuilder(ConcurrentDictionary<string, object?> values)
@@ -49,7 +50,7 @@ public class DefaultValuesComponentBuilder<[DynamicallyAccessedMembers(Dynamical
         var propertyName = propertyInfo?.Name
                         ?? throw new ArgumentException($"The parameter selector '{parameterSelector}' does not resolve to a public property on component '{typeof(TComponent)}'.", nameof(parameterSelector));
 
-        if (!propertyInfo.CanWrite)
+        if (propertyInfo is null || !propertyInfo.CanWrite)
         {
             throw new ArgumentException($"The property '{propertyName}' on component '{typeof(TComponent)}' is read-only and cannot be used for default values.", nameof(parameterSelector));
         }
@@ -91,7 +92,7 @@ public class DefaultValuesComponentBuilder<[DynamicallyAccessedMembers(Dynamical
                 throw new ArgumentException($"Default value for '{propertyName}' on component '{typeof(TComponent)}' cannot be null because the property type '{propertyType}' is non-nullable.", nameof(value));
             }
 
-            var nullabilityInfo = new NullabilityInfoContext().Create(propertyInfo);
+            var nullabilityInfo = NullabilityContext.Create(propertyInfo);
             if (nullabilityInfo.WriteState == NullabilityState.NotNull)
             {
                 throw new ArgumentException($"Default value for '{propertyName}' on component '{typeof(TComponent)}' cannot be null because the property is non-nullable.", nameof(value));

--- a/src/Core/Infrastructure/DefaultValuesComponentBuilder.cs
+++ b/src/Core/Infrastructure/DefaultValuesComponentBuilder.cs
@@ -39,7 +39,7 @@ public class DefaultValuesComponentBuilder<[DynamicallyAccessedMembers(Dynamical
 
         if (parameterSelector.Body is not MemberExpression { Member: PropertyInfo propInfoCandidate })
         {
-            throw new ArgumentException($"The parameter selector '{parameterSelector}' does not resolve to a public property on the component '{typeof(TComponent)}'.", nameof(parameterSelector));
+            throw new ArgumentException($"The parameter selector '{parameterSelector}' does not resolve to a public property on component '{typeof(TComponent)}'.", nameof(parameterSelector));
         }
 
         // Property name
@@ -48,7 +48,15 @@ public class DefaultValuesComponentBuilder<[DynamicallyAccessedMembers(Dynamical
                          : propInfoCandidate;
 
         var propertyName = propertyInfo?.Name
-                        ?? throw new ArgumentException($"The parameter selector '{parameterSelector}' does not resolve to a public property on the component '{typeof(TComponent)}'.", nameof(parameterSelector));
+                        ?? throw new ArgumentException($"The parameter selector '{parameterSelector}' does not resolve to a public property on component '{typeof(TComponent)}'.", nameof(parameterSelector));
+
+        if (!propertyInfo.CanWrite)
+        {
+            throw new ArgumentException($"The property '{propertyName}' on component '{typeof(TComponent)}' is read-only and cannot be used for default values.", nameof(parameterSelector));
+        }
+
+        // Validate that the provided value is compatible with the property type
+        ValidateValueCompatibility(propertyInfo, value, propertyName);
 
         // Add the value to the dictionary, using the property name as the key.
         _values.AddOrUpdate(propertyName, AddFunction, UpdateFunction);
@@ -66,6 +74,37 @@ public class DefaultValuesComponentBuilder<[DynamicallyAccessedMembers(Dynamical
             }
 
             return value;
+        }
+    }
+
+    /// <summary>
+    /// Validates that the provided value is compatible with the specified property type. Throws an exception if the value is not compatible.
+    /// </summary>
+    private static void ValidateValueCompatibility(PropertyInfo propertyInfo, object? value, string propertyName)
+    {
+        var propertyType = propertyInfo.PropertyType;
+        var nullableUnderlyingType = Nullable.GetUnderlyingType(propertyType);
+
+        if (value is null)
+        {
+            if (propertyType.IsValueType && nullableUnderlyingType is null)
+            {
+                throw new ArgumentException($"Default value for '{propertyName}' on component '{typeof(TComponent)}' cannot be null because the property type '{propertyType}' is non-nullable.", nameof(value));
+            }
+
+            var nullabilityInfo = new NullabilityInfoContext().Create(propertyInfo);
+            if (nullabilityInfo.WriteState == NullabilityState.NotNull)
+            {
+                throw new ArgumentException($"Default value for '{propertyName}' on component '{typeof(TComponent)}' cannot be null because the property is non-nullable.", nameof(value));
+            }
+
+            return;
+        }
+
+        var targetType = nullableUnderlyingType ?? propertyType;
+        if (!targetType.IsInstanceOfType(value))
+        {
+            throw new ArgumentException($"Default value for '{propertyName}' on component '{typeof(TComponent)}' must be assignable to '{targetType}', but was '{value.GetType()}'.", nameof(value));
         }
     }
 }

--- a/tests/Core/Infrastructure/DefaultValuesTests.cs
+++ b/tests/Core/Infrastructure/DefaultValuesTests.cs
@@ -10,6 +10,30 @@ public class DefaultValuesTests
 {
     private static FluentDivider CreateDivider() => new(new LibraryConfiguration());
 
+    // Plain POCO (no IFluentComponentBase constraint required by DefaultValuesComponentBuilder<T>) used to
+    // exercise Set() edge cases that are not easily reproducible using real Fluent components.
+    private sealed class SamplePoco
+    {
+        public string? NullableName { get; set; }
+        public string RequiredName { get; set; } = string.Empty;
+        public int? OptionalAge { get; set; }
+        public int Age { get; set; }
+        public string ReadOnlyValue { get; } = "fixed";
+        public string PublicField = string.Empty;
+    }
+
+    // Property inherited from a parent interface is not found by TComponentType.GetProperty(name, type)
+    // when TComponentType is an interface, unlike class hierarchies.
+    private interface IBaseInterface
+    {
+        string? Name { get; set; }
+    }
+
+    private interface IDerivedInterface : IBaseInterface
+    {
+        int Age { get; set; }
+    }
+
     [Fact]
     public void ApplyDefaults_RegisteredDefaultValue_SetsPropertyValue()
     {
@@ -119,5 +143,154 @@ public class DefaultValuesTests
         defaultValues.ApplyDefaults(component);
 
         Assert.Equal("10px", component.Margin);
+    }
+
+    [Fact]
+    public void ApplyDefaults_ForAnyNonGenericComponent_RegistersUsingConcreteType()
+    {
+        var defaultValues = new DefaultValues();
+        defaultValues.ForAny<FluentDivider>().Set(x => x.Inset, true);
+        var component = CreateDivider();
+
+        defaultValues.ApplyDefaults(component);
+
+        Assert.Equal((bool?)true, component.Inset);
+    }
+
+    [Fact]
+    public void Set_CalledTwiceWithSameValue_KeepsRegisteredValue()
+    {
+        var defaultValues = new DefaultValues();
+        var builder = defaultValues.For<FluentDivider>();
+        builder.Set(x => x.Inset, true);
+        builder.Set(x => x.Inset, true);
+        var component = CreateDivider();
+
+        defaultValues.ApplyDefaults(component);
+
+        Assert.Equal((bool?)true, component.Inset);
+    }
+
+    [Fact]
+    public void Set_CalledTwiceWithDifferentValue_UpdatesRegisteredValue()
+    {
+        var defaultValues = new DefaultValues();
+        var builder = defaultValues.For<FluentDivider>();
+        builder.Set(x => x.Inset, true);
+        builder.Set(x => x.Inset, false);
+        var component = CreateDivider();
+
+        defaultValues.ApplyDefaults(component);
+
+        Assert.Equal((bool?)false, component.Inset);
+    }
+
+    [Fact]
+    public void Set_PropertyDeclaredOnBaseType_RegistersUsingBaseComponentPropertyName()
+    {
+        var defaultValues = new DefaultValues();
+        defaultValues.For<FluentDivider>().Set(x => x.Margin, "5px");
+        var component = CreateDivider();
+
+        defaultValues.ApplyDefaults(component);
+
+        Assert.Equal("5px", component.Margin);
+    }
+
+    [Fact]
+    public void Set_NullParameterSelector_ThrowsArgumentNullException()
+    {
+        var defaultValues = new DefaultValues();
+        var builder = defaultValues.For<SamplePoco>();
+
+        Assert.Throws<ArgumentNullException>(() => builder.Set<string?>(null!, "value"));
+    }
+
+    [Fact]
+    public void Set_ParameterSelectorTargetsField_ThrowsArgumentException()
+    {
+        var defaultValues = new DefaultValues();
+        var builder = defaultValues.For<SamplePoco>();
+
+        var exception = Assert.Throws<ArgumentException>(() => builder.Set(x => x.PublicField, "value"));
+
+        Assert.Contains("does not resolve to a public property", exception.Message);
+    }
+
+    [Fact]
+    public void Set_ReadOnlyProperty_ThrowsArgumentException()
+    {
+        var defaultValues = new DefaultValues();
+        var builder = defaultValues.For<SamplePoco>();
+
+        var exception = Assert.Throws<ArgumentException>(() => builder.Set(x => x.ReadOnlyValue, "value"));
+
+        Assert.Contains("is read-only", exception.Message);
+    }
+
+    [Fact]
+    public void Set_NullValueForNonNullableReferenceTypeProperty_ThrowsArgumentException()
+    {
+        var defaultValues = new DefaultValues();
+        var builder = defaultValues.For<SamplePoco>();
+
+        var exception = Assert.Throws<ArgumentException>(() => builder.Set(x => x.RequiredName, null));
+
+        Assert.Contains("cannot be null", exception.Message);
+    }
+
+    [Fact]
+    public void Set_NullValueForNullableReferenceTypeProperty_DoesNotThrow()
+    {
+        var defaultValues = new DefaultValues();
+        var builder = defaultValues.For<SamplePoco>();
+
+        var exception = Record.Exception(() => builder.Set(x => x.NullableName, null));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Set_NullValueForNullableValueTypeProperty_DoesNotThrow()
+    {
+        var defaultValues = new DefaultValues();
+        var builder = defaultValues.For<SamplePoco>();
+
+        var exception = Record.Exception(() => builder.Set(x => x.OptionalAge, null));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Set_InterfacePropertyDeclaredOnParentInterface_ThrowsArgumentException()
+    {
+        var defaultValues = new DefaultValues();
+        var builder = defaultValues.For<IDerivedInterface>();
+
+        var exception = Assert.Throws<ArgumentException>(() => builder.Set(x => x.Name, "value"));
+
+        Assert.Contains("does not resolve to a public property", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateValueCompatibility_NullForNonNullableValueTypeProperty_ThrowsArgumentException()
+    {
+        var propertyInfo = typeof(SamplePoco).GetProperty(nameof(SamplePoco.Age))!;
+
+        var exception = Assert.Throws<ArgumentException>(() =>
+            DefaultValuesComponentBuilder<SamplePoco>.ValidateValueCompatibility(propertyInfo, null, propertyInfo.Name));
+
+        Assert.Contains("cannot be null", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateValueCompatibility_ValueNotAssignableToPropertyType_ThrowsArgumentException()
+    {
+        var propertyInfo = typeof(SamplePoco).GetProperty(nameof(SamplePoco.RequiredName))!;
+
+        var exception = Assert.Throws<ArgumentException>(() =>
+            DefaultValuesComponentBuilder<SamplePoco>.ValidateValueCompatibility(propertyInfo, 42, propertyInfo.Name));
+
+        Assert.Contains("must be assignable", exception.Message);
     }
 }

--- a/tests/Core/Infrastructure/DefaultValuesTests.cs
+++ b/tests/Core/Infrastructure/DefaultValuesTests.cs
@@ -146,6 +146,35 @@ public class DefaultValuesTests
     }
 
     [Fact]
+    public void ApplyDefaults_RegisteredBaseClass_DifferentValues()
+    {
+        var defaultValues = new DefaultValues();
+        defaultValues.For<FluentComponentBase>().Set(x => x.Margin, "10px");
+        defaultValues.For<FluentDivider>().Set(x => x.Padding, "20px");
+        var component = CreateDivider();
+
+        defaultValues.ApplyDefaults(component);
+
+        Assert.Equal("10px", component.Margin);
+        Assert.Equal("20px", component.Padding);
+    }
+
+    [Fact]
+    public void ApplyDefaults_RegisteredBaseClass_OverridesBaseClassValues()
+    {
+        var defaultValues = new DefaultValues();
+        defaultValues.For<FluentComponentBase>().Set(x => x.Margin, "10px");
+        defaultValues.For<FluentDivider>().Set(x => x.Margin, "50px");
+        defaultValues.For<FluentDivider>().Set(x => x.Padding, "20px");
+        var component = CreateDivider();
+
+        defaultValues.ApplyDefaults(component);
+
+        Assert.Equal("50px", component.Margin);
+        Assert.Equal("20px", component.Padding);
+    }
+
+    [Fact]
     public void ApplyDefaults_ForAnyNonGenericComponent_RegistersUsingConcreteType()
     {
         var defaultValues = new DefaultValues();

--- a/tests/Core/Infrastructure/DefaultValuesTests.cs
+++ b/tests/Core/Infrastructure/DefaultValuesTests.cs
@@ -108,4 +108,16 @@ public class DefaultValuesTests
 
         Assert.Null(component.Inset);
     }
+
+    [Fact]
+    public void ApplyDefaults_RegisteredBaseClass()
+    {
+        var defaultValues = new DefaultValues();
+        defaultValues.For<FluentComponentBase>().Set(x => x.Margin, "10px");
+        var component = CreateDivider();
+
+        defaultValues.ApplyDefaults(component);
+
+        Assert.Equal("10px", component.Margin);
+    }
 }

--- a/tests/Core/Infrastructure/DefaultValuesTests.cs
+++ b/tests/Core/Infrastructure/DefaultValuesTests.cs
@@ -1,0 +1,111 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using Xunit;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Tests.Infrastructure;
+
+public class DefaultValuesTests
+{
+    private static FluentDivider CreateDivider() => new(new LibraryConfiguration());
+
+    [Fact]
+    public void ApplyDefaults_RegisteredDefaultValue_SetsPropertyValue()
+    {
+        var defaultValues = new DefaultValues();
+        defaultValues.For<FluentDivider>().Set(x => x.Inset, true);
+        var component = CreateDivider();
+
+        defaultValues.ApplyDefaults(component);
+
+        Assert.Equal((bool?)true, component.Inset);
+    }
+
+    [Fact]
+    public void ApplyDefaults_NoRegisteredDefaults_PropertyRemainsUnset()
+    {
+        var defaultValues = new DefaultValues();
+        var component = CreateDivider();
+
+        defaultValues.ApplyDefaults(component);
+
+        Assert.Null(component.Inset);
+    }
+
+    [Fact]
+    public void ApplyDefaults_UnregisteredComponentType_DoesNotThrow()
+    {
+        var defaultValues = new DefaultValues();
+        defaultValues.For<FluentOption<string>>().Set(x => x.Name, "option-name");
+        var component = CreateDivider();
+
+        var exception = Record.Exception(() => defaultValues.ApplyDefaults(component));
+
+        Assert.Null(exception);
+        Assert.Null(component.Inset);
+    }
+
+    [Fact]
+    public void ApplyDefaults_MultipleRegisteredProperties_SetsAllPropertyValues()
+    {
+        var defaultValues = new DefaultValues();
+        var builder = defaultValues.For<FluentDivider>();
+        builder.Set(x => x.Inset, true);
+        builder.Set(x => x.Vertical, true);
+        var component = CreateDivider();
+
+        defaultValues.ApplyDefaults(component);
+
+        Assert.Equal((bool?)true, component.Inset);
+        Assert.Equal((bool?)true, component.Vertical);
+    }
+
+    [Fact]
+    public void ApplyDefaults_ForAnyGenericComponent_AppliesToAnyClosedGenericType()
+    {
+        var defaultValues = new DefaultValues();
+        defaultValues.ForAny<FluentOption<object>>().Set(x => x.Name, "generic-default");
+        var component = new FluentOption<string>(new LibraryConfiguration());
+
+        defaultValues.ApplyDefaults(component);
+
+        Assert.Equal("generic-default", component.Name);
+    }
+
+    [Fact]
+    public void SetInitialValues_PropertyWithoutRegisteredDefault_SetsInitialValue()
+    {
+        var defaultValues = new DefaultValues();
+        defaultValues.For<FluentDivider>(); // Marks the type as initialized without registering a default value
+        var component = CreateDivider();
+
+        defaultValues.SetInitialValues(component, [(nameof(FluentDivider.Inset), true)]);
+
+        Assert.Equal((bool?)true, component.Inset);
+    }
+
+    [Fact]
+    public void SetInitialValues_PropertyWithRegisteredDefault_KeepsRegisteredValueOverInitialValue()
+    {
+        var defaultValues = new DefaultValues();
+        defaultValues.For<FluentDivider>().Set(x => x.Inset, false);
+        var component = CreateDivider();
+        defaultValues.ApplyDefaults(component);
+
+        defaultValues.SetInitialValues(component, [(nameof(FluentDivider.Inset), true)]);
+
+        Assert.Equal((bool?)false, component.Inset);
+    }
+
+    [Fact]
+    public void SetInitialValues_ComponentTypeNotInitialized_DoesNotSetValue()
+    {
+        var defaultValues = new DefaultValues();
+        var component = CreateDivider();
+
+        defaultValues.SetInitialValues(component, [(nameof(FluentDivider.Inset), true)]);
+
+        Assert.Null(component.Inset);
+    }
+}


### PR DESCRIPTION
# [dev-v5] Extend DefaultValues to set value on a base class

Alternative to #4999

Allow setting a default value on a **base class** so to set it for all derived components. 
This default can be overridden in a derived class. 
So now this works:

```csharp
// Add FluentUI services
builder.Services.AddFluentUIComponents(config =>
{
    // Set RoundedCorners for all charts 
    config.DefaultValues.For<FluentChartBase>().Set(p => p.RoundedCorners, true);

    // But not for DonutCharts
    config.DefaultValues.For<FluentDonutChart>().Set(p => p.RoundedCorners, false);
});
```

## Unit Tests

Enhance the **DefaultValues** functionality by adding unit tests, improving nullability checks, and refining parameter documentation. 

Remove unnecessary attributes and adjust method access modifiers for better encapsulation. This work ensures more robust handling of default values in components.

<img width="1445" height="82" alt="image" src="https://github.com/user-attachments/assets/77b13cdf-c897-4b68-9811-7baa305279a3" />


