### PR TITLE
Target Fluent UI Icons package to .NET 8

### DIFF
--- a/src/Assets/FluentUI.Icons/Components.Icons.Package.csproj
+++ b/src/Assets/FluentUI.Icons/Components.Icons.Package.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFrameworks>$(AssetsNetVersion)</TargetFrameworks>
 		<PackageId>Microsoft.FluentUI.AspNetCore.Components.Icons</PackageId>
 		<AssemblyName>Microsoft.FluentUI.AspNetCore.Components.Icons</AssemblyName>
 		<IsTrimmable>true</IsTrimmable>


### PR DESCRIPTION
# Pull Request

## 📖 Description

Updates the Fluent UI Icons package project to use the shared `AssetsNetVersion` target framework setting instead of hardcoding `net9.0`.

`AssetsNetVersion` is `net8.0`, matching the main Fluent UI components package, the Emoji package, and the individual icon and emoji projects. This allows a .NET 8 Blazor app to reference the complete package set.

### 🎫 Issues

None.

## 👩‍💻 Reviewer Notes

Verify that the Icons package and its referenced icon assemblies are produced under `net8.0`.

## 📑 Test Plan

- `dotnet build src/Assets/FluentUI.Icons/Components.Icons.Package.csproj --configuration Debug`
- `dotnet build src/Assets/FluentUI.Emojis/Components.Emoji.Package.csproj --configuration Debug`

Both package graphs built successfully for `net8.0`.

## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

None.