### PR TITLE
[dev-v5][Layout] Add support for printing

### DIFF
--- a/src/Core/Components/Layout/FluentLayoutItem.razor.css
+++ b/src/Core/Components/Layout/FluentLayoutItem.razor.css
@@ -82,3 +82,29 @@
 .fluent-header-hover:hover {
   background-color: var(--colorBrandBackgroundHover);
 }
+
+/* Printing support */
+@media print {
+  .fluent-layout-item[area="nav"],
+  .fluent-layout-item[area="header"],
+  .fluent-layout-item[area="footer"],
+  .fluent-layout-item[area="aside"] {
+    display: none !important;
+  }
+
+  .fluent-layout,
+  .fluent-layout-item,
+  .fluent-layout-item[area="content"] {
+    display: block !important;
+    position: static !important;
+    width: auto !important;
+    height: auto !important;
+    min-height: 0 !important;
+    max-height: none !important;
+    overflow: visible !important;
+  }
+
+    .fluent-layout-item[area="content"] {
+      grid-area: unset !important;
+    }
+}


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR adds support for printing pages in `FluentLayout`. Header, Nav, Aside and footer will be hidden automatically. In addition the rendering will fallback to a static apporach instead of using grid when a page is being printed.

Before:

<img width="2560" height="1392" alt="grafik" src="https://github.com/user-attachments/assets/43b5fa4e-4d22-4824-90ef-f77d96b402d8" />

After:

<img width="2560" height="1392" alt="grafik" src="https://github.com/user-attachments/assets/69d414cc-4081-402f-9b32-aa3ca91579b2" />


<img width="2560" height="1392" alt="grafik" src="https://github.com/user-attachments/assets/7f39789a-0f78-4323-a643-186487e1017d" />


### 🎫 Issues

Fix #5069 

## 👩‍💻 Reviewer Notes

There is still an issue with the FluentUI tokens which aren't visible in printing mode. For example the buttons aren't displayed as primary.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

