### PR TITLE
[dev-v5][AppBar] Fix not showing 'more' item anymore

### DIFF
--- a/src/Core/Components/AppBar/FluentAppBar.razor
+++ b/src/Core/Components/AppBar/FluentAppBar.razor
@@ -38,7 +38,7 @@
 			@*ToDo: Make styling configurable *@
 			<FluentPopover @bind-Opened="_showMoreItems"
 						   AnchorId="@($"appbar-more-{Id}")"
-						   OffsetVertical="-68"
+						   OffsetVertical="-48"
 						   OffsetHorizontal="320">
 				<ChildContent>
 					<div class="fluent-appbar-popover">

--- a/src/Core/Components/AppBar/FluentAppBar.razor
+++ b/src/Core/Components/AppBar/FluentAppBar.razor
@@ -20,7 +20,7 @@
 		@if (AppsOverflow.Any())
 		{
 			<FluentKeyCode Anchor="@($"appbar-more-{Id}")" OnKeyDown="@HandlePopoverKeyDownAsync" />
-			<div id="@($"appbar-more-{Id}")" class="fluent-appbar-more-item" style="min-width: var(--appbar-item-size);" tabindex="0" fixed title="@Localizer[Localization.LanguageResource.AppBar_MoreItems]" @onclick="@TogglePopoverAsync">
+			<div id="@($"appbar-more-{Id}")" class="fluent-appbar-more-item" style="min-width: var(--appbar-item-size);" tabindex="0" fixed="fixed" title="@Localizer[Localization.LanguageResource.AppBar_MoreItems]" @onclick="@TogglePopoverAsync">
 				<FluentStack Orientation="Orientation.Vertical"
 							 HorizontalAlignment="HorizontalAlignment.Center"
 							 VerticalAlignment="VerticalAlignment.Center"

--- a/src/Core/Components/AppBar/FluentAppBar.razor
+++ b/src/Core/Components/AppBar/FluentAppBar.razor
@@ -20,7 +20,7 @@
 		@if (AppsOverflow.Any())
 		{
 			<FluentKeyCode Anchor="@($"appbar-more-{Id}")" OnKeyDown="@HandlePopoverKeyDownAsync" />
-			<div id="@($"appbar-more-{Id}")" class="fluent-appbar-item" style="min-width: var(--appbar-item-size);" tabindex="0" fixed title="@Localizer[Localization.LanguageResource.AppBar_MoreItems]" @onclick="@TogglePopoverAsync">
+			<div id="@($"appbar-more-{Id}")" class="fluent-appbar-more-item" style="min-width: var(--appbar-item-size);" tabindex="0" fixed title="@Localizer[Localization.LanguageResource.AppBar_MoreItems]" @onclick="@TogglePopoverAsync">
 				<FluentStack Orientation="Orientation.Vertical"
 							 HorizontalAlignment="HorizontalAlignment.Center"
 							 VerticalAlignment="VerticalAlignment.Center"
@@ -38,8 +38,8 @@
 			@*ToDo: Make styling configurable *@
 			<FluentPopover @bind-Opened="_showMoreItems"
 						   AnchorId="@($"appbar-more-{Id}")"
-						   OffsetVertical="-48"
-						   OffsetHorizontal="68">
+						   OffsetVertical="-68"
+						   OffsetHorizontal="320">
 				<ChildContent>
 					<div class="fluent-appbar-popover">
 						@if (PopoverShowSearch)

--- a/src/Core/Components/AppBar/FluentAppBar.razor.css
+++ b/src/Core/Components/AppBar/FluentAppBar.razor.css
@@ -95,7 +95,6 @@
 .fluent-appbar-item[overflow],
 .fluent-appbar-more-item:hover svg[part="icon-rest"],
 .fluent-appbar-more-item:not(:hover):not(.active) svg[part="icon-active"],
-
 .fluent-appbar-more-item[overflow] {
   display: none;
 }
@@ -105,11 +104,11 @@
     display: block;
 }
 
-.fluent-appbar-item[inpopover]:not(:hover) a.active svg[part="icon-active"],
+.fluent-appbar-item[inpopover]:not(:hover) a.active svg[part="icon-active"]
     display: none;
 }
 
-.fluent-appbar-item[inpopover=true]:not(:hover) a.active svg[part="icon-rest"],
+.fluent-appbar-item[inpopover=true]:not(:hover) a.active svg[part="icon-rest"]
 {
     display: block;
 }

