### PR TITLE
fix: add AOT metadata for custom events

### DIFF
--- a/src/Core/Events/AccordionItemEventArgs.cs
+++ b/src/Core/Events/AccordionItemEventArgs.cs
@@ -17,6 +17,7 @@ public class AccordionItemEventArgs : EventArgs
     /// <summary>
     /// Gets the item that was changed.
     /// </summary>
+    [System.Text.Json.Serialization.JsonIgnore]
     public FluentAccordionItem? Item { get; internal set; }
 
     /// <summary>

--- a/src/Core/Events/DropdownEventArgs.cs
+++ b/src/Core/Events/DropdownEventArgs.cs
@@ -7,7 +7,9 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// <summary>
 /// Event arguments for the FluentListBase event.
 /// </summary>
-internal class DropdownEventArgs : EventArgs
+// This type is public because it is included in the public FluentUIJsonSerializerContext.
+// It can be made internal again if the serializer context can be made internal in the future.
+public class DropdownEventArgs : EventArgs
 {
     /// <summary>
     /// Gets or sets the ID of the list.

--- a/src/Core/Events/MenuItemEventArgs.cs
+++ b/src/Core/Events/MenuItemEventArgs.cs
@@ -17,6 +17,7 @@ public class MenuItemEventArgs : EventArgs
     /// <summary>
     /// Gets the item that was changed.
     /// </summary>
+    [System.Text.Json.Serialization.JsonIgnore]
     public FluentMenuItem? Item { get; internal set; }
 
     /// <summary>

--- a/src/Core/Events/RadioEventArgs.cs
+++ b/src/Core/Events/RadioEventArgs.cs
@@ -7,7 +7,9 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// <summary>
 /// Event arguments for the FluentTabs ActiveId changed event.
 /// </summary>
-internal class RadioEventArgs : EventArgs
+// This type is public because it is included in the public FluentUIJsonSerializerContext.
+// It can be made internal again if the serializer context can be made internal in the future.
+public class RadioEventArgs : EventArgs
 {
     /// <summary>
     /// Gets or sets the ID of the dialog.

--- a/src/Core/Events/RadioEventArgs.cs
+++ b/src/Core/Events/RadioEventArgs.cs
@@ -5,19 +5,19 @@
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 /// <summary>
-/// Event arguments for the FluentTabs ActiveId changed event.
+/// Event arguments for a FluentRadioGroup selection change.
 /// </summary>
 // This type is public because it is included in the public FluentUIJsonSerializerContext.
 // It can be made internal again if the serializer context can be made internal in the future.
 public class RadioEventArgs : EventArgs
 {
     /// <summary>
-    /// Gets or sets the ID of the dialog.
+    /// Gets or sets the ID of the changed radio element.
     /// </summary>
     public string? Id { get; set; }
 
     /// <summary>
-    /// Gets or sets new active tab ID.
+    /// Gets or sets the value of the changed radio element.
     /// </summary>
     public string? Value { get; set; }
 }

--- a/src/Core/Events/TabChangeEventArgs.cs
+++ b/src/Core/Events/TabChangeEventArgs.cs
@@ -12,7 +12,7 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 public class TabChangeEventArgs : EventArgs
 {
     /// <summary>
-    /// Gets or sets the ID of the dialog.
+    /// Gets or sets the ID of the tab list.
     /// </summary>
     public string? Id { get; set; }
 

--- a/src/Core/Events/TabChangeEventArgs.cs
+++ b/src/Core/Events/TabChangeEventArgs.cs
@@ -7,7 +7,9 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// <summary>
 /// Event arguments for the FluentTabs ActiveId changed event.
 /// </summary>
-internal class TabChangeEventArgs : EventArgs
+// This type is public because it is included in the public FluentUIJsonSerializerContext.
+// It can be made internal again if the serializer context can be made internal in the future.
+public class TabChangeEventArgs : EventArgs
 {
     /// <summary>
     /// Gets or sets the ID of the dialog.

--- a/src/Core/Events/TreeItemChangedEventArgs.cs
+++ b/src/Core/Events/TreeItemChangedEventArgs.cs
@@ -7,7 +7,9 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// <summary>
 /// Event arguments for the FluentTabs ActiveId changed event.
 /// </summary>
-internal class TreeItemChangedEventArgs : EventArgs
+// This type is public because it is included in the public FluentUIJsonSerializerContext.
+// It can be made internal again if the serializer context can be made internal in the future.
+public class TreeItemChangedEventArgs : EventArgs
 {
     /// <summary>
     /// Gets or sets the ID of the tree item.

--- a/src/Core/Events/TreeItemChangedEventArgs.cs
+++ b/src/Core/Events/TreeItemChangedEventArgs.cs
@@ -5,7 +5,7 @@
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
 /// <summary>
-/// Event arguments for the FluentTabs ActiveId changed event.
+/// Event arguments for a FluentTreeItem selection change.
 /// </summary>
 // This type is public because it is included in the public FluentUIJsonSerializerContext.
 // It can be made internal again if the serializer context can be made internal in the future.

--- a/src/Core/Events/TreeItemToggleEventArgs.cs
+++ b/src/Core/Events/TreeItemToggleEventArgs.cs
@@ -7,6 +7,8 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// <summary>
 /// Event arguments for the TreeItem Expanded event.
 /// </summary>
-internal class TreeItemToggleEventArgs : DialogToggleEventArgs
+// This type is public because it is included in the public FluentUIJsonSerializerContext.
+// It can be made internal again if the serializer context can be made internal in the future.
+public class TreeItemToggleEventArgs : DialogToggleEventArgs
 {
 }

--- a/src/Core/Serialization/FluentUIJsonSerializerContext.cs
+++ b/src/Core/Serialization/FluentUIJsonSerializerContext.cs
@@ -12,6 +12,8 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// </summary>
 /// <remarks>
 /// This API is intended for use with .NET 11 Blazor AOT and may be removed in a future release.
+/// Add <see cref="Default"/> to <c>CircuitOptions.JsonTypeInfoResolvers</c> when publishing an
+/// interactive server application with Native AOT.
 /// </remarks>
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, WriteIndented = true)]
 [JsonSerializable(typeof(Dictionary<string, object?>))]
@@ -21,6 +23,16 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 [JsonSerializable(typeof(bool))]
 [JsonSerializable(typeof(KeyPress))]
 [JsonSerializable(typeof(KeyPress[]))]
+[JsonSerializable(typeof(AccordionItemEventArgs))]
+[JsonSerializable(typeof(DialogToggleEventArgs))]
+[JsonSerializable(typeof(DropdownEventArgs))]
+[JsonSerializable(typeof(MenuItemEventArgs))]
+[JsonSerializable(typeof(OverflowChangedEventArgs))]
+[JsonSerializable(typeof(OverflowChangedItem))]
+[JsonSerializable(typeof(RadioEventArgs))]
+[JsonSerializable(typeof(TabChangeEventArgs))]
+[JsonSerializable(typeof(TreeItemChangedEventArgs))]
+[JsonSerializable(typeof(TreeItemToggleEventArgs))]
 [ExcludeFromCodeCoverage(Justification = "This class is used for source-generated JSON serialization and does not contain any logic to be tested.")]
 [Experimental("FLUENTUI0001")]
 public sealed partial class FluentUIJsonSerializerContext : JsonSerializerContext

--- a/tests/Core/Serialization/EventArgsJsonTests.cs
+++ b/tests/Core/Serialization/EventArgsJsonTests.cs
@@ -1,0 +1,102 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Xunit;
+
+#pragma warning disable FLUENTUI0001
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Tests.Serialization;
+
+public class EventArgsJsonTests
+{
+    public static TheoryData<EventArgs> CustomEventArgs => new()
+    {
+        new AccordionItemEventArgs { Id = "accordion-1", Expanded = true, HeaderText = "Accordion 1" },
+        new DialogToggleEventArgs { Id = "dialog-1", OldState = "closed", NewState = "open", Type = "toggle" },
+        new DropdownEventArgs { Id = "dropdown-1", Type = "change", SelectedOptions = "option-1;option-2" },
+        new MenuItemEventArgs { Id = "menu-item-1", Checked = true, Text = "Menu item 1" },
+        new OverflowChangedEventArgs
+        {
+            Id = "overflow-1",
+            Items =
+            [
+                new OverflowChangedItem
+                {
+                    Id = "overflow-item-1",
+                    Overflow = true,
+                    Text = "Overflow item 1",
+                    Behavior = OverflowBehavior.Fixed,
+                    Index = 1,
+                },
+            ],
+            OverflowCount = 1,
+            FirstOverflowIndex = 1,
+            OrderedItemIds = ["overflow-item-1"],
+        },
+        new RadioEventArgs { Id = "radio-1", Value = "value-1" },
+        new TabChangeEventArgs { Id = "tabs-1", ActiveId = "tab-1" },
+        new TreeItemChangedEventArgs { Id = "tree-item-1", Selected = true },
+        new TreeItemToggleEventArgs { Id = "tree-item-1", OldState = "closed", NewState = "open", Type = "toggle" },
+    };
+
+    [Theory]
+    [MemberData(nameof(CustomEventArgs))]
+    public void EventArgs_RoundTripsUsingGeneratedMetadata(EventArgs value)
+    {
+        var typeInfo = GetTypeInfo(value.GetType());
+        var json = JsonSerializer.Serialize(value, typeInfo);
+
+        var result = JsonSerializer.Deserialize(json, typeInfo);
+
+        Assert.NotNull(result);
+        Assert.Equal(value.GetType(), result.GetType());
+        Assert.Equal(json, JsonSerializer.Serialize(result, typeInfo));
+    }
+
+    [Fact]
+    public void MenuItemEventArgs_DeserializesBrowserPayloadWithoutItem()
+    {
+        const string json = """
+            {"id":"item-1","text":"Item 1","checked":true,"item":{}}
+            """;
+
+        var typeInfo = GetTypeInfo<MenuItemEventArgs>();
+        var result = JsonSerializer.Deserialize(json, typeInfo);
+
+        Assert.NotNull(result);
+        Assert.Equal("item-1", result.Id);
+        Assert.Equal("Item 1", result.Text);
+        Assert.True(result.Checked);
+        Assert.Null(result.Item);
+        Assert.DoesNotContain("\"item\":", JsonSerializer.Serialize(result, typeInfo), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void AccordionItemEventArgs_DeserializesBrowserPayloadWithoutItem()
+    {
+        const string json = """
+            {"id":"item-1","expanded":true,"headerText":"Item 1","item":{}}
+            """;
+
+        var typeInfo = GetTypeInfo<AccordionItemEventArgs>();
+        var result = JsonSerializer.Deserialize(json, typeInfo);
+
+        Assert.NotNull(result);
+        Assert.Equal("item-1", result.Id);
+        Assert.True(result.Expanded);
+        Assert.Equal("Item 1", result.HeaderText);
+        Assert.Null(result.Item);
+        Assert.DoesNotContain("\"item\":", JsonSerializer.Serialize(result, typeInfo), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static JsonTypeInfo GetTypeInfo(Type type) =>
+        FluentUIJsonSerializerContext.Default.GetTypeInfo(type) ??
+        throw new InvalidOperationException($"No JSON metadata was generated for {type}.");
+
+    private static JsonTypeInfo<T> GetTypeInfo<T>() => (JsonTypeInfo<T>)GetTypeInfo(typeof(T));
+}
+
+#pragma warning restore FLUENTUI0001


### PR DESCRIPTION
# Pull Request

## 📖 Description

Adds source-generated JSON metadata for Fluent UI custom event arguments to `FluentUIJsonSerializerContext`, allowing Blazor to deserialize custom browser events in Native AOT applications without reflection-based metadata.

This change:

- Registers all custom event argument roots and nested overflow event data with the existing serializer context.
- Ignores managed-only component references on accordion and menu event arguments so serialization does not traverse component instances.
- Makes serializer-exposed event argument types public, with comments documenting that they can become internal again if the serializer context becomes internal.
- Adds round-trip coverage for every custom event argument type using generated metadata.

### 🎫 Issues

No linked issue.

## 👩‍💻 Reviewer Notes

Please focus on the event type registrations in `FluentUIJsonSerializerContext` and the `[JsonIgnore]` treatment of component back-references. The public visibility changes are required because the public generated context exposes public `JsonTypeInfo<T>` properties for registered types.

## 📑 Test Plan

- Ran `EventArgsJsonTests` after rebasing onto the latest `upstream/dev-v5`: 3 tests passed. The parameterized round-trip test covers all nine custom event argument roots.

## ✅ Checklist

### General

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

Automatic registration with Blazor's .NET 11 `CircuitOptions.JsonTypeInfoResolvers` can be considered once the core package has an appropriate .NET 11 target and server framework reference.