### PR TITLE
[dev-v5] Accessibility - FluentSelect

### DIFF
--- a/src/Core.Scripts/src/Components/List/FluentSelect.ts
+++ b/src/Core.Scripts/src/Components/List/FluentSelect.ts
@@ -29,13 +29,13 @@ export namespace Microsoft.FluentUI.Blazor.Components.Select {
     }
 
     // Accessibility: Set the aria-label and aria-expanded attributes for the button element if they are not already set.
-    const controlButton = element.querySelector('button[slot=control]');
-    if (controlButton) {
-      if (!controlButton.hasAttribute('aria-label')) {
-        controlButton.setAttribute('aria-label', getAccessibleLabel(element));
+    const controlElement = element.querySelector('button[slot=control], input[slot=control]') as HTMLButtonElement | HTMLInputElement | null;
+    if (controlElement) {
+      if (!controlElement.hasAttribute('aria-label')) {
+        controlElement.setAttribute('aria-label', getAccessibleLabel(element));
       }
-      if (!controlButton.hasAttribute('aria-expanded')) {
-        controlButton.setAttribute('aria-expanded', 'false');
+      if (!controlElement.hasAttribute('aria-expanded')) {
+        controlElement.setAttribute('aria-expanded', 'false');
       }
     }
   }

--- a/src/Core.Scripts/src/Components/List/FluentSelect.ts
+++ b/src/Core.Scripts/src/Components/List/FluentSelect.ts
@@ -1,28 +1,35 @@
 import * as FluentUIComponents from '@fluentui/web-components'
 
 export namespace Microsoft.FluentUI.Blazor.Components.Select {
-  export function initialize(id: string) {
-  }
 
   /**
    * Clear the value of the select component with the specified ID.
   */
   export function ClearValue(id: string) {
-    const element = document.getElementById(id) as any;
+    const element = document.getElementById(id) as FluentUIComponents.Dropdown;
     if (element) {
       element.value = null;
     }
   }
 
   /**
-   * For the combo box, set the value with the specified ID.
+   * Initializes the select component with the specified ID.   
    * @param id
-   * @param value
+   * @param defaultValue
    */
-  export function SetComboBoxValue(id: string, value: string) {
-    const element = document.getElementById(id) as any;
-    if (element && element.tagName === 'FLUENT-DROPDOWN' && element._control) {
-      element._control.value = value;
+  export function Initialize(id: string, defaultValue: string) {
+    const element = document.getElementById(id) as FluentDropdownControl;
+    if (!element) {
+      return;
     }
+
+    // By default, the combobox text is not bound to the Value property.
+    if (element.getAttribute('type') === 'combobox' && element.tagName === 'FLUENT-DROPDOWN' && element._control) {
+      element._control.value = defaultValue;
+    }
+  }
+
+  interface FluentDropdownControl extends FluentUIComponents.Dropdown {
+    _control: any; // Access the internal control for combobox type
   }
 }

--- a/src/Core.Scripts/src/Components/List/FluentSelect.ts
+++ b/src/Core.Scripts/src/Components/List/FluentSelect.ts
@@ -1,4 +1,8 @@
-export namespace Microsoft.FluentUI.Blazor.Select {
+import * as FluentUIComponents from '@fluentui/web-components'
+
+export namespace Microsoft.FluentUI.Blazor.Components.Select {
+  export function initialize(id: string) {
+  }
 
   /**
    * Clear the value of the select component with the specified ID.

--- a/src/Core.Scripts/src/Components/List/FluentSelect.ts
+++ b/src/Core.Scripts/src/Components/List/FluentSelect.ts
@@ -27,6 +27,34 @@ export namespace Microsoft.FluentUI.Blazor.Components.Select {
     if (element.getAttribute('type') === 'combobox' && element.tagName === 'FLUENT-DROPDOWN' && element._control) {
       element._control.value = defaultValue;
     }
+
+    // Accessibility: Set the aria-label and aria-expanded attributes for the button element if they are not already set.
+    const controlButton = element.querySelector('button[slot=control]');
+    if (controlButton) {
+      if (!controlButton.hasAttribute('aria-label')) {
+        controlButton.setAttribute('aria-label', getAccessibleLabel(element));
+      }
+      if (!controlButton.hasAttribute('aria-expanded')) {
+        controlButton.setAttribute('aria-expanded', 'false');
+      }
+    }
+  }
+
+  /**
+   * Resolves the accessible label: the label of the parent fluent-field, then the placeholder, then a default text.
+   */
+  function getAccessibleLabel(element: HTMLElement): string {
+    const label = element.closest('fluent-field')?.querySelector('label');
+    if (label?.textContent?.trim()) {
+      return label.textContent.trim();
+    }
+
+    const placeholder = element.getAttribute('placeholder');
+    if (placeholder?.trim()) {
+      return placeholder.trim();
+    }
+
+    return 'Select an option';
   }
 
   interface FluentDropdownControl extends FluentUIComponents.Dropdown {

--- a/src/Core.Scripts/src/ExportedMethods.ts
+++ b/src/Core.Scripts/src/ExportedMethods.ts
@@ -11,6 +11,7 @@ import { Microsoft as FluentTextInput } from './Components/TextInput/TextInput';
 import { Microsoft as FluentOverlayFile } from './Components/Overlay/FluentOverlay';
 import { Microsoft as FluentListBoxContainerFile } from './Components/List/ListBoxContainer';
 import { Microsoft as FluentAutocompleteFile } from './Components/List/FluentAutocomplete';
+import { Microsoft as FluentSelectFile } from './Components/List/FluentSelect';
 import { Microsoft as FluentMenuFile } from './Components/Menu/FluentMenu';
 import { Microsoft as FluentColorPickerFile } from './Components/ColorPicker/FluentColorPicker';
 
@@ -44,6 +45,7 @@ export namespace Microsoft.FluentUI.Blazor.ExportedMethods {
     (window as any).Microsoft.FluentUI.Blazor.Components.Overlay = FluentOverlayFile.FluentUI.Blazor.Components.Overlay;
     (window as any).Microsoft.FluentUI.Blazor.Components.ListBoxContainer = FluentListBoxContainerFile.FluentUI.Blazor.Components.ListBoxContainer;
     (window as any).Microsoft.FluentUI.Blazor.Components.Autocomplete = FluentAutocompleteFile.FluentUI.Blazor.Components.Autocomplete;
+    (window as any).Microsoft.FluentUI.Blazor.Components.Select = FluentSelectFile.FluentUI.Blazor.Components.Select;
     (window as any).Microsoft.FluentUI.Blazor.Components.Menu = FluentMenuFile.FluentUI.Blazor.Components.Menu;
     (window as any).Microsoft.FluentUI.Blazor.Components.ColorPicker = FluentColorPickerFile.FluentUI.Blazor.Components.ColorPicker;
 

--- a/src/Core/Components/List/FluentSelect.razor.cs
+++ b/src/Core/Components/List/FluentSelect.razor.cs
@@ -48,11 +48,8 @@ public partial class FluentSelect<TOption, TValue> : FluentListBase<TOption, TVa
         {
             // By default, the combobox text is not bound to the Value property.
             // This method don't change the SelectedItems and Value properties.
-            if (string.Equals(DropdownType, "combobox", StringComparison.Ordinal))
-            {
-                var defaultText = Value is TOption option ? base.GetOptionText(option) : "";
-                await JSRuntime.InvokeFluentVoidAsync("Microsoft.FluentUI.Blazor.Components.Select.SetComboBoxValue", Id, defaultText);
-            }
+            var defaultText = Value is TOption option ? base.GetOptionText(option) : "";
+            await JSRuntime.InvokeFluentVoidAsync("Microsoft.FluentUI.Blazor.Components.Select.Initialize", Id, defaultText);
         }
 
         await base.OnAfterRenderAsync(firstRender);

--- a/src/Core/Components/List/FluentSelect.razor.cs
+++ b/src/Core/Components/List/FluentSelect.razor.cs
@@ -14,8 +14,6 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 [CascadingTypeParameter(nameof(TValue))]
 public partial class FluentSelect<TOption, TValue> : FluentListBase<TOption, TValue>
 {
-    private const string JAVASCRIPT_FILE = FluentJSModule.JAVASCRIPT_ROOT + "List/FluentSelect.razor.js";
-
     /// <summary />
     public FluentSelect(LibraryConfiguration configuration) : base(configuration) { }
 
@@ -49,15 +47,12 @@ public partial class FluentSelect<TOption, TValue> : FluentListBase<TOption, TVa
     {
         if (firstRender)
         {
-            // Import the JavaScript module
-            await JSModule.ImportJavaScriptModuleAsync(JAVASCRIPT_FILE);
-
             // By default, the combobox text is not bound to the Value property.
             // This method don't change the SelectedItems and Value properties.
             if (string.Equals(DropdownType, "combobox", StringComparison.Ordinal))
             {
                 var defaultText = Value is TOption option ? base.GetOptionText(option) : "";
-                await JSModule.ObjectReference.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Select.SetComboBoxValue", Id, defaultText);
+                await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Components.Select.SetComboBoxValue", Id, defaultText);
             }
         }
 
@@ -69,7 +64,7 @@ public partial class FluentSelect<TOption, TValue> : FluentListBase<TOption, TVa
     /// </summary>
     public async Task ClearAsync()
     {
-        await JSModule.ObjectReference.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Select.ClearValue", Id);
+        await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Components.Select.ClearValue", Id);
 
         CurrentValueAsString = null;
 

--- a/src/Core/Components/List/FluentSelect.razor.cs
+++ b/src/Core/Components/List/FluentSelect.razor.cs
@@ -4,7 +4,6 @@
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components.Utilities;
-using Microsoft.JSInterop;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
@@ -52,7 +51,7 @@ public partial class FluentSelect<TOption, TValue> : FluentListBase<TOption, TVa
             if (string.Equals(DropdownType, "combobox", StringComparison.Ordinal))
             {
                 var defaultText = Value is TOption option ? base.GetOptionText(option) : "";
-                await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Components.Select.SetComboBoxValue", Id, defaultText);
+                await JSRuntime.InvokeFluentVoidAsync("Microsoft.FluentUI.Blazor.Components.Select.SetComboBoxValue", Id, defaultText);
             }
         }
 
@@ -64,7 +63,7 @@ public partial class FluentSelect<TOption, TValue> : FluentListBase<TOption, TVa
     /// </summary>
     public async Task ClearAsync()
     {
-        await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Components.Select.ClearValue", Id);
+        await JSRuntime.InvokeFluentVoidAsync("Microsoft.FluentUI.Blazor.Components.Select.ClearValue", Id);
 
         CurrentValueAsString = null;
 


### PR DESCRIPTION
# [dev-v5] Accessibility - FluentSelect

Update the **FluentSelect** components and improve its JavaScript interop methods. 

Refactor the initialization process to set the combo box value correctly and enhance accessibility by adding necessary ARIA attributes: `aria-label` and `aria-expanded`.

This update ensures a better user experience and compliance with accessibility standards.

## Before

<img width="1034" height="904" alt="image" src="https://github.com/user-attachments/assets/5bfba4ef-1e8a-4454-af14-7dd5b22af15e" />

## After

<img width="1030" height="926" alt="image" src="https://github.com/user-attachments/assets/ecf39b00-7791-43c5-b2b0-d9e25501a54b" />

## Unit Tests

No changes