### PR TITLE
fix: [Inputs] Immediate mode hides an external Value assignment made while the field has focus

### DIFF
--- a/src/Core/Components/Base/FluentInputImmediateManager.cs
+++ b/src/Core/Components/Base/FluentInputImmediateManager.cs
@@ -83,12 +83,25 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
          still typing, it can reset the field to a stale, shorter string mid-keystroke, scrambling
          what the user typed - confirmed via manual and scripted repro on a throttled/high-latency
          connection.
-       - Fix: the rendered value is FROZEN while the field has focus (_hasFocus /
-         _frozenValueAsString) - Blazor never touches the native `value` while the user might
-         still be typing, and resyncs to the confirmed value only once the field loses focus
-         (FocusOutHandlerAsync). This is a hard guarantee, not a timing heuristic: a fixed-duration
-         "wait a bit before rendering" timer was considered and rejected, since it can always be
-         defeated by high-enough or variable network latency.
+       - Fix: while the field has focus the rendered value is FROZEN (_hasFocus / _isFrozen /
+         _frozenValueAsString) - it is kept CONSTANT, so Blazor's diff never touches the native
+         `value` while the user might still be typing, and it resyncs to the confirmed value once
+         the field loses focus (FocusOutHandlerAsync). This is a hard guarantee, not a timing
+         heuristic: a fixed-duration "wait a bit before rendering" timer was considered and
+         rejected, since it can always be defeated by high-enough or variable network latency.
+       - The freeze is scoped to the user's own typing, not to the whole focused period. It holds
+         while the confirmed value keeps following what typing produced (_expectedConfirmedValue,
+         re-baselined on each confirmed keystroke via _typingConfirmed), and lifts as soon as the
+         confirmed value diverges from that: a divergence means the CONSUMER assigned the value
+         from the outside (a lookup dialog selection, a validation rule rewriting the field, a
+         value pushed by another component), which is newer than anything the user typed and has
+         to reach the browser. Freezing on focus alone made such an assignment invisible until the
+         field lost focus - and permanently invisible for a consumer that returns focus to the
+         field after closing a dialog, a common keyboard-navigation pattern.
+       - This cannot be keyed on _pendingImmediateText instead ("freeze only while a keystroke is
+         in flight"): that flag only covers the server-side processing window, leaving the
+         client-side debounce - and the gap between one confirmed keystroke and the next -
+         unprotected, which is exactly what step 3 exists to protect.
 
     4. Render suppression (ShouldRender)
        - Re-renders are also skipped, more generally, while a keystroke is known but not yet
@@ -107,7 +120,20 @@ internal sealed class FluentInputImmediateManager
     private readonly SemaphoreSlim _immediateGate = new(1, 1);
     private string? _pendingImmediateText;
     private bool _hasFocus;
+    private bool _isFrozen;
     private string? _frozenValueAsString;
+
+    // Confirmed value the freeze was taken against, kept up to date with every value the user's own
+    // typing confirms. While the confirmed value follows this trajectory there is nothing new to show
+    // and the freeze holds; the moment it diverges, the consumer assigned the value from the outside
+    // and that assignment has to reach the browser (see GetImmediateValueAsString).
+    private string? _expectedConfirmedValue;
+
+    // Set when this field's own typing has just confirmed a value: the next read re-baselines
+    // _expectedConfirmedValue to whatever the confirmed value became, instead of reading the move as
+    // an external assignment. Deliberately not predicted from the event value - the component's own
+    // parse/format round trip (numeric, date, masked input) can legitimately change the string.
+    private bool _typingConfirmed;
 
     public FluentInputImmediateManager(IFluentInputImmediate input)
     {
@@ -119,25 +145,76 @@ internal sealed class FluentInputImmediateManager
     /// logic below when Immediate is enabled - otherwise there's no per-keystroke round
     /// trip to protect against, so this just returns CurrentValueAsString
     /// directly (never blocking a legitimate external value update while the field has focus).
-    /// While the field has focus in Immediate mode, the value is frozen (never updated) since the
+    /// While the field has focus in Immediate mode, the value is frozen since the
     /// server can never know about keystrokes the browser hasn't transmitted yet - re-rendering it
     /// mid-typing (e.g. under network/server latency) would reset the field to a stale, already-
-    /// superseded value and scramble what the user is typing. It resyncs to the latest known text
-    /// (the pending, not-yet-confirmed keystroke if any, else CurrentValueAsString)
+    /// superseded value and scramble what the user is typing. Freezing works by keeping the rendered
+    /// string CONSTANT, so Blazor's diff never touches the native `value` at all. It resyncs to the
+    /// latest known text (the pending, not-yet-confirmed keystroke if any, else CurrentValueAsString)
     /// as soon as the field loses focus.
+    /// <para>
+    /// The freeze is scoped to the user's own typing, NOT to the whole focused period: it holds while
+    /// the confirmed value keeps following what typing produced (<see cref="_expectedConfirmedValue"/>),
+    /// and lifts as soon as the confirmed value diverges from that. A divergence means the consumer
+    /// assigned the value from the outside - picking a row in a lookup dialog, a validation rule
+    /// rewriting the field, a value pushed by another component - and that assignment is newer than
+    /// anything the user typed, so it must reach the browser. Without this, an external assignment
+    /// made while the field has focus stayed invisible until the field lost focus, and then appeared
+    /// all at once; a consumer that deliberately returns focus to the field after a dialog (a common
+    /// keyboard-navigation pattern) never showed the value at all.
+    /// </para>
+    /// <para>
+    /// Note this cannot be keyed on <see cref="_pendingImmediateText"/> instead: that is only set
+    /// while a keystroke is being processed server-side, so it leaves the client-side debounce window
+    /// (and the gap between one confirmed keystroke and the next) unprotected - precisely the window
+    /// the freeze exists for.
+    /// </para>
     /// </summary>
-    /// 
+    ///
     /// <code>
     /// Use this method in your component to get the string to render as the native element's `value`.
     /// <example>
     /// protected string? ImmediateValueAsString => _immediateManager.GetImmediateValueAsString(CurrentValueAsString);
     /// </example>
     /// </code>
-    internal string? GetImmediateValueAsString(string? currentValueAsString) => !_input.Immediate
-        ? currentValueAsString
-        : _hasFocus
-            ? _frozenValueAsString ??= _pendingImmediateText ?? currentValueAsString
-            : _pendingImmediateText ?? currentValueAsString;
+    internal string? GetImmediateValueAsString(string? currentValueAsString)
+    {
+        if (!_input.Immediate)
+        {
+            return currentValueAsString;
+        }
+
+        if (!_hasFocus)
+        {
+            return _pendingImmediateText ?? currentValueAsString;
+        }
+
+        // First render while focused: take the freeze, and remember the confirmed value it is
+        // relative to. An explicit flag (not a null check on the frozen string) so that freezing on
+        // an empty/null value still sticks.
+        if (!_isFrozen)
+        {
+            _isFrozen = true;
+            _frozenValueAsString = _pendingImmediateText ?? currentValueAsString;
+            _expectedConfirmedValue = currentValueAsString;
+        }
+        else if (_typingConfirmed)
+        {
+            // The confirmed value moved because of this field's own typing: re-baseline and KEEP the
+            // freeze, so the rendered string stays constant and the browser is left alone.
+            _typingConfirmed = false;
+            _expectedConfirmedValue = currentValueAsString;
+        }
+        else if (!string.Equals(currentValueAsString, _expectedConfirmedValue, StringComparison.Ordinal))
+        {
+            // The confirmed value moved for a reason other than this field's typing: adopt it, so the
+            // rendered string changes and Blazor pushes it to the browser.
+            _frozenValueAsString = currentValueAsString;
+            _expectedConfirmedValue = currentValueAsString;
+        }
+
+        return _frozenValueAsString;
+    }
 
     /// <summary>
     /// Handler for the OnInput event. The client already debounces by ImmediateDelay before
@@ -189,6 +266,10 @@ internal sealed class FluentInputImmediateManager
                 if (Volatile.Read(ref _immediateSequence) == sequence)
                 {
                     _pendingImmediateText = null;
+
+                    // Whatever the confirmed value became, it came from this field's typing - the next
+                    // read re-baselines against it instead of mistaking it for an external assignment.
+                    _typingConfirmed = true;
                 }
             }
         }
