### PR TITLE
[dev-v5] Fix font inheritance for fluent-text component

### DIFF
--- a/src/Core/wwwroot/css/default-fuib.css
+++ b/src/Core/wwwroot/css/default-fuib.css
@@ -160,3 +160,12 @@ table[data-selectable] {
       min-width: calc(var(--selectedCheckWidth) - var(--spacingHorizontalS));
       padding: 0 var(--spacingHorizontalS) 0 0;
     }
+
+fluent-text[weight] > * {
+  font-weight: inherit;
+}
+
+fluent-text[size] > * {
+  font-size: inherit;
+  line-height: inherit;
+}


### PR DESCRIPTION
# [dev-v5] Fix font inheritance for fluent-text component

Ensure that the `fluent-text` component inherits font properties such as **weight**, **size**, and **line height** from its parent elements. This change improves consistency in text styling across the application.

