### PR TITLE
[dev-v5] Revert FluentUI package versions to 4.14.4 for stability

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,9 +17,9 @@
   <!-- Independent from TargetFrameWorks-->
   <ItemGroup>
     <!-- For Sample Apps -->
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="5.0.0-rc.4-26180.1" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="5.0.0-rc.4-26180.1" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="5.0.0-rc.4-26180.1" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.14.4" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.14.4" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="4.14.4" />
     <PackageVersion Include="LoxSmoke.DocXml" Version="3.9.0" />
     <!-- MCP SDK (aligned with the MCP 2026-07-28 specification) -->
     <PackageVersion Include="ModelContextProtocol" Version="2.1.0" />


### PR DESCRIPTION
Revert the FluentUI package versions to 4.14.4 to accept the Color property