### PR TITLE
[dev-v5] Add support for styling the internal control

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextInput/FluentTextInput.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextInput/FluentTextInput.md
@@ -124,6 +124,24 @@ You can set the `TextInputType` property to define the type of the text input. T
 
 {{ TextInputTypes }}
 
+## Styling the internal control
+
+Use the `ControlStyle` parameter to apply CSS declarations directly to the internal input control in the component's shadow DOM.
+For example, the following text input displays its entered text in red:
+
+```razor
+<FluentTextInput ControlStyle="color: red !important;" />
+```
+
+For password inputs, use the predefined `FluentTextInput.HidePasswordToggle` style to hide the browser-provided password reveal and credentials autofill buttons:
+
+```razor
+<FluentTextInput TextInputType="TextInputType.Password"
+                 ControlStyle="@FluentTextInput.HidePasswordToggle" />
+```
+
+The style is applied when the component is first rendered and cannot be changed dynamically afterward.
+
 ## Placeholders and autofill
 
 The `Placeholder` parameter is used to set the placeholder text for the input field. This is a short hint that describes the expected value of the input field.

--- a/src/Core.Scripts/src/Components/TextInput/TextInput.ts
+++ b/src/Core.Scripts/src/Components/TextInput/TextInput.ts
@@ -37,6 +37,42 @@ export namespace Microsoft.FluentUI.Blazor.Components.TextInput {
   };
 
   /**
+   * Applies custom CSS to the internal input element (shadow DOM "control" part) by injecting a
+   * scoped <style> element into the component's shadow root. Unlike '::part(control)' from outside,
+   * this can also target pseudo-elements such as '::-ms-reveal' since the style lives in the same
+   * shadow tree as the input.
+   * @param {HTMLElement} element - The host <fluent-text-input>/<fluent-text-area> element
+   * @param {string | null} style - CSS text. Plain declarations without a selector (e.g. 'color: red;')
+   * are applied to the input itself; text containing a selector (e.g. '::-ms-reveal { display: none; }')
+   * is injected as-is.
+   */
+  export function applyControlStyle(element: HTMLElement, style: string | null): void {
+    const shadowRoot = element.shadowRoot;
+    if (!shadowRoot) {
+      return;
+    }
+
+    const styleElement = shadowRoot.querySelector<HTMLStyleElement>('style[data-fluent-control-style]');
+
+    if (!style) {
+      styleElement?.remove();
+      return;
+    }
+
+    const cssText = style.includes('{') ? style : `.control { ${style} }`;
+
+    if (styleElement) {
+      styleElement.textContent = cssText;
+      return;
+    }
+
+    const newStyleElement = document.createElement('style');
+    newStyleElement.setAttribute('data-fluent-control-style', '');
+    newStyleElement.textContent = cssText;
+    shadowRoot.appendChild(newStyleElement);
+  };
+
+  /**
    * Type for elements that support delayed 'immediate' input events
    */
   type InputImmediateElement = (FluentUIComponents.TextInput | FluentUIComponents.TextArea) & {

--- a/src/Core.Scripts/src/Components/TextInput/TextInput.ts
+++ b/src/Core.Scripts/src/Components/TextInput/TextInput.ts
@@ -37,42 +37,6 @@ export namespace Microsoft.FluentUI.Blazor.Components.TextInput {
   };
 
   /**
-   * Applies custom CSS to the internal input element (shadow DOM "control" part) by injecting a
-   * scoped <style> element into the component's shadow root. Unlike '::part(control)' from outside,
-   * this can also target pseudo-elements such as '::-ms-reveal' since the style lives in the same
-   * shadow tree as the input.
-   * @param {HTMLElement} element - The host <fluent-text-input>/<fluent-text-area> element
-   * @param {string | null} style - CSS text. Plain declarations without a selector (e.g. 'color: red;')
-   * are applied to the input itself; text containing a selector (e.g. '::-ms-reveal { display: none; }')
-   * is injected as-is.
-   */
-  export function applyControlStyle(element: HTMLElement, style: string | null): void {
-    const shadowRoot = element.shadowRoot;
-    if (!shadowRoot) {
-      return;
-    }
-
-    const styleElement = shadowRoot.querySelector<HTMLStyleElement>('style[data-fluent-control-style]');
-
-    if (!style) {
-      styleElement?.remove();
-      return;
-    }
-
-    const cssText = style.includes('{') ? style : `.control { ${style} }`;
-
-    if (styleElement) {
-      styleElement.textContent = cssText;
-      return;
-    }
-
-    const newStyleElement = document.createElement('style');
-    newStyleElement.setAttribute('data-fluent-control-style', '');
-    newStyleElement.textContent = cssText;
-    shadowRoot.appendChild(newStyleElement);
-  };
-
-  /**
    * Type for elements that support delayed 'immediate' input events
    */
   type InputImmediateElement = (FluentUIComponents.TextInput | FluentUIComponents.TextArea) & {

--- a/src/Core.Scripts/src/Utilities/Attributes.ts
+++ b/src/Core.Scripts/src/Utilities/Attributes.ts
@@ -36,6 +36,48 @@ export namespace Microsoft.FluentUI.Blazor.Utilities.Attributes {
   }
 
   /**
+   * Applies custom CSS to an element inside a shadow DOM by injecting a scoped <style> element into
+   * the shadow root. Unlike a `::part()` selector applied from outside, this can also target
+   * pseudo-elements (e.g. '::-ms-reveal') since the style lives in the same shadow tree as the target.
+   * @param elementOrId The host element (or its ID) whose shadow root will receive the <style> element.
+   * @param shadowSelector The selector (scoped to the shadow root) that plain CSS declarations apply to, e.g. '.control'.
+   * @param style CSS text. Plain declarations without a selector (e.g. 'color: red;') are wrapped with
+   * `shadowSelector`; text containing a selector (e.g. '::-ms-reveal { display: none; }') is injected as-is.
+   */
+  export function applyShadowStyle(elementOrId: HTMLElement | string, shadowSelector: string, style: string | null): void {
+    let element: HTMLElement | null;
+    if (typeof elementOrId === 'string') {
+      element = document.getElementById(elementOrId);
+    } else {
+      element = elementOrId;
+    }
+
+    const shadowRoot = element?.shadowRoot;
+    if (!shadowRoot) {
+      return;
+    }
+
+    const styleElement = shadowRoot.querySelector<HTMLStyleElement>('style[data-fluent-shadow-style]');
+
+    if (!style) {
+      styleElement?.remove();
+      return;
+    }
+
+    const cssText = style.includes('{') ? style : `${shadowSelector} { ${style} }`;
+
+    if (styleElement) {
+      styleElement.textContent = cssText;
+      return;
+    }
+
+    const newStyleElement = document.createElement('style');
+    newStyleElement.setAttribute('data-fluent-shadow-style', '');
+    newStyleElement.textContent = cssText;
+    shadowRoot.appendChild(newStyleElement);
+  }
+
+  /**
    * Calls reportValidity on a custom element by reference or by id.
    * @param elementOrId The element or its ID.
    * @returns True when reportValidity is available and was called.

--- a/src/Core/Components/Base/IFluentControlStyle.cs
+++ b/src/Core/Components/Base/IFluentControlStyle.cs
@@ -1,0 +1,49 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/*
+ *  -----------------------------------------------------------------------------------------------------------------------------------
+ *  Example of usage (the component class must implement `IFluentComponentElementBase` and `IFluentControlStyle`):
+ *  -----------------------------------------------------------------------------------------------------------------------------------
+ *
+ *  /// <inheritdoc cref="IFluentControlStyle.ControlStyle" />
+ *  [Parameter]
+ *  public string? ControlStyle { get; set; }
+ *
+ *  ------------------------------------------
+ *  And in the `OnAfterRenderAsync` method:
+ *  ------------------------------------------
+ *
+ *  protected override async Task OnAfterRenderAsync(bool firstRender)
+ *  {
+ *      if (firstRender && !string.IsNullOrEmpty(ControlStyle))
+ *      {
+ *          await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Utilities.Attributes.applyShadowStyle", Element, ".control", ControlStyle);
+ *      }
+ *  }
+ *
+ */
+
+/// <summary>
+/// Adds support for applying custom CSS directly to a component's internal "control" element inside its
+/// shadow DOM (the wrapped <c>&lt;input&gt;</c> or <c>&lt;textarea&gt;</c>), for style rules that
+/// <c>::part(control)</c> cannot reach from outside the shadow boundary, such as pseudo-elements like
+/// <c>::-ms-reveal</c> (the Edge password reveal icon).
+/// Only components that expose a single, styleable internal control element should implement this
+/// interface (e.g. <see cref="FluentTextInput"/>, <see cref="FluentTextArea"/>). Components without such
+/// an internal element (e.g. <see cref="FluentCheckbox"/>, <see cref="FluentSwitch"/>) should not, since
+/// their host element can already be styled directly with <see cref="IFluentComponentBase.Style"/>.
+/// </summary>
+public interface IFluentControlStyle
+{
+    /// <summary>
+    /// Gets or sets custom CSS applied to the internal control element (inside the shadow DOM).
+    /// Plain declarations without a selector (e.g. <c>"color: red;"</c>) are applied to the control element
+    /// itself; text containing a selector (e.g. <c>"::-ms-reveal { display: none; }"</c>) is injected as-is.
+    /// Only applied on first render; later changes to this parameter are not reflected.
+    /// </summary>
+    string? ControlStyle { get; set; }
+}

--- a/src/Core/Components/NumberInput/FluentNumberInput.razor.cs
+++ b/src/Core/Components/NumberInput/FluentNumberInput.razor.cs
@@ -14,7 +14,7 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// <summary>
 /// A numeric input component that allows users to enter and edit numeric values.
 /// </summary>
-public partial class FluentNumberInput<TValue> : FluentInputImmediateBase<TValue>, IFluentComponentElementBase, ITooltipComponent
+public partial class FluentNumberInput<TValue> : FluentInputImmediateBase<TValue>, IFluentComponentElementBase, ITooltipComponent, IFluentControlStyle
 {
     private static readonly Dictionary<Type, (object Zero, object Min, object Max, object Step)> TypeDefaults = new()
     {
@@ -163,6 +163,10 @@ public partial class FluentNumberInput<TValue> : FluentInputImmediateBase<TValue
     /// </summary>
     public bool IsDecimal => UnderlyingType == typeof(float) || UnderlyingType == typeof(double) || UnderlyingType == typeof(decimal);
 
+    /// <inheritdoc cref="IFluentControlStyle.ControlStyle" />
+    [Parameter]
+    public string? ControlStyle { get; set; }
+
     /// <summary />
     protected override async Task OnInitializedAsync()
     {
@@ -181,6 +185,11 @@ public partial class FluentNumberInput<TValue> : FluentInputImmediateBase<TValue
 
             // Apply the number mask to the input element
             await ApplyNumberMaskAsync();
+
+            if (!string.IsNullOrEmpty(ControlStyle))
+            {
+                await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Utilities.Attributes.applyShadowStyle", Element, ".control", ControlStyle);
+            }
         }
     }
 

--- a/src/Core/Components/TextArea/FluentTextArea.razor.cs
+++ b/src/Core/Components/TextArea/FluentTextArea.razor.cs
@@ -13,7 +13,7 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// <summary>
 /// A textarea component that allows users to enter and edit multiple lines of text.
 /// </summary>
-public partial class FluentTextArea : FluentInputImmediateBase<string?>, IFluentComponentElementBase, ITooltipComponent, IFluentComponentChangeAfterKeyPress
+public partial class FluentTextArea : FluentInputImmediateBase<string?>, IFluentComponentElementBase, ITooltipComponent, IFluentComponentChangeAfterKeyPress, IFluentControlStyle
 {
 
     /// <summary>
@@ -123,6 +123,10 @@ public partial class FluentTextArea : FluentInputImmediateBase<string?>, IFluent
     [Parameter]
     public bool? Spellcheck { get; set; }
 
+    /// <inheritdoc cref="IFluentControlStyle.ControlStyle" />
+    [Parameter]
+    public string? ControlStyle { get; set; }
+
     /// <inheritdoc cref="ITooltipComponent.Tooltip" />
     [Parameter]
     public string? Tooltip { get; set; }
@@ -172,6 +176,11 @@ public partial class FluentTextArea : FluentInputImmediateBase<string?>, IFluent
 
             // Initialize the change after key press event
             await IFluentComponentChangeAfterKeyPress.InitializeRuntimeAsync(this, JSRuntime, Element);
+
+            if (!string.IsNullOrEmpty(ControlStyle))
+            {
+                await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Utilities.Attributes.applyShadowStyle", Element, ".control", ControlStyle);
+            }
         }
     }
 

--- a/src/Core/Components/TextInput/FluentTextInput.razor.cs
+++ b/src/Core/Components/TextInput/FluentTextInput.razor.cs
@@ -16,6 +16,12 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 public partial class FluentTextInput : FluentInputImmediateBase<string?>, IFluentComponentElementBase, ITooltipComponent, IFluentComponentChangeAfterKeyPress
 {
     /// <summary>
+    /// Tracks the last <see cref="ControlStyle"/> value applied to the internal input element, to avoid
+    /// unnecessary JS interop calls on every render.
+    /// </summary>
+    private string? _appliedControlStyle;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="FluentTextInput"/> class.
     /// </summary>
     public FluentTextInput(LibraryConfiguration configuration) : base(configuration)
@@ -140,6 +146,16 @@ public partial class FluentTextInput : FluentInputImmediateBase<string?>, IFluen
     public string? Width { get; set; }
 
     /// <summary>
+    /// Gets or sets custom CSS applied to the internal <c>input</c> element (the shadow DOM "control" part).
+    /// Unlike <see cref="FluentComponentBase.Style"/> (applied to the host element), this is injected into the
+    /// component's shadow root, so it can also target pseudo-elements that <c>::part(control)</c> can't reach
+    /// from outside (e.g. <c>ControlStyle="::-ms-reveal { display: none; }"</c> to hide the Edge password reveal icon).
+    /// Plain declarations without a selector (e.g. <c>ControlStyle="color: red;"</c>) are applied to the input itself.
+    /// </summary>
+    [Parameter]
+    public string? ControlStyle { get; set; }
+
+    /// <summary>
     /// Gets or sets the text input type. See <see cref="Components.TextInputType"/>
     /// This relies on browser support for different input types and can therefore vary between browsers.
     /// </summary>
@@ -222,6 +238,12 @@ public partial class FluentTextInput : FluentInputImmediateBase<string?>, IFluen
 
                 await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Components.TextMasked.applyPatternMask", Id, MaskPattern, MaskLazy, placeholder);
             }
+        }
+
+        if (!string.Equals(ControlStyle, _appliedControlStyle, StringComparison.Ordinal))
+        {
+            _appliedControlStyle = ControlStyle;
+            await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Components.TextInput.applyControlStyle", Element, ControlStyle);
         }
     }
 

