### PR TITLE
[dev-v5] Preserve custom event handlers for trimming

### DIFF
--- a/src/Core/Components/Accordion/FluentAccordion.razor.cs
+++ b/src/Core/Components/Accordion/FluentAccordion.razor.cs
@@ -21,6 +21,7 @@ public partial class FluentAccordion : FluentComponentBase
     protected string? StyleValue => DefaultStyleBuilder.Build();
 
     /// <summary />
+    [DynamicDependency(nameof(HandleOnAccordionChangedAsync))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(AccordionItemEventArgs))]
     public FluentAccordion(LibraryConfiguration configuration) : base(configuration)
     {

--- a/src/Core/Components/AppBar/FluentAppBar.razor.cs
+++ b/src/Core/Components/AppBar/FluentAppBar.razor.cs
@@ -2,6 +2,7 @@
 // This file is licensed to you under the MIT License.
 // ------------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components.Utilities;
 
@@ -20,6 +21,8 @@ public partial class FluentAppBar : FluentComponentBase
     private IEnumerable<IAppBarItem> _searchResults = [];
 
     /// <summary />
+    [DynamicDependency(nameof(OnOverflowChangedAsync))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(OverflowChangedEventArgs))]
     public FluentAppBar(LibraryConfiguration configuration) : base(configuration)
     {
         Id = Identifier.NewId();

--- a/src/Core/Components/ErrorBoundary/FluentErrorBoundary.razor.cs
+++ b/src/Core/Components/ErrorBoundary/FluentErrorBoundary.razor.cs
@@ -2,6 +2,7 @@
 // This file is licensed to you under the MIT License.
 // ------------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 
@@ -15,6 +16,8 @@ public partial class FluentErrorBoundary : FluentComponentBase
     private ErrorBoundary? ErrorBoundary;
 
     /// <summary />
+    [DynamicDependency(nameof(OnToggleAsync))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(DialogToggleEventArgs))]
     public FluentErrorBoundary(LibraryConfiguration configuration) : base(configuration) { }
 
     /// <summary>

--- a/src/Core/Components/Overflow/FluentOverflow.razor.cs
+++ b/src/Core/Components/Overflow/FluentOverflow.razor.cs
@@ -2,6 +2,7 @@
 // This file is licensed to you under the MIT License.
 // ------------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components.Utilities;
 using Microsoft.JSInterop;
@@ -25,6 +26,8 @@ public partial class FluentOverflow : FluentComponentBase
         .Build();
 
     /// <summary />
