### PR TITLE
Fix FluentKeyCode serialization in AOT apps

### DIFF
--- a/src/Core/Components/KeyCode/FluentKeyCode.razor.cs
+++ b/src/Core/Components/KeyCode/FluentKeyCode.razor.cs
@@ -148,7 +148,7 @@ public partial class FluentKeyCode : FluentComponentBase, IFluentComponentElemen
                 Anchor,
                 ChildContent is null ? null : Element,
                 Only,
-                IgnoreModifier ? Ignore.Union(_Modifiers) : Ignore,
+                IgnoreModifier ? Ignore.Union(_Modifiers).ToArray() : Ignore,
                 StopPropagation,
                 PreventDefault,
                 PreventDefaultOnly,

--- a/tests/Core/Components/KeyCode/FluentKeyCodeTests.razor
+++ b/tests/Core/Components/KeyCode/FluentKeyCodeTests.razor
@@ -65,6 +65,20 @@
     }
 
     [Fact]
+    public void FluentKeyCode_IgnoreModifier_MaterializesIgnoredKeys()
+    {
+        // Arrange & Act
+        var cut = Render(@<FluentKeyCode Anchor="myZone" Ignore="@(new[] { KeyCode.KeyA, KeyCode.Shift })" />);
+
+        // Assert
+        var invocation = Assert.Single(JSInterop.Invocations, invocation =>
+            invocation.Identifier == "Microsoft.FluentUI.Blazor.KeyCode.RegisterKeyCode");
+        var ignoredKeys = Assert.IsType<KeyCode[]>(invocation.Arguments[5]);
+
+        Assert.Equal([KeyCode.KeyA, KeyCode.Shift, KeyCode.Alt, KeyCode.Ctrl, KeyCode.Meta], ignoredKeys);
+    }
+
+    [Fact]
     public async Task FluentKeyCode_CtrlShiftAltMeta()
     {
         FluentKeyCodeEventArgs pressed = new();

--- a/tests/Core/Components/KeyCode/FluentKeyCodeTests.razor
+++ b/tests/Core/Components/KeyCode/FluentKeyCodeTests.razor
@@ -68,8 +68,7 @@
     public void FluentKeyCode_IgnoreModifier_MaterializesIgnoredKeys()
     {
         // Arrange & Act
-        var cut = Render(@<FluentKeyCode Anchor="myZone" Ignore="@(new[] { KeyCode.KeyA, KeyCode.Shift })" />);
-
+        _ = Render(@<FluentKeyCode Anchor="myZone" IgnoreModifier="true" Ignore="@(new[] { KeyCode.KeyA, KeyCode.Shift })" />);
         // Assert
         var invocation = Assert.Single(JSInterop.Invocations, invocation =>
             invocation.Identifier == "Microsoft.FluentUI.Blazor.KeyCode.RegisterKeyCode");


### PR DESCRIPTION
# Pull Request

## 📖 Description

`FluentKeyCode` passed a deferred LINQ union as a JavaScript interop argument when `IgnoreModifier` was enabled. The resulting internal iterator type cannot be named by System.Text.Json source generation, causing serialization to fail in AOT applications.

This change materializes the ignored-key union as a concrete `KeyCode[]` before invoking JavaScript. It preserves the existing filtering and duplicate-removal behavior while making the argument compatible with AOT serialization.

### 🎫 Issues

This issue was found while running Fluent UI Blazor with AOT on .NET 11 as part of [microsoft/aspire#19565](https://github.com/microsoft/aspire/pull/19565).

## 👩‍💻 Reviewer Notes

The behavioral change is limited to the type of the ignored-keys JavaScript interop argument. The regression test verifies that custom ignored keys and modifier keys are passed as one deduplicated `KeyCode[]`.

No additional smoke test is required beyond the focused unit tests.

## 📑 Test Plan

- `dotnet test tests/Core/Components.Tests.csproj --configuration Debug --filter "FullyQualifiedName~FluentKeyCodeTests"` (18 passed)
- `dotnet build src/Core/Microsoft.FluentUI.AspNetCore.Components.csproj --configuration Debug` (0 warnings, 0 errors)

## ✅ Checklist

### General

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

None.