### PR TITLE
[dev-v5] Remove suppression of the xUnit1069 warning 

### DIFF
--- a/tests/Core/Components.Tests.csproj
+++ b/tests/Core/Components.Tests.csproj
@@ -10,7 +10,7 @@
     <IsPackable>false</IsPackable>
     <AssemblyName>Microsoft.FluentUI.AspNetCore.Components.Tests</AssemblyName>
     <RootNamespace>Microsoft.FluentUI.AspNetCore.Components.Tests</RootNamespace>
-    <NoWarn>xUnit1069;BL0016</NoWarn>
+    <NoWarn>BL0016</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Core/Components/Dialog/FluentDialogTests.razor
+++ b/tests/Core/Components/Dialog/FluentDialogTests.razor
@@ -28,6 +28,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentDialog_Render()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var renderOptions = new Templates.DialogRenderOptions();
 
@@ -52,6 +54,8 @@
     [InlineData(null, null)]
     public async Task FluentDialog_Alignment(DialogAlignment? alignment, string? expectedPosition)
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var renderOptions = new Templates.DialogRenderOptions();
 
@@ -86,6 +90,8 @@
     [InlineData("", (DialogAlignment)999)]
     public async Task FluentDialog_Drawer(string expectedContains, DialogAlignment alignment)
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var renderOptions = new Templates.DialogRenderOptions();
 
@@ -113,6 +119,8 @@
     [InlineData(DialogState.Closing, "beforetoggle", "open", "any-new")]
     public async Task FluentDialog_Toggle(DialogState state, string eventType, string oldState, string newState)
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var renderOptions = new Templates.DialogRenderOptions();
         var toggleArgs = new DialogToggleEventArgs()
@@ -156,6 +164,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentDialog_OpenClose()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var renderOptions = new Templates.DialogRenderOptions()
         {
@@ -179,6 +189,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentDialog_ActionToClose()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var renderOptions = new Templates.DialogRenderOptions();
 
@@ -205,6 +217,8 @@
     [ClassData(typeof(Data.ShortcutData))]
     public async Task FluentDialog_ShortcutToClose(Data.ShortcutDataItem item)
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var renderOptions = item.RenderOptions ?? new Templates.DialogRenderOptions();
 
@@ -244,6 +258,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentDialog_ShortcutInvalid()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var renderOptions = new Templates.DialogRenderOptions()
         {
@@ -274,6 +290,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentDialog_WithInstance()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var renderOptions = new Templates.DialogRenderOptions();
 
@@ -294,6 +312,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentDialog_ComponentRule()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var renderOptions = new Templates.DialogRenderOptions();
 
@@ -313,6 +333,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentDialog_ProviderRequired()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var renderOptions = new Templates.DialogRenderOptions();
         DialogProvider.Instance.UpdateId(null);
@@ -409,6 +431,8 @@
     [InlineData("type=\"modal\"", false)]
     public async Task FluentDialog_Modal(string expectedContains, bool? modal)
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var renderOptions = new Templates.DialogRenderOptions();
 
@@ -431,6 +455,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentDialog_InverseActions()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var renderOptions = new Templates.DialogRenderOptions();
 
@@ -475,6 +501,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentDialog_PreventDismissOnEscape_Default_DoesNotCallJs()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var preventEscapeSetup = JSInterop.SetupVoid("Microsoft.FluentUI.Blazor.Components.Dialog.SetPreventEscapeClose", _ => true);
         var renderOptions = new Templates.DialogRenderOptions();
@@ -495,6 +523,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentDialog_PreventDismissOnEscape_True_CallsJs()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var preventEscapeSetup = JSInterop.SetupVoid("Microsoft.FluentUI.Blazor.Components.Dialog.SetPreventEscapeClose", _ => true);
         var renderOptions = new Templates.DialogRenderOptions();
@@ -518,6 +548,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentDialog_PreventDismissOnEscape_False_DoesNotCallJs()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var preventEscapeSetup = JSInterop.SetupVoid("Microsoft.FluentUI.Blazor.Components.Dialog.SetPreventEscapeClose", _ => true);
         var renderOptions = new Templates.DialogRenderOptions();
@@ -540,6 +572,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentDialog_PreventDismissOnEscape_TrueThenFalse_OnlyFirstDialogCallsJs()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var preventEscapeSetup = JSInterop.SetupVoid("Microsoft.FluentUI.Blazor.Components.Dialog.SetPreventEscapeClose", _ => true);
         var firstRenderOptions = new Templates.DialogRenderOptions() { AutoClose = true };
@@ -595,6 +629,8 @@
     [InlineData("full", DialogSize.Full)]
     public async Task FluentDialog_Size(string? expected, DialogSize? size)
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var renderOptions = new Templates.DialogRenderOptions();
 
@@ -626,6 +662,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentDialog_MarginPadding()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var renderOptions = new Templates.DialogRenderOptions();
 

--- a/tests/Core/Components/Dialog/FluentDrawerTests.razor
+++ b/tests/Core/Components/Dialog/FluentDrawerTests.razor
@@ -27,6 +27,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentDrawer_Render()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var renderOptions = new Templates.DialogRenderOptions();
 
@@ -50,6 +52,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentDrawer_Options()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var renderOptions = new Templates.DialogRenderOptions();
 
@@ -72,6 +76,8 @@
     [InlineData("position=\"end\"", DialogAlignment.End)]
     public async Task FluentDrawer_Position(string expectedContains, DialogAlignment alignment)
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var renderOptions = new Templates.DialogRenderOptions();
 
@@ -111,7 +117,7 @@
                });
 
         // Don't wait for the dialog to be closed
