### PR TITLE
[dev-v5] Fix dialog shortcut handling and simplify active element retrieval

### DIFF
--- a/src/Core.Scripts/src/Components/Dialog/FluentDialog.ts
+++ b/src/Core.Scripts/src/Components/Dialog/FluentDialog.ts
@@ -1,14 +1,5 @@
 export namespace Microsoft.FluentUI.Blazor.Components.Dialog {
 
-  const getDeepActiveElement = (): HTMLElement | null => {
-    let activeElement: Element | null = document.activeElement;
-    while (activeElement instanceof HTMLElement && activeElement.shadowRoot?.activeElement) {
-      activeElement = activeElement.shadowRoot.activeElement;
-    }
-
-    return activeElement instanceof HTMLElement ? activeElement : null;
-  };
-
   /**
    * Tag names of non-modal, transient elements (e.g. toasts) that reuse the
    * dialog toggle plumbing but must never restore focus when they open or close.
@@ -112,9 +103,14 @@ export namespace Microsoft.FluentUI.Blazor.Components.Dialog {
       return false;
     }
 
-    const activeElement = getDeepActiveElement();
-    if (!activeElement || !dialog.contains(activeElement)) {
+    const activeElement = document.activeElement;
+    if (!(activeElement instanceof HTMLElement) || !dialog.contains(activeElement)) {
       return false;
+    }
+
+    // The dialog surface itself receives focus when no interactive content does (e.g. MessageBox).
+    if (activeElement === dialog) {
+      return true;
     }
 
     // Keep shortcuts active for explicit dialog action surfaces.

--- a/tests/Core/Components/Dialog/FluentMessageBoxTests.razor
+++ b/tests/Core/Components/Dialog/FluentMessageBoxTests.razor
@@ -8,6 +8,7 @@
     public FluentMessageBoxTests()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
+        JSInterop.Setup<bool>("Microsoft.FluentUI.Blazor.Components.Dialog.ShouldHandleShortcut", _ => true).SetResult(true);
         Services.AddFluentUIComponents(options => options.UseGlobalOverlay = false);
 
         DialogService = Services.GetRequiredService<IDialogService>();
@@ -152,6 +153,22 @@
 
         // Assert
         DialogProvider.Verify();
+    }
+
+    [Theory(Timeout = TEST_TIMEOUT)]
+    [InlineData("Y", false)]
+    [InlineData("N", true)]
+    public async Task ShowConfirmationAsync_ShortcutPressed_ReturnsExpectedResult(string shortcut, bool expectedCancelled)
+    {
+        // Arrange
+        var dialogTask = DialogService.ShowConfirmationAsync("My message");
+
+        // Act
+        DialogProvider.Find("fluent-dialog").KeyDown(shortcut);
+        var result = await dialogTask;
+
+        // Assert
+        Assert.Equal(expectedCancelled, result.Cancelled);
     }
 
     [Fact(Timeout = TEST_TIMEOUT)]


### PR DESCRIPTION
# [dev-v5] Fix dialog shortcut handling and simplify active element retrieval

Fixes #5212, #4983 and #4562

Enhance the dialog's shortcut handling by simplifying the retrieval of the active element. 
This change improves the user experience by ensuring that shortcuts function correctly within the dialog context. 

Additionally, tests have been added to verify the expected behavior when shortcuts are pressed.

**Note:** The `getDeepActiveElement` function was removed because dialog shortcut handling must evaluate the focused Web Component host, while traversing into its Shadow DOM prevents reliable detection of whether focus belongs to the dialog or its action area.

## Unit Tests

Added

