### PR TITLE
[v4] Update package versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="coverlet.msbuild" Version="10.0.1" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
-    <PackageVersion Include="AngleSharp.CSS" Version="1.0.1" />
+    <PackageVersion Include="AngleSharp.CSS" Version="1.0.0-beta.154" />
     <!-- Shared dependencies -->
     <PackageVersion Include="Markdig.Signed" Version="1.3.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.6.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,34 +2,34 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <RuntimeVersion8>8.0.0</RuntimeVersion8>
-    <AspNetCoreVersion8>8.0.29</AspNetCoreVersion8>
-    <EfCoreVersion8>8.0.29</EfCoreVersion8>
-    <RuntimeVersion9>9.0.18</RuntimeVersion9>
-    <AspNetCoreVersion9>9.0.18</AspNetCoreVersion9>
-    <EfCoreVersion9>9.0.18</EfCoreVersion9>
-    <RuntimeVersion10>10.0.10</RuntimeVersion10>
-    <AspNetCoreVersion10>10.0.10</AspNetCoreVersion10>
-    <EfCoreVersion10>10.0.10</EfCoreVersion10>
+    <AspNetCoreVersion8>8.0.30</AspNetCoreVersion8>
+    <EfCoreVersion8>8.0.30</EfCoreVersion8>
+    <RuntimeVersion9>9.0.19</RuntimeVersion9>
+    <AspNetCoreVersion9>9.0.19</AspNetCoreVersion9>
+    <EfCoreVersion9>9.0.19</EfCoreVersion9>
+    <RuntimeVersion10>10.0.11</RuntimeVersion10>
+    <AspNetCoreVersion10>10.0.11</AspNetCoreVersion10>
+    <EfCoreVersion10>10.0.11</EfCoreVersion10>
   </PropertyGroup>
   <ItemGroup>
     <!-- For Sample Apps -->
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.14.2" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" version="4.14.2" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="4.14.2" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.14.4" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.14.4" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="4.14.4" />
     <!-- Test dependencies -->
     <PackageVersion Include="bunit" Version="1.40.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="coverlet.msbuild" Version="10.0.1" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
-    <PackageVersion Include="AngleSharp.CSS" Version="1.0.0-beta.157" />
+    <PackageVersion Include="AngleSharp.CSS" Version="1.0.1" />
     <!-- Shared dependencies -->
     <PackageVersion Include="Markdig.Signed" Version="1.3.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.OData.Client" Version="8.4.3" />
-    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.OData.Client" Version="8.4.4" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="18.7.23" />
     <PackageVersion Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">

