### PR TITLE
feat: add DataGrid virtualization options

### DIFF
--- a/.github/workflows/build-core-lib.yml
+++ b/.github/workflows/build-core-lib.yml
@@ -98,7 +98,7 @@ jobs:
        working-directory: ${{ github.workspace }}
 
      - name: Tests .NET 11.0
-       run: dotnet test ./tests/Core/Components.Tests.csproj --logger:trx --results-directory ./TestResults --verbosity normal --configuration Release /p:ExampleNetVersion=net11.0
+       run: dotnet test ./tests/Core/Components.Tests.csproj --report-trx --results-directory ./TestResults --verbosity normal --configuration Release /p:ExampleNetVersion=net11.0
        working-directory: ${{ github.workspace }}
 
      - name: Publish Unit Tests

--- a/.github/workflows/build-core-lib.yml
+++ b/.github/workflows/build-core-lib.yml
@@ -64,6 +64,11 @@ jobs:
         dotnet-version: 10.0.x
         dotnet-quality: preview
 
+     - name: Setup .NET 11.0
+       uses: actions/setup-dotnet@v4
+       with:
+        dotnet-version: 11.0.100-preview.7.26381.103
+
      # Build
 
      - name: Restore
@@ -90,6 +95,10 @@ jobs:
              dotnet test "$test" --report-trx --results-directory ./TestResults --configuration Release --coverage --coverage-output-format cobertura
            fi
          done
+       working-directory: ${{ github.workspace }}
+
+     - name: Tests .NET 11.0
+       run: dotnet test ./tests/Core/Components.Tests.csproj --logger:trx --results-directory ./TestResults --verbosity normal --configuration Release /p:ExampleNetVersion=net11.0
        working-directory: ${{ github.workspace }}
 
      - name: Publish Unit Tests
@@ -228,6 +237,11 @@ jobs:
       with:
         dotnet-version: 10.0.x
         dotnet-quality: preview
+
+    - name: Setup .NET 11.0
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 11.0.100-preview.7.26381.103
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,8 +22,11 @@
     <!-- Target .NET versions for multi-targeting -->
     <!-- Used with the published libraries: Core; McpServer; Charts; DataGrid adapters -->
     <!-- Debug: minimum version for faster builds; Release: full multi-targeting -->
-    <TargetNetVersions Condition="'$(Configuration)' == 'Release'">net8.0;net9.0;net10.0</TargetNetVersions>
+    <TargetNetVersions Condition="'$(Configuration)' == 'Release'">net8.0;net9.0;net10.0;net11.0</TargetNetVersions>
     <TargetNetVersions Condition="'$(Configuration)' != 'Release'">$(NetVersion)</TargetNetVersions>
+
+    <!-- .NET 11 Preview 7 reports BL0016 across the existing JS interop architecture. -->
+    <NoWarn Condition="'$(TargetFramework)' == 'net11.0' Or '$(ExampleNetVersion)' == 'net11.0'">$(NoWarn);BL0016</NoWarn>
 
     <!-- Versioning -->
     <VersionFile>5.0.0</VersionFile>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -122,10 +122,8 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="$(EfCoreVersion11)" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(EfCoreVersion11)" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="$(EfCoreVersion11)" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(RuntimeVersion11)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="$(RuntimeVersion11)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(RuntimeVersion11)" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(RuntimeVersion11)" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="$(RuntimeVersion11)" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="$(RuntimeVersion11)" />
     <PackageVersion Include="System.Text.Json" Version="$(RuntimeVersion11)" />

--- a/_ListOutdatedDependencies.ps1
+++ b/_ListOutdatedDependencies.ps1
@@ -5,7 +5,7 @@
 
 .DESCRIPTION
     Temporarily switches the <NetVersion> property in Directory.Build.props to each of
-    net8.0, net9.0 and net10.0, runs `dotnet outdated` for the solution, and
+    net8.0, net9.0, net10.0 and net11.0, runs `dotnet outdated` for the solution, and
     aggregates the results into a single de-duplicated summary list.
     Also lists outdated npm packages (via npm-check-updates) for the Core.Scripts and
     Charts.Scripts projects, without changing any package.json or lock file.
@@ -24,7 +24,7 @@ $ErrorActionPreference = 'Stop'
 $repoRoot = $PSScriptRoot
 $propsPath = Join-Path $repoRoot 'Directory.Build.props'
 $slnPath = Join-Path $repoRoot 'Microsoft.FluentUI-v5.slnx'
-$netVersions = @('net8.0', 'net9.0', 'net10.0')
+$netVersions = @('net8.0', 'net9.0', 'net10.0', 'net11.0')
 $netVersionPattern = '<NetVersion>net\d+\.\d+</NetVersion>'
 $exampleVersionPattern = '<ExampleNetVersion>net\d+\.\d+</ExampleNetVersion>'
 # Demo/Samples/Tests projects require net9.0+ (see ExampleNetVersion comment in Directory.Build.props).

