### PR TITLE
fix: [DataGrid] Virtualized grid permanently stuck on empty content once TotalItemCount is ever 0

### DIFF
--- a/src/Core/Components/DataGrid/FluentDataGrid.razor
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor
@@ -55,8 +55,13 @@
                 {
                     @if (Virtualize)
                     {
-                        if (_internalGridContext.TotalItemCount == 0 && _virtualizeComponent is not null)
+                        if (_internalGridContext.TotalItemCount == 0 && _virtualizeItemsProvided)
                         {
+                            @* The provider has reported zero items, so this render replaces the Virtualize
+                               component with the empty content, disposing the instance captured by the @ref.
+                               Clear the reference so refreshes don't delegate to the dead instance;
+                               RefreshDataCoreAsync re-mounts Virtualize by resetting the flag (#5151). *@
+                            _virtualizeComponent = null;
                             @_renderEmptyContent
                         }
                         else

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -1588,7 +1588,14 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     private string? StyleValue => DefaultStyleBuilder
         .AddStyle("grid-template-columns", _internalGridTemplateColumns, !string.IsNullOrWhiteSpace(_internalGridTemplateColumns) && DisplayMode == DataGridDisplayMode.Grid)
         .AddStyle("grid-template-rows", "auto 1fr", (_internalGridContext.Items.Count == 0 || Items is null || EffectiveLoadingValue) && DisplayMode == DataGridDisplayMode.Grid)
-        .AddStyle("height", "100%", _internalGridContext.TotalItemCount == 0 || EffectiveLoadingValue)
+        // The 100% stretch vertically centers the empty/loading content rows. It must NOT apply
+        // while a virtualized grid is still waiting for its first provider result: the only rows
+        // are the two zero-height Virtualize spacers, and stretching the table inflates them,
+        // defeating Virtualize's startup guard for the after spacer (spacerAfter.offsetHeight > 0).
+        // The stale "after spacer visible" observation is then applied once the real count arrives,
+        // so the grid jumped to the tail of the data set and back — a visible double flash and two
+        // wasted provider round-trips on every first load.
+        .AddStyle("height", "100%", (_internalGridContext.TotalItemCount == 0 && (!Virtualize || _virtualizeItemsProvided)) || EffectiveLoadingValue)
         .AddStyle("border-collapse", "separate", GenerateHeader == DataGridGeneratedHeaderType.Sticky)
         .AddStyle("border-spacing", "0", GenerateHeader == DataGridGeneratedHeaderType.Sticky)
         .AddStyle("width", "100%", DisplayMode == DataGridDisplayMode.Table)

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -70,6 +70,11 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     private GridItemsProvider<TGridItem>? _lastAssignedItemsProvider;
     private CancellationTokenSource? _pendingDataLoadCancellationTokenSource;
     private bool _isFirstVirtualizeProviderCall = true;
+
+    // True once ProvideVirtualizedItemsAsync has applied a provider result. Gates the virtualized
+    // empty content: "zero items" only means "no data" after the provider has actually answered,
+    // not during the initial load window between the Virtualize mount and its first query (#5151).
+    private bool _virtualizeItemsProvided;
     private Exception? _lastError;
     private GridItemsProviderRequest<TGridItem>? _lastRequest;
     private bool _forceRefreshData;
@@ -1353,9 +1358,12 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
                 _pendingDataLoadCancellationTokenSource = null;
                 return;
             }
-            // If Virtualize is true but we don't have a reference to the component yet,
-            // it means we're still in the first render. The Virtualize component will call us when it's ready,
-            // so we can just wait for that instead of trying to load data now.
+            // If Virtualize is true but we don't have a reference to the component, either we're still in
+            // the first render, or the empty content replaced (and disposed) the component after the
+            // provider reported zero items. Clear the flag so the re-render below re-mounts Virtualize;
+            // it will call us when it's ready, so we can just wait for that instead of trying to load
+            // data now (#5151).
+            _virtualizeItemsProvided = false;
             _pendingDataLoadCancellationTokenSource = null;
             thisLoadCts.Dispose();
             Loading = false;
@@ -1457,15 +1465,23 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
             // the current viewport. In the case where you're also paginating then it means what's conceptually on the current page.
             // TODO: This currently assumes we always want to expand the last page to have ItemsPerPage rows, but the experience might
             //       be better if we let the last page only be as big as its number of actual rows.
+            var isFirstProviderResult = !_virtualizeItemsProvided;
+            var totalItemCountChanged = _internalGridContext.TotalItemCount != providerResult.TotalItemCount;
+
             _internalGridContext.TotalItemCount = providerResult.TotalItemCount;
             _internalGridContext.TotalViewItemCount = Pagination?.ItemsPerPage ?? providerResult.TotalItemCount;
+            _virtualizeItemsProvided = true;
 
             if (RefreshItems is null)
             {
                 Pagination?.SetTotalItemCountAsync(_internalGridContext.TotalItemCount);
             }
 
-            if ((_internalGridContext.TotalItemCount > 0 && Loading != false) || _lastError != null)
+            // The grid (not Virtualize) renders the empty content and the table's aria-rowcount, so it
+            // must re-render whenever the provider's answer changes what the grid shows: the first result
+            // (which may be "no data") and any change in the total count. Loads that keep the same total
+            // (scrolling) are rendered by Virtualize itself and skip this, as before (#5151).
+            if (isFirstProviderResult || totalItemCountChanged || Loading != false || _lastError != null)
             {
                 Loading = false;
                 _ = InvokeAsync(StateHasChanged);

--- a/tests/Core/Components/DataGrid/FluentDataGridTests.razor
+++ b/tests/Core/Components/DataGrid/FluentDataGridTests.razor
@@ -488,18 +488,20 @@
     }
 
     [Fact]
-    public async Task FluentDataGrid_Virtualize_NoEmptyContentBeforeFirstProviderResult()
+    public void FluentDataGrid_Virtualize_NoEmptyContentBeforeFirstProviderResult()
     {
         // Companion regression test for #5151: a re-render that happens after the Virtualize
         // component is mounted but before its first provider call completes must NOT latch the
         // empty content (doing so disposes Virtualize before it ever loads, killing the grid).
 
-        // Arrange
+        // Arrange: the provider is held open deterministically (no wall-clock timing) so the
+        // whole test runs inside the "first provider call has not completed yet" window.
         var items = GetRandomCustomers(10).ToList();
+        var providerHold = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         GridItemsProvider<Customer> itemsProvider = async req =>
         {
-            await Task.Delay(100); // Simulate async delay
+            await providerHold.Task;
             return GridItemsProviderResult.From<Customer>(
                 items: items.Skip(req.StartIndex).Take(req.Count ?? items.Count).ToArray(),
                 totalItemCount: items.Count);
@@ -518,12 +520,14 @@
 
         // Act: re-render during the initial load window (the provider has not answered yet)
         cut.Render();
-        await Task.Delay(50, Xunit.TestContext.Current.CancellationToken);
         cut.Render();
 
         // Assert: no empty content shown; the Virtualize spacer rows are still there
         Assert.Empty(cut.FindAll("tr[row-state=empty-content]"));
         Assert.NotEmpty(cut.FindAll("tbody tr[aria-hidden=true]"));
+
+        // Release the provider so any pending call completes before the renderer is disposed
+        providerHold.SetResult();
     }
 
     private async Task<GridItemsProviderResult<Customer>> RefreshItemsAsync(GridItemsProviderRequest<Customer> req)

--- a/tests/Core/Components/DataGrid/FluentDataGridTests.razor
+++ b/tests/Core/Components/DataGrid/FluentDataGridTests.razor
@@ -394,7 +394,11 @@
 
         Assert.NotEmpty(rows); // Asserting that there are rows present
         //Assert.Equal(101, rows.Count);  //In bUnit the actual height of the grid can't be determined, so we just check that at least one row is rendered.
-        Assert.Equal(2, rows.Count);  //In bUnit the actual height of the grid can't be determined, so we just check that at least one row is rendered.
+        // 21 = header row + the 20 items of the current page. This was the expected value before #4972;
+        // it regressed to 2 because the empty content could dispose the Virtualize component during
+        // initialization, and is restored by the #5151 fix (the empty content now only renders after
+        // the provider has reported a result).
+        Assert.Equal(21, rows.Count);
 
     }
 
@@ -429,6 +433,97 @@
 
         Assert.NotEmpty(rows); // Asserting that there are rows present
         Assert.True(rows.Count >= 1);  //In bUnit the actual height of the grid can't be determined, so we just check that at least one row is rendered.
+    }
+
+    [Fact]
+    public async Task FluentDataGrid_Virtualize_RefreshDataAsync_RecoversFromEmpty()
+    {
+        // Regression test for #5151: with Virtualize="true", once the ItemsProvider reports
+        // TotalItemCount = 0 the empty content replaces (and disposes) the Virtualize component.
+        // A later RefreshDataAsync, issued after the provider has data, must re-mount Virtualize
+        // and leave the empty state instead of delegating to the disposed instance forever.
+        // (bUnit cannot measure the viewport, so recovery is asserted through the empty content
+        // disappearing and the Virtualize spacer rows re-appearing, not through visible data rows.)
+
+        // Arrange
+        FluentDataGrid<Customer>? grid = default!;
+        var items = new List<Customer>(); // empty at first — data not loaded yet
+
+        GridItemsProvider<Customer> itemsProvider = req =>
+            ValueTask.FromResult(GridItemsProviderResult.From<Customer>(
+                items: items.Skip(req.StartIndex).Take(req.Count ?? items.Count).ToArray(),
+                totalItemCount: items.Count));
+
+        var cut = Render<FluentDataGrid<Customer>>(
+            @<div style="height: 400px; max-width: 800px; overflow-y: scroll;">
+                <FluentDataGrid @ref="grid" TGridItem="Customer" ItemsProvider="itemsProvider" ItemSize=32 Virtualize="true" DisplayMode="DataGridDisplayMode.Table">
+                    <ChildContent>
+                        <PropertyColumn Property="@(x => x.Name)" />
+                    </ChildContent>
+                    <EmptyContent><p>empty content</p></EmptyContent>
+                </FluentDataGrid>
+            </div>
+        );
+
+        // Make the (still mounted) Virtualize query the provider: it reports zero items,
+        // so the grid must show the empty content
+        await cut.InvokeAsync(() => grid!.RefreshDataAsync());
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll("tr[row-state=empty-content]")));
+
+        // Act: data becomes available and the host refreshes the grid
+        items.AddRange(GetRandomCustomers(10));
+        await cut.InvokeAsync(() => grid!.RefreshDataAsync());
+
+        // Assert: the empty content is gone and Virtualize is mounted again (its spacer rows are back)
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Empty(cut.FindAll("tr[row-state=empty-content]"));
+            Assert.NotEmpty(cut.FindAll("tbody tr[aria-hidden=true]"));
+        });
+
+        // And a subsequent refresh reaches the provider again: the grid reflects the new total count
+        await cut.InvokeAsync(() => grid!.RefreshDataAsync());
+        cut.Render();
+        cut.WaitForAssertion(() => Assert.Equal("11", cut.Find("table").GetAttribute("aria-rowcount")));
+    }
+
+    [Fact]
+    public async Task FluentDataGrid_Virtualize_NoEmptyContentBeforeFirstProviderResult()
+    {
+        // Companion regression test for #5151: a re-render that happens after the Virtualize
+        // component is mounted but before its first provider call completes must NOT latch the
+        // empty content (doing so disposes Virtualize before it ever loads, killing the grid).
+
+        // Arrange
+        var items = GetRandomCustomers(10).ToList();
+
+        GridItemsProvider<Customer> itemsProvider = async req =>
+        {
+            await Task.Delay(100); // Simulate async delay
+            return GridItemsProviderResult.From<Customer>(
+                items: items.Skip(req.StartIndex).Take(req.Count ?? items.Count).ToArray(),
+                totalItemCount: items.Count);
+        };
+
+        var cut = Render<FluentDataGrid<Customer>>(
+            @<div style="height: 400px; max-width: 800px; overflow-y: scroll;">
+                <FluentDataGrid TGridItem="Customer" ItemsProvider="itemsProvider" ItemSize=32 Virtualize="true" DisplayMode="DataGridDisplayMode.Table">
+                    <ChildContent>
+                        <PropertyColumn Property="@(x => x.Name)" />
+                    </ChildContent>
+                    <EmptyContent><p>empty content</p></EmptyContent>
+                </FluentDataGrid>
+            </div>
+        );
+
+        // Act: re-render during the initial load window (the provider has not answered yet)
+        cut.Render();
+        await Task.Delay(50, Xunit.TestContext.Current.CancellationToken);
+        cut.Render();
+
+        // Assert: no empty content shown; the Virtualize spacer rows are still there
+        Assert.Empty(cut.FindAll("tr[row-state=empty-content]"));
+        Assert.NotEmpty(cut.FindAll("tbody tr[aria-hidden=true]"));
     }
 
     private async Task<GridItemsProviderResult<Customer>> RefreshItemsAsync(GridItemsProviderRequest<Customer> req)