--- a/_ListOutdatedDependencies.ps1
+++ b/_ListOutdatedDependencies.ps1
@@ -1,0 +1,143 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Lists all outdated NuGet and npm packages for the solution, across every supported target framework.
+
+.DESCRIPTION
+    Runs `dotnet outdated` for the solution (projects already multi-target
+    net8.0/net9.0/net10.0 via <TargetFrameworks>) and groups the results by
+    $(TargetFramework).
+    Also lists outdated npm packages (via npm-check-updates) for the Core.Assets project,
+    without changing any package.json or lock file.
+
+.NOTES
+    Requires the dotnet-outdated-tool and npm-check-updates:
+        dotnet tool install --global dotnet-outdated-tool --add-source https://api.nuget.org/v3/index.json
+        npm install --global npm-check-updates --registry https://registry.npmjs.org/
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = $PSScriptRoot
+$slnPath = Join-Path $repoRoot 'Microsoft.FluentUI.sln'
+$npmProjects = @('src/Core.Assets')
+
+# Key = "TargetFramework|Name|OldVersion|NewVersion", used to avoid duplicate rows across projects.
+$updates = [ordered]@{}
+
+Write-Host "`n=== Checking outdated NuGet packages ===" -ForegroundColor Cyan
+
+$reportPath = Join-Path $repoRoot 'outdated.json'
+if (Test-Path $reportPath) {
+    Remove-Item $reportPath -Force
+}
+
+try {
+    dotnet outdated $slnPath --version-lock Major --pre-release Never -o $reportPath -of json
+
+    if (-not (Test-Path $reportPath)) {
+        throw "No report generated (dotnet-outdated-tool might not be installed)."
+    }
+
+    $report = Get-Content -Path $reportPath -Raw | ConvertFrom-Json
+    foreach ($project in $report.Projects) {
+        foreach ($targetFramework in $project.TargetFrameworks) {
+            foreach ($dependency in $targetFramework.Dependencies) {
+                $key = "$($targetFramework.Name)|$($dependency.Name)|$($dependency.ResolvedVersion)|$($dependency.LatestVersion)"
+                if (-not $updates.Contains($key)) {
+                    $updates[$key] = [pscustomobject]@{
+                        TargetFramework = $targetFramework.Name
+                        Package         = $dependency.Name
+                        OldVersion      = $dependency.ResolvedVersion
+                        NewVersion      = $dependency.LatestVersion
+                    }
+                }
+            }
+        }
+    }
+}
+finally {
+    if (Test-Path $reportPath) {
+        Remove-Item $reportPath -Force
+    }
+}
+
+$targetFrameworks = $updates.Values | Select-Object -ExpandProperty TargetFramework -Unique | Sort-Object
+$summary = $updates.Values | Sort-Object TargetFramework, Package, OldVersion
+
+Write-Host "`n=== Summary of outdated NuGet packages (grouped by target framework) ===" -ForegroundColor Green
+foreach ($targetFramework in $targetFrameworks) {
+    $group = $summary | Where-Object { $_.TargetFramework -eq $targetFramework }
+    if ($group) {
+        Write-Host "`n-- $targetFramework --" -ForegroundColor Yellow
+        $group | Select-Object Package, OldVersion, NewVersion | Format-Table -AutoSize
+    }
+}
+
+# Key = "Project|Name|OldVersion|NewVersion", used to avoid duplicate rows.
+$npmUpdates = [ordered]@{}
+
+foreach ($npmProject in $npmProjects) {
+    Write-Host "`n=== Checking outdated npm packages for $npmProject ===" -ForegroundColor Cyan
+
+    $packageFilePath = Join-Path $repoRoot "$npmProject/package.json"
+    try {
+        $jsonOutput = ncu --packageFile $packageFilePath --jsonUpgraded 2>&1 | Out-String
+        $upgraded = $jsonOutput | ConvertFrom-Json
+    }
+    catch {
+        Write-Warning "ncu failed for ${npmProject}: $_"
+        continue
+    }
+
+    $currentPackageJson = Get-Content -Path $packageFilePath -Raw | ConvertFrom-Json
+    foreach ($property in $upgraded.PSObject.Properties) {
+        $packageName = $property.Name
+        $newVersion = $property.Value -replace '^[\^~]', ''
+        $oldVersion = $null
+        foreach ($section in @('dependencies', 'devDependencies')) {
+            if ($currentPackageJson.$section -and $currentPackageJson.$section.PSObject.Properties[$packageName]) {
+                $oldVersion = $currentPackageJson.$section.$packageName -replace '^[\^~]', ''
+                break
+            }
+        }
+
+        $key = "$npmProject|$packageName|$oldVersion|$newVersion"
+        if (-not $npmUpdates.Contains($key)) {
+            $npmUpdates[$key] = [pscustomobject]@{
+                Project    = $npmProject
+                Package    = $packageName
+                OldVersion = $oldVersion
+                NewVersion = $newVersion
+            }
+        }
+    }
+}
+
+if ($npmUpdates.Count -gt 0) {
+    Write-Host "`n=== Summary of outdated npm packages (grouped by project) ===" -ForegroundColor Green
+    foreach ($npmProject in $npmProjects) {
+        $group = $npmUpdates.Values | Where-Object { $_.Project -eq $npmProject } | Sort-Object Package
+        if ($group) {
+            Write-Host "`n-- $npmProject --" -ForegroundColor Yellow
+            $group | Select-Object Package, OldVersion, NewVersion | Format-Table -AutoSize
+        }
+    }
+}
+
+Write-Host "`n=== Next steps: apply the updates manually ===" -ForegroundColor Green
+Write-Host @'
+
+NuGet packages:
+  1. Update the versions listed above in Directory.Packages.props.
+  2. Review shared version properties (RuntimeVersion*, AspNetCoreVersion*, EfCoreVersion*) so packages
+     that reference them stay aligned for each target framework.
+  3. Restore and build the solution:
+       dotnet restore ./Microsoft.FluentUI.sln
+       dotnet build ./Microsoft.FluentUI.sln --configuration Release
+
+npm packages:
+  1. Update the versions listed above in src/Core.Assets/package.json.
+  2. Reinstall to regenerate the lock files:
+       npm install --prefix ./src/Core.Assets
+'@