--- a/src/Core/Components/AppBar/FluentAppBar.razor.css
+++ b/src/Core/Components/AppBar/FluentAppBar.razor.css
@@ -19,7 +19,8 @@
   }
 
 
-    .fluent-appbar .fluent-appbar-item:hover {
+    .fluent-appbar .fluent-appbar-item:hover,
+    .fluent-appbar .fluent-appbar-more-item:hover {
       background-color: var(--colorNeutralBackground5Hover);
     }
 
@@ -94,7 +95,7 @@
 .fluent-appbar-item[overflow],
 .fluent-appbar-more-item:hover svg[part="icon-rest"],
 .fluent-appbar-more-item:not(:hover):not(.active) svg[part="icon-active"],
-.fluent-appbar-more-item:not(:hover) a.active svg[part="icon-rest"],
+
 .fluent-appbar-more-item[overflow] {
   display: none;
 }
@@ -105,11 +106,10 @@
 }
 
 .fluent-appbar-item[inpopover]:not(:hover) a.active svg[part="icon-active"],
-.fluent-appbar-more-item[inpopover]:not(:hover) a.active svg[part="icon-active"] {
     display: none;
 }
 
 .fluent-appbar-item[inpopover=true]:not(:hover) a.active svg[part="icon-rest"],
-.fluent-appbar-more-item[inpopover=true]:not(:hover) a.active svg[part="icon-rest"] {
+{
     display: block;
 }

--- a/src/Core/Components/AppBar/FluentAppBar.razor.css
+++ b/src/Core/Components/AppBar/FluentAppBar.razor.css
@@ -11,7 +11,7 @@
     background-color: var(--colorNeutralBackground2);
   }
 
-  .fluent-appbar .fluent-appbar-item {
+  .fluent-appbar .fluent-appbar-item, .fluent-appbar .fluent-appbar-more-item {
     --appbar-active-indicator-width: 2px;
     cursor: pointer;
     width: var(--appbar-item-size);
@@ -91,18 +91,25 @@
 .fluent-appbar-item:hover svg[part="icon-rest"],
 .fluent-appbar-item:not(:hover):not(.active) svg[part="icon-active"],
 .fluent-appbar-item:not(:hover) a.active svg[part="icon-rest"],
-.fluent-appbar-item[overflow] {
-    display: none;
+.fluent-appbar-item[overflow],
+.fluent-appbar-more-item:hover svg[part="icon-rest"],
+.fluent-appbar-more-item:not(:hover):not(.active) svg[part="icon-active"],
+.fluent-appbar-more-item:not(:hover) a.active svg[part="icon-rest"],
+.fluent-appbar-more-item[overflow] {
+  display: none;
 }
 
-.fluent-appbar-item:not(:hover) .active svg[part="icon-active"] {
+.fluent-appbar-item:not(:hover) .active svg[part="icon-active"],
+.fluent-appbar-more-item:not(:hover) .active svg[part="icon-active"] {
     display: block;
 }
 
-.fluent-appbar-item[inpopover]:not(:hover) a.active svg[part="icon-active"] {
+.fluent-appbar-item[inpopover]:not(:hover) a.active svg[part="icon-active"],
+.fluent-appbar-more-item[inpopover]:not(:hover) a.active svg[part="icon-active"] {
     display: none;
 }
 
-.fluent-appbar-item[inpopover=true]:not(:hover) a.active svg[part="icon-rest"] {
+.fluent-appbar-item[inpopover=true]:not(:hover) a.active svg[part="icon-rest"],
+.fluent-appbar-more-item[inpopover=true]:not(:hover) a.active svg[part="icon-rest"] {
     display: block;
 }

--- a/tests/Core/Components/AppBar/FluentAppBarTests.razor
+++ b/tests/Core/Components/AppBar/FluentAppBarTests.razor
@@ -566,7 +566,7 @@
 		cut.Render();
 
 		// Show popover by clicking the "More" button
-		var moreButton = cut.Find(".fluent-appbar-item[fixed]");
+		var moreButton = cut.Find(".fluent-appbar-more-item[fixed]");
 		await moreButton.ClickAsync();
 		cut.Render();
 


### PR DESCRIPTION
Because of the earlier Overflow refactor, the 'more' item was now considered to be one of the regular items that could be placed in the overflow popup (because of the selector name being the same). This PR fixes that by supplying a different selector (= class) to this special item