-        await Task.CompletedTask;
+        await Task.CompletedTask.WaitAsync(Xunit.TestContext.Current.CancellationToken);
 
         // Assert
         var dialog = DialogProvider.Find("fluent-drawer");
@@ -132,6 +138,8 @@
     [InlineData("type=\"non-modal\"", false)]
     public async Task FluentDrawer_Modal(string expectedContains, bool? modal)
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var renderOptions = new Templates.DialogRenderOptions();
 
@@ -154,6 +162,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentDrawer_InverseActions()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var renderOptions = new Templates.DialogRenderOptions();
 
@@ -187,6 +197,8 @@
     [InlineData("full", DialogSize.Full)]
     public async Task FluentDrawer_Size(string? expected, DialogSize? size)
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var renderOptions = new Templates.DialogRenderOptions();
 

--- a/tests/Core/Components/Dialog/FluentMessageBoxTests.razor
+++ b/tests/Core/Components/Dialog/FluentMessageBoxTests.razor
@@ -32,7 +32,7 @@
         var dialogTask = DialogService.ShowSuccessAsync("My message");
 
         // Don't wait for the dialog to be closed
-        await Task.CompletedTask;
+        await Task.CompletedTask.WaitAsync(Xunit.TestContext.Current.CancellationToken);
 
         // Assert
         DialogProvider.Verify();
@@ -41,6 +41,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBox_SuccessCustomized()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Act
         var dialogTask = DialogService.ShowSuccessAsync("My message", "My title", "OK");
 
@@ -54,6 +56,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBox_Info()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Act
         var dialogTask = DialogService.ShowInfoAsync("My message");
 
@@ -67,6 +71,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBox_InfoCustomized()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Act
         var dialogTask = DialogService.ShowInfoAsync("My message", "My title", "OK");
 
@@ -80,6 +86,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBox_Warning()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Act
         var dialogTask = DialogService.ShowWarningAsync("My message");
 
@@ -93,6 +101,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBox_WarningCustomized()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Act
         var dialogTask = DialogService.ShowWarningAsync("My message", "My title", "OK");
 
@@ -106,6 +116,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBox_Error()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Act
         var dialogTask = DialogService.ShowErrorAsync("My message");
 
@@ -119,6 +131,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBox_ErrorCustomized()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Act
         var dialogTask = DialogService.ShowErrorAsync("My message", "My title", "OK");
 
@@ -132,6 +146,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBox_Confirmation()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Act
         var dialogTask = DialogService.ShowConfirmationAsync("My message");
 
@@ -145,6 +161,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBox_ConfirmationCustomized()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Act
         var dialogTask = DialogService.ShowConfirmationAsync("My message", "My title", "Yes", "No");
 