--- a/tests/Core/Components/DataGrid/FluentDataGridTests.razor
+++ b/tests/Core/Components/DataGrid/FluentDataGridTests.razor
@@ -530,6 +530,52 @@
         providerHold.SetResult();
     }
 
+    [Fact]
+    public void FluentDataGrid_Virtualize_NoTableStretchBeforeFirstProviderResult()
+    {
+        // The 100% table stretch that centers the empty/loading content must not apply while a
+        // virtualized grid awaits its first provider result: the only rows are the zero-height
+        // Virtualize spacers, and stretching the table inflates them, defeating Virtualize's
+        // startup guard for the after spacer (spacerAfter.offsetHeight > 0) — the grid visibly
+        // jumps to the tail of the data set and back on every first load.
+
+        // Arrange: the provider is held open so the assertions run inside the initial load window
+        var providerHold = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        GridItemsProvider<Customer> itemsProvider = async req =>
+        {
+            await providerHold.Task;
+            return GridItemsProviderResult.From<Customer>(
+                items: Array.Empty<Customer>(), totalItemCount: 0);
+        };
+
+        var cut = Render<FluentDataGrid<Customer>>(
+            @<div style="height: 400px; max-width: 800px; overflow-y: scroll;">
+                @* Loading="false" (controlled): with uncontrolled loading the loading-content row
+                   replaces Virtualize and the stretch is legitimate — the poisoned window exists
+                   once Virtualize is mounted (spacers only) while TotalItemCount is still 0. *@
+                <FluentDataGrid TGridItem="Customer" ItemsProvider="itemsProvider" ItemSize=32 Virtualize="true" Loading="false" DisplayMode="DataGridDisplayMode.Table">
+                    <ChildContent>
+                        <PropertyColumn Property="@(x => x.Name)" />
+                    </ChildContent>
+                    <EmptyContent><p>empty content</p></EmptyContent>
+                </FluentDataGrid>
+            </div>
+        );
+
+        // Assert: no stretch during the initial load window (the provider has not answered yet)
+        Assert.DoesNotContain("height: 100%", cut.Find("table").GetAttribute("style"));
+
+        // Act: the provider reports the genuinely empty set
+        providerHold.SetResult();
+
+        // Assert: the empty content row is rendered and vertically centered again (stretch is back)
+        cut.WaitForAssertion(() =>
+        {
+            Assert.NotEmpty(cut.FindAll("tr[row-state=empty-content]"));
+            Assert.Contains("height: 100%", cut.Find("table").GetAttribute("style"));
+        });
+    }
+
     private async Task<GridItemsProviderResult<Customer>> RefreshItemsAsync(GridItemsProviderRequest<Customer> req)
     {
         await Task.Delay(100); // Simulate async delay

--- a/tests/Core/Components/DataGrid/FluentDataGridTests.razor
+++ b/tests/Core/Components/DataGrid/FluentDataGridTests.razor
@@ -1,4 +1,5 @@
 ﻿@using Bunit.TestDoubles
+@using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.FluentUI.AspNetCore.Components.DataGrid.Infrastructure
 @using Microsoft.FluentUI.AspNetCore.Components.Extensions
 @using Microsoft.FluentUI.AspNetCore.Components.Localization
@@ -443,7 +444,7 @@
         // A later RefreshDataAsync, issued after the provider has data, must re-mount Virtualize
         // and leave the empty state instead of delegating to the disposed instance forever.
         // (bUnit cannot measure the viewport, so recovery is asserted through the empty content
-        // disappearing and the Virtualize spacer rows re-appearing, not through visible data rows.)
+        // disappearing and the Virtualize component re-appearing, not through visible data rows.)
 
         // Arrange
         FluentDataGrid<Customer>? grid = default!;
@@ -474,11 +475,13 @@
         items.AddRange(GetRandomCustomers(10));
         await cut.InvokeAsync(() => grid!.RefreshDataAsync());
 
-        // Assert: the empty content is gone and Virtualize is mounted again (its spacer rows are back)
+        // Assert: the empty content is gone and Virtualize is mounted again. Queried as a
+        // component (not through the spacer markup): the spacer rows only carry aria-hidden on
+        // net10, so a DOM selector is not TFM-agnostic.
         cut.WaitForAssertion(() =>
         {
             Assert.Empty(cut.FindAll("tr[row-state=empty-content]"));
-            Assert.NotEmpty(cut.FindAll("tbody tr[aria-hidden=true]"));
+            Assert.NotEmpty(cut.FindComponents<Virtualize<(int, Customer)>>());
         });
 
         // And a subsequent refresh reaches the provider again: the grid reflects the new total count
@@ -522,9 +525,11 @@
         cut.Render();
         cut.Render();
 
-        // Assert: no empty content shown; the Virtualize spacer rows are still there
+        // Assert: no empty content shown and Virtualize still mounted. Queried as a component
+        // (not through the spacer markup): the spacer rows only carry aria-hidden on net10, so a
+        // DOM selector is not TFM-agnostic.
         Assert.Empty(cut.FindAll("tr[row-state=empty-content]"));
-        Assert.NotEmpty(cut.FindAll("tbody tr[aria-hidden=true]"));
+        Assert.NotEmpty(cut.FindComponents<Virtualize<(int, Customer)>>());
 
         // Release the provider so any pending call completes before the renderer is disposed
         providerHold.SetResult();


### PR DESCRIPTION
Fixes #5151 — as discussed there, this takes the "null out / stop trusting `_virtualizeComponent` once the empty branch unmounts it" route.

## The bug

With `Virtualize="true"`, the empty content branch used `_virtualizeComponent is not null` as a proxy for "the provider has answered". That proxy turns true one render after `<Virtualize>` mounts — **before its first provider call completes** — so:

1. Any re-render during the initial load window replaced the component with the empty content, **disposing Virtualize before it ever loaded** (this is how the grid in our app died on first open).
2. The `@ref` field was never cleared, so every later `RefreshDataAsync()` delegated to the disposed instance and the grid could never leave the "No data to show." state (the repro in #5151).

## The fix

- **New `_virtualizeItemsProvided` flag**, set when `ProvideVirtualizedItemsAsync` applies a provider result. The empty content now only renders after the provider has actually reported zero items — never during the initial load window.
- **The empty branch clears the stale `@ref`** when it unmounts `<Virtualize>`, and `RefreshDataCoreAsync` resets the flag when the reference is null, so the re-render re-mounts `<Virtualize>` and re-queries the provider. Refreshes recover from the empty state.
- **`ProvideVirtualizedItemsAsync` re-renders the grid on the first provider result and whenever the total count changes.** The grid (not Virtualize) renders the empty content and the table's `aria-rowcount`, so both stayed stale otherwise (`aria-rowcount` sat at its previous value until something else happened to re-render the grid). Scroll loads with an unchanged total are rendered by Virtualize itself and skip this, as before.

## Tests

- `FluentDataGrid_Virtualize_RefreshDataAsync_RecoversFromEmpty` — provider reports 0, empty content shows, data becomes available, `RefreshDataAsync()` re-mounts Virtualize and leaves the empty state (fails on `dev-v5` without the fix).
- `FluentDataGrid_Virtualize_NoEmptyContentBeforeFirstProviderResult` — a re-render during the initial load window must not latch the empty content (fails on `dev-v5` without the fix).
- `FluentDataGrid_Virtualize` expects **21 rows again** (header + the 20 items of the page). This was the expected value before #4972; it regressed to 2 in that PR precisely because the empty content could dispose Virtualize during initialization, and the assertion was relaxed to match. The fix restores the original behavior.

Full `Components.Tests` suite: 3823/3823 passing locally (net10.0).

Also verified end-to-end in a real Blazor Server app (the one #5151 came from) against a locally packed build:

| Scenario | rc.5 | rc.5 + this fix |
|---|---|---|
| Open screen (1001 rows, ItemsProvider) | stuck on "No data to show." | rows render, `aria-rowcount="1002"` |
| Filter to zero matches | n/a (already dead) | "No data to show.", `aria-rowcount="1"` |
| Remove filter | n/a | recovers instantly, rows + correct count |

## Checklist

- [x] Tests added/updated for changes
- [x] Changes have been tested locally
- [ ] Documentation updated if needed (no public API changes)
- [x] Follows project coding standards