--- a/eng/pipelines/build-all-lib.yml
+++ b/eng/pipelines/build-all-lib.yml
@@ -142,6 +142,12 @@ extends:
             version: 10.0.x
             includePreviewVersions: true
 
+        - task: UseDotNet@2
+          displayName: 'Install .NET 11.0'
+          inputs:
+            version: 11.0.100-preview.7.26381.103
+            includePreviewVersions: true
+
         # Set version number (exclude some folders)
         - task: PowerShell@2
           displayName: 'Versioning $(Build.BuildNumber)'

--- a/eng/pipelines/build-core-lib.yml
+++ b/eng/pipelines/build-core-lib.yml
@@ -165,6 +165,12 @@ extends:
             version: 10.0.x
             includePreviewVersions: true
 
+        - task: UseDotNet@2
+          displayName: 'Install .NET 11.0'
+          inputs:
+            version: 11.0.100-preview.7.26381.103
+            includePreviewVersions: true
+
         # Set version number (exclude some folders)
         - task: PowerShell@2
           displayName: 'Versioning $(Build.BuildNumber)'

--- a/examples/Demo/FluentUI.Demo.Client/DebugPages/EditFormPage.razor
+++ b/examples/Demo/FluentUI.Demo.Client/DebugPages/EditFormPage.razor
@@ -132,7 +132,11 @@
 
     void ValidateForm()
     {
+#if NET11_OR_GREATER
+        _ = form.EditContext?.ValidateAsync();
+#else
         form.EditContext?.Validate();
+#endif
     }
 
     void SetFormToValid()

--- a/examples/Demo/FluentUI.Demo.Client/DebugPages/EditFormPage.razor
+++ b/examples/Demo/FluentUI.Demo.Client/DebugPages/EditFormPage.razor
@@ -132,7 +132,7 @@
 
     void ValidateForm()
     {
-#if NET11_OR_GREATER
+#if NET11_0_OR_GREATER
         _ = form.EditContext?.ValidateAsync();
 #else
         form.EditContext?.Validate();

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DataGrid/Pages/DataGridVirtualizePage.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DataGrid/Pages/DataGridVirtualizePage.md
@@ -17,3 +17,55 @@ Enabling virtualization is just a matter of passing `Virtualize="true"`. For it 
 properly and reliably, every row rendered must have the same known height. **This is handled by the `FluentDataGrid` code**
 
 {{ DataGridVirtualize }}
+
+## Positioning and anchoring in .NET 11
+
+When targeting .NET 11, a virtualized grid can open at a specific zero-based row index, scroll to a row
+programmatically, and keep the viewport anchored as provider data changes. Out-of-range indexes are clamped by
+the underlying `Virtualize` component.
+
+An `ItemComparer` should compare stable item identity rather than object references when an items provider
+returns new instances across requests.
+
+```razor
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+
+<FluentButton OnClick="ScrollToTopAsync">Back to top</FluentButton>
+
+<div style="height: 400px; overflow-y: auto;">
+	<FluentDataGrid @ref="_grid"
+					TGridItem="Product"
+					ItemsProvider="LoadProductsAsync"
+					Virtualize="true"
+					InitialItemIndex="500"
+					AnchorMode="VirtualizeAnchorMode.End"
+					ItemComparer="ProductIdComparer.Instance"
+					ItemSize="32"
+					DisplayMode="DataGridDisplayMode.Table">
+		<PropertyColumn Property="@(product => product.Name)" />
+	</FluentDataGrid>
+</div>
+
+@code {
+	private FluentDataGrid<Product>? _grid;
+
+	private Task ScrollToTopAsync()
+		=> _grid!.ScrollToItemAsync(0);
+
+	private sealed class ProductIdComparer : IEqualityComparer<Product>
+	{
+		public static ProductIdComparer Instance { get; } = new();
+
+		public bool Equals(Product? first, Product? second)
+			=> first?.Id == second?.Id;
+
+		public int GetHashCode(Product product)
+			=> product.Id.GetHashCode();
+	}
+}
+```
+
+`InitialItemIndex` is applied only on the first interactive render. Use `ScrollToItemAsync` after the grid has
+rendered for later navigation. Calling it before rendering or while `Virtualize` is disabled throws an
+`InvalidOperationException`. Cancellation and repeated-call behavior are delegated to the underlying virtualizer;
+when calls overlap, the last call wins.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Drag/Examples/DragDropNested.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Drag/Examples/DragDropNested.razor
@@ -175,8 +175,6 @@
                 targetRow.Columns.Add(source);
             }
         }
