### PR TITLE
[dev-v5] Refactor FluentTooltip 

### DIFF
--- a/src/Core/Components/Tooltip/FluentTooltip.razor
+++ b/src/Core/Components/Tooltip/FluentTooltip.razor
@@ -8,8 +8,8 @@
                     class="@ClassValue"
                     style="@StyleValue"
                     anchor="@Anchor"
-                    delay="@Delay"
-                    positioning="@Positioning.ToAttributeValue()"
+                    delay="@(Delay ?? LibraryConfiguration?.Tooltip.Delay)"
+                    positioning="@((Positioning ?? LibraryConfiguration?.Tooltip.Positioning).ToAttributeValue())"
                     @ondialogtoggle="@OnToggleAsync"
                     @attributes="AdditionalAttributes">
         @ChildContent

--- a/src/Core/Components/Tooltip/FluentTooltip.razor.cs
+++ b/src/Core/Components/Tooltip/FluentTooltip.razor.cs
@@ -72,7 +72,8 @@ public partial class FluentTooltip : FluentComponentBase
     public string Anchor { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets number of milliseconds to delay the tooltip from showing/hiding on hover. Default is 250ms.
+    /// Gets or sets number of milliseconds to delay the tooltip from showing/hiding on hover.
+    /// The default value is `null`. Internally the component uses 250ms when no value is provided.
     /// </summary>
     [Parameter]
     public int? Delay { get; set; }

--- a/src/Core/Components/Tooltip/FluentTooltipProvider.razor
+++ b/src/Core/Components/Tooltip/FluentTooltipProvider.razor
@@ -7,7 +7,8 @@
     {
         @foreach (var tooltip in TooltipService.Items.Values)
         {
-            <FluentTooltip UseTooltipService="false"
+            <FluentTooltip @key="tooltip.Id"
+                           UseTooltipService="false"
                            Id="@tooltip.Id"
                            Class="@tooltip.ClassValue"
                            Style="@tooltip.StyleValue"

--- a/src/Core/Components/Tooltip/Services/LibraryTooltipOptions.cs
+++ b/src/Core/Components/Tooltip/Services/LibraryTooltipOptions.cs
@@ -29,7 +29,7 @@ public class LibraryTooltipOptions
 
     /// <summary>
     /// Gets or sets number of milliseconds to delay the tooltip from showing/hiding on hover.
-    /// Default is 250ms.
+    /// The default value is `null`. Internally the component uses 250ms when no value is provided.
     /// </summary>
     public int? Delay { get; set; }
 }

--- a/src/Core/Components/Tooltip/Services/LibraryTooltipOptions.cs
+++ b/src/Core/Components/Tooltip/Services/LibraryTooltipOptions.cs
@@ -21,4 +21,15 @@ public class LibraryTooltipOptions
     /// If set to true, add the FluentTooltipProvider component at end of the MainLayout.razor page.
     /// </summary>
     public bool UseServiceProvider { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the default tooltip positioning.
+    /// </summary>
+    public Positioning? Positioning { get; set; }
+
+    /// <summary>
+    /// Gets or sets number of milliseconds to delay the tooltip from showing/hiding on hover.
+    /// Default is 250ms.
+    /// </summary>
+    public int? Delay { get; set; }
 }

--- a/tests/Core/Components/Tooltip/FluentTooltipTests.razor
+++ b/tests/Core/Components/Tooltip/FluentTooltipTests.razor
@@ -56,6 +56,24 @@
         Assert.Equal("500", att);
     }
 
+    [Fact]
+    public void FluentTooltip_ConfigurationDelay_AppliesDefaultDelay()
+    {
+        // Arrange
+        Services.GetRequiredService<LibraryConfiguration>().Tooltip.Delay = 500;
+
+        var cut = Render(@<div>
+            <FluentTooltipProvider />
+            <FluentTooltip Anchor="MyButton">My content</FluentTooltip>
+        </div>);
+
+        // Act
+        var att = cut.Find("fluent-tooltip").GetAttribute("delay");
+
+        // Assert
+        Assert.Equal("500", att);
+    }
+
     [Theory]
     [InlineData(Positioning.AboveEnd)]
     [InlineData(Positioning.AboveStart)]
@@ -85,6 +103,24 @@
 
         // Assert
         Assert.Equal(positioning.ToAttributeValue(), att);
+    }
+
+    [Fact]
+    public void FluentTooltip_ConfigurationPositioning_AppliesDefaultPositioning()
+    {
+        // Arrange
+        Services.GetRequiredService<LibraryConfiguration>().Tooltip.Positioning = Positioning.After;
+
+        var cut = Render(@<div>
+            <FluentTooltipProvider />
+            <FluentTooltip Anchor="MyButton">My content</FluentTooltip>
+        </div>);
+
+        // Act
+        var att = cut.Find("fluent-tooltip").GetAttribute("positioning");
+
+        // Assert
+        Assert.Equal("after", att);
     }
 
     [Fact]
@@ -235,6 +271,32 @@
         // Assert
         tooltips = Services.GetRequiredService<ITooltipService>().Items;
         Assert.Empty(tooltips);
+    }
+
+    [Fact]
+    public void FluentTooltip_Provider_AnchorChange_RecreatesTooltip()
+    {
+        var buttonId = "FirstButton";
+        var tooltipText = "First tooltip";
+
+        var cut = Render(@<FluentStack>
+            <FluentTooltipProvider />
+            <FluentButton @key="buttonId" Id="@buttonId" Tooltip="@tooltipText" />
+        </FluentStack>);
+
+        var firstTooltip = cut.FindComponent<FluentTooltip>().Instance;
+
+        buttonId = "SecondButton";
+        tooltipText = "Second tooltip";
+        cut.FindComponent<FluentStack>().Render();
+
+        cut.WaitForAssertion(() =>
+        {
+            var secondTooltip = cut.FindComponent<FluentTooltip>().Instance;
+
+            Assert.NotSame(firstTooltip, secondTooltip);
+            Assert.Equal("SecondButton", secondTooltip.Anchor);
+        });
     }
 
 #pragma warning disable CS0618 // Type or member is obsolete


### PR DESCRIPTION
# [dev-v5] Refactor FluentTooltip 

- In the default service mode, the issue appears to be caused by the link between a tooltip and its anchored element. FluentTooltipProvider associates them using Blazor’s auto-generated element ID. When content re-renders, Blazor may reuse that ID for a different element, while the tooltip remains linked to the previous registration.
As a result, the tooltip may become associated with the wrong anchor or lose its anchor entirely. 

- Refactor `FluentTooltip` and `FluentTooltipProvider` to utilize **default values for delay and positioning**. 
- Add tests to ensure the correct application of these default configurations. 

## Example

### Before

https://github.com/user-attachments/assets/3c46e69f-39a4-4bdd-95df-990bc77401c6

### After

https://github.com/user-attachments/assets/1b6dfbbd-6b73-4f9e-9ba2-09cbc22dfa20


```razor
<FluentButton OnClick="@RerenderButtonAsync">Re-render button</FluentButton>

@if (_isLoading)
{
    <FluentButton @key="_renderVersion" Loading="true" Tooltip="Loading...">Loading...</FluentButton>
}
else
{
    <FluentButton @key="_renderVersion" Tooltip="Delete">Delete</FluentButton>
}

@code
{
    private bool _isLoading;
    private int _renderVersion;

    private async Task RerenderButtonAsync()
    {
        _isLoading = true;
        _renderVersion++;

        await Task.Delay(500);

        _isLoading = false;
        _renderVersion++;
    }
}
```

## Unit Tests

Added