### PR TITLE
[dev-v5][Docs] Add FluentNumberField migration guide

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Number/FluentNumber.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Number/FluentNumber.md
@@ -73,3 +73,7 @@ When using the up/down buttons or arrow keys, the value is always updated immedi
 ## API FluentNumberInput
 
 {{ API Type=FluentNumberInput<int> }}
+
+## Migrating to v5
+
+{{ INCLUDE File=MigrationFluentNumberField }}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextInput/FluentTextInput.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextInput/FluentTextInput.md
@@ -168,3 +168,7 @@ If you still want to use these placeholder values, then you need to disable auto
 ## API FluentTextInput
 
 {{ API Type=FluentTextInput }}
+
+## Migrating to v5
+
+{{ INCLUDE File=MigrationFluentTextField }}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentNumberField.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentNumberField.md
@@ -16,9 +16,9 @@ hidden: true
 | `Appearance` (`FluentInputAppearance`) | `Appearance` (`TextInputAppearance`) | Enum renamed |
 | `Disabled` | `Disabled`  | Type changed from `bool` to `bool?` |
 | `Size` (`int?`) | `Size` (`TextInputSize?`) | Changed from pixel count to enum | 
-| `Min` (`string?`) | `Min` (`TValue?`) | Changed from `string?` to generic type | 
-| `Max` (`string?`) | `Max` (`TValue?`) | Changed from `string?` to generic type | 
-| `Step` (`string`) | `Step` (`TValue?`) | Changed from `string` to generic type | 
+| `Min` (`string?`) | `Min` (`TValue`) | Changed from `string?` to generic type | 
+| `Max` (`string?`) | `Max` (`TValue`) | Changed from `string?` to generic type | 
+| `Step` (`string`) | `Step` (`TValue`) | Changed from `string` to generic type | 
 
 
 ### Removed properties

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentNumberField.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentNumberField.md
@@ -1,0 +1,56 @@
+---
+title: Migration FluentNumberField
+route: /Migration/NumberField
+hidden: true
+---
+
+`FluentNumberField` has been **removed in V5** and replaced by the new `FluentNumberInput` component.
+
+`FluentNumberInput` has been completely **rebuilt from the ground up** and provides improved number input handling, including support for different `CultureInfo` settings.
+
+
+### FluentNumberField → FluentNumberInput
+
+| V4 Property | V5 Property | Change |
+|-------------|-------------|--------|
+| `Appearance` (`FluentInputAppearance`) | `Appearance` (`TextInputAppearance`) | Enum renamed |
+| `Disabled` | `Disabled`  | Type changed from `bool` to `bool?` |
+| `Size` (`int?`) | `Size` (`TextInputSize?`) | Changed from pixel count to enum | 
+| `Min` (`string?`) | `Min` (`TValue?`) | Changed from `string?` to generic type | 
+| `Max` (`string?`) | `Max` (`TValue?`) | Changed from `string?` to generic type | 
+| `Step` (`string`) | `Step` (`TValue?`) | Changed from `string` to generic type | 
+
+
+### Removed properties
+- `AutoComplete`
+- `ChildContent` use `Value` or `@bind-Value` instead
+- `DataList`
+- `ParsingErrorMessage` use `MessageTemplate` in combination with `MessageCondition` instead
+- `MaxLength`
+- `MinLength`
+
+### FluentNumberField migration
+
+  ```razor
+  <!-- V4 -->
+  <FluentNumberField TValue="int"
+                     @bind-Value="quantity"
+                     Min="0" Max="100" Step="1"
+                     Appearance="FluentInputAppearance.Outline" />
+
+  <!-- V5: Use FluentNumberInput -->
+  <FluentNumberInput @bind-Value="quantity"
+                     Min="0"
+                     Max="100"
+                     Step="1"
+                     Appearance="TextInputAppearance.Outline" />
+  ```
+
+ ### Appearance mapping
+
+| V4 `FluentInputAppearance` | V5 `TextInputAppearance` |
+|---------------------------|-------------------------|
+| `FluentInputAppearance.Outline` | `TextInputAppearance.Outline` |
+| `FluentInputAppearance.Filled` | `TextInputAppearance.FilledDarker` |
+
+Migration helper available: `FluentInputAppearance.Filled.ToTextInputAppearance()`

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentTextField.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentTextField.md
@@ -4,72 +4,54 @@ route: /Migration/TextField
 hidden: true
 ---
 
