### PR TITLE
fix: prevent custom event and tooltip errors

### DIFF
--- a/src/Core.Scripts/src/Components/Overflow/FluentOverflow.ts
+++ b/src/Core.Scripts/src/Components/Overflow/FluentOverflow.ts
@@ -152,7 +152,7 @@ export namespace Microsoft.FluentUI.Blazor.Components.Overflow {
 
       // Notify listeners of state change via custom event
       if (payloadChanged) {
-        this.dispatchEvent(new CustomEvent("overflowchange", {
+        const eventInit = {
           detail: {
             items: result.overflowItems,
             overflowCount: result.overflowCount,
@@ -161,7 +161,12 @@ export namespace Microsoft.FluentUI.Blazor.Components.Overflow {
           },
           bubbles: true,
           composed: true
-        }));
+        };
+
+        // Preserve overflowchange for JavaScript consumers and emit a distinct internal
+        // event for Blazor because .NET 11 rejects identical custom and browser event names.
+        this.dispatchEvent(new CustomEvent("overflowchange", eventInit));
+        this.dispatchEvent(new CustomEvent("fluentoverflowchange", eventInit));
       }
     }
 

--- a/src/Core.Scripts/src/FluentUICustomEvents.ts
+++ b/src/Core.Scripts/src/FluentUICustomEvents.ts
@@ -1,4 +1,13 @@
 import { Microsoft as FluentDialogFile } from "./Components/Dialog/FluentDialog";
+import { defineOnce } from './RegistrationState';
+
+// Blazor Web Apps can invoke both Web and Server startup hooks. Keep registrations
+// in shared global state because .NET 11 rejects registering the same custom event twice.
+function registerCustomEventType(blazor: Blazor, eventName: string, options: EventTypeOptions) {
+  defineOnce(`fluentui:custom-event:${eventName}`, () => {
+    blazor.registerCustomEventType(eventName, options);
+  });
+}
 
 export namespace Microsoft.FluentUI.Blazor.FluentUICustomEvents {
 
@@ -11,7 +20,7 @@ export namespace Microsoft.FluentUI.Blazor.FluentUICustomEvents {
   */
 
   export function Accordion(blazor: Blazor) {
-    blazor.registerCustomEventType('accordionchange', {
+    registerCustomEventType(blazor, 'accordionchange', {
       browserEventName: 'change',
       createEventArgs: event => {
 
@@ -33,7 +42,7 @@ export namespace Microsoft.FluentUI.Blazor.FluentUICustomEvents {
 
   export function DialogToggle(blazor: Blazor) {
 
-    blazor.registerCustomEventType('dialogbeforetoggle', {
+    registerCustomEventType(blazor, 'dialogbeforetoggle', {
       browserEventName: 'beforetoggle',
       createEventArgs: (event: any) => {
         FluentDialogFile.FluentUI.Blazor.Components.Dialog.DialogToggle_PreviousActiveElement(event.target.id, event.detail?.newState ?? event.newState);
@@ -46,7 +55,7 @@ export namespace Microsoft.FluentUI.Blazor.FluentUICustomEvents {
       }
     });
 
-    blazor.registerCustomEventType('dialogtoggle', {
+    registerCustomEventType(blazor, 'dialogtoggle', {
       browserEventName: 'toggle',
       createEventArgs: (event: any) => {
         return {
@@ -60,7 +69,7 @@ export namespace Microsoft.FluentUI.Blazor.FluentUICustomEvents {
   }
 
   export function MenuItem(blazor: Blazor) {
-    blazor.registerCustomEventType('menuitemchange', {
+    registerCustomEventType(blazor, 'menuitemchange', {
       browserEventName: 'change',
       createEventArgs: event => {
         return {
@@ -76,7 +85,7 @@ export namespace Microsoft.FluentUI.Blazor.FluentUICustomEvents {
 
     // Event when an element is selected or deselected
     // from the dropdown list: listbox, select, combobox, ...
-    blazor.registerCustomEventType('dropdownchange', {
+    registerCustomEventType(blazor, 'dropdownchange', {
       browserEventName: 'change',
       createEventArgs: (event: any) => {
         return {
@@ -87,7 +96,7 @@ export namespace Microsoft.FluentUI.Blazor.FluentUICustomEvents {
       }
     });
 
-    blazor.registerCustomEventType('listchange', {
+    registerCustomEventType(blazor, 'listchange', {
       browserEventName: 'listboxchange',
       createEventArgs: (event: any)=> {
         return {
@@ -102,7 +111,7 @@ export namespace Microsoft.FluentUI.Blazor.FluentUICustomEvents {
   export function Tabs(blazor: Blazor) {
 
     // Event when a tab is selected
-    blazor.registerCustomEventType('tabchange', {
+    registerCustomEventType(blazor, 'tabchange', {
       browserEventName: 'change',
       createEventArgs: (event: any) => {
         return {
@@ -116,7 +125,7 @@ export namespace Microsoft.FluentUI.Blazor.FluentUICustomEvents {
   export function RadioGroup(blazor: Blazor) {
 
     // Event when a radio element is changed
-    blazor.registerCustomEventType('radiochange', {
+    registerCustomEventType(blazor, 'radiochange', {
       browserEventName: 'change',
       createEventArgs: (event: any) => {
         return {
@@ -130,7 +139,7 @@ export namespace Microsoft.FluentUI.Blazor.FluentUICustomEvents {
   export function TreeView(blazor: Blazor) {
 
     // Event when an element is selected or deselected
-    blazor.registerCustomEventType('treechanged', {
+    registerCustomEventType(blazor, 'treechanged', {
       browserEventName: 'change',
       createEventArgs: (event: EventType) => {
         return {
@@ -141,7 +150,7 @@ export namespace Microsoft.FluentUI.Blazor.FluentUICustomEvents {
     });
 
     // Event when an element is expanded or collapsed
-    blazor.registerCustomEventType('treetoggle', {
+    registerCustomEventType(blazor, 'treetoggle', {
       browserEventName: 'toggle',
       createEventArgs: (event: any) => {
         return {
@@ -155,7 +164,7 @@ export namespace Microsoft.FluentUI.Blazor.FluentUICustomEvents {
   }
 
   export function TextInput(blazor: Blazor) {
-    blazor.registerCustomEventType('textimmediate', {
+    registerCustomEventType(blazor, 'textimmediate', {
       browserEventName: 'immediate',
       createEventArgs: (event: any)=> {
        return {
@@ -168,8 +177,10 @@ export namespace Microsoft.FluentUI.Blazor.FluentUICustomEvents {
   }
 
   export function Overflow(blazor: Blazor) {
-    blazor.registerCustomEventType('overflowchange', {
-      browserEventName: 'overflowchange',
+    registerCustomEventType(blazor, 'overflowchange', {
+      // .NET 11 requires a custom event name to differ from its browser event name.
+      // FluentOverflow emits this internal event with the public overflowchange event.
+      browserEventName: 'fluentoverflowchange',
       createEventArgs: (event: any) => {
         return {
           id: event.target?.id ?? '',

--- a/src/Core.Scripts/src/FluentUIWebComponentsOverride.ts
+++ b/src/Core.Scripts/src/FluentUIWebComponentsOverride.ts
@@ -8,6 +8,10 @@ export namespace Microsoft.FluentUI.Override {
         handleNavigation(newTab: boolean): void;
     }
 
+    interface TooltipElement extends HTMLElement {
+        showPopover(): void;
+    }
+
     /**
      * Override the default behavior of the Fluent UI Web Components to use Blazor's features.
     */
@@ -25,6 +29,12 @@ export namespace Microsoft.FluentUI.Override {
              */
             const link = await registry.whenDefined('fluent-link');
             link.prototype.handleNavigation = handleNavigation;
+
+            /**
+             * fluent-tooltip
+             */
+            const tooltip = await registry.whenDefined('fluent-tooltip');
+            tooltip.prototype.showPopover = showTooltipPopover;
         });
     }
 
@@ -49,6 +59,16 @@ export namespace Microsoft.FluentUI.Override {
         else {
             this.internalProxyAnchor.click();
         }
+    }
+
+    function showTooltipPopover(this: TooltipElement): void {
+        // A tooltip's delayed show callback can run after its dialog removes it from the DOM.
+        // Chromium throws when showPopover is called in that state, so discard the stale callback.
+        if (!this.isConnected) {
+            return;
+        }
+
+        HTMLElement.prototype.showPopover.call(this);
     }
 
     /**

--- a/src/Core.Scripts/src/FluentUIWebComponentsOverride.ts
+++ b/src/Core.Scripts/src/FluentUIWebComponentsOverride.ts
@@ -34,7 +34,16 @@ export namespace Microsoft.FluentUI.Override {
              * fluent-tooltip
              */
             const tooltip = await registry.whenDefined('fluent-tooltip');
-            tooltip.prototype.showPopover = showTooltipPopover;
+            const showTooltipPopover = tooltip.prototype.showPopover;
+            tooltip.prototype.showPopover = function (this: TooltipElement): void {
+                // A tooltip's delayed show callback can run after its dialog removes it from the DOM.
+                // Chromium throws when showPopover is called in that state, so discard the stale callback.
+                if (!this.isConnected) {
+                    return;
+                }
+
+                showTooltipPopover.call(this);
+            };
         });
     }
 
@@ -59,16 +68,6 @@ export namespace Microsoft.FluentUI.Override {
         else {
             this.internalProxyAnchor.click();
         }
-    }
-
-    function showTooltipPopover(this: TooltipElement): void {
-        // A tooltip's delayed show callback can run after its dialog removes it from the DOM.
-        // Chromium throws when showPopover is called in that state, so discard the stale callback.
-        if (!this.isConnected) {
-            return;
-        }
-
-        HTMLElement.prototype.showPopover.call(this);
     }
 
     /**


### PR DESCRIPTION
# Pull Request

## 📖 Description

Removes the need for the application-level startup workaround used with Fluent UI Blazor 5.0.0-rc.5:

- Registers each Fluent custom event once through the existing global registration state, preventing duplicate registration when Blazor Web and Server startup hooks both run.
- Maps the Blazor `overflowchange` custom event to a distinct internal `fluentoverflowchange` browser event, as required by .NET 11.
- Continues dispatching the public `overflowchange` DOM event for JavaScript consumers.
- Overrides `showPopover()` only for `fluent-tooltip` so a delayed tooltip callback is ignored after the element has been disconnected. This avoids Chromium's invalid-state exception without modifying `HTMLElement.prototype` globally.

The failures were found while running Fluent UI Blazor with Native AOT on .NET 11 in [microsoft/aspire#19565](https://github.com/microsoft/aspire/pull/19565).

### 🎫 Issues

Related to #4626.

## 👩‍💻 Reviewer Notes

Please focus on the dual overflow event dispatch and the global `defineOnce` registration key. The public Blazor event remains `overflowchange`, and the documented DOM event remains available; `fluentoverflowchange` is an internal bridge event.

The tooltip override intentionally delegates to the original `fluent-tooltip` `showPopover` implementation only while the tooltip remains connected.

## 📑 Test Plan

- `npm run build`
- `node ./esbuild.config.mjs --build-mode=Release`
- `git diff --check`
- Confirmed no TypeScript diagnostics in the changed files.

## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [ ] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

No follow-up work is currently required.