--- a/src/Core/Components/TextInput/FluentTextInput.razor.cs
+++ b/src/Core/Components/TextInput/FluentTextInput.razor.cs
@@ -16,6 +16,16 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 public partial class FluentTextInput : FluentInputImmediateBase<string?>, IFluentComponentElementBase, ITooltipComponent, IFluentComponentChangeAfterKeyPress, IFluentControlStyle
 {
     /// <summary>
+    /// Gets the CSS rules to hide browser-provided password reveal and credentials AutoFill buttons.
+    /// </summary>
+    public const string HidePasswordToggle = "::-ms-reveal { display: none !important; } ::-webkit-credentials-auto-fill-button { display: none !important; visibility: hidden; pointer-events: none; }";
+
+    /// <summary>
+    /// Gets the CSS rule to hide the contacts AutoFill button in WebKit-based browsers.
+    /// </summary>
+    public const string HideContactsToggle = "::-webkit-contacts-auto-fill-button { display: none !important; visibility: hidden; pointer-events: none; }";
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="FluentTextInput"/> class.
     /// </summary>
     public FluentTextInput(LibraryConfiguration configuration) : base(configuration)

--- a/src/Core/Components/TextInput/FluentTextInput.razor.cs
+++ b/src/Core/Components/TextInput/FluentTextInput.razor.cs
@@ -13,14 +13,8 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// <summary>
 /// A text input component that allows users to enter and edit a single line of text.
 /// </summary>
-public partial class FluentTextInput : FluentInputImmediateBase<string?>, IFluentComponentElementBase, ITooltipComponent, IFluentComponentChangeAfterKeyPress
+public partial class FluentTextInput : FluentInputImmediateBase<string?>, IFluentComponentElementBase, ITooltipComponent, IFluentComponentChangeAfterKeyPress, IFluentControlStyle
 {
-    /// <summary>
-    /// Tracks the last <see cref="ControlStyle"/> value applied to the internal input element, to avoid
-    /// unnecessary JS interop calls on every render.
-    /// </summary>
-    private string? _appliedControlStyle;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="FluentTextInput"/> class.
     /// </summary>
@@ -145,13 +139,7 @@ public partial class FluentTextInput : FluentInputImmediateBase<string?>, IFluen
     [Parameter]
     public string? Width { get; set; }
 
-    /// <summary>
-    /// Gets or sets custom CSS applied to the internal <c>input</c> element (the shadow DOM "control" part).
-    /// Unlike <see cref="FluentComponentBase.Style"/> (applied to the host element), this is injected into the
-    /// component's shadow root, so it can also target pseudo-elements that <c>::part(control)</c> can't reach
-    /// from outside (e.g. <c>ControlStyle="::-ms-reveal { display: none; }"</c> to hide the Edge password reveal icon).
-    /// Plain declarations without a selector (e.g. <c>ControlStyle="color: red;"</c>) are applied to the input itself.
-    /// </summary>
+    /// <inheritdoc cref="IFluentControlStyle.ControlStyle" />
     [Parameter]
     public string? ControlStyle { get; set; }
 
@@ -238,12 +226,11 @@ public partial class FluentTextInput : FluentInputImmediateBase<string?>, IFluen
 
                 await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Components.TextMasked.applyPatternMask", Id, MaskPattern, MaskLazy, placeholder);
             }
-        }
 