-- ### Three components merged into one 
+### Two components merged into one 
 
-  `FluentTextField`, `FluentNumberField`, and `FluentSearch` have been **removed** in V5.
-  They are all replaced by `FluentTextInput`.
+`FluentTextField` and `FluentSearch` have been **removed** in V5. They are all replaced by `FluentTextInput`.
 
-- ### Component mapping
+### Component mapping
 
-  | V4 Component | V5 Replacement |
-  |-------------|----------------|
-  | `FluentTextField` | `FluentTextInput` |
-  | `FluentNumberField` | `FluentTextInput` with `TextInputType="TextInputType.Number"` |
-  | `FluentSearch` | `FluentTextInput` with a search icon in `StartTemplate` |
+| V4 Component | V5 Replacement |
+|-------------|----------------|
+| `FluentTextField` | `FluentTextInput` |
+| `FluentSearch` | `FluentTextInput` with a search icon in `StartTemplate` |
 
-- ### FluentTextField → FluentTextInput
+### FluentTextField → FluentTextInput
 
-  | V4 Property | V5 Property | Change |
-  |-------------|-------------|--------|
-  | `TextFieldType` (`TextFieldType?`) | `TextInputType` (`TextInputType?`) | Enum renamed |
-  | `Appearance` (`FluentInputAppearance`) | `Appearance` (`TextInputAppearance`) | Enum renamed |
-  | `Size` (`int?`) | `Size` (`TextInputSize?`) | Changed from pixel count to enum |
-  | `InputMode` (`InputMode?`) | `InputMode` (`TextInputMode?`) | Enum renamed |
-  | `ChildContent` | — | **Removed** — use `StartTemplate`/`EndTemplate` |
-  | `Maxlength` | `MaxLength` | Casing changed |
-  | `Minlength` | `MinLength` | Casing changed |
-  | `DataList` | `DataList` | Same |
+| V4 Property | V5 Property | Change |
+|-------------|-------------|--------|
+| `TextFieldType` (`TextFieldType?`) | `TextInputType` (`TextInputType?`) | Enum renamed |
+| `Appearance` (`FluentInputAppearance`) | `Appearance` (`TextInputAppearance`) | Enum renamed |
+| `Disabled` | `Disabled`  | Type changed from `bool` to `bool?` |
+| `Size` (`int?`) | `Size` (`TextInputSize?`) | Changed from pixel count to enum |
+| `InputMode` (`InputMode?`) | `InputMode` (`TextInputMode?`) | Enum renamed |
+| `ChildContent` | — | **Removed** — use `StartTemplate`/`EndTemplate` |
+| `Maxlength` | `MaxLength` | Casing changed |
+| `Minlength` | `MinLength` | Casing changed |
+| `DataList` | `DataList` | Same |
 
-- ### FluentNumberField migration
 
-  ```xml
-  <!-- V4 -->
-  <FluentNumberField TValue="int" @bind-Value="quantity"
-                     Min="0" Max="100" Step="1"
-                     Appearance="FluentInputAppearance.Outline" />
+### FluentSearch migration
 
-  <!-- V5: Use FluentTextInput with type="number" or FluentSlider -->
-  <FluentTextInput @bind-Value="quantityStr"
-                   TextInputType="TextInputType.Number"
-                   Appearance="TextInputAppearance.Outline" />
-  ```
+```razor
+<!-- V4 -->
+<FluentSearch @bind-Value="searchText"
+            Appearance="FluentInputAppearance.Outline" />
 
-  > ⚠️ `FluentNumberField` had built-in numeric parsing with `Min`/`Max`/`Step`/`HideStep` properties.
-  > `FluentTextInput` is string-based. For numeric input with validation,
-  > consider using `FluentSlider` or adding custom validation logic.
+<!-- V5 -->
+<FluentTextInput @bind-Value="searchText"
+                Appearance="TextInputAppearance.Outline"
+                Placeholder="Search...">
+    <StartTemplate>
+        <FluentIcon Value="@(new Icons.Regular.Size16.Search())" />
+    </StartTemplate>
+</FluentTextInput>
+```
 