@@ -160,6 +178,8 @@
     [InlineData("N", true)]
     public async Task ShowConfirmationAsync_ShortcutPressed_ReturnsExpectedResult(string shortcut, bool expectedCancelled)
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var dialogTask = DialogService.ShowConfirmationAsync("My message");
 
@@ -174,6 +194,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBox_EmptyOptions()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Act
         var dialogTask = DialogService.ShowMessageBoxAsync(new());
 

--- a/tests/Core/Components/MessageBar/FluentMessageBarProviderTests.razor
+++ b/tests/Core/Components/MessageBar/FluentMessageBarProviderTests.razor
@@ -44,6 +44,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBarProvider_ShowInfo_RendersMessage()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cut = Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
 
@@ -65,6 +67,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBarProvider_ShowSuccess_RendersMessage()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cut = Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
 
@@ -80,6 +84,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBarProvider_ShowWarning_RendersMessage()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cut = Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
 
@@ -95,6 +101,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBarProvider_ShowError_RendersMessage()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cut = Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
 
@@ -110,6 +118,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBarProvider_ShowMessage_OptionsObject()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cut = Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
 
@@ -137,6 +147,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBarProvider_Section_OnlyRendersMatchingSection()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cutA = Render(@<FluentMessageBarProvider Section="section-A" />);
         var cutB = Render(@<FluentMessageBarProvider Section="section-B" />);
@@ -154,6 +166,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBarProvider_Section_CaseInsensitive()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cut = Render(@<FluentMessageBarProvider Section="LOWER" />);
 
@@ -169,6 +183,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBarProvider_Dismiss_RemovesMessage()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cut = Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
 
@@ -195,6 +211,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBarProvider_CloseAsync_ById_Closes()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cut = Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
 
@@ -220,6 +238,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBarProvider_CloseAsync_UnknownId_ReturnsFalse()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
 
@@ -236,6 +256,8 @@
     [InlineData("   ")]
     public async Task FluentMessageBarProvider_CloseAsync_InvalidId_ReturnsFalse(string? id)
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
 
@@ -249,6 +271,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBarProvider_CloseAsync_Instance_Programmatic()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cut = Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
 
@@ -279,6 +303,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBarProvider_CloseAsync_Instance_WithMessageBarResult()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cut = Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
 
@@ -312,6 +338,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBarProvider_CloseAsync_NonInstance_NoOp()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
 
@@ -324,6 +352,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBarProvider_CloseAllAsync_RemovesAll()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cut = Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
 
@@ -347,6 +377,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBarProvider_DoubleClose_NoOp()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cut = Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
 
@@ -389,7 +421,7 @@
             o.ResultTiming = MessageBarResultTiming.Closed;
         });
 