-        if (!string.Equals(ControlStyle, _appliedControlStyle, StringComparison.Ordinal))
-        {
-            _appliedControlStyle = ControlStyle;
-            await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Components.TextInput.applyControlStyle", Element, ControlStyle);
+            if (!string.IsNullOrEmpty(ControlStyle))
+            {
+                await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Utilities.Attributes.applyShadowStyle", Element, ".control", ControlStyle);
+            }
         }
     }
 

--- a/tests/Core/Components/Number/FluentNumberTests.razor
+++ b/tests/Core/Components/Number/FluentNumberTests.razor
@@ -403,6 +403,20 @@
         cut.Verify();
     }
 
+    [Fact]
+    public void FluentNumber_ControlStyle_AppliesStyleToInternalControl()
+    {
+        // Arrange and Act
+        Render(@<FluentNumberInput TValue="int" ControlStyle="color: red;" />);
+
+        // Assert
+        var invocation = JSInterop.VerifyInvoke("Microsoft.FluentUI.Blazor.Utilities.Attributes.applyShadowStyle");
+        Assert.Equal(3, invocation.Arguments.Count);
+        Assert.IsType<ElementReference>(invocation.Arguments[0]);
+        Assert.Equal(".control", invocation.Arguments[1]);
+        Assert.Equal("color: red;", invocation.Arguments[2]);
+    }
+
     [Theory]
     [InlineData(NumberInputStepVisibility.Visible)]
     [InlineData(NumberInputStepVisibility.Hidden)]