+    [DynamicDependency(nameof(OnOverflowChangedAsync))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(OverflowChangedEventArgs))]
     public FluentOverflow(LibraryConfiguration configuration) : base(configuration)
     {
         Id = Identifier.NewId();

--- a/src/Core/Components/Overlay/FluentOverlay.razor.cs
+++ b/src/Core/Components/Overlay/FluentOverlay.razor.cs
@@ -15,6 +15,8 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 public partial class FluentOverlay : FluentComponentBase
 {
     /// <summary />
+    [DynamicDependency(nameof(OnToggleAsync))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(DialogToggleEventArgs))]
     public FluentOverlay(LibraryConfiguration configuration) : base(configuration)
     {
         Id = Identifier.NewId();

--- a/src/Core/Components/Popover/FluentPopover.razor.cs
+++ b/src/Core/Components/Popover/FluentPopover.razor.cs
@@ -2,6 +2,7 @@
 // This file is licensed to you under the MIT License.
 // ------------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components.Utilities;
 
@@ -13,6 +14,8 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 public partial class FluentPopover : FluentComponentBase
 {
     /// <summary />
+    [DynamicDependency(nameof(OnToggleAsync))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(DialogToggleEventArgs))]
     public FluentPopover(LibraryConfiguration configuration) : base(configuration)
     {
         Id = Identifier.NewId();

--- a/src/Core/Components/Radio/FluentRadioGroup.razor.cs
+++ b/src/Core/Components/Radio/FluentRadioGroup.razor.cs
@@ -25,6 +25,8 @@ public partial class FluentRadioGroup<TValue> : FluentInputBase<TValue>, IFluent
     /// Initializes a new instance of the <see cref="FluentRadioGroup{TRadioValue}"/> class.
     /// </summary>
     /// <param name="configuration">The configuration settings used to initialize the radio group. This parameter cannot be null.</param>
+    [DynamicDependency(nameof(RadioChangeHandlerAsync))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(RadioEventArgs))]
     public FluentRadioGroup(LibraryConfiguration configuration) : base(configuration) { }
 
     /// <inheritdoc />

--- a/src/Core/Components/Toast/FluentToast.razor.cs
+++ b/src/Core/Components/Toast/FluentToast.razor.cs
@@ -2,6 +2,7 @@
 // This file is licensed to you under the MIT License.
 // ------------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components.Utilities;
 
@@ -16,6 +17,8 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 public partial class FluentToast : FluentComponentBase
 {
     /// <summary />
+    [DynamicDependency(nameof(OnToggleAsync))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(DialogToggleEventArgs))]
     public FluentToast(LibraryConfiguration configuration) : base(configuration)
     {
         Id = Identifier.NewId();

--- a/src/Core/Components/TreeView/FluentTreeItem.razor.cs
+++ b/src/Core/Components/TreeView/FluentTreeItem.razor.cs
@@ -2,6 +2,7 @@
 // This file is licensed to you under the MIT License.
 // ------------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.FluentUI.AspNetCore.Components.Utilities;
@@ -19,6 +20,10 @@ public partial class FluentTreeItem : FluentComponentBase
     private static readonly MarkupStringSanitized DefaultIcon_Collapsed = new($"<svg collapsed {DefaultIcon_CommonSvgAttributes}>{DefaultIcon_CommonSvgPath}</svg>", isSanitized: true);
 
     /// <summary/>
+    [DynamicDependency(nameof(OnTreeChangedAsync))]
+    [DynamicDependency(nameof(OnTreeToggleAsync))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(TreeItemChangedEventArgs))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(TreeItemToggleEventArgs))]
     public FluentTreeItem(LibraryConfiguration configuration) : base(configuration)
     {
         Id = Identifier.NewId();

--- a/src/Core/Components/TreeView/FluentTreeView.razor.cs
+++ b/src/Core/Components/TreeView/FluentTreeView.razor.cs
@@ -22,8 +22,6 @@ public partial class FluentTreeView : FluentComponentBase
     /// <summary>
     /// Initializes a new instance of the <see cref="FluentTreeView"/> class.
     /// </summary>
-    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(TreeItemChangedEventArgs))]
-    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(TreeItemToggleEventArgs))]
     public FluentTreeView(LibraryConfiguration configuration) : base(configuration)
     {
         Id = Identifier.NewId();


### PR DESCRIPTION
# Pull Request

## 📖 Description

Preserve custom Blazor event handlers and their event argument members when applications are trimmed or published with Native AOT.

This adds the established `DynamicDependency` annotations to the components that directly bind radio, dialog toggle, overflow, accordion, and tree events. Tree event preservation is moved from `FluentTreeView` to `FluentTreeItem`, which owns the browser event handlers.

### 🎫 Issues

None.

## 👩‍💻 Reviewer Notes

Please focus on whether each custom event's preservation metadata is attached to the component that directly binds the event. No runtime behavior is changed.

A separate smoke test is not required.

## 📑 Test Plan

- `dotnet build src/Core/Microsoft.FluentUI.AspNetCore.Components.csproj --configuration Debug --no-incremental`
- 173 focused tests covering Radio, Accordion, AppBar, ErrorBoundary, Overflow, Overlay, Popover, Toast, and TreeView components

## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

None.