-
-        StateHasChanged();
     }
 
     private void OnDropElement(FluentDragEventArgs<FormElement> e)
@@ -213,8 +211,6 @@
                 targetColumn.Elements.Add(source);
             }
         }
-
-        StateHasChanged();
     }
 
     public class Form

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/General/Theme/Designer/ThemeDesigner.razor.cs
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/General/Theme/Designer/ThemeDesigner.razor.cs
@@ -94,7 +94,5 @@ public partial class ThemeDesigner
         await ThemeService.SetThemeToElementAsync(_themePreviewElement, settings);
         await ThemeService.SetThemeAsync(settings);
         await ThemeService.ClearStoredThemeSettingsAsync();
-
-        StateHasChanged();
     }
 }

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Mcp/Examples/AISkillsDownload.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Mcp/Examples/AISkillsDownload.razor
@@ -147,7 +147,6 @@
     private async Task DownloadAllAsync()
     {
         _downloadingAll = true;
-        StateHasChanged();
 
         try
         {
@@ -161,7 +160,6 @@
         finally
         {
             _downloadingAll = false;
-            StateHasChanged();
         }
     }
 

--- a/examples/Demo/FluentUI.Demo/Program.cs
+++ b/examples/Demo/FluentUI.Demo/Program.cs
@@ -39,7 +39,9 @@ var app = builder.Build();
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
+#if !NET11_0_OR_GREATER
     app.UseWebAssemblyDebugging();
+#endif
 }
 else
 {

--- a/examples/Tools/FluentUI.Demo.DocViewer/Components/MarkdownViewer.razor.cs
+++ b/examples/Tools/FluentUI.Demo.DocViewer/Components/MarkdownViewer.razor.cs
@@ -81,7 +81,6 @@ public partial class MarkdownViewer
         {
             HttpClient.BaseAddress ??= new Uri(NavigationManager.BaseUri);
             await McpDocumentationService.LoadAsync(HttpClient, "/mcp-documentation.json").ConfigureAwait(true);
-            StateHasChanged();
         }
     }
 

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor
@@ -66,14 +66,7 @@
                         }
                         else
                         {
-                            <Virtualize @ref="@_virtualizeComponent"
-                                        TItem="(int RowIndex, TGridItem Data)"
-                                        ItemSize="@ItemSize"
-                                        OverscanCount="@OverscanCount"
-                                        ItemsProvider="@ProvideVirtualizedItemsAsync"
-                                        ItemContent="@(item => builder => RenderRow(builder, item.RowIndex, item.Data))"
-                                        Placeholder="@(placeholderContext => builder => RenderPlaceholderRow(builder, placeholderContext))"
-                                        SpacerElement="tr" />
+                            @((RenderFragment)RenderVirtualize)
                         }
                     }
                     else
