### PR TITLE
[dev-v5] Fix the TimePicker width 

### DIFF
--- a/src/Core/Components/DateTime/FluentTimePicker.razor.css
+++ b/src/Core/Components/DateTime/FluentTimePicker.razor.css
@@ -1,0 +1,3 @@
+.fluent-timepicker fluent-dropdown > input[slot="control"] {
+    width: 100%;
+}


### PR DESCRIPTION
# [dev-v5] Fix the TimePicker width 

The `Width` property is not applied correctly to **FluentTimePicker**… only for small widths (e.g., 150 px).
See #5057

The internal WebComponent `fluent-dropdown` enforces a `min-width: 160px`.
This fix will therefore correct the size, but only if the width is greater than or equal to 160px

Another feature (see PR #5061) will resolve this issue