@@ -230,7 +311,10 @@ internal sealed class FluentInputImmediateManager
     internal async Task FocusOutHandlerAsync(FocusEventArgs e, Func<Task>? action = null)
     {
         _hasFocus = false;
+        _isFrozen = false;
         _frozenValueAsString = null;
+        _expectedConfirmedValue = null;
+        _typingConfirmed = false;
 
         if (action is not null)
         {

--- a/tests/Core/Components/TextInput/FluentTextInputTests.razor
+++ b/tests/Core/Components/TextInput/FluentTextInputTests.razor
@@ -238,6 +238,65 @@ expectedDelayedValue)
     }
 
     [Fact]
+    public void FluentInputText_Immediate_WhileFocused_ValueAttributeReflectsExternalUpdates()
+    {
+        // Arrange: focused, in Immediate mode, and the user has NOT typed anything
+        var cut = Render(@<FluentTextInput Value="init" Immediate="true" ImmediateDelay="0" />);
+        var textInput = cut.FindComponent<FluentTextInput>();
+        var element = cut.Find("fluent-text-input");
+        element.TriggerEvent("onfocusin", new FocusEventArgs());
+
+        // Act: the consumer assigns the value from the outside while the field still has focus -
+        // e.g. the row picked in a lookup dialog, with focus returned to the field on close.
+        textInput.Render(parameters => parameters.Add(p => p.Value, "external"));
+
+        // Assert: the freeze protects the user's typing, not arbitrary assignments. An external
+        // value is newer than anything typed, so it must reach the browser now - not stay invisible
+        // until the field loses focus (and never, if the consumer keeps focus here).
+        Assert.Equal("external", cut.Find("fluent-text-input").GetAttribute("value"));
+    }
+
+    [Fact]
+    public void FluentInputText_Immediate_ExternalUpdateAfterTyping_WhileStillFocused_Reflected()
+    {
+        // Arrange: focused, and the user typed - so the rendered value is frozen at "init"
+        var value = "init";
+        var cut = Render(@<FluentTextInput @bind-Value="@value"                 Immediate="true"                 ImmediateDelay="0" />);
+        var element = cut.Find("fluent-text-input");
+        element.TriggerEvent("onfocusin", new FocusEventArgs());
+        element.TriggerEvent("ontextimmediate", new ChangeEventArgs() { Value = "typed" });
+        Assert.Equal("init", cut.Find("fluent-text-input").GetAttribute("value"));
+
+        // Act: NOW the consumer overwrites the value from the outside (a validation rule rewriting
+        // the field, a lookup selection...), still without losing focus
+        cut.FindComponent<FluentTextInput>()
+            .Render(parameters => parameters.Add(p => p.Value, "external"));
+
+        // Assert: the assignment wins over the frozen typing snapshot
+        Assert.Equal("external", cut.Find("fluent-text-input").GetAttribute("value"));
+    }
+
+    [Fact]
+    public void FluentInputText_Immediate_RepeatedTyping_KeepsValueAttributeFrozen()
+    {
+        // Arrange
+        var value = "init";
+        var cut = Render(@<FluentTextInput @bind-Value="@value"                 Immediate="true"                 ImmediateDelay="0" />);
+        var element = cut.Find("fluent-text-input");
+        element.TriggerEvent("onfocusin", new FocusEventArgs());
+
+        // Act: several confirmed keystrokes in a row, still focused
+        element.TriggerEvent("ontextimmediate", new ChangeEventArgs() { Value = "ty" });
+        element.TriggerEvent("ontextimmediate", new ChangeEventArgs() { Value = "typ" });
+        element.TriggerEvent("ontextimmediate", new ChangeEventArgs() { Value = "typed" });
+
+        // Assert: each confirmed keystroke re-baselines the freeze instead of reading as an external
+        // assignment, so the rendered value never moves and the browser is left alone throughout.
+        Assert.Equal("typed", value);
+        Assert.Equal("init", cut.Find("fluent-text-input").GetAttribute("value"));
+    }
+
+    [Fact]
     public void FluentInputText_NotImmediate_WhileFocused_ValueAttributeReflectsExternalUpdates()
     {
         // Arrange


### PR DESCRIPTION
Fixes #5196

## The problem

In `Immediate` mode the rendered `value` was frozen for the **whole period the field has focus**, so any value the consuming app assigned from the outside while the field had focus never reached the browser: it stayed invisible until the field lost focus and then appeared all at once. When the consumer deliberately returns focus to the field — closing a lookup/selection dialog and focusing the field it belongs to, a common keyboard-navigation pattern — the value was never shown at all, even though the bound property was correct.

## Why the freeze exists, and what actually needed changing

The freeze is load-bearing and I kept it. It stops a re-render from resetting the native input to a stale string while the user is still typing (the browser may hold keystrokes the server hasn't received yet), and it works by keeping the rendered string **constant** so Blazor's diff never touches the DOM.

What was wrong was its **scope**. That protection is about the user's own typing, not about arbitrary assignments: an external assignment is newer than anything the user typed and has to win. `FluentInputText_NotImmediate_WhileFocused_ValueAttributeReflectsExternalUpdates` already asserts exactly this for the non-immediate path ("the freeze must not apply - the DOM reflects the update right away, not after blur"); this PR makes `Immediate` mode meet the same expectation.

## The change

The freeze is now scoped to typing instead of to focus. It holds while the confirmed value keeps following what typing produced (`_expectedConfirmedValue`, re-baselined after each confirmed keystroke via `_typingConfirmed`), and lifts as soon as the confirmed value diverges from that trajectory — a divergence means the consumer assigned the value.

`_typingConfirmed` deliberately does **not** predict the new value from the event args: the component's own parse/format round trip (numeric, date, masked input) can legitimately change the string, so the next read re-baselines against whatever the confirmed value actually became.

Also replaced the `??=` freeze latch with an explicit `_isFrozen` flag, so freezing on a `null`/empty value sticks instead of re-evaluating on every read.

## Rejected alternative (worth recording)

Keying the freeze on `_pendingImmediateText is not null` — "freeze only while a keystroke is in flight" — looks like the obvious one-liner and is wrong. That flag is only set while a keystroke is being processed server-side, so it leaves the **client-side debounce window**, and the gap between one confirmed keystroke and the next, unprotected. That is precisely what the freeze is for (see technical note 3 in the file). It fixes the dialog case and reintroduces the typing corruption the note describes. I left a comment in the code so it does not get "simplified" into that later.

## Tests

Three added to `FluentTextInputTests`:

- `FluentInputText_Immediate_WhileFocused_ValueAttributeReflectsExternalUpdates` — external assignment with focus and no prior typing.
- `FluentInputText_Immediate_ExternalUpdateAfterTyping_WhileStillFocused_Reflected` — external assignment after the user typed, still focused.
- `FluentInputText_Immediate_RepeatedTyping_KeepsValueAttributeFrozen` — several confirmed keystrokes in a row keep the rendered value frozen, i.e. the typing protection is intact.

The existing `FluentInputText_Immediate_WhileFocused_ValueAttributeStaysFrozen` and `FluentInputText_Immediate_OnFocusOut_UnfreezesAndResyncsValueAttribute` still pass unchanged. Full Core suite: 3865/3865.

## Verified in a real app

Blazor Server app, `FluentTextInput` with `Immediate="true"`: picking a row in a lookup dialog now shows the value immediately with focus returned to the field (attribute, property and shadow `input` all updated). Counter-check on typing: while typing in another field the rendered attribute stays constant and the input keeps exactly what was typed — no reset.
