### PR TITLE
[dev-v5] Fix FluentCombobox to disable multiple selection in filtered example

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/List/Combobox/Examples/ComboboxFiltered.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/List/Combobox/Examples/ComboboxFiltered.razor
@@ -9,7 +9,7 @@
 <FluentCombobox Label="Country"
                 Placeholder="Select your country"
                 Items="@FilteredCountries"
-                Multiple="true"
+                Multiple="false"
                 Immediate="true"
                 @bind-ImmediateText="@ImmediateText"
                 @bind-ImmediateText:after="@FilterCountries"


### PR DESCRIPTION
# [dev-v5] Fix FluentCombobox to disable multiple selection in filtered example

Update the FluentCombobox example to prevent multiple selections when filtering countries. 
