### PR TITLE
[dev-v5] FluentTextInput - Add aria-label support using FluentField

### DIFF
--- a/src/Core/Components/Base/IFluentControlAriaLabel.cs
+++ b/src/Core/Components/Base/IFluentControlAriaLabel.cs
@@ -1,0 +1,10 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+internal interface IFluentControlAriaLabel
+{
+    string? AriaLabel { get; set; }
+}

--- a/src/Core/Components/Field/FluentField.razor.cs
+++ b/src/Core/Components/Field/FluentField.razor.cs
@@ -7,7 +7,6 @@ using System.Reflection;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.FluentUI.AspNetCore.Components.Utilities;
-using Microsoft.JSInterop;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
@@ -22,7 +21,6 @@ public partial class FluentField : FluentComponentBase, IFluentField
     private readonly EventHandler<ValidationStateChangedEventArgs> _validationStateChangedHandler;
     private FieldIdentifier _fieldIdentifier;
     private bool _hasFieldIdentifier;
-    private string? _appliedControlAriaLabel;
 
     /// <summary />
     public FluentField(LibraryConfiguration configuration) : base(configuration)
@@ -204,36 +202,27 @@ public partial class FluentField : FluentComponentBase, IFluentField
     {
         await base.OnAfterRenderAsync(firstRender);
 
-        // The <label> rendered above targets the wrapped component's host element (e.g. <fluent-text-input>),
-        // but the real focusable control lives inside that host's shadow DOM and has no accessible name of its
-        // own: light-DOM `for`/`aria-labelledby` cannot cross the shadow boundary. Rather than relying on each
-        // component's internal (and inconsistent) shadow-DOM label, push a plain-text `aria-label` directly onto
-        // the shadow ".control" element, the same way for every wrapped component.
-        var ariaLabel = GetControlAriaLabel();
-
-        if (string.Equals(_appliedControlAriaLabel, ariaLabel, StringComparison.Ordinal))
+        if (firstRender)
         {
-            return;
-        }
+            if (this.InputComponent is FluentTextInput ||
+                this.InputComponent is FluentTextArea ||
+                this.InputComponent is FluentNumberInput<object>)
+            {
+                // The <label> rendered above targets the wrapped component's host element (e.g. <fluent-text-input>),
+                // but the real focusable control lives inside that host's shadow DOM and has no accessible name of its
+                // own: light-DOM `for`/`aria-labelledby` cannot cross the shadow boundary. Rather than relying on each
+                // component's internal (and inconsistent) shadow-DOM label, push a plain-text `aria-label` directly onto
+                // the shadow ".control" element, the same way for every wrapped component.
+                var ariaLabel = GetControlAriaLabel();
+                var targetId = GetId("input");
 
-        _appliedControlAriaLabel = ariaLabel;
+                if (string.IsNullOrEmpty(targetId) || string.IsNullOrEmpty(ariaLabel))
+                {
+                    return;
+                }
 
-        var targetId = GetId("input");
-        if (string.IsNullOrEmpty(targetId) || string.IsNullOrEmpty(ariaLabel))
-        {
-            return;
-        }
-
-        try
-        {
-            await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Utilities.Attributes.copyToShadow", targetId, ".control", "aria-label", ariaLabel);
-        }
-        catch (Exception ex) when (ex is JSDisconnectedException ||
-                                   ex is OperationCanceledException ||
-                                   ex is InvalidOperationException)
-        {
-            // The JSRuntime side may routinely be unavailable during lifecycle transitions.
-            // This is not an error.
+                await JSRuntime.InvokeFluentVoidAsync("Microsoft.FluentUI.Blazor.Utilities.Attributes.copyToShadow", targetId, ".control", "aria-label", ariaLabel);
+            }
         }
     }
 

--- a/src/Core/Components/Field/FluentField.razor.cs
+++ b/src/Core/Components/Field/FluentField.razor.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.FluentUI.AspNetCore.Components.Utilities;
+using Microsoft.JSInterop;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
@@ -21,6 +22,7 @@ public partial class FluentField : FluentComponentBase, IFluentField
     private readonly EventHandler<ValidationStateChangedEventArgs> _validationStateChangedHandler;
     private FieldIdentifier _fieldIdentifier;
     private bool _hasFieldIdentifier;
+    private string? _appliedControlAriaLabel;
 
     /// <summary />
     public FluentField(LibraryConfiguration configuration) : base(configuration)
@@ -195,6 +197,60 @@ public partial class FluentField : FluentComponentBase, IFluentField
         DetachValidationStateChangedListener();
         GC.SuppressFinalize(this);
         return base.DisposeAsync();