@@ -91,6 +84,29 @@
 </CascadingValue>
 
 @code {
+    // RenderTreeBuilder is required while Virtualize parameters are target-framework conditional.
+    // Replace this with Razor markup when older targets no longer require these #if directives.
+    private void RenderVirtualize(RenderTreeBuilder builder)
+    {
+        builder.OpenComponent<Virtualize<(int RowIndex, TGridItem Data)>>(0);
+        builder.AddAttribute(1, nameof(Virtualize<(int, TGridItem)>.ItemSize), ItemSize);
+        builder.AddAttribute(2, nameof(Virtualize<(int, TGridItem)>.OverscanCount), OverscanCount);
+#if NET9_0_OR_GREATER
+        builder.AddAttribute(3, nameof(Virtualize<(int, TGridItem)>.MaxItemCount), MaxItemCount);
+#endif
+#if NET11_0_OR_GREATER
+        builder.AddAttribute(4, nameof(Virtualize<(int, TGridItem)>.InitialItemIndex), InitialItemIndex);
+        builder.AddAttribute(5, nameof(Virtualize<(int, TGridItem)>.AnchorMode), AnchorMode);
+        builder.AddAttribute(6, nameof(Virtualize<(int, TGridItem)>.ItemComparer), _virtualizeItemComparer);
+#endif
+        builder.AddAttribute(7, nameof(Virtualize<(int, TGridItem)>.ItemsProvider), (ItemsProviderDelegate<(int, TGridItem)>)ProvideVirtualizedItemsAsync);
+        builder.AddAttribute(8, nameof(Virtualize<(int, TGridItem)>.ItemContent), (RenderFragment<(int RowIndex, TGridItem Data)>)(item => contentBuilder => RenderRow(contentBuilder, item.RowIndex, item.Data)));
+        builder.AddAttribute(9, nameof(Virtualize<(int, TGridItem)>.Placeholder), (RenderFragment<PlaceholderContext>)(placeholderContext => contentBuilder => RenderPlaceholderRow(contentBuilder, placeholderContext)));
+        builder.AddAttribute(10, nameof(Virtualize<(int, TGridItem)>.SpacerElement), "tr");
+        builder.AddComponentReferenceCapture(11, value => _virtualizeComponent = (Virtualize<(int, TGridItem)>)value);
+        builder.CloseComponent();
+    }
+
     private void RenderNonVirtualizedRows(RenderTreeBuilder __builder)
     {
         var initialRowIndex = (GenerateHeader != DataGridGeneratedHeaderType.None) ? 2 : 1; // aria-rowindex is 1-based, plus 1 if there is a header

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -34,10 +34,35 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
         Resize,
     }
 
+#if NET11_0_OR_GREATER
+    // Adapts ItemComparer to the virtualizer's (row index, item) shape while comparing item identity only.
+    // Reading from the owner on each call ensures parameter updates take effect.
+    private sealed class VirtualizeItemComparer(FluentDataGrid<TGridItem> owner) : IEqualityComparer<(int, TGridItem)>
+    {
+        private readonly FluentDataGrid<TGridItem> _owner = owner;
+
+        private IEqualityComparer<TGridItem> ItemComparer => _owner._itemComparer ?? EqualityComparer<TGridItem>.Default;
+
+        public bool Equals((int, TGridItem) first, (int, TGridItem) second)
+        {
+            return ItemComparer.Equals(first.Item2, second.Item2);
+        }
+
+        public int GetHashCode((int, TGridItem) item)
+        {
+            return item.Item2 is null ? 0 : ItemComparer.GetHashCode(item.Item2);
+        }
+    }
+#endif
+
     private const string JAVASCRIPT_FILE = FluentJSModule.JAVASCRIPT_ROOT + "DataGrid/FluentDataGrid.razor.js";
 
     private ElementReference? _gridReference;
     private Virtualize<(int, TGridItem)>? _virtualizeComponent;
+#if NET11_0_OR_GREATER
+    private IEqualityComparer<TGridItem>? _itemComparer;
+    private readonly IEqualityComparer<(int, TGridItem)> _virtualizeItemComparer;
+#endif
     private IAsyncQueryExecutor? _asyncQueryExecutor;
     private AsyncServiceScope? _scope;
     private bool _asyncQueryExecuted;
@@ -94,6 +119,9 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
         _renderEmptyContent = RenderEmptyContent;
         _renderLoadingContent = RenderLoadingContent;
         _renderErrorContent = RenderErrorContent;
+    #if NET11_0_OR_GREATER
+        _virtualizeItemComparer = new VirtualizeItemComparer(this);
+    #endif
 
         // As a special case, we don't issue the first data load request until we've collected the initial set of columns
         // This is so we can apply default sort order (or any future per-column options) before loading data
@@ -169,6 +197,15 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     [Parameter]
     public int OverscanCount { get; set; } = 3;
 
+#if NET9_0_OR_GREATER
+    /// <summary>
+    /// This is applicable only when using <see cref="Virtualize"/>. It defines the maximum number of items
+    /// that can be rendered, even when the viewport would otherwise require more items.
+    /// </summary>
+    [Parameter]
+    public int MaxItemCount { get; set; } = 100;
+#endif
+
     /// <summary>
     /// This is applicable only when using <see cref="Virtualize"/>. It defines an expected height in pixels for
     /// each row, allowing the virtualization mechanism to fetch the correct number of items to match the display
@@ -176,6 +213,39 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     /// </summary>
     [Parameter]
     public float ItemSize { get; set; } = 32;
+
+#if NET11_0_OR_GREATER
+    /// <summary>
+    /// This is applicable only when using <see cref="Virtualize"/>. Gets or sets the zero-based index of the
+    /// row to scroll to on first interactive render. Applied once when the grid first knows its item count and
+    /// ignored on subsequent re-renders; to scroll programmatically at any later point, call
+    /// <see cref="ScrollToItemAsync(int, CancellationToken)"/>. Out-of-range values are clamped. The default value,
+    /// <c>0</c>, means no initial scroll.
+    /// </summary>
+    [Parameter]
+    public int InitialItemIndex { get; set; }
+
+    /// <summary>
+    /// This is applicable only when using <see cref="Virtualize"/>. Gets or sets the anchor mode that controls
+    /// how the viewport behaves at the edges of the list
+    /// when new items arrive during virtualization. The default is <see cref="VirtualizeAnchorMode.Start"/>.
+    /// </summary>
+    [Parameter]
+    public VirtualizeAnchorMode AnchorMode { get; set; } = VirtualizeAnchorMode.Start;
+
+    /// <summary>
+    /// This is applicable only when using <see cref="Virtualize"/>. Gets or sets a comparer used during
+    /// virtualization to detect whether items were prepended or appended between data loads.
+    /// Provide a comparer that compares items by a stable unique identifier.
+    /// Defaults to <see cref="EqualityComparer{T}.Default"/>.
+    /// </summary>
+    [Parameter]
+    public IEqualityComparer<TGridItem>? ItemComparer
+    {
+        get => _itemComparer;
+        set => _itemComparer = value;
+    }
+#endif
 
     /// <summary>
     /// If true, renders draggable handles around the column headers and adds a button to invoke a resize UI.
@@ -1335,6 +1405,30 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
         _forceRefreshData = force;
         await RefreshDataCoreAsync();
     }
