### PR TITLE
[dev-v5] FluentAnchorButton FluentLink - Overriding navigation behavior to utilize Blazor's features

### DIFF
--- a/src/Core.Scripts/src/FluentUIWebComponentsOverride.ts
+++ b/src/Core.Scripts/src/FluentUIWebComponentsOverride.ts
@@ -2,21 +2,25 @@
 /// <reference path="./d-ts/Blazor.d.ts" />
 
 export namespace Microsoft.FluentUI.Override {
-
     /**
      * Override the default behavior of the Fluent UI Web Components to use Blazor's features.
     */
     export function overrideComponents() {
 
-        /* Original code: https://github.com/microsoft/fluentui/blob/master/packages/web-components/src/anchor-button/anchor-button.base.ts
+        /**
+         * fluent-anchor-button
+         */
+        waitForCustomElements().then(async registry => {
+            const anchorButton = await registry.whenDefined('fluent-anchor-button');
+            const proto = anchorButton.prototype;
 
-           private handleNavigation(newTab: boolean): void {
-             newTab ? window.open(this.href, '_blank') : this.internalProxyAnchor.click();
-           }
-        */
+            /* 
+                Original code: https://github.com/microsoft/fluentui/blob/master/packages/web-components/src/anchor-button/anchor-button.base.ts
 
-        customElements.whenDefined('fluent-anchor-button').then(() => {
-            const proto = customElements.get('fluent-anchor-button').prototype;
+                private handleNavigation(newTab: boolean): void {
+                    newTab ? window.open(this.href, '_blank') : this.internalProxyAnchor.click();
+                }
+            */
             proto.handleNavigation = function (newTab: boolean): void {
                 if (newTab) {
                     window.open(this.href, '_blank');
@@ -25,13 +29,35 @@ export namespace Microsoft.FluentUI.Override {
 
                 const url = new URL(this.href, document.baseURI);
                 if (url.origin === location.origin) {
-                    Blazor.navigateTo(url.pathname + url.search + url.hash, false);
+                    const forceLoad = this.getAttribute('force-load') === 'true';
+                    console.log(`fluent-anchor-button handleNavigation: navigating to ${url.pathname + url.search + url.hash} using Blazor.navigateTo with forceLoad=${forceLoad}`);
+                    Blazor.navigateTo(url.pathname + url.search + url.hash, forceLoad);
                 }
-                else {
-                    this.internalProxyAnchor.click()
-                    //location.href = this.href;
+                else {                    
+                    console.log(`fluent-anchor-button handleNavigation: navigating to ${this.href} using internalProxyAnchor.click()`);
+                    this.internalProxyAnchor.click();
                 }
             };
+        });
+    }
+
+    /**
+     * Wait for the customElements registry to be available before overriding the components.
+     * This is necessary because the Fluent UI Web Components are defined asynchronously.
+     * @returns A promise that resolves with the customElements registry.
+     */
+    function waitForCustomElements(): Promise<CustomElementRegistry> {
+        return new Promise(resolve => {
+            const checkCustomElements = () => {
+                if (typeof customElements !== 'undefined') {
+                    resolve(customElements);
+                    return;
+                }
+
+                setTimeout(checkCustomElements, 10);
+            };
+
+            checkCustomElements();
         });
     }
 }

--- a/src/Core.Scripts/src/FluentUIWebComponentsOverride.ts
+++ b/src/Core.Scripts/src/FluentUIWebComponentsOverride.ts
@@ -1,0 +1,37 @@
+
+/// <reference path="./d-ts/Blazor.d.ts" />
+
+export namespace Microsoft.FluentUI.Override {
+
+    /**
+     * Override the default behavior of the Fluent UI Web Components to use Blazor's features.
+    */
+    export function overrideComponents() {
+
+        /* Original code: https://github.com/microsoft/fluentui/blob/master/packages/web-components/src/anchor-button/anchor-button.base.ts
+
+           private handleNavigation(newTab: boolean): void {
+             newTab ? window.open(this.href, '_blank') : this.internalProxyAnchor.click();
+           }
+        */
+
+        customElements.whenDefined('fluent-anchor-button').then(() => {
+            const proto = customElements.get('fluent-anchor-button').prototype;
+            proto.handleNavigation = function (newTab: boolean): void {
+                if (newTab) {
+                    window.open(this.href, '_blank');
+                    return;
+                }
+
+                const url = new URL(this.href, document.baseURI);
+                if (url.origin === location.origin) {
+                    Blazor.navigateTo(url.pathname + url.search + url.hash, false);
+                }
+                else {
+                    this.internalProxyAnchor.click()
+                    //location.href = this.href;
+                }
+            };
+        });
+    }
+}

--- a/src/Core.Scripts/src/FluentUIWebComponentsOverride.ts
+++ b/src/Core.Scripts/src/FluentUIWebComponentsOverride.ts
@@ -2,43 +2,53 @@
 /// <reference path="./d-ts/Blazor.d.ts" />
 
 export namespace Microsoft.FluentUI.Override {
+    interface NavigationElement extends HTMLElement {
+        href: string;
+        internalProxyAnchor: { click(): void };
+        handleNavigation(newTab: boolean): void;
+    }
+
     /**
      * Override the default behavior of the Fluent UI Web Components to use Blazor's features.
     */
     export function overrideComponents() {
-
-        /**
-         * fluent-anchor-button
-         */
         waitForCustomElements().then(async registry => {
-            const anchorButton = await registry.whenDefined('fluent-anchor-button');
-            const proto = anchorButton.prototype;
 
-            /* 
-                Original code: https://github.com/microsoft/fluentui/blob/master/packages/web-components/src/anchor-button/anchor-button.base.ts
-
-                private handleNavigation(newTab: boolean): void {
-                    newTab ? window.open(this.href, '_blank') : this.internalProxyAnchor.click();
-                }
+            /**
+             * fluent-anchor-button
             */
-            proto.handleNavigation = function (newTab: boolean): void {
-                if (newTab) {
-                    window.open(this.href, '_blank');
-                    return;
-                }
+            const anchorButton = await registry.whenDefined('fluent-anchor-button');
+            anchorButton.prototype.handleNavigation = handleNavigation;
 
-                const url = new URL(this.href, document.baseURI);
-                if (url.origin === location.origin) {
-                    const forceLoad = this.getAttribute('force-load') === 'true';
-                    console.log(`fluent-anchor-button handleNavigation: navigating to ${url.pathname + url.search + url.hash} using Blazor.navigateTo with forceLoad=${forceLoad}`);
-                    Blazor.navigateTo(url.pathname + url.search + url.hash, forceLoad);
-                }
-                else {                    
-                    console.log(`fluent-anchor-button handleNavigation: navigating to ${this.href} using internalProxyAnchor.click()`);
-                    this.internalProxyAnchor.click();
-                }
-            };
+            /**
+             * fluent-link
+             */
+            const link = await registry.whenDefined('fluent-link');
+            link.prototype.handleNavigation = handleNavigation;
         });
+    }
+
+    /* 
+        Original code: https://github.com/microsoft/fluentui/blob/master/packages/web-components/src/anchor-button/anchor-button.base.ts
+
+        private handleNavigation(newTab: boolean): void {
+            newTab ? window.open(this.href, '_blank') : this.internalProxyAnchor.click();
+        }
+    */
+    function handleNavigation(this: NavigationElement, newTab: boolean): void {
+        if (newTab) {
+            window.open(this.href, '_blank');
+            return;
+        }
+
+        const url = new URL(this.href, document.baseURI);
+        if (url.origin === location.origin) {
+            const forceLoad = this.getAttribute('force-load') === 'true';
+            Blazor.navigateTo(url.pathname + url.search + url.hash, forceLoad);
+        }
+        else {
+            this.internalProxyAnchor.click();
+        }
     }
 
     /**

--- a/src/Core.Scripts/src/Startup.ts
+++ b/src/Core.Scripts/src/Startup.ts
@@ -1,6 +1,7 @@
 import { Microsoft as LoggerFile } from './Utilities/Logger';
 import { Microsoft as ThemeFile } from './Utilities/Theme';
 import { Microsoft as FluentUIComponentsFile } from './FluentUIWebComponents';
+import { Microsoft as FluentUIWebComponentsOverrideFile } from './FluentUIWebComponentsOverride';
 import { Microsoft as FluentPageScriptFile } from './Components/PageScript/FluentPageScript';
 import { Microsoft as FluentPopoverFile } from './Components/Popover/FluentPopover';
 import { Microsoft as FluentOverlayFile } from './Components/Overlay/FluentOverlay';
@@ -16,6 +17,7 @@ export namespace Microsoft.FluentUI.Blazor.Startup {
   // Alias
   import Logger = LoggerFile.FluentUI.Blazor.Utilities.Logger;
   import FluentUIComponents = FluentUIComponentsFile.FluentUI.Blazor.FluentUIWebComponents;
+  import FluentUIOverride = FluentUIWebComponentsOverrideFile.FluentUI.Override;
   import FluentPageScript = FluentPageScriptFile.FluentUI.Blazor.Components.PageScript;
   import FluentPopover = FluentPopoverFile.FluentUI.Blazor.Components.Popover;
   import FluentOverlay = FluentOverlayFile.FluentUI.Blazor.Components.Overlay;
@@ -41,6 +43,9 @@ export namespace Microsoft.FluentUI.Blazor.Startup {
 
     // Define Fluent UI components
     FluentUIComponents.defineComponents();
+
+    // Override Fluent UI components to use Blazor's features
+    FluentUIOverride.overrideComponents();
 
     // Finishing
     beforeStartCalled = true;

--- a/src/Core.Scripts/src/d-ts/Blazor.d.ts
+++ b/src/Core.Scripts/src/d-ts/Blazor.d.ts
@@ -12,6 +12,8 @@ interface ThemeSettings {
 interface Blazor {
   addEventListener?: (name: string, callback: (event: any) => void) => void;
 
+  navigateTo: (uri: string, options: NavigationOptions | boolean) => void;
+
   registerCustomEventType(eventName: string, options: EventTypeOptions): void;
 
   theme: {
@@ -41,3 +43,5 @@ interface Blazor {
     switchDirection(): void,
   }
 }
+
+declare const Blazor: Blazor;

--- a/src/Core/Components/Button/FluentAnchorButton.razor
+++ b/src/Core/Components/Button/FluentAnchorButton.razor
@@ -19,6 +19,7 @@
                       name="@Name"
                       role="@(string.IsNullOrEmpty(Title) ? null : "link")"
                       aria-label="@Title"
+                      force-load="@(ForceLoad ? "true" : null)"
                       @attributes="@AdditionalAttributes">
     @if (IconStart != null)
     {

--- a/src/Core/Components/Button/FluentAnchorButton.razor.cs
+++ b/src/Core/Components/Button/FluentAnchorButton.razor.cs
@@ -148,6 +148,13 @@ public partial class FluentAnchorButton : FluentComponentBase, ITooltipComponent
     [Parameter]
     public string? Tooltip { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether the navigation should force a full page load instead of using Blazor's built-in navigation.
+    /// Default is <see langword="false" />, which uses Blazor's navigation.
+    /// </summary>
+    [Parameter]
+    public bool ForceLoad { get; set; }
+
     /// <summary />
     protected override async Task OnInitializedAsync()
     {

--- a/src/Core/Components/Link/FluentLink.razor
+++ b/src/Core/Components/Link/FluentLink.razor
@@ -14,6 +14,7 @@
 			 class="@ClassValue"
 			 style="@StyleValue"
              clickable="@OnClick.HasDelegate"
+			 force-load="@(ForceLoad ? "true" : null)"
 			 @onclick="@OnClickHandlerAsync"
 			 @attributes="AdditionalAttributes">
 	@if (IconStart is not null)

--- a/src/Core/Components/Link/FluentLink.razor.cs
+++ b/src/Core/Components/Link/FluentLink.razor.cs
@@ -102,6 +102,13 @@ public partial class FluentLink : FluentComponentBase, ITooltipComponent
     [Parameter]
     public string? Tooltip { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether the navigation should force a full page load instead of using Blazor's built-in navigation.
+    /// Default is <see langword="false" />, which uses Blazor's navigation.
+    /// </summary>
+    [Parameter]
+    public bool ForceLoad { get; set; }
+
     /// <summary />
     protected override async Task OnInitializedAsync()
     {

--- a/tests/Core/Components/Button/FluentAnchorButtonTests.razor
+++ b/tests/Core/Components/Button/FluentAnchorButtonTests.razor
@@ -34,6 +34,19 @@
     }
 
     [Theory]
+    [InlineData(false, null)]
+    [InlineData(true, "true")]
+    public void FluentAnchorButton_ForceLoadAttribute(bool forceLoad, string? expectedValue)
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentAnchorButton ForceLoad="@forceLoad">fluent-anchor-button</FluentAnchorButton>);
+
+        // Assert
+        var attribute = cut.Find("fluent-anchor-button").GetAttribute("force-load");
+        Assert.Equal(expectedValue, attribute);
+    }
+
+    [Theory]
     [InlineData(LinkTarget.Blank, "_blank")]
     [InlineData(LinkTarget.Parent, "_parent")]
     [InlineData(LinkTarget.Self, "_self")]

--- a/tests/Core/Components/Link/FluentLinkTests.razor
+++ b/tests/Core/Components/Link/FluentLinkTests.razor
@@ -45,6 +45,19 @@
 		cut.Verify();
 	}
 
+	[Theory]
+	[InlineData(false, null)]
+	[InlineData(true, "true")]
+	public void FluentLink_ForceLoadAttribute(bool forceLoad, string? expectedValue)
+	{
+		// Arrange && Act
+		var cut = Render(@<FluentLink ForceLoad="@forceLoad">fluent-link</FluentLink>);
+
+		// Assert
+		var attribute = cut.Find("fluent-link").GetAttribute("force-load");
+		Assert.Equal(expectedValue, attribute);
+	}
+
 	[Fact]
 	public void FluentLink_hreflang()
 	{


### PR DESCRIPTION
# [dev-v5] FluentAnchorButton FluentLink - Overriding navigation behavior to utilize Blazor's features

See #5022

This update integrates Fluent UI Web Components with Blazor by **overriding navigation behavior to utilize Blazor's features**. It introduces a `ForceLoad` parameter for `FluentAnchorButton` and `FluentLink` components, allowing for full page navigation when needed. 

```razor
<FluentAnchorButton Href="/AppBar">Button to AppBar (ForceLoad=false)</FluentAnchorButton>
<FluentAnchorButton Href="/AppBar" ForceLoad="true">Button to AppBar (ForceLoad=true)</FluentAnchorButton>
<FluentLink Href="/AppBar">Link to AppBar (ForceLoad=false)</FluentLink>
<FluentLink Href="/AppBar" ForceLoad="true">Link to AppBar (ForceLoad=true)</FluentLink>
```

https://github.com/user-attachments/assets/a9427544-0df4-4b02-a4ab-0d8df8517927



## Unit tests

Tests for the new `ForceLoad` attribute ensure proper functionality.