### PR TITLE
fix: [DataGrid] arrow key navigation scrolls the grid again, clears sticky headers and stops throwing at dataset edges

### DIFF
--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.ts
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.ts
@@ -122,7 +122,11 @@ export namespace Microsoft.FluentUI.Blazor.DataGrid {
       }
     };
     const keyboardNavigation = (sibling: HTMLElement | null) => {
-      if (sibling !== null) {
+      // A truthy check also filters out undefined: the adjacent-cell lookups return undefined when
+      // navigating past the first/last row, and the strict null comparison let that through,
+      // throwing "Cannot read properties of undefined (reading 'matches')" on every extra key
+      // press at the dataset boundary.
+      if (sibling) {
         // th elements are not focusable; transfer focus to the inner header button instead.
         if (sibling.matches('th')) {
           const headerButton = sibling.querySelector<HTMLElement>('[col-sort-button], [col-options-button]');

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.ts
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.ts
@@ -121,11 +121,11 @@ export namespace Microsoft.FluentUI.Blazor.DataGrid {
         }
       }
     };
-    const keyboardNavigation = (sibling: HTMLElement | null) => {
-      // A truthy check also filters out undefined: the adjacent-cell lookups return undefined when
-      // navigating past the first/last row, and the strict null comparison let that through,
-      // throwing "Cannot read properties of undefined (reading 'matches')" on every extra key
-      // press at the dataset boundary.
+    // The adjacent-cell lookups return undefined when navigating past the first/last row, so the
+    // signature reflects it and the truthy guard below filters it out; the previous strict null
+    // comparison let undefined through, throwing "Cannot read properties of undefined (reading
+    // 'matches')" on every extra key press at the dataset boundary.
+    const keyboardNavigation = (sibling: HTMLElement | null | undefined) => {
       if (sibling) {
         // th elements are not focusable; transfer focus to the inner header button instead.
         if (sibling.matches('th')) {
@@ -134,6 +134,9 @@ export namespace Microsoft.FluentUI.Blazor.DataGrid {
             sibling = headerButton;
           }
         }
+
+        // Resolved once per navigation step (not per focus retry) to keep the per-key work low.
+        const stickyHeader = gridElement.querySelector<HTMLElement>("tr[row-type='sticky-header']");
 
         const focusSibling = () => {
           // preventScroll keeps the focus event from scrolling ancestors on its own (the reason it
@@ -145,14 +148,20 @@ export namespace Microsoft.FluentUI.Blazor.DataGrid {
           // re-introducing the dialog jumps.
           // A sticky header row overlays the top edge of the scrollport, so a cell brought to the
           // very top by 'nearest' would land behind it: scroll-margin keeps the cell clear of the
-          // overlay (no-op for grids without a sticky header).
-          const stickyHeader = gridElement.querySelector<HTMLElement>("tr[row-type='sticky-header']");
-          if (sibling && stickyHeader && !stickyHeader.contains(sibling)) {
-            sibling.style.setProperty('scroll-margin-block-start', `${stickyHeader.offsetHeight}px`);
+          // overlay. The margin is re-derived from the current header height on every step and
+          // cleared when it does not apply, so no stale per-cell inline style survives header
+          // size changes or sticky toggling.
+          if (sibling) {
+            if (stickyHeader && !stickyHeader.contains(sibling)) {
+              sibling.style.setProperty('scroll-margin-block-start', `${stickyHeader.offsetHeight}px`);
+            }
+            else {
+              sibling.style.removeProperty('scroll-margin-block-start');
+            }
           }
           sibling?.focus({ preventScroll: true });
           sibling?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
-          start = sibling;
+          start = sibling ?? null;
         };
 
         // Defer focusing until after the current key event completes so focus traps

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.ts
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.ts
@@ -132,7 +132,15 @@ export namespace Microsoft.FluentUI.Blazor.DataGrid {
         }
 
         const focusSibling = () => {
+          // preventScroll keeps the focus event from scrolling ancestors on its own (the reason it
+          // was introduced for grids hosted in Drawers/Dialogs), but it also suppressed the scroll
+          // that keeps the focused cell visible: arrow navigation walked out of the viewport and,
+          // with Virtualize, never triggered loading the next rows, so navigation died at the edge
+          // of the rendered window. Scroll the cell into view explicitly with 'nearest' (minimal
+          // scrolling, no-op when already visible) to restore the pre-rc.5 behavior without
+          // re-introducing the dialog jumps.
           sibling?.focus({ preventScroll: true });
+          sibling?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
           start = sibling;
         };
 

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.ts
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.ts
@@ -139,6 +139,13 @@ export namespace Microsoft.FluentUI.Blazor.DataGrid {
           // of the rendered window. Scroll the cell into view explicitly with 'nearest' (minimal
           // scrolling, no-op when already visible) to restore the pre-rc.5 behavior without
           // re-introducing the dialog jumps.
+          // A sticky header row overlays the top edge of the scrollport, so a cell brought to the
+          // very top by 'nearest' would land behind it: scroll-margin keeps the cell clear of the
+          // overlay (no-op for grids without a sticky header).
+          const stickyHeader = gridElement.querySelector<HTMLElement>("tr[row-type='sticky-header']");
+          if (sibling && stickyHeader && !stickyHeader.contains(sibling)) {
+            sibling.style.setProperty('scroll-margin-block-start', `${stickyHeader.offsetHeight}px`);
+          }
           sibling?.focus({ preventScroll: true });
           sibling?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
           start = sibling;


### PR DESCRIPTION
Fixes #5153 — restores the scroll that arrow-key navigation lost in rc.5, keeps the focused cell clear of sticky header rows, and stops the `matches` TypeErrors at the dataset edges.

## The bug

#4983 changed `keyboardNavigation`'s `focusSibling` to `sibling.focus({ preventScroll: true })` to stop grids hosted in Drawers/Dialogs from scrolling their ancestors on focus. But that focus call was also the only thing keeping the focused cell in view, so since rc.5:

- Arrow navigation walks the focus out of the viewport — the grid never scrolls.
- With `Virtualize="true"` navigation dies at the edge of the rendered window: the scroll container never moves, so Virtualize never materializes the next rows, and every further arrow press throws `TypeError: Cannot read properties of undefined (reading 'matches')`.

## The fix (3 commits)

1. **Scroll explicitly after focusing** — keep `preventScroll: true` (the Drawer/Dialog scenario from #4983 stays fixed) and call `sibling.scrollIntoView({ block: 'nearest', inline: 'nearest' })`: a no-op when the cell is already visible, so hosted grids don't jump, while scrolling grids recover the pre-rc.5 behavior and Virtualize keeps loading rows.
2. **Respect sticky header rows** — `'nearest'` scrolls the target to the scrollport's top edge, which a sticky header row (`GenerateHeader` = `Sticky`) overlays: walking upwards left the focused cell hidden behind the header. Setting `scroll-margin-block-start` to the sticky row's height before scrolling keeps the cell clear of the overlay (no-op for grids without a sticky header; the pre-rc.5 plain `.focus()` scroll had this same blind spot).
3. **Guard against out-of-range siblings** — the adjacent-cell lookups return `undefined` when navigating past the first/last row, and `keyboardNavigation`'s strict `!== null` check let that through: every extra key press at the dataset boundary threw the `matches` TypeError (the same error that flooded the console while navigation was stuck at the virtualized edge).

## Tests

No bUnit coverage for this one: the behavior lives in `FluentDataGrid.razor.ts` (keyboard handlers + browser scrolling), which the unit tests can't drive.

Verified end-to-end in the Blazor Server app #5153 came from, against a locally packed build of this branch (virtualized `ItemsProvider` grid, ~2.5k rows, sticky header):

| Scenario | rc.5 / dev-v5 | this branch |
|---|---|---|
| Hold ArrowDown from the top | dies at the last rendered row (~40), grid never scrolls, `matches` TypeError on every press | traverses the whole set, scroll follows the focus |
| Walk back up to row 1 | n/a (already stuck) | traverses back; the first row lands *below* the sticky header, not behind it |
| Extra ArrowUp presses on the first row | `matches` TypeError per press | clean no-op, focus stays on the cell (0 console errors) |

The Drawer/Dialog scenario from #4983 is unaffected by design: `preventScroll` is kept and `'nearest'` doesn't move anything when the cell is already visible.

## Checklist

- [ ] Tests added/updated for changes (TS/browser-driven behavior — not coverable by bUnit; E2E-verified above)
- [x] Changes have been tested locally
- [ ] Documentation updated if needed (no public API changes)
- [x] Follows project coding standards