+
+#if NET11_0_OR_GREATER
+    /// <summary>
+    /// Scrolls the virtualized grid so the row at <paramref name="itemIndex"/> is aligned to the top of the scrollable area.
+    /// </summary>
+    /// <remarks>
+    /// Each call cancels any previously-running <see cref="ScrollToItemAsync(int, CancellationToken)"/> operation.
+    /// Must be called on the renderer's synchronization context; background-thread callers should wrap with
+    /// <see cref="ComponentBase.InvokeAsync(Func{Task})"/>.
+    /// </remarks>
+    /// <param name="itemIndex">The zero-based index of the row to scroll to.</param>
+    /// <param name="cancellationToken">A token that lets the caller request cancellation.</param>
+    /// <returns>A <see cref="Task"/> that completes when the target is aligned or superseded by another call.</returns>
+    public Task ScrollToItemAsync(int itemIndex, CancellationToken cancellationToken = default)
+    {
+        if (!Virtualize || _virtualizeComponent is null)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(ScrollToItemAsync)} can only be used when {nameof(Virtualize)} is enabled and the grid has been rendered.");
+        }
+
+        return _virtualizeComponent.ScrollToItemAsync(itemIndex, cancellationToken);
+    }
+#endif
 
     // Same as RefreshDataAsync, except without forcing a re-render. We use this from OnParametersSetAsync
     // because in that case there's going to be a re-render anyway.

--- a/src/Core/Components/PullToRefresh/FluentPullToRefresh.razor.cs
+++ b/src/Core/Components/PullToRefresh/FluentPullToRefresh.razor.cs
@@ -300,6 +300,7 @@ public partial class FluentPullToRefresh : FluentComponentBase
             if (!hasMoreData)
             {
                 SetPullStatus(PullStatus.NoData);
+                StateHasChanged();
                 await Task.Delay(StatusUpdateMessageTimeout);
             }
             else

--- a/src/Core/Components/Wizard/FluentWizard.razor.cs
+++ b/src/Core/Components/Wizard/FluentWizard.razor.cs
@@ -208,8 +208,6 @@ public partial class FluentWizard : FluentComponentBase
             {
                 await ValueChanged.InvokeAsync(Value);
             }
-
-            StateHasChanged();
         }
     }
 
@@ -235,8 +233,6 @@ public partial class FluentWizard : FluentComponentBase
             {
                 await ValueChanged.InvokeAsync(Value);
             }
-
-            StateHasChanged();
         }
     }
 

--- a/src/Core/Components/Wizard/FluentWizardStep.razor.cs
+++ b/src/Core/Components/Wizard/FluentWizardStep.razor.cs
@@ -196,6 +196,8 @@ public partial class FluentWizardStep : FluentComponentBase
     /// <summary>
     /// Validates all registered EditContexts.
     /// </summary>
+#pragma warning disable CS0618
+    // TODO: Make this method asynchronous and use EditContext.ValidateAsync when the public API can be changed.
     public bool ValidateEditContexts()
     {
         var isValid = true;
@@ -219,6 +221,7 @@ public partial class FluentWizardStep : FluentComponentBase
 
         return isValid;
     }
+#pragma warning restore CS0618
 
     /// <summary />
     public override async ValueTask DisposeAsync()

--- a/src/Core/Microsoft.FluentUI.AspNetCore.Components.csproj
+++ b/src/Core/Microsoft.FluentUI.AspNetCore.Components.csproj
@@ -88,7 +88,7 @@
 
   <!-- Dependencies -->
   <ItemGroup>
-	  <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.TypeScript.MSBuild" Condition="'$(TargetFramework)'=='$(NetVersion)'">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Core/Microsoft.FluentUI.AspNetCore.Components.csproj
+++ b/src/Core/Microsoft.FluentUI.AspNetCore.Components.csproj
@@ -89,8 +89,6 @@
   <!-- Dependencies -->
   <ItemGroup>
 	  <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.TypeScript.MSBuild" Condition="'$(TargetFramework)'=='$(NetVersion)'">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Tools/McpServer/Services/DocumentationService.cs