--- a/tests/Core/Components/TextArea/FluentTextAreaTests.razor
+++ b/tests/Core/Components/TextArea/FluentTextAreaTests.razor
@@ -197,4 +197,18 @@
         Assert.Equal("height: 100px;", cut.Find("fluent-textarea").GetAttribute("style"));
         Assert.Equal("width: 150px;", cut.Find("fluent-field").GetAttribute("style"));
     }
+
+    [Fact]
+    public void FluentTextArea_ControlStyle_AppliesStyleToInternalControl()
+    {
+        // Arrange && Act
+        Render(@<FluentTextArea ControlStyle="color: red;" />);
+
+        // Assert
+        var invocation = JSInterop.VerifyInvoke("Microsoft.FluentUI.Blazor.Utilities.Attributes.applyShadowStyle");
+        Assert.Equal(3, invocation.Arguments.Count);
+        Assert.IsType<ElementReference>(invocation.Arguments[0]);
+        Assert.Equal(".control", invocation.Arguments[1]);
+        Assert.Equal("color: red;", invocation.Arguments[2]);
+    }
 }

--- a/tests/Core/Components/TextInput/FluentTextInputTests.razor
+++ b/tests/Core/Components/TextInput/FluentTextInputTests.razor
@@ -217,6 +217,20 @@
     }
 
     [Fact]