+    }
+
+    /// <inheritdoc />
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+
+        // The <label> rendered above targets the wrapped component's host element (e.g. <fluent-text-input>),
+        // but the real focusable control lives inside that host's shadow DOM and has no accessible name of its
+        // own: light-DOM `for`/`aria-labelledby` cannot cross the shadow boundary. Rather than relying on each
+        // component's internal (and inconsistent) shadow-DOM label, push a plain-text `aria-label` directly onto
+        // the shadow ".control" element, the same way for every wrapped component.
+        var ariaLabel = GetControlAriaLabel();
+
+        if (string.Equals(_appliedControlAriaLabel, ariaLabel, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        _appliedControlAriaLabel = ariaLabel;
+
+        var targetId = GetId("input");
+        if (string.IsNullOrEmpty(targetId) || string.IsNullOrEmpty(ariaLabel))
+        {
+            return;
+        }
+
+        try
+        {
+            await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Utilities.Attributes.copyToShadow", targetId, ".control", "aria-label", ariaLabel);
+        }
+        catch (Exception ex) when (ex is JSDisconnectedException ||
+                                   ex is OperationCanceledException ||
+                                   ex is InvalidOperationException)
+        {
+            // The JSRuntime side may routinely be unavailable during lifecycle transitions.
+            // This is not an error.
+        }
+    }
+
+    /// <summary>
+    /// Computes the plain-text accessible name to apply to the wrapped control, from <see cref="IFluentField.Label"/>
+    /// (⚠️ <see cref="IFluentField.LabelTemplate"/> and <see cref="IFluentField.LabelInfo"/> are not plain text and
+    /// are not reflected here), suffixed with the localized "required" indicator when applicable.
+    /// </summary>
+    private string? GetControlAriaLabel()
+    {
+        if (string.IsNullOrWhiteSpace(Parameters.Label))
+        {
+            return null;
+        }
+
+        return Parameters.Label +
+               (Parameters.Required == true ? $", {Localizer[Localization.LanguageResource.FluentInputBase_Required]}" : string.Empty);
     }
 
     internal string? GetId(string slot)

--- a/src/Core/Components/Field/FluentField.razor.cs
+++ b/src/Core/Components/Field/FluentField.razor.cs
@@ -205,7 +205,7 @@ public partial class FluentField : FluentComponentBase, IFluentField
         if (firstRender)
         {
             // Only for FluentTextInput, FluentTextArea and FluentNumberInput
-            if (InputComponent is IFluentControlStyle)
+            if (InputComponent is IFluentControlAriaLabel)
             {
                 // The <label> rendered above targets the wrapped component's host element (e.g. <fluent-text-input>),
                 // but the real focusable control lives inside that host's shadow DOM and has no accessible name of its
@@ -232,13 +232,14 @@ public partial class FluentField : FluentComponentBase, IFluentField
     /// </summary>
     private string? GetControlAriaLabel()
     {
-        if (string.IsNullOrWhiteSpace(Parameters.Label))
+        var label = (InputComponent as IFluentControlAriaLabel)?.AriaLabel ?? Parameters.Label;
+
+        if (string.IsNullOrWhiteSpace(label))
         {
             return null;
         }
 
-        return Parameters.Label +
-               (Parameters.Required == true ? $", {Localizer[Localization.LanguageResource.FluentInputBase_Required]}" : string.Empty);
+        return label + (Parameters.Required == true ? $", {Localizer[Localization.LanguageResource.FluentInputBase_Required]}" : string.Empty);
     }
 
     internal string? GetId(string slot)

--- a/src/Core/Components/Field/FluentField.razor.cs
+++ b/src/Core/Components/Field/FluentField.razor.cs
@@ -204,9 +204,8 @@ public partial class FluentField : FluentComponentBase, IFluentField
 
         if (firstRender)
         {
-            if (this.InputComponent is FluentTextInput ||
-                this.InputComponent is FluentTextArea ||
-                this.InputComponent is FluentNumberInput<object>)
+            // Only for FluentTextInput, FluentTextArea and FluentNumberInput
+            if (InputComponent is IFluentControlStyle)
             {
                 // The <label> rendered above targets the wrapped component's host element (e.g. <fluent-text-input>),
                 // but the real focusable control lives inside that host's shadow DOM and has no accessible name of its

--- a/src/Core/Components/NumberInput/FluentNumberInput.razor.cs
+++ b/src/Core/Components/NumberInput/FluentNumberInput.razor.cs
@@ -14,7 +14,7 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// <summary>
 /// A numeric input component that allows users to enter and edit numeric values.
 /// </summary>
-public partial class FluentNumberInput<TValue> : FluentInputImmediateBase<TValue>, IFluentComponentElementBase, ITooltipComponent, IFluentControlStyle
+public partial class FluentNumberInput<TValue> : FluentInputImmediateBase<TValue>, IFluentComponentElementBase, ITooltipComponent, IFluentControlStyle, IFluentControlAriaLabel
 {
     private static readonly Dictionary<Type, (object Zero, object Min, object Max, object Step)> TypeDefaults = new()
     {

--- a/src/Core/Components/TextArea/FluentTextArea.razor.cs
+++ b/src/Core/Components/TextArea/FluentTextArea.razor.cs
@@ -13,7 +13,7 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// <summary>
 /// A textarea component that allows users to enter and edit multiple lines of text.
 /// </summary>
-public partial class FluentTextArea : FluentInputImmediateBase<string?>, IFluentComponentElementBase, ITooltipComponent, IFluentComponentChangeAfterKeyPress, IFluentControlStyle
+public partial class FluentTextArea : FluentInputImmediateBase<string?>, IFluentComponentElementBase, ITooltipComponent, IFluentComponentChangeAfterKeyPress, IFluentControlStyle, IFluentControlAriaLabel
 {
 
     /// <summary>

--- a/src/Core/Components/TextInput/FluentTextInput.razor.cs
+++ b/src/Core/Components/TextInput/FluentTextInput.razor.cs
@@ -13,7 +13,7 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// <summary>
 /// A text input component that allows users to enter and edit a single line of text.
 /// </summary>
-public partial class FluentTextInput : FluentInputImmediateBase<string?>, IFluentComponentElementBase, ITooltipComponent, IFluentComponentChangeAfterKeyPress, IFluentControlStyle
+public partial class FluentTextInput : FluentInputImmediateBase<string?>, IFluentComponentElementBase, ITooltipComponent, IFluentComponentChangeAfterKeyPress, IFluentControlStyle, IFluentControlAriaLabel
 {
     /// <summary>
     /// Gets the CSS rules to hide browser-provided password reveal and credentials AutoFill buttons.

--- a/src/Core/Extensions/JSRuntimeExtensions.cs
+++ b/src/Core/Extensions/JSRuntimeExtensions.cs
@@ -1,0 +1,61 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.JSInterop;
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// Extension methods for <see cref="IJSRuntime"/>.
+/// </summary>
+internal static class JSRuntimeExtensions
+{
+    /// <summary>
+    /// Invokes a JavaScript function that returns void, and ignores exceptions that occur when the JS runtime is disconnected or the operation is canceled.
+    /// </summary>
+    /// <param name="jsRuntime"></param>
+    /// <param name="identifier"></param>
+    /// <param name="args"></param>
+    /// <returns></returns>
+    public static async ValueTask InvokeFluentVoidAsync(this IJSRuntime jsRuntime, string identifier, params object?[] args)
+    {
+        try
+        {
+            await jsRuntime.InvokeVoidAsync(identifier, args);
+        }
+        catch (Exception ex) when (ex is JSDisconnectedException ||
+                                   ex is OperationCanceledException ||
+                                   ex is InvalidOperationException)
+        {
+            // Ignore exceptions that occur when the JS runtime is disconnected or the operation is canceled.
+        }
+    }
+
+    /// <summary>
+    /// Invokes a JavaScript function that returns a value, and ignores exceptions that occur when the JS runtime is disconnected or the operation is canceled.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="jsRuntime"></param>
+    /// <param name="identifier"></param>
+    /// <param name="args"></param>
+    /// <returns></returns>
+    public static async ValueTask<T> InvokeFluentAsync<[DynamicallyAccessedMembers(
+        DynamicallyAccessedMemberTypes.PublicConstructors |
+        DynamicallyAccessedMemberTypes.PublicFields |
+        DynamicallyAccessedMemberTypes.PublicProperties)] T>(this IJSRuntime jsRuntime, string identifier, params object?[] args)
+    {
+        try
+        {
+            return await jsRuntime.InvokeAsync<T>(identifier, args);
+        }
+        catch (Exception ex) when (ex is JSDisconnectedException ||
+                                   ex is OperationCanceledException ||
+                                   ex is InvalidOperationException)
+        {
+            // Ignore exceptions that occur when the JS runtime is disconnected or the operation is canceled.
+            return default!;
+        }
+    }
+}

--- a/src/Core/Extensions/JSRuntimeExtensions.cs
+++ b/src/Core/Extensions/JSRuntimeExtensions.cs
@@ -41,7 +41,7 @@ internal static class JSRuntimeExtensions
     /// <param name="identifier"></param>
     /// <param name="args"></param>
     /// <returns></returns>
-    public static async ValueTask<T> InvokeFluentAsync<[DynamicallyAccessedMembers(
+    public static async ValueTask<T?> InvokeFluentAsync<[DynamicallyAccessedMembers(
         DynamicallyAccessedMemberTypes.PublicConstructors |
         DynamicallyAccessedMemberTypes.PublicFields |
         DynamicallyAccessedMemberTypes.PublicProperties)] T>(this IJSRuntime jsRuntime, string identifier, params object?[] args)
@@ -55,7 +55,7 @@ internal static class JSRuntimeExtensions
                                    ex is InvalidOperationException)
         {
             // Ignore exceptions that occur when the JS runtime is disconnected or the operation is canceled.
-            return default!;
+            return default;
         }
     }
 }

--- a/tests/Core/Components/Field/FluentFieldTests.razor
+++ b/tests/Core/Components/Field/FluentFieldTests.razor
@@ -21,6 +21,18 @@
     }
 
     [Fact]
+    public void FluentField_NumberInput_CopiesAccessibleNameToInternalControl()
+    {
+        // Arrange & Act
+        using var context = new IdentifierContext(_ => "myId");
+        Render(@<FluentNumberInput TValue="int" Label="Number" />);
+
+        // Assert
+        var invocation = JSInterop.VerifyInvoke("Microsoft.FluentUI.Blazor.Utilities.Attributes.copyToShadow");
+        Assert.Equal(["myId", ".control", "aria-label", "Number"], invocation.Arguments);
+    }
+
+    [Fact]
     public void FluentField_DefaultTemplate()
     {
         // Arrange & Act

--- a/tests/Core/Components/TextInput/FluentTextInputTests.razor
+++ b/tests/Core/Components/TextInput/FluentTextInputTests.razor
@@ -217,13 +217,15 @@
     }
 
     [Theory]
-    [InlineData(false, "Name")]
-    [InlineData(true, "Name, Required")]
-    public void FluentInputText_Label_CopiesAccessibleNameToInternalControl(bool required, string expectedAriaLabel)
+    [InlineData(false, null, "Name")]
+    [InlineData(true, null, "Name, Required")]
+    [InlineData(false, "Custom name", "Custom name")]
+    [InlineData(true, "Custom name", "Custom name, Required")]
+    public void FluentInputText_Label_CopiesAccessibleNameToInternalControl(bool required, string? ariaLabel, string expectedAriaLabel)
     {
         // Arrange && Act
         using var context = new IdentifierContext(_ => "myId");
-        Render(@<FluentTextInput Label="Name" Required="@required" />);
+        Render(@<FluentTextInput Label="Name" AriaLabel="@ariaLabel" Required="@required" />);
 
         // Assert
         var invocation = JSInterop.VerifyInvoke("Microsoft.FluentUI.Blazor.Utilities.Attributes.copyToShadow");

--- a/tests/Core/Components/TextInput/FluentTextInputTests.razor
+++ b/tests/Core/Components/TextInput/FluentTextInputTests.razor
@@ -216,6 +216,20 @@
         Assert.Equal("width: 100px;", cut.Find("fluent-field").GetAttribute("style"));
     }
 
+    [Theory]
+    [InlineData(false, "Name")]
+    [InlineData(true, "Name, Required")]
+    public void FluentInputText_Label_CopiesAccessibleNameToInternalControl(bool required, string expectedAriaLabel)
+    {
+        // Arrange && Act
+        using var context = new IdentifierContext(_ => "myId");
+        Render(@<FluentTextInput Label="Name" Required="@required" />);
+
+        // Assert
+        var invocation = JSInterop.VerifyInvoke("Microsoft.FluentUI.Blazor.Utilities.Attributes.copyToShadow");
+        Assert.Equal(["myId", ".control", "aria-label", expectedAriaLabel], invocation.Arguments);
+    }
+
     [Fact]
     public void FluentInputText_ControlStyle_AppliesStyleToInternalControl()
     {


### PR DESCRIPTION
# [dev-v5] `FluentTextInput` - Add aria-label support using FluentField

Fixes #4980 (TextInput, TextArea, Number).

**Input** controls wrapped by `FluentField` did not expose an accessible name because the external label targets the web-component host, while the focusable control lives inside its shadow DOM.

I intentionally did not use the web component’s label slot. `FluentField` provides additional layout features such as label **positioning**, **width**, **alignment** behavior. Moving the label into the web component would bypass or complicate those features.

- Keeps label rendering managed by `FluentField`.
- Copies the plain-text label to the shadow DOM `.control` element as an `aria-label`.
- Supports **FluentTextInput**, **FluentTextArea**, and **FluentNumberInput**.
- Appends the localized “Required” text for required fields.
- Adds guarded JS interop extensions for disconnected, cancelled, or unavailable runtimes.
- Adds tests covering regular and required accessible labels.

`LabelTemplate` and `LabelInfo` are not used to generate the accessible name because they cannot reliably be converted to plain text.

**Before**
<img width="1018" height="252" alt="image" src="https://github.com/user-attachments/assets/e80a39af-f0bd-409b-9f35-6e7ed81c4a82" />

**After**
<img width="1011" height="253" alt="image" src="https://github.com/user-attachments/assets/e33266fd-c1f3-46d5-ad6d-358bf87510dc" />


## Unit Tests

Updated