+++ b/src/Tools/McpServer/Services/DocumentationService.cs
@@ -220,7 +220,7 @@ public partial class DocumentationService
         // Remove headers and get first meaningful paragraph
         var lines = content.Split('\n')
             .Select(l => l.Trim())
-            .Where(l => !string.IsNullOrEmpty(l) && !l.StartsWith('#'))
+            .Where(l => !string.IsNullOrEmpty(l) && !l.StartsWith("#", StringComparison.Ordinal))
             .Take(3);
 
         var summary = string.Join(' ', lines);

--- a/src/Tools/McpServer/Services/MigrationService.cs
+++ b/src/Tools/McpServer/Services/MigrationService.cs
@@ -220,7 +220,7 @@ public partial class MigrationService
     {
         var lines = content.Split('\n')
             .Select(l => l.Trim())
-            .Where(l => !string.IsNullOrEmpty(l) && !l.StartsWith('#'))
+            .Where(l => !string.IsNullOrEmpty(l) && !l.StartsWith("#", StringComparison.Ordinal))
             .Take(3);
 
         var summary = string.Join(' ', lines);

--- a/tests/Core/Components.Tests.csproj
+++ b/tests/Core/Components.Tests.csproj
@@ -10,7 +10,7 @@
     <IsPackable>false</IsPackable>
     <AssemblyName>Microsoft.FluentUI.AspNetCore.Components.Tests</AssemblyName>
     <RootNamespace>Microsoft.FluentUI.AspNetCore.Components.Tests</RootNamespace>
-    <NoWarn>xUnit1069</NoWarn>
+    <NoWarn>xUnit1069;BL0016</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Core/Components/DataGrid/FluentDataGridTests.razor
+++ b/tests/Core/Components/DataGrid/FluentDataGridTests.razor
@@ -369,6 +369,152 @@
         builder.AddContent(0, text);
     };
 
