### PR TITLE
[dev-v5] Update @fluentui/web-components to version 3.0.2

### DIFF
--- a/src/Charts.Scripts/package-lock.json
+++ b/src/Charts.Scripts/package-lock.json
@@ -7,10 +7,11 @@
       "name": "microsoft.fluentui.aspnetcore.components.charts.assets",
       "license": "ISC",
       "dependencies": {
-        "@fluentui/web-components": "^3.0.0",
+        "@fluentui/web-components": "^3.0.2",
         "@microsoft/fast-element": "^3.0.1",
         "@microsoft/fast-web-utilities": "^6.0.0",
-        "d3-axis": "3.0.0",
+        "d3-array": "^3.2.4",
+        "d3-axis": "^3.0.0",
         "d3-format": "^3.0.0",
         "d3-scale": "^4.0.0",
         "d3-selection": "^3.0.0",
@@ -18,7 +19,8 @@
         "d3-time-format": "^4.1.0"
       },
       "devDependencies": {
-        "@types/d3-axis": "3.0.6",
+        "@types/d3-array": "^3.2.2",
+        "@types/d3-axis": "^3.0.6",
         "@types/d3-format": "^3.0.0",
         "@types/d3-scale": "^4.0.0",
         "@types/d3-selection": "^3.0.0",
@@ -482,9 +484,9 @@
       }
     },
     "node_modules/@fluentui/web-components": {
-      "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@fluentui/web-components/-/web-components-3.0.0.tgz",
-      "integrity": "sha1-Sg1jD7YieSHPjWo75FgUA7H5D9A=",
+      "version": "3.0.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@fluentui/web-components/-/web-components-3.0.2.tgz",
+      "integrity": "sha1-figl9gEzjcbCQs4gSnGcw0CNufg=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/tokens": "^1.0.0-alpha.23",
@@ -528,6 +530,13 @@
       "dependencies": {
         "tslib": "^2.8.0"
       }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha1-4CFRRk0C1KG0RkbQ/NuT+viP3ow=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/d3-axis": {
       "version": "3.0.6",
@@ -605,16 +614,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha1-7Gj+CmQaKdhxFXnK9kHQW64fIoU=",
+      "version": "5.0.8",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha1-E1rQ2NgI6xjrXg7Joh86C5LvGM8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/convert-hex": {

--- a/src/Charts.Scripts/package.json
+++ b/src/Charts.Scripts/package.json
@@ -33,7 +33,7 @@
     "rimraf": "6.1.3"
   },
   "dependencies": {
-    "@fluentui/web-components": "^3.0.0",
+    "@fluentui/web-components": "^3.0.2",
     "@microsoft/fast-element": "^3.0.1",
     "@microsoft/fast-web-utilities": "^6.0.0",
     "d3-format": "^3.0.0",

--- a/src/Core.Scripts/package-lock.json
+++ b/src/Core.Scripts/package-lock.json
@@ -7,7 +7,7 @@
       "name": "microsoft.fluentui.aspnetcore.components.assets",
       "license": "ISC",
       "dependencies": {
-        "@fluentui/web-components": "^3.0.0"
+        "@fluentui/web-components": "^3.0.2"
       },
       "devDependencies": {
         "@types/sortablejs": "^1.15.9",
@@ -582,9 +582,9 @@
       }
     },
     "node_modules/@fluentui/web-components": {
-      "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@fluentui/web-components/-/web-components-3.0.0.tgz",
-      "integrity": "sha1-Sg1jD7YieSHPjWo75FgUA7H5D9A=",
+      "version": "3.0.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@fluentui/web-components/-/web-components-3.0.2.tgz",
+      "integrity": "sha1-figl9gEzjcbCQs4gSnGcw0CNufg=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/tokens": "^1.0.0-alpha.23",
@@ -999,16 +999,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha1-7Gj+CmQaKdhxFXnK9kHQW64fIoU=",
+      "version": "5.0.8",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha1-E1rQ2NgI6xjrXg7Joh86C5LvGM8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/convert-hex": {

--- a/src/Core.Scripts/package.json
+++ b/src/Core.Scripts/package.json
@@ -27,6 +27,6 @@
     "typescript": "5.9.3"
   },
   "dependencies": {
-    "@fluentui/web-components": "^3.0.0"
+    "@fluentui/web-components": "^3.0.2"
   }
 }


### PR DESCRIPTION
# [dev-v5] Update @fluentui/web-components to version 3.0.2

Upgrade the @fluentui/web-components dependency to version 3.0.2 in both package.json and package-lock.json files. This change ensures compatibility with the latest features and fixes provided by the updated package. Additionally, update related dependencies to maintain consistency across the project.

