### PR TITLE
[dev-v5] Re-export beforeStart and afterStarted functions

### DIFF
--- a/src/Core.Scripts/src/index.ts
+++ b/src/Core.Scripts/src/index.ts
@@ -19,11 +19,21 @@
 
 import { Microsoft as StartupFile } from './Startup';
 import Startup = StartupFile.FluentUI.Blazor.Startup;
+import { StartedMode } from './d-ts/StartedMode';
+
 
 // Re-export the beforeStart and afterStarted methods
+export function beforeStart(options: WebStartOptions, mode: StartedMode) {
+  Startup.beforeStart(options, mode);
+}
+
 export const beforeWebStart = Startup.beforeWebStart;
 export const beforeServerStart = Startup.beforeServerStart;
 export const beforeWebAssemblyStart = Startup.beforeWebAssemblyStart;
+
+export function afterStarted(blazor: Blazor, mode: StartedMode) {
+  Startup.afterStarted(blazor, mode);
+}
 
 export const afterWebStarted = Startup.afterWebStarted;
 export const afterServerStarted = Startup.afterServerStarted;

--- a/src/Core.Scripts/src/index.ts
+++ b/src/Core.Scripts/src/index.ts
@@ -23,7 +23,7 @@ import { StartedMode } from './d-ts/StartedMode';
 
 
 // Re-export the beforeStart and afterStarted methods
