### PR TITLE
[dev-v5] Version to RC5

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,7 +28,7 @@
     <!-- Versioning -->
     <VersionFile>5.0.0</VersionFile>
     <VersionPrefix>5.0.0</VersionPrefix>
-    <VersionSuffix>RC.4</VersionSuffix>
+    <VersionSuffix>RC.5</VersionSuffix>
 
     <Authors>Microsoft</Authors>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>

--- a/NEWS-BANNER.md
+++ b/NEWS-BANNER.md
@@ -2,5 +2,5 @@
 Title: New release available
 Intent: Success
 ---
-Version RC4 is now available with many new components.
+Version RC5 is now available with many new components.
 Check out the GitHub changelog for all the details and breaking changes.


### PR DESCRIPTION
# [dev-v5] Version to RC5

Update the version suffix to RC5 in the project configuration and reflect this change in the news banner. This release includes new components and improvements.