+    public void FluentInputText_ControlStyle_AppliesStyleToInternalControl()
+    {
+        // Arrange && Act
+        Render(@<FluentTextInput ControlStyle="color: red;" />);
+
+        // Assert
+        var invocation = JSInterop.VerifyInvoke("Microsoft.FluentUI.Blazor.Utilities.Attributes.applyShadowStyle");
+        Assert.Equal(3, invocation.Arguments.Count);
+        Assert.IsType<ElementReference>(invocation.Arguments[0]);
+        Assert.Equal(".control", invocation.Arguments[1]);
+        Assert.Equal("color: red;", invocation.Arguments[2]);
+    }
+
+    [Fact]
     public void FluentInputText_MaskPattern()
     {
         // Arrange && Act


### PR DESCRIPTION
# [dev-v5] Add support for styling the internal control

Introduce the ability to apply custom CSS styles directly to the internal controls of Fluent components, specifically the `FluentTextInput`. This enhancement allows for greater flexibility in styling, addressing the need for customizability in component appearance without breaking existing functionality. Implement the `IFluentControlStyle` interface to facilitate this feature across relevant components.

## Styling the internal control

Use the `ControlStyle` parameter to apply CSS declarations directly to the internal input control in the component's shadow DOM.
For example, the following text input displays its entered text in red:

```razor
<FluentTextInput ControlStyle="color: red !important;" />
```

For password inputs, use the predefined `FluentTextInput.HidePasswordToggle` style to hide the browser-provided password reveal and credentials autofill buttons:

```razor
<FluentTextInput TextInputType="TextInputType.Password"
                 ControlStyle="@FluentTextInput.HidePasswordToggle" />
```

The style is applied when the component is first rendered and cannot be changed dynamically afterward.


https://github.com/user-attachments/assets/85fa24bc-19a7-4ffe-aab9-79597297eeb1



## Technical

- `IFluentControlStyle.cs` : opt-in interface exposing `ControlStyle`.
- `FluentTextInput`, `FluentTextArea`, `FluentNumberInput` now all implement `IFluentControlStyle` and JS call applied during the first rendering.
- `Attributes.ts`: JS helper to `applyShadowStyle(elementOrId, shadowSelector, style)`, taking the selector as a parameter (.control for all three) instead of hardcoding it.

Why `FluentCheckbox`, `FluentSwitch`, ... were dropped from the plan: inspecting the actual @fluentui/web-components templates showed they have no internal `<input>` at all — just `<slot>` + `SVG/span` indicators, driven by ARIA on the host itself. There's nothing extra inside their shadow DOM to reach beyond the host, which Style/Class already covers directly. `FluentRadioGroup`, `FluentSelect`/`FluentListbox`/`FluentAutocomplete`, `FluentCalendar` are composite/group components without a single scalar "control" element either, so they're excluded too.

## Unit Tests

No changes