### PR TITLE
[dev-v5] Enhance immediate input handling for external value updates

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextInput/Examples/DebugPages/TextInputImmediateFast.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextInput/Examples/DebugPages/TextInputImmediateFast.razor
@@ -21,10 +21,34 @@
 
         <FluentLabel>Value = @Value2</FluentLabel>
     </FluentStack>
+
+    <FluentStack Orientation="Orientation.Vertical">
+        <FluentTextInput Value="@Value3"
+                         Immediate="true"
+                         ImmediateDelay="0" />
+        <FluentLabel>Value = @Value3</FluentLabel>
+    </FluentStack>
 </FluentStack>
 
 @code
 {
     string Value1 = "";
     string Value2 = "";
+    string Value3 = "init";
+
+    protected override void OnInitialized()
+    {
+        _ = UpdateValue3Async();
+    }
+
+    private async Task UpdateValue3Async()
+    {
+        using PeriodicTimer timer = new(TimeSpan.FromSeconds(5));
+
+        while (await timer.WaitForNextTickAsync())
+        {
+            Value3 = $"{DateTime.Now:HH:mm:ss}";
+            await InvokeAsync(StateHasChanged);
+        }
+    }
 }

--- a/src/Core/Components/Base/FluentInputImmediateBase.cs
+++ b/src/Core/Components/Base/FluentInputImmediateBase.cs
@@ -52,6 +52,13 @@ public abstract class FluentInputImmediateBase<TValue> : FluentInputBase<TValue>
     [Parameter]
     public EventCallback<FocusEventArgs> OnFocusOut { get; set; }
 
+    /// <inheritdoc />
+    public override Task SetParametersAsync(ParameterView parameters)
+    {
+        _immediateManager.CheckAndSetExternalValue(parameters, Value, FormatValueAsString);
+        return base.SetParametersAsync(parameters);
+    }
+
     /// <see cref="FluentInputImmediateManager.GetImmediateValueAsString(string?)" />
     protected string? ImmediateValueAsString => _immediateManager.GetImmediateValueAsString(CurrentValueAsString);
 

--- a/src/Core/Components/Base/FluentInputImmediateManager.cs
+++ b/src/Core/Components/Base/FluentInputImmediateManager.cs
@@ -3,7 +3,6 @@
 // ------------------------------------------------------------------------
 
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
 
