### PR TITLE
[dev-v5] Fix overlay flickering by deferring dialog opening

### DIFF
--- a/src/Core.Scripts/src/Components/Overlay/FluentOverlay.ts
+++ b/src/Core.Scripts/src/Components/Overlay/FluentOverlay.ts
@@ -22,7 +22,9 @@ export namespace Microsoft.FluentUI.Blazor.Components.Overlay {
     private dialog: HTMLDialogElement | null = null;
     private resizeObserver: ResizeObserver | null = null;
     private clickHandler: ((ev: MouseEvent) => any) | null = null;
+    private showFrame: number | null = null;
 
+    // Records the requested visibility before the internal dialog exists and while opening is deferred.
     private _opened: boolean = false;
 
     /************************
@@ -66,6 +68,10 @@ export namespace Microsoft.FluentUI.Blazor.Components.Overlay {
       const contentSlot = document.createElement('slot');
       this.dialog.appendChild(contentSlot);
       shadow.appendChild(this.dialog);
+
+      if (this._opened) {
+        this.show();
+      }
     }
 
     /*************** 
@@ -205,49 +211,70 @@ export namespace Microsoft.FluentUI.Blazor.Components.Overlay {
 
     // Public method to open the dialog
     public show() {
-      if (this.dialog && !this.dialog.open) {
+      this._opened = true;
 
-        this.dialog.setAttribute('style', this.dialogStyle);
-        this.dialog.setAttribute('class', this.dialogClass);
+      if (this.dialog && !this.dialog.open && this.showFrame === null) {
+        // Defer opening for two frames so an immediate close can cancel it before the dialog is painted.
+        this.showFrame = requestAnimationFrame(() => {
+          this.showFrame = requestAnimationFrame(() => {
+            this.showFrame = null;
 
-        // Prevent to use ESC key to close the dialog
-        // https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/closedBy#browser_compatibility
-        if (this.closeMode === 'manual') {
-          this.dialog.setAttribute('closedBy', 'none');
-        }
+            if (!this._opened || !this.dialog || this.dialog.open) {
+              return;
+            }
 
-        if (this.fullscreen === false) {
-          this.ensureParentPositioning();
-          this.createResizeObserver();
-          this.positionDialogInContainer();
-        }
-        else {
-          this.positionDialogClear();
-        }
+            this.dialog.setAttribute('style', this.dialogStyle);
+            this.dialog.setAttribute('class', this.dialogClass);
 
-        if (this.background) {
-          this.style.setProperty('--overlayBackground', this.background);
-        }
+            // Prevent to use ESC key to close the dialog
+            // https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/closedBy#browser_compatibility
+            if (this.closeMode === 'manual') {
+              this.dialog.setAttribute('closedBy', 'none');
+            }
 
-        if (this.interactive || !this.fullscreen) {
-          this.dialog.show();
-        } else {
-          this.dialog.showModal();
-        }
+            if (this.fullscreen === false) {
+              this.ensureParentPositioning();
+              this.createResizeObserver();
+              this.positionDialogInContainer();
+            }
+            else {
+              this.positionDialogClear();
+            }
 
-        if (!this.clickHandler) {
-          this.clickHandler = (e) => this.onClick(e);
+            if (this.background) {
+              this.style.setProperty('--overlayBackground', this.background);
+            }
 
-          // Use capture phase and delay listener registration to avoid capturing the current click
-          setTimeout(() => {
-            document.addEventListener('click', this.clickHandler!);
-          }, 0);
-        }
+            if (this.interactive || !this.fullscreen) {
+              this.dialog.show();
+            } else {
+              this.dialog.showModal();
+            }
+
+            if (!this.clickHandler) {
+              this.clickHandler = (e) => this.onClick(e);
+
+              // Use capture phase and delay listener registration to avoid capturing the current click
+              setTimeout(() => {
+                if (this.clickHandler) {
+                  document.addEventListener('click', this.clickHandler);
+                }
+              }, 0);
+            }
+          });
+        });
       }
     }
 
     // Public method to close the dialog
     public close() {
+      this._opened = false;
+
+      if (this.showFrame !== null) {
+        cancelAnimationFrame(this.showFrame);
+        this.showFrame = null;
+      }
+
       if (this.dialog && this.dialog.open) {
         this.dialog.close();
 
@@ -356,6 +383,11 @@ export namespace Microsoft.FluentUI.Blazor.Components.Overlay {
     // Cleanup when element is removed from DOM
     disconnectedCallback() {
       this.cleanResizeObserver();
+
+      if (this.showFrame !== null) {
+        cancelAnimationFrame(this.showFrame);
+        this.showFrame = null;
+      }
 
       // Remove the click event listener if it exists
       if (this.clickHandler) {


### PR DESCRIPTION
# [dev-v5] Fix overlay flickering by deferring dialog opening

See #5187

Defer the opening of the dialog to prevent flickering when it is immediately closed. This change enhances the user experience by ensuring the dialog only opens if it remains requested after a brief delay. **No breaking changes introduced.**

**Example**

```csharp
async Task OnClickAsync()
{
    await DialogService.ShowOverlayAsync();
    await DialogService.HideOverlayAsync();
}
```
**Before**

https://github.com/user-attachments/assets/ed0eec7c-edb8-4250-82b4-e9727a0d1be4



**After**

https://github.com/user-attachments/assets/999b1f80-3479-4c56-98e7-d04ea654fae2



Fixes global and component overlay flickering when an overlay is shown and immediately hidden, for example:

```csharp
await DialogService.ShowOverlayAsync();
await DialogService.HideOverlayAsync();
```

The native `<dialog>` could briefly open and emit asynchronous toggle events before the close operation completed. These events could update the Blazor `Visible` state and trigger repeated open/close transitions.

Overlay opening is now deferred for two animation frames and remains cancellable during that period. Calling `close()` immediately after `show()` cancels the pending opening before the dialog is painted or emits toggle events.

The implementation also:

- Records the requested visibility while the internal dialog is not yet initialized.
- Preserves overlays initially rendered with `Visible="true"`.
- Cancels pending animation frames when closing or disconnecting the component.
- Prevents delayed click-handler registration after the overlay has closed.
- Preserves normal show and close behavior.
