### PR TITLE
[dev-v5] Add ValidateClassNames property in LibraryConfiguration

### DIFF
--- a/src/Core/Infrastructure/LibraryConfiguration.cs
+++ b/src/Core/Infrastructure/LibraryConfiguration.cs
@@ -74,19 +74,33 @@ public class LibraryConfiguration
     /// </summary>
     public bool UseGlobalOverlay { get; set; } = true;
 
-    /* TODO: Implement these properties
-     
+    /// <summary>
+    /// Static backing store for <see cref="ValidateClassNames"/>: shared process-wide, not per <see cref="LibraryConfiguration"/> instance.
+    /// </summary>
+    private static bool s_validateClassNames = true;
+
     /// <summary>
     /// Gets or sets the value indicating whether the library should validate CSS class names.
     /// respecting the following regex: "^-?[_a-zA-Z]+[_a-zA-Z0-9-]*$".
     /// Default is true.
     /// </summary>
+    /// <remarks>
+    /// This setting is stored statically, so changing it applies to the whole application (all DI scopes/instances),
+    /// not just the current <see cref="LibraryConfiguration"/> instance.
+    /// </remarks>
     public bool ValidateClassNames
     {
-        get => Utilities.CssBuilder.ValidateClassNames;
-        set => Utilities.CssBuilder.ValidateClassNames = value;
+        get => s_validateClassNames;
+        set => s_validateClassNames = value;
     }
-    
+
+    /// <summary>
+    /// Gets the current, process-wide <see cref="ValidateClassNames"/> value for use by <see cref="Utilities.CssBuilder"/>.
+    /// </summary>
+    internal static bool ShouldValidateClassNames => s_validateClassNames;
+
+    /* TODO: Implement these properties
+
     /// <summary>
     /// Gets or sets the function that formats the URL of the collocated JavaScript file,
     /// adding the return value as a query string parameter.

--- a/src/Core/Infrastructure/LibraryConfiguration.cs
+++ b/src/Core/Infrastructure/LibraryConfiguration.cs
@@ -77,7 +77,7 @@ public class LibraryConfiguration
     /// <summary>
     /// Static backing store for <see cref="ValidateClassNames"/>: shared process-wide, not per <see cref="LibraryConfiguration"/> instance.
     /// </summary>
-    private static bool s_validateClassNames = true;
+    private static volatile bool s_validateClassNames = true;
 
     /// <summary>
     /// Gets or sets the value indicating whether the library should validate CSS class names.

--- a/src/Core/Utilities/CssBuilder.cs
+++ b/src/Core/Utilities/CssBuilder.cs
@@ -15,14 +15,8 @@ public readonly partial struct CssBuilder
 {
     private readonly HashSet<string> _classes;
     private readonly string[]? _userClasses;
-    private readonly bool _validateClassNames = ValidateClassNames;
+    private readonly bool _validateClassNames = LibraryConfiguration.ShouldValidateClassNames;
     private static readonly Regex s_validClassNameRegex = GenerateValidClassNameRegex();
-
-    /// <summary>
-    /// Validate CSS class, which must respect the following regex: "^-?[_a-zA-Z]+[_a-zA-Z0-9-]*$".
-    /// Default is true.
-    /// </summary>
-    public static bool ValidateClassNames { get; set; } = true;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CssBuilder"/> class.

--- a/tests/Core/Utilities/CssBuilderTests.cs
+++ b/tests/Core/Utilities/CssBuilderTests.cs
@@ -219,6 +219,80 @@ public partial class CssBuilderTests
     }
 
     [Fact]
+    public void LibraryConfiguration_ValidateClassNames_DefaultsToTrue()
+    {
+        // Arrange
+        var configuration = new LibraryConfiguration();
+
+        // Act & Assert
+        Assert.True(configuration.ValidateClassNames);
+    }
+
+    [Fact]
+    public void LibraryConfiguration_ValidateClassNames_DisablesCssBuilderValidation()
+    {
+        // Arrange
+        var configuration = new LibraryConfiguration();
+
+        try
+        {
+            // Act
+            configuration.ValidateClassNames = false;
+            var cssBuilder = new CssBuilder();
+            cssBuilder.AddClass("123-invalid-class");
+
+            // Assert
+            Assert.Equal("123-invalid-class", cssBuilder.Build());
+        }
+        finally
+        {
+            configuration.ValidateClassNames = true;
+        }
+    }
+
+    [Fact]
+    public void LibraryConfiguration_ValidateClassNames_IsSharedAcrossInstances()
+    {
+        // Arrange: the setting is backed by a static field, so it is shared process-wide.
+        var configuration1 = new LibraryConfiguration();
+        var configuration2 = new LibraryConfiguration();
+
+        try
+        {
+            // Act
+            configuration1.ValidateClassNames = false;
+
+            // Assert
+            Assert.False(configuration2.ValidateClassNames);
+        }
+        finally
+        {
+            configuration1.ValidateClassNames = true;
+        }
+    }
+
+    [Fact]
+    public void LibraryConfiguration_ShouldValidateClassNames_ReflectsValidateClassNames()
+    {
+        // Arrange
+        var configuration = new LibraryConfiguration();
+
+        try
+        {
+            // Act
+            configuration.ValidateClassNames = false;
+
+            // Assert
+            Assert.False(LibraryConfiguration.ShouldValidateClassNames);
+        }
+        finally
+        {
+            configuration.ValidateClassNames = true;
+            Assert.True(LibraryConfiguration.ShouldValidateClassNames);
+        }
+    }
+
+    [Fact]
     public void CssBuilder_MinifyCss()
     {
         // Arrange


### PR DESCRIPTION
# [dev-v5] Add ValidateClassNames property in LibraryConfiguration

Introduce a new `ValidateClassNames` property in `LibraryConfiguration` to control CSS class name validation across the application. 
This change enhances configurability and maintains existing validation logic.

```csharp
builder.Services.AddFluentUIComponents(config => config.ValidateClassNames = false);
```

> **Note**: This setting is stored statically, so changing it applies to the whole application (all DI scopes/instances),
> not just the current `LibraryConfiguration` instance.

Update `CssBuilder` to utilize this property, ensuring consistent behavior. 

## Unit Tests

Add tests to verify the functionality and shared state of the validation setting across instances. 