-        var result = await task;
+        var result = await task.WaitAsync(Xunit.TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(MessageBarCloseReason.TimedOut, result.Reason);
@@ -398,6 +430,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBarProvider_ResultTiming_Visible_CompletesBeforeClose()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cut = Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
 
@@ -420,6 +454,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBarProvider_ResultTiming_Closed_WaitsUntilClose()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cut = Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
 
@@ -445,6 +481,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBarProvider_Lifetime_Zero_StaysOpen()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cut = Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
 
@@ -470,6 +508,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBarProvider_OnStatusChange_RaisesAllEvents()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cut = Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
 
@@ -497,6 +537,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBarProvider_DuplicateId_Throws()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
 
@@ -529,6 +571,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBarProvider_ShowMessage_NullOptions_Throws()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
 
@@ -545,6 +589,8 @@
     [InlineData("   ")]
     public async Task FluentMessageBarProvider_ShowMessage_EmptySection_Throws(string? section)
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
 
@@ -562,6 +608,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBarProvider_NotRendered_Throws()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange: no FluentMessageBarProvider rendered
 
         // Act & Assert
@@ -574,6 +622,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBarProvider_Dispose_UnsubscribesAndAllowsAnotherProvider()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var first = Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
 
@@ -593,6 +643,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBarProvider_AllProvidersDisposed_ServiceUnavailable()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var provider = Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
 
@@ -609,6 +661,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBarProvider_CustomComponent_Rendered()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cut = Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
 
@@ -629,6 +683,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBarProvider_CustomComponent_OptionsObject()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cut = Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
         var options = new MessageBarOptions
@@ -649,6 +705,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBarProvider_EmptyMessage_DoesNotRenderContent()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cut = Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
 
@@ -665,6 +723,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBarProvider_MultipleMessages_OrderedByIndex()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cut = Render(@<FluentMessageBarProvider Section="@TEST_SECTION" />);
 
@@ -686,6 +746,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentMessageBarProvider_TwoProviders_DifferentSections()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cutA = Render(@<FluentMessageBarProvider Section="A" />);
         var cutB = Render(@<FluentMessageBarProvider Section="B" />);

--- a/tests/Core/Components/Toast/FluentToastProviderTests.razor
+++ b/tests/Core/Components/Toast/FluentToastProviderTests.razor
@@ -56,6 +56,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentToastProvider_ShowInfo_RendersToast()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cut = Render(@<FluentToastProvider />);
 
@@ -75,6 +77,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentToastProvider_ShowToast_RendersTitle()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cut = Render(@<FluentToastProvider />);
 
@@ -108,6 +112,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentToastProvider_FooterContent_NotInverted_RendersLinkWithoutInvertedColor()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cut = Render(@<FluentToastProvider />);
 
@@ -130,6 +136,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentToastProvider_FooterContent_InvertedFromOptions_RendersLinkWithInvertedColor()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cut = Render(@<FluentToastProvider />);
 
@@ -153,6 +161,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentToastProvider_FooterContent_InvertedFromConfiguration_RendersLinkWithInvertedColor()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         Services.GetRequiredService<LibraryConfiguration>().Toast.Inverted = true;
         var cut = Render(@<FluentToastProvider />);
@@ -176,6 +186,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentToastProvider_FooterContent_PrimaryAndSecondaryActions_RendersBothLinks()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cut = Render(@<FluentToastProvider />);
 
@@ -200,6 +212,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentToastProvider_FooterContent_PrimaryActionOnly_RendersPrimaryLink()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cut = Render(@<FluentToastProvider />);
 
@@ -223,6 +237,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentToastProvider_FooterContent_SecondaryActionOnly_RendersSecondaryLink()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cut = Render(@<FluentToastProvider />);
 
@@ -246,6 +262,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentToastProvider_FooterContent_NoActions_RendersNoFooter()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var cut = Render(@<FluentToastProvider />);
 
@@ -267,6 +285,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentToastProvider_FooterContent_QuickActionClicked_InvokesOnClickAsync()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         var invoked = false;
         var cut = Render(@<FluentToastProvider />);
@@ -311,6 +331,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentToastProvider_SynchronizeToastQueue_PromotesQueuedToastsUpToMaxCount()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         Services.GetRequiredService<LibraryConfiguration>().Toast.MaxToastCount = 2;
         var cut = Render(@<FluentToastProvider />);
@@ -335,6 +357,8 @@
     [Fact(Timeout = TEST_TIMEOUT)]
     public async Task FluentToastProvider_SynchronizeToastQueue_PromotesAllQueuedToasts_WhenUnderMaxCount()
     {
+        Xunit.TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+
         // Arrange
         Services.GetRequiredService<LibraryConfiguration>().Toast.MaxToastCount = 5;
         var cut = Render(@<FluentToastProvider />);

--- a/tests/Core/Components/Toast/FluentToastProviderTests.razor
+++ b/tests/Core/Components/Toast/FluentToastProviderTests.razor
@@ -88,11 +88,11 @@
             Title = "Direct options",
             Intent = ToastIntent.Success,
         });
-        await Task.CompletedTask;
+        await Task.CompletedTask.WaitAsync(Xunit.TestContext.Current.CancellationToken);
 
         // Assert
         cut.WaitForAssertion(() => Assert.Contains("Direct options", cut.Markup));
-    }  
+    }
 
     [Fact]
     public void FluentToastProvider_Dispose_DoesNotThrow()


### PR DESCRIPTION
# [dev-v5] Remove suppression of the xUnit1069 warning 

Implement cancellation token support in Unit Tests. 
Remove suppression of the xUnit1069 warning to ensure proper cancellation token checks in tests. 

This change enhances test reliability and compliance with cancellation practices.

## Unit Tests

No changes