-- ### FluentSearch migration
+### Appearance mapping
 
-  ```xml
-  <!-- V4 -->
-  <FluentSearch @bind-Value="searchText"
-                Appearance="FluentInputAppearance.Outline" />
+| V4 `FluentInputAppearance` | V5 `TextInputAppearance` |
+|---------------------------|-------------------------|
+| `FluentInputAppearance.Outline` | `TextInputAppearance.Outline` |
+| `FluentInputAppearance.Filled` | `TextInputAppearance.FilledDarker` |
 
-  <!-- V5 -->
-  <FluentTextInput @bind-Value="searchText"
-                   Appearance="TextInputAppearance.Outline"
-                   Placeholder="Search...">
-      <StartTemplate>
-          <FluentIcon Value="@(new Icons.Regular.Size16.Search())" />
-      </StartTemplate>
-  </FluentTextInput>
-  ```
-
-- ### Appearance mapping
-
-  | V4 `FluentInputAppearance` | V5 `TextInputAppearance` |
-  |---------------------------|-------------------------|
-  | `FluentInputAppearance.Outline` | `TextInputAppearance.Outline` |
-  | `FluentInputAppearance.Filled` | `TextInputAppearance.FilledDarker` |
-
-  Migration helper available: `FluentInputAppearance.Filled.ToTextInputAppearance()`
+Migration helper available: `FluentInputAppearance.Filled.ToTextInputAppearance()`

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentTextField.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentTextField.md
@@ -1,11 +1,10 @@
 ---
-title: Migration FluentTextField, FluentNumberField, FluentSearch
+title: Migration FluentTextField, FluentSearch
 route: /Migration/TextField
 hidden: true
 ---
 
 ### Two components merged into one 
-
 `FluentTextField` and `FluentSearch` have been **removed** in V5. They are all replaced by `FluentTextInput`.
 
 ### Component mapping

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationIndex.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationIndex.md
@@ -78,7 +78,8 @@ Each page below covers specific component changes, removed components, and new a
   | FluentBreadcrumb | *(no direct replacement)* | [Migration](/Migration/Breadcrumb) |
   | FluentDesignTheme / FluentDesignSystemProvider | CSS theming system | [Migration](/Migration/DesignTheme) |
   | FluentNavMenu / FluentNavMenuTree | `FluentNav` | [Migration](/Migration/NavMenu) |
-  | FluentTextField / FluentNumberField / FluentSearch | `FluentTextInput` | [Migration](/Migration/TextField) |
+  | FluentTextField / FluentSearch | `FluentTextInput` | [Migration](/Migration/TextField) |
+  | FluentNumberField | `FluentNumberInput` | [Migration](/Migration/NumberField) |
   | FluentToast / FluentToastProvider | `FluentMessageBar` | [Migration](/Migration/Toast) |
   | FluentToolbar | `FluentStack` | [Migration](/Migration/Toolbar) |
   | FluentWizard | *(no direct replacement)* | [Migration](/Migration/Wizard) |
@@ -94,5 +95,6 @@ Each page below covers specific component changes, removed components, and new a
   | FluentNav | `FluentNavMenu` / `FluentNavMenuTree` | [Migration](/Migration/NavMenu) |
   | FluentRatingDisplay | `FluentRating` | [Migration](/Migration/RatingDisplay) |
   | FluentText | `FluentLabel` (typography) | [Migration](/Migration/Text) |
-  | FluentTextInput | `FluentTextField` / `FluentNumberField` / `FluentSearch` | [Migration](/Migration/TextField) |
+  | FluentTextInput | `FluentTextField` / `FluentSearch` | [Migration](/Migration/TextField) |
+  | FluentNumberInput | `FluentNumberField` | [Migration](/Migration/NumberField) |
   | FluentTheme (CSS system) | `FluentDesignTheme` / `FluentDesignSystemProvider` | [Migration](/Migration/DesignTheme) |


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR adds a migration guide for `FluentNumberField` to `FluentNumberInput`. In addition the migration guide for `FluentTextField` has been updated and all parts regarding a migration for numeric has been removed from here.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [ ] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