-export function beforeStart(options: WebStartOptions, mode: StartedMode) {
+export function beforeStart(options: WebStartOptions, mode: StartedMode = StartedMode.Web) {
   Startup.beforeStart(options, mode);
 }
 
@@ -31,7 +31,7 @@ export const beforeWebStart = Startup.beforeWebStart;
 export const beforeServerStart = Startup.beforeServerStart;
 export const beforeWebAssemblyStart = Startup.beforeWebAssemblyStart;
 
-export function afterStarted(blazor: Blazor, mode: StartedMode) {
+export function afterStarted(blazor: Blazor, mode: StartedMode = StartedMode.Web) {
   Startup.afterStarted(blazor, mode);
 }
 

--- a/src/Templates/Microsoft.FluentUI.AspNetCore.Templates.csproj
+++ b/src/Templates/Microsoft.FluentUI.AspNetCore.Templates.csproj
@@ -129,8 +129,6 @@
       <!-- NOTE: These must be added in pairs, with text to replace first, then replacement text second -->
       <Replacements Include="!!REPLACE_WITH_LATEST_VERSION!!" />
       <Replacements Include="$(PackageVersion)" />
-      <Replacements Include="!!REPLACE_WITH_LATEST_ICONS_VERSION!!" />
-      <Replacements Include="$(IconsPackageVersion)" />
       <Replacements Include="!!REPLACE_WITH_LATEST_ASPIRE_VERSION!!" />
       <Replacements Include="$(AspirePackageVersion)" />
       <Replacements Include="!!REPLACE_WITH_ASPNETCORE_8_VERSION!!" />

--- a/src/Templates/templates/aspire-starter/Aspire-StarterApplication.1.Web/Aspire-StarterApplication.1.Web.csproj
+++ b/src/Templates/templates/aspire-starter/Aspire-StarterApplication.1.Web/Aspire-StarterApplication.1.Web.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <ProjectReference Include="..\XmlEncodedProjectName.ServiceDefaults\XmlEncodedProjectName.ServiceDefaults.csproj" />
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_ICONS_VERSION!!" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
   </ItemGroup>
 
   <!--#if (UseRedisCache) -->

--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWebCSharp.1.Client/BlazorWebCSharp.1.Client.csproj
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWebCSharp.1.Client/BlazorWebCSharp.1.Client.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="!!REPLACE_WITH_ASPNETCORE_10_VERSION!!" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="!!REPLACE_WITH_ASPNETCORE_10_VERSION!!" Condition="'$(IndividualLocalAuth)' == 'True'" />
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_ICONS_VERSION!!" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
   </ItemGroup>
 
 </Project>

--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWebCSharp.1/BlazorWebCSharp.1.csproj
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWebCSharp.1/BlazorWebCSharp.1.csproj
@@ -31,6 +31,6 @@
   <!--#endif -->
   <ItemGroup>
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_ICONS_VERSION!!" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
   </ItemGroup>
 </Project>

--- a/src/Templates/templates/blazorweb-csharp-9/BlazorWeb-CSharp.Client/BlazorWeb-CSharp.Client.csproj
+++ b/src/Templates/templates/blazorweb-csharp-9/BlazorWeb-CSharp.Client/BlazorWeb-CSharp.Client.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="!!REPLACE_WITH_ASPNETCORE_9_VERSION!!" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="!!REPLACE_WITH_ASPNETCORE_9_VERSION!!" Condition="'$(IndividualLocalAuth)' == 'True'" />
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_ICONS_VERSION!!" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
   </ItemGroup>
 
 </Project>

--- a/src/Templates/templates/blazorweb-csharp-9/BlazorWeb-CSharp/BlazorWeb-CSharp.csproj
+++ b/src/Templates/templates/blazorweb-csharp-9/BlazorWeb-CSharp/BlazorWeb-CSharp.csproj
@@ -30,6 +30,6 @@
   <!--#endif -->
   <ItemGroup>
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_ICONS_VERSION!!" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
   </ItemGroup>
 </Project>

--- a/src/Templates/templates/componentswebassembly-csharp-10/ComponentsWebAssembly-CSharp.csproj
+++ b/src/Templates/templates/componentswebassembly-csharp-10/ComponentsWebAssembly-CSharp.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="!!REPLACE_WITH_ASPNETCORE_10_VERSION!!" Condition="'$(IndividualLocalAuth)' == 'true'"/>
     <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="!!REPLACE_WITH_ASPNETCORE_10_VERSION!!" Condition="('$(OrganizationalAuth)' == 'true' OR '$(IndividualB2CAuth)' == 'true')"/>
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_ICONS_VERSION!!" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
   </ItemGroup>
 
   <!--#if PWA -->

--- a/src/Templates/templates/componentswebassembly-csharp-9/ComponentsWebAssembly-CSharp.csproj
+++ b/src/Templates/templates/componentswebassembly-csharp-9/ComponentsWebAssembly-CSharp.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="!!REPLACE_WITH_ASPNETCORE_9_VERSION!!" Condition="'$(IndividualLocalAuth)' == 'true'"/>
     <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="!!REPLACE_WITH_ASPNETCORE_9_VERSION!!" Condition="('$(OrganizationalAuth)' == 'true' OR '$(IndividualB2CAuth)' == 'true')"/>
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_ICONS_VERSION!!" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
   </ItemGroup>
 
   <!--#if PWA -->

--- a/src/Templates/templates/maui-blazor-solution-10/MauiApp.1.Shared/Layout/MainLayout.razor
+++ b/src/Templates/templates/maui-blazor-solution-10/MauiApp.1.Shared/Layout/MainLayout.razor
@@ -5,7 +5,7 @@
         <FluentLayoutHamburger />
         MauiApp.1
     </FluentLayoutItem>
-    <FluentLayoutItem Area="LayoutArea.Navigation">
+    <FluentLayoutItem Area="LayoutArea.Navigation" Style="background-color: var(--colorNeutralBackground4);">
         <NavMenu />
     </FluentLayoutItem>
     <FluentLayoutItem Area="LayoutArea.Content" Class="main">

--- a/src/Templates/templates/maui-blazor-solution-10/MauiApp.1.Shared/MauiApp.1.Shared.csproj
+++ b/src/Templates/templates/maui-blazor-solution-10/MauiApp.1.Shared/MauiApp.1.Shared.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="!!REPLACE_WITH_ASPNETCORE_10_VERSION!!" />
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_ICONS_VERSION!!" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
   </ItemGroup>
 
 </Project>

--- a/src/Templates/templates/maui-blazor-solution-10/MauiApp.1.Web.Client/MauiApp.1.Web.Client.csproj
+++ b/src/Templates/templates/maui-blazor-solution-10/MauiApp.1.Web.Client/MauiApp.1.Web.Client.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="!!REPLACE_WITH_ASPNETCORE_10_VERSION!!" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="!!REPLACE_WITH_ASPNETCORE_10_VERSION!!" Condition="'$(IndividualLocalAuth)' == 'True'" />
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_ICONS_VERSION!!" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Templates/templates/maui-blazor-solution-10/MauiApp.1.Web/MauiApp.1.Web.csproj
+++ b/src/Templates/templates/maui-blazor-solution-10/MauiApp.1.Web/MauiApp.1.Web.csproj
@@ -32,7 +32,7 @@
   <!--#endif -->
   <ItemGroup>
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_ICONS_VERSION!!" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
   </ItemGroup>
 
 </Project>

--- a/src/Templates/templates/maui-blazor-solution-10/MauiApp.1/MauiApp.1.csproj
+++ b/src/Templates/templates/maui-blazor-solution-10/MauiApp.1/MauiApp.1.csproj
@@ -75,7 +75,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_ICONS_VERSION!!" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
     <ProjectReference Include="..\XmlEncodedAppName.Shared\XmlEncodedAppName.Shared.csproj" />
   </ItemGroup>
 

--- a/src/Templates/templates/maui-blazor-solution-10/MauiApp.1/MauiProgram.cs
+++ b/src/Templates/templates/maui-blazor-solution-10/MauiApp.1/MauiProgram.cs
@@ -32,8 +32,6 @@ public static class MauiProgram
         builder.Services.AddBlazorWebViewDeveloperTools();
         builder.Logging.AddDebug();
 #endif
-        //+:cnd:noEmit
-
         return builder.Build();
     }
 }

--- a/src/Templates/templates/maui-blazor-solution-10/MauiApp.1/wwwroot/index.html
+++ b/src/Templates/templates/maui-blazor-solution-10/MauiApp.1/wwwroot/index.html
@@ -18,8 +18,6 @@
     <div id="app">Loading...</div>
 
     <script src="_framework/blazor.webview.js" autostart="false"></script>
-    <script type="module" src="fluentui-hybrid-bootstrap.js"></script>
-
 </body>
 
 </html>


### PR DESCRIPTION
Legacy `beforeStart` and `afterStarted` functions are needed for BlazorWebView (WPF, MAUI, WinForms) as those do not support the new-style hooks (`beforeWebStart`, `afterWebStarted`, etc.) 
