### PR TITLE
[dev-v5] FluentMenu - Add RenderWhen parameter for deferred rendering

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Menu/Examples/MenuRenderWhen.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Menu/Examples/MenuRenderWhen.razor
@@ -1,16 +1,34 @@
-<FluentButton Id="btnMenu"
-              OnClick="@(() => RenderMenu = true)">
-    Actions
-</FluentButton>
+<FluentStack HorizontalGap="24px">
+    <!-- Differ the menu rendering and keep the menu in the DOM -->
+    <FluentButton Id="btnMenu1"
+                  OnClick="@(() => RenderMenu1 = true)">
+        Open Menu 1
+    </FluentButton>
 
-<FluentMenu Trigger="btnMenu"
-            RenderWhen="@(() => RenderMenu)">
-    <FluentMenuList>
-        <FluentMenuItem>Action 1</FluentMenuItem>
-        <FluentMenuItem>Action 2</FluentMenuItem>
-    </FluentMenuList>
-</FluentMenu>
+    <FluentMenu Trigger="btnMenu1"
+                RenderWhen="@(() => RenderMenu1)">
+        <FluentMenuList>
+            <FluentMenuItem>Action 1</FluentMenuItem>
+            <FluentMenuItem>Action 2</FluentMenuItem>
+        </FluentMenuList>
+    </FluentMenu>
 
+    <!-- Differ the menu rendering and remove the menu from the DOM when closed -->
+    <FluentButton Id="btnMenu2"
+                  OnClick="@(() => RenderMenu2 = true)">
+        Open Menu 2
+    </FluentButton>
+
+    <FluentMenu Trigger="btnMenu2"
+                RenderWhen="@(() => RenderMenu2)"
+                OpenedChanged="@(opened => RenderMenu2 = opened)">
+        <FluentMenuList>
+            <FluentMenuItem>Action 1</FluentMenuItem>
+            <FluentMenuItem>Action 2</FluentMenuItem>
+        </FluentMenuList>
+    </FluentMenu>
+</FluentStack>
 @code {
-    bool RenderMenu;
+    bool RenderMenu1;
+    bool RenderMenu2;
 }

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Menu/Examples/MenuRenderWhen.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Menu/Examples/MenuRenderWhen.razor
@@ -1,7 +1,8 @@
-<FluentStack HorizontalGap="24px">
+<FluentStack>
     <!-- Differ the menu rendering and keep the menu in the DOM -->
     <FluentButton Id="btnMenu1"
-                  OnClick="@(() => RenderMenu1 = true)">
+                  OnClick="@(() => RenderMenu1 = true)"
+                  Margin="@Margin.All2">
         Open Menu 1
     </FluentButton>
 
@@ -15,7 +16,8 @@
 
     <!-- Differ the menu rendering and remove the menu from the DOM when closed -->
     <FluentButton Id="btnMenu2"
-                  OnClick="@(() => RenderMenu2 = true)">
+                  OnClick="@(() => RenderMenu2 = true)"
+                  Margin="@Margin.All2">
         Open Menu 2
     </FluentButton>
 
@@ -28,6 +30,7 @@
         </FluentMenuList>
     </FluentMenu>
 </FluentStack>