--- a/src/Core.Assets/package-lock.json
+++ b/src/Core.Assets/package-lock.json
@@ -12,8 +12,8 @@
       "devDependencies": {
         "@microsoft/fast-element": "1.14.0",
         "@microsoft/fast-foundation": "2.50.0",
-        "@typescript-eslint/eslint-plugin": "^8.65.0",
-        "@typescript-eslint/parser": "^8.65.0",
+        "@typescript-eslint/eslint-plugin": "^8.66.0",
+        "@typescript-eslint/parser": "^8.66.0",
         "esbuild": "0.28.1",
         "esbuild-plugin-inline-css": "^0.0.1",
         "eslint": "^10.8.0",
@@ -745,17 +745,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.65.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
-      "integrity": "sha1-Cljfb+qMC/azlvUYB3CZvIt2K7U=",
+      "version": "8.66.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
+      "integrity": "sha1-duhqpaJFn79bvXqDnA3AzOHVYiQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.65.0",
-        "@typescript-eslint/type-utils": "8.65.0",
-        "@typescript-eslint/utils": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0",
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/type-utils": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -768,22 +768,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.65.0",
+        "@typescript-eslint/parser": "^8.66.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.65.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/parser/-/parser-8.65.0.tgz",
-      "integrity": "sha1-UpXBBYwKHddG7yi6r5wDQdvfA9w=",
+      "version": "8.66.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/parser/-/parser-8.66.0.tgz",
+      "integrity": "sha1-iOOGXs9zsBGBNOfLgx2oepYaV6E=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.65.0",
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0",
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -799,14 +799,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.65.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
-      "integrity": "sha1-Zfu8mhWRq/+uq1UTIA+EgnHLCqU=",
+      "version": "8.66.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
+      "integrity": "sha1-go94iJXfUtnrK1Q0RaOloT41q04=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.65.0",
-        "@typescript-eslint/types": "^8.65.0",
+        "@typescript-eslint/tsconfig-utils": "^8.66.0",
+        "@typescript-eslint/types": "^8.66.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -821,14 +821,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.65.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
-      "integrity": "sha1-lUcgLOfmCOe2KD31hXA7mAoOpw0=",
+      "version": "8.66.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/scope-manager/-/scope-manager-8.66.0.tgz",
+      "integrity": "sha1-T//Mbr0N+f55g8AlaWdWfqb1rGM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0"
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -839,9 +839,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.65.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
-      "integrity": "sha1-NvFo/NuxKV90Rv8DeWZ/mMPPG/M=",
+      "version": "8.66.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
+      "integrity": "sha1-OokGbFB6owVB3BdoBGhbS0ROHlI=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -856,15 +856,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.65.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
-      "integrity": "sha1-0xbXUi2Tz/TNFPMF4C898tgE+cE=",
+      "version": "8.66.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/type-utils/-/type-utils-8.66.0.tgz",
+      "integrity": "sha1-sjFTA+ynL62a+nvk9Y8FPI8qBHk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0",
-        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -881,9 +881,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.65.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/types/-/types-8.65.0.tgz",
-      "integrity": "sha1-PoZzhBand8i4klq0Z0X0js+QTJ8=",
+      "version": "8.66.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/types/-/types-8.66.0.tgz",
+      "integrity": "sha1-PKyrlNO1ZMHUjFbrN7ifiabUhHk=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -895,16 +895,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.65.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
-      "integrity": "sha1-8fUUgI9qpxPi1niuj/WSpl4WMq8=",
+      "version": "8.66.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
+      "integrity": "sha1-GjjDqX3Gxmm2bVhdf5DrxPuzKlA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.65.0",
-        "@typescript-eslint/tsconfig-utils": "8.65.0",
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0",
+        "@typescript-eslint/project-service": "8.66.0",
+        "@typescript-eslint/tsconfig-utils": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -923,16 +923,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.65.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/utils/-/utils-8.65.0.tgz",
-      "integrity": "sha1-r+3ZdKDI3u71U7UJ31gAuv1hWnI=",
+      "version": "8.66.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/utils/-/utils-8.66.0.tgz",
+      "integrity": "sha1-4nfWdCcEPNyiWA7pGqYpIeRomWk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.65.0",
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0"
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -947,13 +947,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.65.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
-      "integrity": "sha1-43BME8tKHCJFTBq/KP9HN+FQGMY=",
+      "version": "8.66.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/visitor-keys/-/visitor-keys-8.66.0.tgz",
+      "integrity": "sha1-TElOlHRfsnJKTzejEAkeVrZE0Yo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/types": "8.66.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1028,9 +1028,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha1-E1rQ2NgI6xjrXg7Joh86C5LvGM8=",
+      "version": "5.0.9",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha1-fHJDiAm1+lur9UGZofHCgaaYT88=",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/Core.Assets/package.json
+++ b/src/Core.Assets/package.json
@@ -14,8 +14,8 @@
   "devDependencies": {
     "@microsoft/fast-element": "1.14.0",
     "@microsoft/fast-foundation": "2.50.0",
-    "@typescript-eslint/eslint-plugin": "^8.65.0",
-    "@typescript-eslint/parser": "^8.65.0",
+    "@typescript-eslint/eslint-plugin": "^8.66.0",
+    "@typescript-eslint/parser": "^8.66.0",
     "esbuild": "0.28.1",
     "esbuild-plugin-inline-css": "^0.0.1",
     "eslint": "^10.8.0",


### PR DESCRIPTION
[v4] Update package versions

Introduce a script that identifies outdated NuGet and npm packages across the solution, enhancing maintenance and upgrade processes. Update package versions to improve stability and compatibility. This change does not introduce breaking changes.


**Note**

AngleSharp.CSS 1.0.1 required AngleSharp >= 1.5.0, which forced NuGet to bump the transitive AngleSharp package from 1.2.0 (the version bunit.web 1.40.0 was compiled against) to 1.5.0. Since Bunit.Web.dll's RefreshableElementCollection was compiled against AngleSharp 1.2.0's IHtmlCollection<T> indexer, loading the newer incompatible AngleSharp 1.5.0 at runtime caused a MissingMethodException.

Fix: pinned the central AngleSharp.CSS package version in Directory.Packages.props down to 1.0.0-beta.154 (resolved to 1.0.0-beta.157), which keeps the transitive AngleSharp core package at 1.2.0, matching what bUnit expects. Verified the previously failing test FluentWizard_NavigateNext now passes, and the test project builds successfully.
