### PR TITLE
[dev-v5][FluentDatePicker] Fix clearing validation error after invalid input

### DIFF
--- a/src/Core/Components/DateTime/FluentDatePicker.razor
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor
@@ -3,6 +3,7 @@
 @typeparam TValue
 
 <FluentTextInput Id="@Id"
+                 @ref="_input"
                  ValidationFieldFor="@ValueExpression"
                  Class="@ClassValue"
                  Style="@StyleValue"

--- a/src/Core/Components/DateTime/FluentDatePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor.cs
@@ -193,7 +193,6 @@ public partial class FluentDatePicker<TValue> : FluentCalendarBase<TValue>
 
         await OnSelectedDateHandlerAsync(updatedValue is null ? default : updatedValue.Value.ConvertToTValue<TValue>());
 
-
         if (!DateTime.TryParse(_input.CurrentValueOrDefault, Culture, DateTimeStyles.None, out _))
         {
             var formattedValue = FormatValueAsString(updatedValue is null ? default : updatedValue.Value.ConvertToTValue<TValue>());

--- a/src/Core/Components/DateTime/FluentDatePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor.cs
@@ -20,6 +20,8 @@ public partial class FluentDatePicker<TValue> : FluentCalendarBase<TValue>
     private FluentCalendar<TValue> _calendar = default!;
     private FluentIcon<Icon> _icon = default!;
 
+    private FluentTextInput _input = default!;
+
     /// <summary>
     /// Initializes a new instance of the FluentDatePicker class using the specified library configuration.
     /// </summary>
@@ -190,6 +192,13 @@ public partial class FluentDatePicker<TValue> : FluentCalendarBase<TValue>
         }
 
         await OnSelectedDateHandlerAsync(updatedValue is null ? default : updatedValue.Value.ConvertToTValue<TValue>());
+
+
+        if (!DateTime.TryParse(_input.CurrentValueOrDefault, Culture, DateTimeStyles.None, out _))
+        {
+            var formattedValue = FormatValueAsString(updatedValue is null ? default : updatedValue.Value.ConvertToTValue<TValue>());
+            await _input.ValueChanged.InvokeAsync(formattedValue);
+        }
     }
 
     /// <summary />

--- a/tests/Core/Components/DateTimes/FluentDatePickerTests.razor
+++ b/tests/Core/Components/DateTimes/FluentDatePickerTests.razor
@@ -855,6 +855,42 @@
         Assert.Contains("Production date is required", messages[0].TextContent);
     }
 
+    [Fact]
+    public void FluentDatePicker_SelectValidDate_ClearsValidationMessage()
+    {
+        // Arrange – fix "now" so the calendar renders a known month
+        var today = new System.DateTime(2024, 3, 1);
+        using var context = new DateTimeProviderContext(today);
+
+        var model = new DatePickerValidationModel();
+        var cut = Render(
+            @<EditForm Model="@model">
+                <DataAnnotationsValidator />
+                <FluentDatePicker TValue="DateTime?"
+                                  Label="Production Date"
+                                  Name="production-date"
+                                  Culture="@InvariantCulture"
+                                  @bind-Value="@model.ProductionDate" />
+            </EditForm>);
+
+        // Act – (2) enter an invalid date string to produce a validation message
+        var input = cut.Find("fluent-text-input");
+        input.Change("not-a-date");
+
+        // Validation message should now be present
+        var messages = cut.FindAll("fluent-field fluent-text[slot='message']");
+        Assert.NotEmpty(messages);
+
+        // Act – (3) open the calendar and select a valid date (15th of the current month)
+        input.Click();
+        var day = cut.Find(".day[value='2024-03-15']");
+        day.Click();
+
+        // Assert – (4) the validation message is cleared
+        var messagesAfter = cut.FindAll("fluent-field fluent-text[slot='message']");
+        Assert.Empty(messagesAfter);
+    }
+
     private class DatePickerValidationModel
     {
         [Required(ErrorMessage = "Production date is required")]


### PR DESCRIPTION
Fix #5122 

For some reason, the text input in the date picker was not triggered to re-process the DatePicker's validation state when the contents of the input is not a DateTime. This PR adds a check for that situation.

All tests still pass

I was not able to fix it any other way, but if you think a different approach is better, feel free to change