+
 @code {
     bool RenderMenu1;
     bool RenderMenu2;

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Menu/Examples/MenuRenderWhen.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Menu/Examples/MenuRenderWhen.razor
@@ -1,0 +1,16 @@
+<FluentButton Id="btnMenu"
+              OnClick="@(() => RenderMenu = true)">
+    Actions
+</FluentButton>
+
+<FluentMenu Trigger="btnMenu"
+            RenderWhen="@(() => RenderMenu)">
+    <FluentMenuList>
+        <FluentMenuItem>Action 1</FluentMenuItem>
+        <FluentMenuItem>Action 2</FluentMenuItem>
+    </FluentMenuList>
+</FluentMenu>
+
+@code {
+    bool RenderMenu;
+}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Menu/FluentMenu.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Menu/FluentMenu.md
@@ -88,6 +88,15 @@ This is useful for menus whose content is expensive to create, depends on data t
 be present in the DOM until the user requests it. The parameter is optional; when it is not set, the menu is always
 rendered and behaves as usual.
 
+The example below demonstrates two ways to use `RenderWhen`:
+
+1. **Defer rendering and keep the menu in the DOM.** The first menu sets its rendering condition to `true` when the
+	button is clicked. After its first opening, the condition remains `true`, so the menu stays in the DOM and can be
+	reopened without being rendered again.
+2. **Defer rendering and remove the menu from the DOM when it closes.** The second menu uses `OpenedChanged` to update
+	its rendering condition. When the menu closes, the callback receives `false`, causing the menu and its content to be
+	removed from the DOM. The menu is rendered again the next time its button is clicked.
+
 {{ MenuRenderWhen }}
 
 ## Menu item slots

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Menu/FluentMenu.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Menu/FluentMenu.md
@@ -78,6 +78,18 @@ await Menu.OpenMenuAsync("Target2", targetOffsetLeft: 10, targetOffsetTop: 5);
 
 {{ MenuProgrammaticMultipleTargets }}
 
+## RenderWhen
+
+Use the `RenderWhen` parameter to defer rendering a menu until it is needed. It accepts a `Func<bool>` that is
+evaluated whenever the component renders. While the function returns `false`, the menu and its child content are not
+added to the DOM. When it returns `true`, the menu is rendered, initialized, and opened automatically.
+
+This is useful for menus whose content is expensive to create, depends on data that is loaded on demand, or should not
+be present in the DOM until the user requests it. The parameter is optional; when it is not set, the menu is always
+rendered and behaves as usual.
+
+{{ MenuRenderWhen }}
+
 ## Menu item slots
 A menu item can has slots that can be used for specific content. The slots are `indicator`, `start`, `end` and `submenu-glyph`. In the `FluentMenuItem`
 component, we have made parameters use icons for the content of these. The available parameters are `IconIndicator`, `IconStart`, `IconEnd` and `IconSubmenu`.

--- a/src/Core.Scripts/src/Components/Menu/FluentMenu.ts
+++ b/src/Core.Scripts/src/Components/Menu/FluentMenu.ts
@@ -1,4 +1,5 @@
 import { Menu, MenuList } from "@fluentui/web-components";
+import { DotNet } from "../../d-ts/Microsoft.JSInterop";
 
 export namespace Microsoft.FluentUI.Blazor.Components.Menu {
   const menuAbortControllers = new Map<string, AbortController>();

--- a/src/Core.Scripts/src/Components/Menu/FluentMenu.ts
+++ b/src/Core.Scripts/src/Components/Menu/FluentMenu.ts
@@ -1,14 +1,16 @@
 import { Menu, MenuList } from "@fluentui/web-components";
 
 export namespace Microsoft.FluentUI.Blazor.Components.Menu {
+  const menuAbortControllers = new Map<string, AbortController>();
 
   /**
    * Initializes the menu by associating it with a trigger element and setting up the necessary styles for positioning.
    * @param id The id of the fluent-menu element to initialize.
    * @param triggerId The id of the trigger element that will open the menu when clicked.
    * @param openMenu Whether to open the menu after initialization.
+   * @param dotNetHelper The .NET component notified when the menu's open state changes.
    */
-  export function Initialize(id: string, triggerId: string, openMenu: boolean) {
+  export function Initialize(id: string, triggerId: string, openMenu: boolean, dotNetHelper?: DotNet.DotNetObject) {
     const initWithRetry = (attempt: number = 0) => {
       const trigger = document.getElementById(triggerId) as HTMLElement | null;
       const menu = document.getElementById(id) as Menu | null;
@@ -39,12 +41,30 @@ export namespace Microsoft.FluentUI.Blazor.Components.Menu {
       menuList.style["position-anchor" as any] = `--anchor-${triggerId}`;
       menu.slottedTriggersChanged(menu.slottedTriggers ?? [], [trigger]);
 
+      menuAbortControllers.get(id)?.abort();
+      if (dotNetHelper) {
+        const abortController = new AbortController();
+        menuAbortControllers.set(id, abortController);
+        menuList.addEventListener("toggle", (event: ToggleEvent) => {
+          void dotNetHelper.invokeMethodAsync("FluentMenu.OpenedChangedAsync", event.newState === "open");
+        }, { signal: abortController.signal });
+      }
+
       if (openMenu) {
         menu.openMenu();
       }
     };
 
     initWithRetry();
+  }
+
+  /**
+   * Removes event listeners associated with the specified menu.
+   * @param id The id of the fluent-menu element to dispose.
+   */
+  export function Dispose(id: string) {
+    menuAbortControllers.get(id)?.abort();
+    menuAbortControllers.delete(id);
   }
 
   /**

--- a/src/Core.Scripts/src/Components/Menu/FluentMenu.ts
+++ b/src/Core.Scripts/src/Components/Menu/FluentMenu.ts
@@ -6,8 +6,9 @@ export namespace Microsoft.FluentUI.Blazor.Components.Menu {
    * Initializes the menu by associating it with a trigger element and setting up the necessary styles for positioning.
    * @param id The id of the fluent-menu element to initialize.
    * @param triggerId The id of the trigger element that will open the menu when clicked.
+   * @param openMenu Whether to open the menu after initialization.
    */
-  export function Initialize(id: string, triggerId: string) {
+  export function Initialize(id: string, triggerId: string, openMenu: boolean) {
     const initWithRetry = (attempt: number = 0) => {
       const trigger = document.getElementById(triggerId) as HTMLElement | null;
       const menu = document.getElementById(id) as Menu | null;
@@ -37,6 +38,10 @@ export namespace Microsoft.FluentUI.Blazor.Components.Menu {
 
       menuList.style["position-anchor" as any] = `--anchor-${triggerId}`;
       menu.slottedTriggersChanged(menu.slottedTriggers ?? [], [trigger]);
+
+      if (openMenu) {
+        menu.openMenu();
+      }
     };
 
     initWithRetry();

--- a/src/Core/Components/Menu/FluentMenu.razor
+++ b/src/Core/Components/Menu/FluentMenu.razor
@@ -1,7 +1,7 @@
 ﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 @inherits FluentComponentBase
 
-@if (RenderWhen?.Invoke() ?? true)
+@if (_renderMenu)
 {
     <CascadingValue Value="this" IsFixed="true">
         <fluent-menu id="@Id"

--- a/src/Core/Components/Menu/FluentMenu.razor
+++ b/src/Core/Components/Menu/FluentMenu.razor
@@ -1,15 +1,18 @@
 ﻿@namespace Microsoft.FluentUI.AspNetCore.Components
-@using Microsoft.FluentUI.AspNetCore.Components.Extensions
 @inherits FluentComponentBase
-<CascadingValue Value="this" IsFixed="true">
-    <fluent-menu id="@Id"
-                 class="@ClassValue"
-                 style="@StyleValue"
-                 open-on-hover="@OpenOnHover"
-                 open-on-context="@OpenOnContext"
-                 close-on-scroll="@CloseOnScroll"
-                 persist-on-item-click="@PersistOnItemClick"
-                 @attributes="AdditionalAttributes">
-        @ChildContent
-    </fluent-menu>
-</CascadingValue>
+
+@if (RenderWhen?.Invoke() ?? true)
+{
+    <CascadingValue Value="this" IsFixed="true">
+        <fluent-menu id="@Id"
+                     class="@ClassValue"
+                     style="@StyleValue"
+                     open-on-hover="@OpenOnHover"
+                     open-on-context="@OpenOnContext"
+                     close-on-scroll="@CloseOnScroll"
+                     persist-on-item-click="@PersistOnItemClick"
+                     @attributes="AdditionalAttributes">
+            @ChildContent
+        </fluent-menu>
+    </CascadingValue>
+}

--- a/src/Core/Components/Menu/FluentMenu.razor.cs
+++ b/src/Core/Components/Menu/FluentMenu.razor.cs
@@ -13,6 +13,8 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// </summary>
 public partial class FluentMenu : FluentComponentBase, ITooltipComponent
 {
+    private bool _wasRendered;
+
     /// <summary>
     /// Constructs a new instance of <see cref="FluentMenu"/>.
     /// Sets the Id to a new random value
@@ -91,6 +93,12 @@ public partial class FluentMenu : FluentComponentBase, ITooltipComponent
     [Parameter]
     public string? Tooltip { get; set; }
 
+    /// <summary>
+    /// Gets or sets the condition that determines whether the menu is rendered.
+    /// </summary>
+    [Parameter]
+    public Func<bool>? RenderWhen { get; set; }
+
     /// <summary />
     protected override async Task OnInitializedAsync()
     {
@@ -100,13 +108,14 @@ public partial class FluentMenu : FluentComponentBase, ITooltipComponent
     /// <summary />
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (firstRender)
+        var renderMenu = RenderWhen?.Invoke() ?? true;
+
+        if (Trigger != null && renderMenu && (firstRender || !_wasRendered))
         {
-            if (Trigger != null)
-            {
-                await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Components.Menu.Initialize", Id, Trigger);
-            }
+            await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Components.Menu.Initialize", Id, Trigger, RenderWhen is not null);
         }
+
+        _wasRendered = renderMenu;
     }
 
     /// <summary>

--- a/src/Core/Components/Menu/FluentMenu.razor.cs
+++ b/src/Core/Components/Menu/FluentMenu.razor.cs
@@ -13,6 +13,8 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// </summary>
 public partial class FluentMenu : FluentComponentBase, ITooltipComponent
 {
+    private DotNetObjectReference<FluentMenu>? _dotNetHelper;
+    private bool _openedChangedSubscribed;
     private bool _wasRendered;
 
     /// <summary>
@@ -89,6 +91,15 @@ public partial class FluentMenu : FluentComponentBase, ITooltipComponent
     [Parameter]
     public EventCallback<MenuItemEventArgs> OnCheckedChanged { get; set; }
 
+    /// <summary>
+    /// Gets or sets the callback that is invoked when the menu's open state changes.
+    /// </summary>
+    /// <remarks>
+    /// The callback receives <see langword="true"/> when the menu opens and <see langword="false"/> when it closes.
+    /// </remarks>
+    [Parameter]
+    public EventCallback<bool> OpenedChanged { get; set; }
+
     /// <inheritdoc cref="ITooltipComponent.Tooltip" />
     [Parameter]
     public string? Tooltip { get; set; }
@@ -109,13 +120,38 @@ public partial class FluentMenu : FluentComponentBase, ITooltipComponent
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         var renderMenu = RenderWhen?.Invoke() ?? true;
+        var subscribeToOpenedChanged = OpenedChanged.HasDelegate;
 
-        if (Trigger != null && renderMenu && (firstRender || !_wasRendered))
+        if (Trigger != null && renderMenu && (firstRender || !_wasRendered || (subscribeToOpenedChanged && !_openedChangedSubscribed)))
         {
-            await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Components.Menu.Initialize", Id, Trigger, RenderWhen is not null);
+            if (subscribeToOpenedChanged)
+            {
+                _dotNetHelper ??= DotNetObjectReference.Create(this);
+            }
+
+            await JSRuntime.InvokeFluentVoidAsync(
+                "Microsoft.FluentUI.Blazor.Components.Menu.Initialize",
+                Id,
+                Trigger,
+                RenderWhen is not null,
+                subscribeToOpenedChanged ? _dotNetHelper : null);
         }
 
+        _openedChangedSubscribed = subscribeToOpenedChanged;
         _wasRendered = renderMenu;
+    }
+
+    /// <summary>
+    /// Called by JavaScript when the menu's open state changes.
+    /// </summary>
+    /// <param name="opened">A value indicating whether the menu is open.</param>
+    [JSInvokable("FluentMenu.OpenedChangedAsync")]
+    public async Task OnOpenedChangedAsync(bool opened)
+    {
+        if (OpenedChanged.HasDelegate)
+        {
+            await OpenedChanged.InvokeAsync(opened);
+        }
     }
 
     /// <summary>
@@ -159,5 +195,17 @@ public partial class FluentMenu : FluentComponentBase, ITooltipComponent
         {
             await OnClick.InvokeAsync(args);
         }
+    }
+
+    /// <inheritdoc />
+    public override async ValueTask DisposeAsync()
+    {
+        if (_dotNetHelper is not null)
+        {
+            await JSRuntime.InvokeFluentVoidAsync("Microsoft.FluentUI.Blazor.Components.Menu.Dispose", Id);
+            _dotNetHelper.Dispose();
+        }
+
+        await base.DisposeAsync();
     }
 }

--- a/src/Core/Components/Menu/FluentMenu.razor.cs
+++ b/src/Core/Components/Menu/FluentMenu.razor.cs
@@ -15,6 +15,7 @@ public partial class FluentMenu : FluentComponentBase, ITooltipComponent
 {
     private DotNetObjectReference<FluentMenu>? _dotNetHelper;
     private bool _openedChangedSubscribed;
+    private bool _renderMenu = true;
     private bool _wasRendered;
 
     /// <summary>
@@ -117,12 +118,17 @@ public partial class FluentMenu : FluentComponentBase, ITooltipComponent
     }
 
     /// <summary />
+    protected override void OnParametersSet()
+    {
+        _renderMenu = RenderWhen?.Invoke() ?? true;
+    }
+
+    /// <summary />
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        var renderMenu = RenderWhen?.Invoke() ?? true;
         var subscribeToOpenedChanged = OpenedChanged.HasDelegate;
 
-        if (Trigger != null && renderMenu && (firstRender || !_wasRendered || (subscribeToOpenedChanged && !_openedChangedSubscribed)))
+        if (Trigger != null && _renderMenu && (firstRender || !_wasRendered || (subscribeToOpenedChanged && !_openedChangedSubscribed)))
         {
             if (subscribeToOpenedChanged)
             {
@@ -138,7 +144,7 @@ public partial class FluentMenu : FluentComponentBase, ITooltipComponent
         }
 
         _openedChangedSubscribed = subscribeToOpenedChanged;
-        _wasRendered = renderMenu;
+        _wasRendered = _renderMenu;
     }
 
     /// <summary>

--- a/tests/Core/Components/Menu/FluentMenuTests.razor
+++ b/tests/Core/Components/Menu/FluentMenuTests.razor
@@ -95,22 +95,30 @@
     {
         // Arrange
         var renderMenu = false;
+        var renderWhenInvocationCount = 0;
+        Func<bool> renderWhen = () =>
+        {
+            renderWhenInvocationCount++;
+            return renderMenu;
+        };
         var cut = Render<FluentMenu>(parameters => parameters
             .Add(component => component.Trigger, "trigger")
-            .Add(component => component.RenderWhen, () => renderMenu)
+            .Add(component => component.RenderWhen, renderWhen)
             .AddChildContent("Menu item"));
 
         Assert.Empty(cut.FindAll("fluent-menu"));
+        Assert.Equal(1, renderWhenInvocationCount);
         Assert.DoesNotContain(JSInterop.Invocations, invocation =>
             invocation.Identifier == "Microsoft.FluentUI.Blazor.Components.Menu.Initialize");
 
         // Act
         renderMenu = true;
         cut.Render(parameters => parameters
-            .Add(component => component.RenderWhen, () => renderMenu));
+            .Add(component => component.RenderWhen, renderWhen));
 
         // Assert
         Assert.Single(cut.FindAll("fluent-menu"));
+        Assert.Equal(2, renderWhenInvocationCount);
         var invocation = Assert.Single(JSInterop.Invocations, invocation =>
             invocation.Identifier == "Microsoft.FluentUI.Blazor.Components.Menu.Initialize");
         Assert.True((bool)invocation.Arguments[2]!);

--- a/tests/Core/Components/Menu/FluentMenuTests.razor
+++ b/tests/Core/Components/Menu/FluentMenuTests.razor
@@ -90,6 +90,32 @@
         cut.Verify();
     }
 
+    [Fact]
+    public void FluentMenu_RenderWhen_RendersAndOpensWhenConditionBecomesTrue()
+    {
+        // Arrange
+        var renderMenu = false;
+        var cut = Render<FluentMenu>(parameters => parameters
+            .Add(component => component.Trigger, "trigger")
+            .Add(component => component.RenderWhen, () => renderMenu)
+            .AddChildContent("Menu item"));
+
+        Assert.Empty(cut.FindAll("fluent-menu"));
+        Assert.DoesNotContain(JSInterop.Invocations, invocation =>
+            invocation.Identifier == "Microsoft.FluentUI.Blazor.Components.Menu.Initialize");
+
+        // Act
+        renderMenu = true;
+        cut.Render(parameters => parameters
+            .Add(component => component.RenderWhen, () => renderMenu));
+
+        // Assert
+        Assert.Single(cut.FindAll("fluent-menu"));
+        var invocation = Assert.Single(JSInterop.Invocations, invocation =>
+            invocation.Identifier == "Microsoft.FluentUI.Blazor.Components.Menu.Initialize");
+        Assert.True((bool)invocation.Arguments[2]!);
+    }
+
 
     [Fact]
     public void FluentMenu_OpenMenu()

--- a/tests/Core/Components/Menu/FluentMenuTests.razor
+++ b/tests/Core/Components/Menu/FluentMenuTests.razor
@@ -116,6 +116,28 @@
         Assert.True((bool)invocation.Arguments[2]!);
     }
 
+    [Fact]
+    public async Task FluentMenu_OpenedChanged_NotifiesWhenMenuOpensAndCloses()
+    {
+        // Arrange
+        var states = new List<bool>();
+        var cut = Render<FluentMenu>(parameters => parameters
+            .Add(component => component.Trigger, "trigger")
+            .Add(component => component.OpenedChanged, states.Add)
+            .AddChildContent("Menu item"));
+
+        var initialization = Assert.Single(JSInterop.Invocations, invocation =>
+            invocation.Identifier == "Microsoft.FluentUI.Blazor.Components.Menu.Initialize");
+        Assert.NotNull(initialization.Arguments[3]);
+
+        // Act
+        await cut.Instance.OnOpenedChangedAsync(true);
+        await cut.Instance.OnOpenedChangedAsync(false);
+
+        // Assert
+        Assert.Equal([true, false], states);
+    }
+
 
     [Fact]
     public void FluentMenu_OpenMenu()


### PR DESCRIPTION
# [dev-v5] FluentMenu - Add RenderWhen parameter for deferred rendering

Use the `RenderWhen` parameter to defer rendering a menu until it is needed. It accepts a `Func<bool>` that is
evaluated whenever the component renders. While the function returns `false`, the menu and its child content are not
added to the DOM. When it returns `true`, the menu is rendered, initialized, and opened automatically.

This is useful for menus whose content is expensive to create, depends on data that is loaded on demand, or should not
be present in the DOM until the user requests it. The parameter is optional; when it is not set, the menu is always
rendered and behaves as usual.

The example below demonstrates two ways to use `RenderWhen`:

1. **Defer rendering and keep the menu in the DOM.** The first menu sets its rendering condition to `true` when the
	button is clicked. After its first opening, the condition remains `true`, so the menu stays in the DOM and can be
	reopened without being rendered again.
2. **Defer rendering and remove the menu from the DOM when it closes.** The second menu uses `OpenedChanged` to update
	its rendering condition. When the menu closes, the callback receives `false`, causing the menu and its content to be
	removed from the DOM. The menu is rendered again the next time its button is clicked.

```razor
<FluentStack HorizontalGap="24px">
    <!-- Differ the menu rendering and keep the menu in the DOM -->
    <FluentButton Id="btnMenu1"
                  OnClick="@(() => RenderMenu1 = true)">
        Open Menu 1
    </FluentButton>

    <FluentMenu Trigger="btnMenu1"
                RenderWhen="@(() => RenderMenu1)">
        <FluentMenuList>
            <FluentMenuItem>Action 1</FluentMenuItem>
            <FluentMenuItem>Action 2</FluentMenuItem>
        </FluentMenuList>
    </FluentMenu>

    <!-- Differ the menu rendering and remove the menu from the DOM when closed -->
    <FluentButton Id="btnMenu2"
                  OnClick="@(() => RenderMenu2 = true)">
        Open Menu 2
    </FluentButton>

    <FluentMenu Trigger="btnMenu2"
                RenderWhen="@(() => RenderMenu2)"
                OpenedChanged="@(opened => RenderMenu2 = opened)">
        <FluentMenuList>
            <FluentMenuItem>Action 1</FluentMenuItem>
            <FluentMenuItem>Action 2</FluentMenuItem>
        </FluentMenuList>
    </FluentMenu>
</FluentStack>

@code {
    bool RenderMenu1;
    bool RenderMenu2;
}
```



https://github.com/user-attachments/assets/4576a3db-04a0-436e-a8ff-f868b542b8da



