### PR TITLE
[dev-v5] Update FluentRadio to combine LabelTemplate with ChildContent

### DIFF
--- a/src/Core/Components/Radio/FluentRadio.razor
+++ b/src/Core/Components/Radio/FluentRadio.razor
@@ -6,7 +6,7 @@
              Class="@ClassValue"
              Style="@StyleValue"
              Label="@GetLabel()"
-             LabelTemplate="@LabelTemplate"
+             LabelTemplate="@LabelTemplate.CombinedWith(ChildContent)"
              IncludeInputSlot="false"
              LabelWidth="@LabelWidth"
              Disabled="@GetDisabled()"

--- a/src/Core/Components/Radio/FluentRadio.razor.cs
+++ b/src/Core/Components/Radio/FluentRadio.razor.cs
@@ -99,7 +99,7 @@ public partial class FluentRadio<TValue> : FluentComponentBase, IDisposable
     /// <summary />
     internal string? GetLabel()
     {
-        if (LabelTemplate is not null)
+        if (LabelTemplate is not null || ChildContent is not null)
         {
             return null; // LabelTemplate will be rendered separately
         }

--- a/tests/Core/Components/Radio/FluentRadioTests.razor
+++ b/tests/Core/Components/Radio/FluentRadioTests.razor
@@ -114,6 +114,25 @@
     }
 
     [Fact]
+    public void FluentRadio_Label_LabelTemplateAndChildContent()
+    {
+        // Arrange
+        var cut = Render(
+            @<FluentRadioGroup TValue="string">
+                <FluentRadio Id="MyOption" TValue="string">
+                    <LabelTemplate>LabelTemplate</LabelTemplate>
+                    <ChildContent>Content</ChildContent>
+                </FluentRadio>
+            </FluentRadioGroup>);
+
+        // Act
+        var label = cut.Find("label").TextContent.Replace("\n", "").Replace("\r", "").Replace(" ", "");
+
+        // Assert
+        Assert.Equal("LabelTemplateContent", label);
+    }
+
+    [Fact]
     public void FluentRadio_Name()
     {
         // Arrange & Act


### PR DESCRIPTION
# [dev-v5] Update FluentRadio to combine LabelTemplate with ChildContent

Combine `LabelTemplate` with `ChildContent` in the `FluentRadio` component to enhance label rendering. 
This change includes a corresponding test to verify the functionality. 

No breaking changes introduced.