@@ -158,7 +157,7 @@ internal sealed class FluentInputImmediateManager
     {
         if (_input.Immediate && _hasFocus)
         {
-            if (parameters.TryGetValue<TValue?>(nameof(InputBase<>.Value), out var newValue) &&
+            if (parameters.TryGetValue<TValue?>(nameof(FluentInputBase<>.Value), out var newValue) &&
                 !EqualityComparer<TValue?>.Default.Equals(newValue, value))
             {
                 _frozenValueAsString = formatValueAsString(newValue);

--- a/src/Core/Components/Base/FluentInputImmediateManager.cs
+++ b/src/Core/Components/Base/FluentInputImmediateManager.cs
@@ -3,6 +3,7 @@
 // ------------------------------------------------------------------------
 
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
 
@@ -32,6 +33,12 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 
         [Parameter]
         public EventCallback<FocusEventArgs> OnFocusOut { get; set; }
+
+        public override Task SetParametersAsync(ParameterView parameters)
+        {
+            _immediateManager.CheckAndSetExternalValue(parameters, Value, FormatValueAsString);
+            return base.SetParametersAsync(parameters);
+        }
 
         protected string? ImmediateValueAsString
             => _immediateManager.GetImmediateValueAsString(CurrentValueAsString);
@@ -138,6 +145,26 @@ internal sealed class FluentInputImmediateManager
         : _hasFocus
             ? _frozenValueAsString ??= _pendingImmediateText ?? currentValueAsString
             : _pendingImmediateText ?? currentValueAsString;
+
+    /// <summary>
+    /// Detects a new value supplied by the parent while the input is focused and updates the
+    /// frozen rendered value so the external change is displayed immediately.
+    /// </summary>
+    /// <typeparam name="TValue">The input value type.</typeparam>
+    /// <param name="parameters">The parameters supplied by the parent component.</param>
+    /// <param name="value">The current input value before applying the parameters.</param>
+    /// <param name="formatValueAsString">The function used to format the new value for rendering.</param>
+    internal void CheckAndSetExternalValue<TValue>(ParameterView parameters, TValue? value, Func<TValue?, string?> formatValueAsString)
+    {
+        if (_input.Immediate && _hasFocus)
+        {
+            if (parameters.TryGetValue<TValue?>(nameof(InputBase<>.Value), out var newValue) &&
+                !EqualityComparer<TValue?>.Default.Equals(newValue, value))
+            {
+                _frozenValueAsString = formatValueAsString(newValue);
+            }
+        }
+    }
 
     /// <summary>
     /// Handler for the OnInput event. The client already debounces by ImmediateDelay before

--- a/src/Core/Components/List/FluentCombobox.cs
+++ b/src/Core/Components/List/FluentCombobox.cs
@@ -152,6 +152,13 @@ public partial class FluentCombobox<TOption, TValue> : FluentSelect<TOption, TVa
             : default(TOption);
     }
 
+    /// <inheritdoc />
+    public override Task SetParametersAsync(ParameterView parameters)
+    {
+        _immediateManager.CheckAndSetExternalValue(parameters, Value, FormatValueAsString);
+        return base.SetParametersAsync(parameters);
+    }
+
     /// <see cref="FluentInputImmediateManager.GetImmediateValueAsString(string?)" />
     protected string? ImmediateValueAsString => _immediateManager.GetImmediateValueAsString(CurrentValueAsString);
 

--- a/tests/Core/Components/TextInput/FluentTextInputTests.razor
+++ b/tests/Core/Components/TextInput/FluentTextInputTests.razor
@@ -283,6 +283,65 @@ expectedDelayedValue)
         Assert.True(cut.FindComponent<FluentTextInput>().Instance.FocusLost);
     }
 
+    [Fact]
+    public void FluentInputText_Immediate_WhileFocused_ValueAttributeReflectsExternalUpdates()
+    {
+        // Arrange: focused, in Immediate mode, and the user has NOT typed anything
+        var cut = Render(@<FluentTextInput Value="init" Immediate="true" ImmediateDelay="0" />);
+        var textInput = cut.FindComponent<FluentTextInput>();
+        var element = cut.Find("fluent-text-input");
+        element.TriggerEvent("onfocusin", new FocusEventArgs());
+
+        // Act: the consumer assigns the value from the outside while the field still has focus -
+        // e.g. the row picked in a lookup dialog, with focus returned to the field on close.
+        textInput.Render(parameters => parameters.Add(p => p.Value, "external"));
+
+        // Assert: the freeze protects the user's typing, not arbitrary assignments. An external
+        // value is newer than anything typed, so it must reach the browser now - not stay invisible
+        // until the field loses focus (and never, if the consumer keeps focus here).
+        Assert.Equal("external", cut.Find("fluent-text-input").GetAttribute("value"));
+    }
+
+    [Fact]
+    public void FluentInputText_Immediate_ExternalUpdateAfterTyping_WhileStillFocused_Reflected()
+    {
+        // Arrange: focused, and the user typed - so the rendered value is frozen at "init"
+        var value = "init";
+        var cut = Render(@<FluentTextInput @bind-Value="@value" Immediate="true" ImmediateDelay="0" />);
+        var element = cut.Find("fluent-text-input");
+        element.TriggerEvent("onfocusin", new FocusEventArgs());
+        element.TriggerEvent("ontextimmediate", new ChangeEventArgs() { Value = "typed" });
+        Assert.Equal("init", cut.Find("fluent-text-input").GetAttribute("value"));
+
+        // Act: NOW the consumer overwrites the value from the outside (a validation rule rewriting
+        // the field, a lookup selection...), still without losing focus
+        cut.FindComponent<FluentTextInput>()
+            .Render(parameters => parameters.Add(p => p.Value, "external"));
+
+        // Assert: the assignment wins over the frozen typing snapshot
+        Assert.Equal("external", cut.Find("fluent-text-input").GetAttribute("value"));
+    }
+
+    [Fact]
+    public void FluentInputText_Immediate_RepeatedTyping_KeepsValueAttributeFrozen()
+    {
+        // Arrange
+        var value = "init";
+        var cut = Render(@<FluentTextInput @bind-Value="@value" Immediate="true" ImmediateDelay="0" />);
+        var element = cut.Find("fluent-text-input");
+        element.TriggerEvent("onfocusin", new FocusEventArgs());
+
+        // Act: several confirmed keystrokes in a row, still focused
+        element.TriggerEvent("ontextimmediate", new ChangeEventArgs() { Value = "ty" });
+        element.TriggerEvent("ontextimmediate", new ChangeEventArgs() { Value = "typ" });
+        element.TriggerEvent("ontextimmediate", new ChangeEventArgs() { Value = "typed" });
+
+        // Assert: each confirmed keystroke re-baselines the freeze instead of reading as an external
+        // assignment, so the rendered value never moves and the browser is left alone throughout.
+        Assert.Equal("typed", value);
+        Assert.Equal("init", cut.Find("fluent-text-input").GetAttribute("value"));
+    }
+
     [Theory]
     [InlineData(FluentInputAppearance.Filled, TextInputAppearance.FilledDarker)]
     [InlineData(FluentInputAppearance.Outline, TextInputAppearance.Outline)]


### PR DESCRIPTION
# [dev-v5] Enhance immediate input handling for external value updates

Improve handling of immediate input components to reflect **external value changes** while focused. 
Add tests to ensure that external updates are correctly displayed without losing user input.
This change enhances user experience by ensuring that the latest external values are visible immediately.

## Before

https://github.com/user-attachments/assets/d3726ce8-482e-4582-94f2-5716d549a321

## After

https://github.com/user-attachments/assets/e189687b-a866-48e5-8bcb-c1ddd8bd4610

## Unit Tests

Added (same than #5197)