+#if NET9_0_OR_GREATER
+    [Fact]
+    public void FluentDataGrid_Virtualize_SetsMaxItemCount()
+    {
+        // Arrange && Act
+        var cut = Render<FluentDataGrid<Customer>>(
+            @<FluentDataGrid TGridItem="Customer" Items="@GetCustomers().AsQueryable()" Virtualize="true" MaxItemCount="42">
+                <PropertyColumn Property="@(customer => customer.Name)" />
+            </FluentDataGrid>);
+
+        // Assert
+        var virtualize = cut.FindComponent<Virtualize<(int, Customer)>>();
+        Assert.Equal(42, virtualize.Instance.MaxItemCount);
+    }
+#endif
+
+#if NET11_0_OR_GREATER
+    [Fact]
+    public void FluentDataGrid_Virtualize_SetsNet11VirtualizationParameters()
+    {
+        // Arrange
+        var customers = GetCustomers().ToArray();
+        var itemComparer = EqualityComparer<Customer>.Create(
+            (first, second) => first?.Id == second?.Id,
+            customer => customer.Id);
+        GridItemsProvider<Customer> itemsProvider = request =>
+            ValueTask.FromResult(GridItemsProviderResult.From(
+                customers
+                    .Skip(request.StartIndex)
+                    .Take(request.Count ?? customers.Length)
+                    .Select(customer => customer with { })
+                    .ToArray(),
+                customers.Length));
+
+        // Act
+        var cut = Render<FluentDataGrid<Customer>>(
+            @<FluentDataGrid TGridItem="Customer"
+                             ItemsProvider="@itemsProvider"
+                             Virtualize="true"
+                             InitialItemIndex="2"
+                             AnchorMode="VirtualizeAnchorMode.End"
+                             ItemComparer="@itemComparer">
+                <PropertyColumn Property="@(customer => customer.Name)" />
+            </FluentDataGrid>);
+
+        // Assert
+        var virtualize = cut.FindComponent<Virtualize<(int, Customer)>>().Instance;
+        var firstCustomer = customers[0];
+        var equivalentCustomer = firstCustomer with { };
+        var differentCustomer = customers[1];
+
+        Assert.Equal(2, virtualize.InitialItemIndex);
+        Assert.Equal(VirtualizeAnchorMode.End, virtualize.AnchorMode);
+        Assert.True(virtualize.ItemComparer.Equals((1, firstCustomer), (99, equivalentCustomer)));
+        Assert.False(virtualize.ItemComparer.Equals((1, firstCustomer), (1, differentCustomer)));
+    }
+
+    [Fact]
+    public void FluentDataGrid_ScrollToItemAsync_VirtualizationDisabled_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var cut = Render<FluentDataGrid<Customer>>(
+            @<FluentDataGrid TGridItem="Customer" Items="@GetCustomers().AsQueryable()">
+                <PropertyColumn Property="@(customer => customer.Name)" />
+            </FluentDataGrid>);
+
+        // Act
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+        {
+            _ = cut.Instance.ScrollToItemAsync(1, Xunit.TestContext.Current.CancellationToken);
+        });
+
+        // Assert
+        Assert.Contains(nameof(FluentDataGrid<Customer>.Virtualize), exception.Message);
+    }
+
+    [Fact]
+    public void FluentDataGrid_ScrollToItemAsync_VirtualizerNotRendered_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        GridItemsProvider<Customer> itemsProvider = request =>
+            ValueTask.FromResult(GridItemsProviderResult.From(Array.Empty<Customer>(), 0));
+
+        var cut = Render<FluentDataGrid<Customer>>(
+            @<FluentDataGrid TGridItem="Customer"
+                             ItemsProvider="@itemsProvider"
+                             Virtualize="true"
+                             Loading="true">
+                <PropertyColumn Property="@(customer => customer.Name)" />
+            </FluentDataGrid>);
+
+        // Act
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+        {
+            _ = cut.Instance.ScrollToItemAsync(1, Xunit.TestContext.Current.CancellationToken);
+        });
+
+        // Assert
+        Assert.Contains("grid has been rendered", exception.Message);
+    }
+
+    [Fact]
+    public async Task FluentDataGrid_ScrollToItemAsync_CanceledToken_ThrowsOperationCanceledException()
+    {
+        // Arrange
+        FluentDataGrid<Customer>? grid = null;
+        var cut = Render<FluentDataGrid<Customer>>(
+            @<FluentDataGrid @ref="grid" TGridItem="Customer" Items="@GetRandomCustomers(100)" Virtualize="true">
+                <PropertyColumn Property="@(customer => customer.Name)" />
+            </FluentDataGrid>);
+        using var cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(Xunit.TestContext.Current.CancellationToken);
+        await cancellationSource.CancelAsync();
+
+        // Act && Assert
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await cut.InvokeAsync(() => grid!.ScrollToItemAsync(10, cancellationSource.Token)));
+    }
+
+    [Fact]
+    public async Task FluentDataGrid_ScrollToItemAsync_RepeatedCalls_BothCallsCompleteSuccessfully()
+    {
+        // Arrange
+        FluentDataGrid<Customer>? grid = null;
+        var cut = Render<FluentDataGrid<Customer>>(
+            @<FluentDataGrid @ref="grid" TGridItem="Customer" Items="@GetRandomCustomers(1000)" Virtualize="true">
+                <PropertyColumn Property="@(customer => customer.Name)" />
+            </FluentDataGrid>);
+        Task? firstCall = null;
+        Task? secondCall = null;
+
+        // Act
+        await cut.InvokeAsync(() =>
+        {
+            firstCall = grid!.ScrollToItemAsync(500, Xunit.TestContext.Current.CancellationToken);
+            secondCall = grid.ScrollToItemAsync(750, Xunit.TestContext.Current.CancellationToken);
+        });
+
+        await firstCall!.WaitAsync(TimeSpan.FromSeconds(5), Xunit.TestContext.Current.CancellationToken);
+        await secondCall!.WaitAsync(TimeSpan.FromSeconds(5), Xunit.TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(firstCall.IsCompletedSuccessfully);
+        Assert.True(secondCall.IsCompletedSuccessfully);
+    }
+#endif
+
     [Fact]
     public async Task FluentDataGrid_Virtualize()
     {

--- a/tests/Core/Components/PullToRefresh/FluentPullToRefreshTests.razor
+++ b/tests/Core/Components/PullToRefresh/FluentPullToRefreshTests.razor
@@ -338,13 +338,16 @@
     public async Task FluentPullToRefresh_OnTouchEnd_WithMoreData_CompletesThenResets()
     {
         var refreshCalls = 0;
+        var refreshStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var refreshCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var cut = Render<FluentPullToRefresh>(parameters => parameters
             .Add(p => p.EmulateTouch, false)
             .Add(p => p.StatusUpdateMessageTimeout, 10)
-            .Add(p => p.OnRefreshAsync, () =>
+            .Add(p => p.OnRefreshAsync, async () =>
             {
                 refreshCalls++;
-                return Task.FromResult(true);
+                refreshStarted.SetResult(true);
+                return await refreshCompletion.Task;
             })
             .Add(p => p.ChildContent, builder => builder.AddContent(0, "Content")));
 
@@ -352,7 +355,10 @@
         var container = cut.Find("div.fluent-pull-container");
         var touchEndTask = container.TriggerEventAsync("ontouchend", CreateTouchEventArgs(0));
 
-        await cut.WaitForAssertionAsync(() => Assert.Equal(PullStatus.Completed, GetPullStatus(cut)));
+        await refreshStarted.Task;
+        var completedStatusTask = cut.WaitForAssertionAsync(() => Assert.Equal(PullStatus.Completed, GetPullStatus(cut)));
+        refreshCompletion.SetResult(true);
+        await completedStatusTask;
 
         await touchEndTask;
 
@@ -364,17 +370,26 @@
     [Fact]
     public async Task FluentPullToRefresh_OnTouchEnd_NoMoreData_ShowsNoDataBeforeReset()
     {
+        var refreshStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var refreshCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var cut = Render<FluentPullToRefresh>(parameters => parameters
             .Add(p => p.EmulateTouch, false)
             .Add(p => p.StatusUpdateMessageTimeout, 10)
-            .Add(p => p.OnRefreshAsync, () => Task.FromResult(false))
+            .Add(p => p.OnRefreshAsync, async () =>
+            {
+                refreshStarted.SetResult(true);
+                return await refreshCompletion.Task;
+            })
             .Add(p => p.ChildContent, builder => builder.AddContent(0, "Content")));
 
         await SetDistanceAsync(cut, 80);
         var container = cut.Find("div.fluent-pull-container");
         var touchEndTask = container.TriggerEventAsync("ontouchend", CreateTouchEventArgs(0));
 
-        await cut.WaitForAssertionAsync(() => Assert.Equal(PullStatus.NoData, GetPullStatus(cut)));
+        await refreshStarted.Task;
+        var noDataStatusTask = cut.WaitForAssertionAsync(() => Assert.Equal(PullStatus.NoData, GetPullStatus(cut)));
+        refreshCompletion.SetResult(false);
+        await noDataStatusTask;
 
         await touchEndTask;
 

--- a/tests/Core/Components/Wizard/FluentWizardAdvancedTests.razor
+++ b/tests/Core/Components/Wizard/FluentWizardAdvancedTests.razor
@@ -66,7 +66,9 @@
 
         // Act 2: make model valid, then finish again
         model.Name = "John";
+    #pragma warning disable CS0618
         await cut.InvokeAsync(() => editContext.Validate());
+    #pragma warning restore CS0618
         await cut.InvokeAsync(() => wizard.FinishAsync(validateEditContexts: true));
 
         // Assert 2
@@ -219,7 +221,9 @@
 
         // Act: valid model
         model.Name = "John";
+    #pragma warning disable CS0618
         await cut.InvokeAsync(() => editContext.Validate());
+    #pragma warning restore CS0618
         await cut.InvokeAsync(() => wizard.FinishAsync(validateEditContexts: true));
 
         // Assert valid path


### PR DESCRIPTION
# Pull Request

## 📖 Description

Adds virtualization controls to `FluentDataGrid` and forwards them to its internal `Virtualize` component.

- Adds `MaxItemCount` for .NET 9 and later.
- Adds .NET 11 support for `InitialItemIndex`, `AnchorMode`, `ItemComparer`, and `ScrollToItemAsync`.
- Adapts `ItemComparer` to the grid's internal row-index/item tuple while comparing item identity only.
- Adds .NET 11 Release targeting and installs the latest public .NET 11 SDK (Preview 7) in GitHub Actions and Azure Pipelines.
- Updates DataGrid documentation and tests.
- Resolves net11 compatibility diagnostics in existing Wizard and MCP Server code.

### 🎫 Issues

Closes #5158

## 👩‍💻 Reviewer Notes

The .NET 11 APIs are conditionally available under `NET11_0_OR_GREATER`. `AnchorMode` and `ItemComparer` are stable APIs in .NET 11 RC1 and are not annotated or documented as experimental.

The public item comparer is wrapped because the internal virtualizer operates on `(rowIndex, item)` tuples. The wrapper intentionally ignores row indexes and reads the current comparer so parameter updates take effect.

## 📑 Test Plan

- `dotnet build src/Core/Microsoft.FluentUI.AspNetCore.Components.csproj --configuration Release` (zero warnings/errors)
- `dotnet test tests/Core/Components.Tests.csproj --configuration Release -p:ExampleNetVersion=net11.0` (3,856 passed)
- `dotnet test tests/Core/Components.Tests.csproj --configuration Release --framework net9.0` (3,851 passed)
- Focused Wizard advanced tests passed on net9.0.

## ✅ Checklist

### General

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

### MCP Server

- [ ] I have added or updated MCP Server tools/prompts/resources
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my MCP Server changes

## ⏭ Next Steps

Update the .NET 11 SDK and package pins when the next public .NET 11 release is published.