### PR TITLE
[dev-v5] Implement overflow functionality for FluentTabs component

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsOverflow.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsOverflow.razor
@@ -1,0 +1,28 @@
+<div style="background-color: var(--colorNeutralBackground4); border: 1px solid var(--colorNeutralStroke1); max-width: 100%; min-width: 240px; overflow: auto; padding: 8px; resize: horizontal; width: 520px;">
+    <FluentTabs Overflow="true">
+        <FluentTab Header="Overview">
+            Overview content
+        </FluentTab>
+        <FluentTab Header="Activity">
+            Activity content
+        </FluentTab>
+        <FluentTab Header="Messages">
+            Messages content
+        </FluentTab>
+        <FluentTab Header="Files">
+            Files content
+        </FluentTab>
+        <FluentTab Header="Shared links">
+            Shared links content
+        </FluentTab>
+        <FluentTab Header="Members">
+            Members content
+        </FluentTab>
+        <FluentTab Header="Permissions">
+            Permissions content
+        </FluentTab>
+        <FluentTab Header="Settings">
+            Settings content
+        </FluentTab>
+    </FluentTabs>
+</div>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsOverflow.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/Examples/TabsOverflow.razor
@@ -1,4 +1,4 @@
-<div style="background-color: var(--colorNeutralBackground4); border: 1px solid var(--colorNeutralStroke1); max-width: 100%; min-width: 240px; overflow: auto; padding: 8px; resize: horizontal; width: 520px;">
+<div style="@($"padding: 8px; overflow: auto; resize: horizontal; {CommonStyles.NeutralBorder1}")">
     <FluentTabs Overflow="true">
         <FluentTab Header="Overview">
             Overview content

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/FluentTabs.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Tabs/FluentTabs.md
@@ -14,9 +14,6 @@ and require less scrolling.
 For navigation beyond closely related categories, use a [FluentLink](/link) instead.
 To initiate an action, use a [FluentButton](/button) instead.
 
-> [!NOTE] For the moment, there are no 'scrolling' functions when the number of tabs is too large
-> in relation to the size of the container or screen.
-
 ## Default
 
 To know which tab is selected, you can bind the `ActiveTabId` or `ActiveTab` parameter to a variable.
@@ -51,6 +48,16 @@ In the following example, the `Deferred` parameter is set to `true` for Tab two.
 This tab will be loaded after 2 seconds of processing (to simulate a long running process).
 
 {{ TabsDeferred }}
+
+## Overflow
+
+Set the `Overflow` parameter to `true` to move tabs that do not fit in the available space into a menu.
+The active tab remains visible as the container is resized.
+Resize the container from its lower-right corner to see tabs move into and out of the overflow menu.
+
+A tab can be disabled by setting the `Disabled` parameter to `true`.
+
+{{ TabsOverflow }}
 
 ## Dynamic
 

--- a/src/Core.Scripts/src/Components/Overflow/AttachedOverflowController.ts
+++ b/src/Core.Scripts/src/Components/Overflow/AttachedOverflowController.ts
@@ -1,0 +1,412 @@
+/** Represents an item returned in an overflow state payload. */
+export interface OverflowItem {
+  Id: string;
+  Overflow: boolean;
+  Text: string;
+  Behavior?: string | null;
+  Index?: number;
+}
+
+/** Represents the current overflow state of an attached host. */
+export interface OverflowState {
+  overflowItems: OverflowItem[];
+  overflowCount: number;
+  firstOverflowIndex: number;
+  orderedItemIds: string[];
+}
+
+/** Extended overflow state with change detection and orientation metadata. */
+export interface RefreshResult extends OverflowState {
+  overflowChanged: boolean;
+  isHorizontal: boolean;
+  containerSize: number;
+}
+
+/** Extended HTMLElement interface to track cached overflow size measurements. */
+export interface OverflowElement extends HTMLElement {
+  overflowSize?: number | null;
+}
+
+/** Extended host interface for components that recalculate their managed children. */
+export interface OverflowHostElement extends HTMLElement {
+  tabsChanged?: () => void;
+}
+
+/** Calculates overflow state for an attached host. */
+export type RefreshContainer = (
+  container: HTMLElement,
+  isHorizontal: boolean,
+  querySelector: string | null,
+  threshold: number,
+  lastHandledState: boolean | null,
+  containerGap: number,
+  maxRenderedItems: number,
+  pinnedItemId?: string | null
+) => RefreshResult;
+
+/** Applies the overflow algorithm to an existing element without adding a wrapper. */
+export class AttachedOverflowController {
+  private resizeObserver?: ResizeObserver;
+  private mutationObserver?: MutationObserver;
+  private resizeTimeout?: number;
+  private mutationTimeout?: number;
+  private refreshAnimationFrame?: number;
+  private lastHandledState: boolean | null = null;
+  private lastContainerSize = 0;
+  private cachedContainerGap: number | null = null;
+  private state: OverflowState = emptyOverflowState();
+  private hiddenByController = new Set<OverflowElement>();
+  private expectedHiddenMutations = new WeakMap<OverflowElement, boolean>();
+
+  constructor(
+    private readonly refreshContainer: RefreshContainer,
+    private readonly host: OverflowHostElement,
+    private querySelector: string,
+    private threshold: number,
+    private maxRenderedItems: number,
+    private pinnedItemIdAttribute: string | null,
+    private synchronizeHidden: boolean,
+    private notifyHostItemsChanged: boolean
+  ) {
+  }
+
+  connect() {
+    this.setupObservers();
+    this.scheduleRefresh();
+  }
+
+  update(
+    querySelector: string,
+    threshold: number,
+    maxRenderedItems: number,
+    pinnedItemIdAttribute: string | null,
+    synchronizeHidden: boolean,
+    notifyHostItemsChanged: boolean
+  ) {
+    this.querySelector = querySelector;
+    this.threshold = threshold;
+    this.maxRenderedItems = maxRenderedItems;
+    this.pinnedItemIdAttribute = pinnedItemIdAttribute;
+    this.synchronizeHidden = synchronizeHidden;
+    this.notifyHostItemsChanged = notifyHostItemsChanged;
+    this.lastContainerSize = 0;
+    this.cachedContainerGap = null;
+    this.scheduleRefresh();
+  }
+
+  disconnect() {
+    this.cleanupObservers();
+
+    for (const item of this.hiddenByController) {
+      item.removeAttribute("overflow");
+      item.overflowSize = null;
+      item.hidden = false;
+    }
+
+    const managedItems = this.getManagedItems();
+    for (const item of managedItems) {
+      item.removeAttribute("overflow");
+      item.overflowSize = null;
+    }
+
+    this.hiddenByController.clear();
+    if (this.notifyHostItemsChanged) {
+      this.host.tabsChanged?.();
+    }
+  }
+
+  refresh() {
+    this.flushScheduledRefresh();
+  }
+
+  getOverflowState(): OverflowState {
+    if (this.refreshAnimationFrame !== undefined || this.resizeTimeout !== undefined || this.mutationTimeout !== undefined) {
+      this.flushScheduledRefresh();
+    }
+
+    return {
+      overflowItems: [...this.state.overflowItems],
+      overflowCount: this.state.overflowCount,
+      firstOverflowIndex: this.state.firstOverflowIndex,
+      orderedItemIds: [...this.state.orderedItemIds]
+    };
+  }
+
+  private scheduleRefresh() {
+    if (!this.host.isConnected || this.refreshAnimationFrame !== undefined) {
+      return;
+    }
+
+    this.refreshAnimationFrame = requestAnimationFrame(() => {
+      this.refreshAnimationFrame = undefined;
+      if (this.host.isConnected) {
+        this.refreshNow();
+      }
+    });
+  }
+
+  private flushScheduledRefresh() {
+    clearTimeout(this.resizeTimeout);
+    this.resizeTimeout = undefined;
+    clearTimeout(this.mutationTimeout);
+    this.mutationTimeout = undefined;
+
+    if (this.refreshAnimationFrame !== undefined) {
+      cancelAnimationFrame(this.refreshAnimationFrame);
+      this.refreshAnimationFrame = undefined;
+    }
+
+    if (this.host.isConnected) {
+      this.refreshNow();
+    }
+  }
+
+  private refreshNow() {
+    const isHorizontal = this.host.getAttribute("orientation") !== "vertical";
+    const result = this.refreshContainer(
+      this.host,
+      isHorizontal,
+      this.querySelector,
+      this.threshold,
+      this.lastHandledState,
+      this.getContainerGap(),
+      this.maxRenderedItems,
+      this.getPinnedItemId()
+    );
+    this.lastHandledState = result.isHorizontal;
+    this.lastContainerSize = result.containerSize;
+
+    const visibilityChanged = this.synchronizeManagedVisibility();
+    const payloadChanged = result.overflowChanged
+      || this.state.overflowCount !== result.overflowCount
+      || this.state.firstOverflowIndex !== result.firstOverflowIndex
+      || !areStringArraysEqual(this.state.orderedItemIds, result.orderedItemIds)
+      || !areOverflowItemsEqual(this.state.overflowItems, result.overflowItems);
+
+    this.state = result;
+
+    if (visibilityChanged && this.notifyHostItemsChanged) {
+      this.host.tabsChanged?.();
+    }
+
+    if (payloadChanged) {
+      const eventInit = {
+        detail: {
+          items: result.overflowItems,
+          overflowCount: result.overflowCount,
+          firstOverflowIndex: result.firstOverflowIndex,
+          orderedItemIds: result.orderedItemIds
+        },
+        bubbles: true,
+        composed: true
+      };
+
+      this.host.dispatchEvent(new CustomEvent("overflowchange", eventInit));
+      this.host.dispatchEvent(new CustomEvent("fluentoverflowchange", eventInit));
+    }
+  }
+
+  private setupObservers() {
+    if (typeof ResizeObserver !== "undefined") {
+      this.resizeObserver = new ResizeObserver(() => {
+        if (this.refreshAnimationFrame !== undefined) {
+          return;
+        }
+
+        clearTimeout(this.resizeTimeout);
+        this.resizeTimeout = window.setTimeout(() => {
+          this.resizeTimeout = undefined;
+          const isHorizontal = this.host.getAttribute("orientation") !== "vertical";
+          const currentSize = isHorizontal ? this.host.offsetWidth : this.host.offsetHeight;
+          this.cachedContainerGap = null;
+          if (currentSize === this.lastContainerSize) {
+            return;
+          }
+
+          this.lastContainerSize = currentSize;
+          this.scheduleRefresh();
+        }, 16);
+      });
+      this.resizeObserver.observe(this.host);
+    }
+
+    this.mutationObserver = new MutationObserver((mutations) => {
+      let shouldRefresh = false;
+
+      for (const mutation of mutations) {
+        if (mutation.type === "childList") {
+          if (mutation.target === this.host) {
+            this.lastContainerSize = 0;
+            shouldRefresh = true;
+          }
+          continue;
+        }
+
+        const target = mutation.target as OverflowElement;
+        if (target === this.host) {
+          if (mutation.attributeName === "orientation") {
+            this.lastContainerSize = 0;
+            this.cachedContainerGap = null;
+          }
+          shouldRefresh = true;
+          continue;
+        }
+
+        if (target.parentElement !== this.host) {
+          continue;
+        }
+
+        if (mutation.attributeName === "hidden") {
+          const expectedHidden = this.expectedHiddenMutations.get(target);
+          if (expectedHidden === target.hidden) {
+            this.expectedHiddenMutations.delete(target);
+            continue;
+          }
+        }
+
+        if (mutation.attributeName === "class"
+          || mutation.attributeName === "style"
+          || mutation.attributeName === "behavior"
+          || mutation.attributeName === "hidden") {
+          target.overflowSize = null;
+        }
+        shouldRefresh = true;
+      }
+
+      if (!shouldRefresh) {
+        return;
+      }
+
+      clearTimeout(this.mutationTimeout);
+      this.mutationTimeout = undefined;
+      if (this.refreshAnimationFrame !== undefined) {
+        return;
+      }
+
+      this.mutationTimeout = window.setTimeout(() => {
+        this.mutationTimeout = undefined;
+        this.scheduleRefresh();
+      }, 16);
+    });
+    this.mutationObserver.observe(this.host, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["id", "behavior", "class", "style", "hidden", "activeid", "orientation"]
+    });
+  }
+
+  private cleanupObservers() {
+    this.resizeObserver?.disconnect();
+    this.resizeObserver = undefined;
+    this.mutationObserver?.disconnect();
+    this.mutationObserver = undefined;
+    clearTimeout(this.resizeTimeout);
+    this.resizeTimeout = undefined;
+    clearTimeout(this.mutationTimeout);
+    this.mutationTimeout = undefined;
+    if (this.refreshAnimationFrame !== undefined) {
+      cancelAnimationFrame(this.refreshAnimationFrame);
+      this.refreshAnimationFrame = undefined;
+    }
+  }
+
+  private synchronizeManagedVisibility(): boolean {
+    if (!this.synchronizeHidden) {
+      return false;
+    }
+
+    let changed = false;
+    const managedItems = this.getManagedItems();
+    const managedItemSet = new Set(managedItems);
+
+    for (const item of managedItems) {
+      if (item.hasAttribute("overflow")) {
+        if (!item.hidden) {
+          this.expectedHiddenMutations.set(item, true);
+          item.hidden = true;
+          this.hiddenByController.add(item);
+          changed = true;
+        }
+      } else if (this.hiddenByController.delete(item)) {
+        this.expectedHiddenMutations.set(item, false);
+        item.hidden = false;
+        changed = true;
+      }
+    }
+
+    for (const item of this.hiddenByController) {
+      if (!managedItemSet.has(item)) {
+        this.hiddenByController.delete(item);
+      }
+    }
+
+    return changed;
+  }
+
+  private getManagedItems(): OverflowElement[] {
+    return Array.from(this.host.querySelectorAll<OverflowElement>(buildQuerySelector(this.querySelector)));
+  }
+
+  private getPinnedItemId(): string | null {
+    return this.pinnedItemIdAttribute
+      ? this.host.getAttribute(this.pinnedItemIdAttribute)
+      : null;
+  }
+
+  private getContainerGap(): number {
+    if (this.cachedContainerGap === null) {
+      const gap = Number.parseFloat(window.getComputedStyle(this.host).gap);
+      this.cachedContainerGap = Number.isFinite(gap) ? gap : 0;
+    }
+
+    return this.cachedContainerGap;
+  }
+}
+
+function emptyOverflowState(): OverflowState {
+  return {
+    overflowItems: [],
+    overflowCount: 0,
+    firstOverflowIndex: -1,
+    orderedItemIds: []
+  };
+}
+
+function areOverflowItemsEqual(left: OverflowItem[], right: OverflowItem[]): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  for (let index = 0; index < left.length; index++) {
+    const leftItem = left[index];
+    const rightItem = right[index];
+    if (leftItem.Id !== rightItem.Id || leftItem.Text !== rightItem.Text || leftItem.Index !== rightItem.Index) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function areStringArraysEqual(left: string[], right: string[]): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  for (let index = 0; index < left.length; index++) {
+    if (left[index] !== right[index]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function buildQuerySelector(querySelector: string | null): string {
+  if (!querySelector) {
+    return ":scope > :not(.fluent-overflow-more)";
+  }
+
+  return `:scope > ${querySelector}`;
+}

--- a/src/Core.Scripts/src/Components/Overflow/AttachedOverflowController.ts
+++ b/src/Core.Scripts/src/Components/Overflow/AttachedOverflowController.ts
@@ -58,6 +58,7 @@ export class AttachedOverflowController {
   private hiddenByController = new Set<OverflowElement>();
   private expectedHiddenMutations = new WeakMap<OverflowElement, boolean>();
 
+  /** Creates a controller that applies overflow behavior directly to an existing host. */
   constructor(
     private readonly refreshContainer: RefreshContainer,
     private readonly host: OverflowHostElement,
@@ -70,11 +71,13 @@ export class AttachedOverflowController {
   ) {
   }
 
+  /** Starts observing the host and schedules its initial overflow measurement. */
   connect() {
     this.setupObservers();
     this.scheduleRefresh();
   }
 
+  /** Updates runtime options and invalidates measurements affected by those options. */
   update(
     querySelector: string,
     threshold: number,
@@ -94,6 +97,7 @@ export class AttachedOverflowController {
     this.scheduleRefresh();
   }
 
+  /** Stops observation and restores items whose visibility was managed by this controller. */
   disconnect() {
     this.cleanupObservers();
 
@@ -115,11 +119,14 @@ export class AttachedOverflowController {
     }
   }
 
+  /** Immediately recalculates overflow after canceling any scheduled refresh work. */
   refresh() {
     this.flushScheduledRefresh();
   }
 
+  /** Returns a defensive snapshot of the latest overflow state. */
   getOverflowState(): OverflowState {
+    // Imperative reads must include any DOM changes already queued for measurement.
     if (this.refreshAnimationFrame !== undefined || this.resizeTimeout !== undefined || this.mutationTimeout !== undefined) {
       this.flushScheduledRefresh();
     }
@@ -132,7 +139,10 @@ export class AttachedOverflowController {
     };
   }
 
+  /** Coalesces automatic refresh requests into one measurement per animation frame. */
   private scheduleRefresh() {
+    // Observer callbacks often arrive in the same DOM update; one pending frame is enough
+    // to measure the final layout produced by the entire burst.
     if (!this.host.isConnected || this.refreshAnimationFrame !== undefined) {
       return;
     }
@@ -145,6 +155,7 @@ export class AttachedOverflowController {
     });
   }
 
+  /** Cancels deferred refresh paths and synchronously measures the connected host. */
   private flushScheduledRefresh() {
     clearTimeout(this.resizeTimeout);
     this.resizeTimeout = undefined;
@@ -161,6 +172,7 @@ export class AttachedOverflowController {
     }
   }
 
+  /** Measures overflow, synchronizes item visibility, and publishes meaningful changes. */
   private refreshNow() {
     const isHorizontal = this.host.getAttribute("orientation") !== "vertical";
     const result = this.refreshContainer(
@@ -174,6 +186,8 @@ export class AttachedOverflowController {
       this.getPinnedItemId()
     );
     this.lastHandledState = result.isHorizontal;
+    // Keep the size read performed by the algorithm so ResizeObserver's follow-up
+    // notification does not trigger an identical second measurement.
     this.lastContainerSize = result.containerSize;
 
     const visibilityChanged = this.synchronizeManagedVisibility();
@@ -201,14 +215,18 @@ export class AttachedOverflowController {
         composed: true
       };
 
+      // Keep the browser-facing event while providing a distinct name for Blazor's
+      // custom-event bridge, which cannot share a native event name in .NET 11.
       this.host.dispatchEvent(new CustomEvent("overflowchange", eventInit));
       this.host.dispatchEvent(new CustomEvent("fluentoverflowchange", eventInit));
     }
   }
 
+  /** Observes size and relevant DOM changes that can invalidate overflow calculations. */
   private setupObservers() {
     if (typeof ResizeObserver !== "undefined") {
       this.resizeObserver = new ResizeObserver(() => {
+        // A pending frame will consume the latest dimensions regardless of its trigger.
         if (this.refreshAnimationFrame !== undefined) {
           return;
         }
@@ -259,6 +277,7 @@ export class AttachedOverflowController {
         if (mutation.attributeName === "hidden") {
           const expectedHidden = this.expectedHiddenMutations.get(target);
           if (expectedHidden === target.hidden) {
+            // Ignore the observer echo produced by synchronizeManagedVisibility.
             this.expectedHiddenMutations.delete(target);
             continue;
           }
@@ -296,6 +315,7 @@ export class AttachedOverflowController {
     });
   }
 
+  /** Disconnects observers and cancels all pending refresh work. */
   private cleanupObservers() {
     this.resizeObserver?.disconnect();
     this.resizeObserver = undefined;
@@ -311,6 +331,7 @@ export class AttachedOverflowController {
     }
   }
 
+  /** Mirrors overflow attributes to hidden state and reports whether visibility changed. */
   private synchronizeManagedVisibility(): boolean {
     if (!this.synchronizeHidden) {
       return false;
@@ -335,6 +356,7 @@ export class AttachedOverflowController {
       }
     }
 
+    // Detached or no-longer-managed items must not remain owned by this controller.
     for (const item of this.hiddenByController) {
       if (!managedItemSet.has(item)) {
         this.hiddenByController.delete(item);
@@ -344,16 +366,19 @@ export class AttachedOverflowController {
     return changed;
   }
 
+  /** Finds direct children selected for overflow management. */
   private getManagedItems(): OverflowElement[] {
     return Array.from(this.host.querySelectorAll<OverflowElement>(buildQuerySelector(this.querySelector)));
   }
 
+  /** Resolves the pinned item identifier from the configured host attribute. */
   private getPinnedItemId(): string | null {
     return this.pinnedItemIdAttribute
       ? this.host.getAttribute(this.pinnedItemIdAttribute)
       : null;
   }
 
+  /** Reads and caches the host gap used by the overflow measurement algorithm. */
   private getContainerGap(): number {
     if (this.cachedContainerGap === null) {
       const gap = Number.parseFloat(window.getComputedStyle(this.host).gap);
@@ -364,6 +389,7 @@ export class AttachedOverflowController {
   }
 }
 
+/** Creates the initial state used before the first host measurement. */
 function emptyOverflowState(): OverflowState {
   return {
     overflowItems: [],
@@ -373,6 +399,7 @@ function emptyOverflowState(): OverflowState {
   };
 }
 
+/** Compares the item fields included in overflow change payloads. */
 function areOverflowItemsEqual(left: OverflowItem[], right: OverflowItem[]): boolean {
   if (left.length !== right.length) {
     return false;
@@ -389,6 +416,7 @@ function areOverflowItemsEqual(left: OverflowItem[], right: OverflowItem[]): boo
   return true;
 }
 
+/** Compares two ordered identifier collections without allocating intermediate arrays. */
 function areStringArraysEqual(left: string[], right: string[]): boolean {
   if (left.length !== right.length) {
     return false;
@@ -403,6 +431,7 @@ function areStringArraysEqual(left: string[], right: string[]): boolean {
   return true;
 }
 
+/** Restricts the configured selector to direct children of the attached host. */
 function buildQuerySelector(querySelector: string | null): string {
   if (!querySelector) {
     return ":scope > :not(.fluent-overflow-more)";

--- a/src/Core.Scripts/src/Components/Overflow/FluentOverflow.ts
+++ b/src/Core.Scripts/src/Components/Overflow/FluentOverflow.ts
@@ -1,4 +1,5 @@
 import { StartedMode } from "../../d-ts/StartedMode";
+import { AttachedOverflowController } from "./AttachedOverflowController";
 
 /**
  * Fluent Overflow Component Implementation
@@ -414,7 +415,8 @@ export namespace Microsoft.FluentUI.Blazor.Components.Overflow {
     threshold: number,
     lastHandledState: boolean | null,
     containerGap: number,
-    maxRenderedItems: number
+    maxRenderedItems: number,
+    pinnedItemId: string | null = null
   ): RefreshResult {
     const localQuerySelector = buildQuerySelector(querySelector);
     const allItems = Array.from(container.querySelectorAll<OverflowElement>(localQuerySelector));
@@ -438,7 +440,7 @@ export namespace Microsoft.FluentUI.Blazor.Components.Overflow {
         continue;
       }
 
-      if (fixedMode !== null) {
+      if (fixedMode !== null || element.id === pinnedItemId) {
         fixedItems.push(element);
         continue;
       }
@@ -520,6 +522,13 @@ export namespace Microsoft.FluentUI.Blazor.Components.Overflow {
 
     let overflowChanged = false;
 
+    for (const element of fixedItems) {
+      if (element.hasAttribute("overflow")) {
+        element.removeAttribute("overflow");
+        overflowChanged = true;
+      }
+    }
+
     for (const element of ellipsisItems) {
       if (element.style.flexShrink !== desiredFlexShrink) {
         element.style.flexShrink = desiredFlexShrink;
@@ -551,10 +560,15 @@ export namespace Microsoft.FluentUI.Blazor.Components.Overflow {
     };
   }
 
-  function getCurrentOverflowState(container: HTMLElement, querySelector: string | null, maxRenderedItems: number): OverflowState {
+  function getCurrentOverflowState(
+    container: HTMLElement,
+    querySelector: string | null,
+    maxRenderedItems: number,
+    pinnedItemId: string | null = null
+  ): OverflowState {
     const localQuerySelector = buildQuerySelector(querySelector);
     const managedItems = Array.from(container.querySelectorAll<OverflowElement>(localQuerySelector))
-      .filter(element => !element.hasAttribute("behavior"));
+      .filter(element => !element.hasAttribute("behavior") && element.id !== pinnedItemId);
 
     const overflowStates = managedItems.map(element => element.hasAttribute("overflow"));
     let overflowCount = 0;
@@ -670,6 +684,15 @@ export namespace Microsoft.FluentUI.Blazor.Components.Overflow {
     return height + margin;
   }
 
+  function emptyOverflowState(): OverflowState {
+    return {
+      overflowItems: [],
+      overflowCount: 0,
+      firstOverflowIndex: -1,
+      orderedItemIds: []
+    };
+  }
+
   /**
    * Registers the FluentOverflow custom element with the browser's custom elements registry.
    * Called during component initialization by the Blazor runtime.
@@ -683,6 +706,63 @@ export namespace Microsoft.FluentUI.Blazor.Components.Overflow {
     }
   };
 
+  interface AttachedOverflowRegistration {
+    element: HTMLElement;
+    controller: AttachedOverflowController;
+  }
+
+  const attachedControllers = new Map<string, AttachedOverflowRegistration>();
+
+  /** Attaches overflow behavior to an existing element. */
+  export function Initialize(
+    id: string,
+    querySelector: string,
+    threshold: number,
+    maxRenderedItems: number,
+    pinnedItemIdAttribute: string | null,
+    synchronizeHidden: boolean,
+    notifyHostItemsChanged: boolean
+  ): void {
+    const element = document.getElementById(id);
+    if (!element || element instanceof FluentOverflow) {
+      return;
+    }
+
+    const existingRegistration = attachedControllers.get(id);
+    if (existingRegistration?.element === element) {
+      existingRegistration.controller.update(
+        querySelector,
+        threshold,
+        maxRenderedItems,
+        pinnedItemIdAttribute,
+        synchronizeHidden,
+        notifyHostItemsChanged
+      );
+      return;
+    }
+
+    existingRegistration?.controller.disconnect();
+
+    const controller = new AttachedOverflowController(
+      refreshContainer,
+      element,
+      querySelector,
+      threshold,
+      maxRenderedItems,
+      pinnedItemIdAttribute,
+      synchronizeHidden,
+      notifyHostItemsChanged
+    );
+    attachedControllers.set(id, { element, controller });
+    controller.connect();
+  }
+
+  /** Removes overflow behavior attached with Initialize. */
+  export function Dispose(id: string): void {
+    attachedControllers.get(id)?.controller.disconnect();
+    attachedControllers.delete(id);
+  }
+
   /**
    * Triggers a refresh of the overflow state for the specified container element.
    * Used by Blazor to manually recalculate overflow when needed.
@@ -690,8 +770,13 @@ export namespace Microsoft.FluentUI.Blazor.Components.Overflow {
    * @param id - The HTML id of the FluentOverflow container
    */
   export function Refresh(id: string): void {
-    const element = document.getElementById(id) as FluentOverflow | null;
-    element?.refresh();
+    const element = document.getElementById(id);
+    if (element instanceof FluentOverflow) {
+      element.refresh();
+      return;
+    }
+
+    attachedControllers.get(id)?.controller.refresh();
   }
 
   /**
@@ -702,12 +787,11 @@ export namespace Microsoft.FluentUI.Blazor.Components.Overflow {
    * @returns The current OverflowState or default empty state if element not found
    */
   export function GetOverflowState(id: string): OverflowState {
-    const element = document.getElementById(id) as FluentOverflow | null;
-    return element?.getOverflowState() ?? {
-      overflowItems: [],
-      overflowCount: 0,
-      firstOverflowIndex: -1,
-      orderedItemIds: []
-    };
+    const element = document.getElementById(id);
+    if (element instanceof FluentOverflow) {
+      return element.getOverflowState();
+    }
+
+    return attachedControllers.get(id)?.controller.getOverflowState() ?? emptyOverflowState();
   }
 }

--- a/src/Core.Scripts/src/Components/Tabs/FluentTabs.ts
+++ b/src/Core.Scripts/src/Components/Tabs/FluentTabs.ts
@@ -1,4 +1,5 @@
 export namespace Microsoft.FluentUI.Blazor.Components.Tabs {
+  const observers = new Map<string, MutationObserver>();
 
   /**
    * Initiates the list of tabs when a tab is added or removed
@@ -11,6 +12,8 @@ export namespace Microsoft.FluentUI.Blazor.Components.Tabs {
     if (!tabsContainer || !tabsList) {
       return;
     }
+
+    Dispose(id);
 
     const observer = new MutationObserver((mutations) => {
       mutations.forEach((mutation) => {
@@ -31,5 +34,12 @@ export namespace Microsoft.FluentUI.Blazor.Components.Tabs {
     });
 
     observer.observe(tabsContainer, { childList: true });
+    observers.set(id, observer);
+  }
+
+  /** Stops observing tab-panel additions and removals for a FluentTabs instance. */
+  export function Dispose(id: string): void {
+    observers.get(id)?.disconnect();
+    observers.delete(id);
   }
 }

--- a/src/Core.Scripts/src/Components/Tabs/FluentTabs.ts
+++ b/src/Core.Scripts/src/Components/Tabs/FluentTabs.ts
@@ -1,5 +1,6 @@
 export namespace Microsoft.FluentUI.Blazor.Components.Tabs {
   const observers = new Map<string, MutationObserver>();
+  const keyboardControllers = new Map<string, AbortController>();
 
   /**
    * Initiates the list of tabs when a tab is added or removed
@@ -15,6 +16,14 @@ export namespace Microsoft.FluentUI.Blazor.Components.Tabs {
 
     Dispose(id);
 
+    // Listen for keydown events on the tabs container to handle overflow navigation
+    const keyboardController = new AbortController();
+    tabsContainer.addEventListener('keydown',
+      (event: KeyboardEvent) => handleOverflowKeyDown(event, id, tabsContainer, tabsList),
+      { capture: true, signal: keyboardController.signal });
+    keyboardControllers.set(id, keyboardController);
+
+    // Observe for childList mutations (tab-panel additions/removals) in the tabs container
     const observer = new MutationObserver((mutations) => {
       mutations.forEach((mutation) => {
         if (mutation.type === 'childList') {
@@ -41,5 +50,44 @@ export namespace Microsoft.FluentUI.Blazor.Components.Tabs {
   export function Dispose(id: string): void {
     observers.get(id)?.disconnect();
     observers.delete(id);
+    keyboardControllers.get(id)?.abort();
+    keyboardControllers.delete(id);
+  }
+
+  /** Handles keydown events for the overflow menu navigation. */
+  function handleOverflowKeyDown(
+    event: KeyboardEvent,
+    id: string,
+    tabsContainer: HTMLElement,
+    tabsList: HTMLElement
+  ): void {
+    if (event.defaultPrevented
+      || tabsList.getAttribute('orientation') === 'vertical'
+      || (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft')
+      || !tabsList.querySelector('fluent-tab[overflow]')) {
+      return;
+    }
+
+    const menuButton = document.getElementById(`${id}-more`) as HTMLElement | null;
+    if (!menuButton || !tabsContainer.contains(menuButton) || menuButton.hasAttribute('disabled')) {
+      return;
+    }
+
+    const visibleTabs = Array.from(
+      tabsList.querySelectorAll<HTMLElement>('fluent-tab:not([hidden]):not([disabled])')
+    );
+    const lastVisibleTab = visibleTabs.at(-1);
+    if (!lastVisibleTab) {
+      return;
+    }
+
+    const source = event.composedPath().find(node => node instanceof HTMLElement);
+    if (event.key === 'ArrowRight' && source === lastVisibleTab) {
+      event.preventDefault();
+      menuButton.focus();
+    } else if (event.key === 'ArrowLeft' && source === menuButton) {
+      event.preventDefault();
+      lastVisibleTab.focus();
+    }
   }
 }

--- a/src/Core.Scripts/src/ExportedMethods.ts
+++ b/src/Core.Scripts/src/ExportedMethods.ts
@@ -15,6 +15,7 @@ import { Microsoft as FluentSelectFile } from './Components/List/FluentSelect';
 import { Microsoft as FluentMenuFile } from './Components/Menu/FluentMenu';
 import { Microsoft as FluentColorPickerFile } from './Components/ColorPicker/FluentColorPicker';
 import { Microsoft as FluentKeyCodeFile } from './Components/KeyCode/FluentKeyCode';
+import { Microsoft as FluentOverflowFile } from './Components/Overflow/FluentOverflow';
 
 export namespace Microsoft.FluentUI.Blazor.ExportedMethods {
 
@@ -50,6 +51,7 @@ export namespace Microsoft.FluentUI.Blazor.ExportedMethods {
     (window as any).Microsoft.FluentUI.Blazor.Components.Menu = FluentMenuFile.FluentUI.Blazor.Components.Menu;
     (window as any).Microsoft.FluentUI.Blazor.Components.ColorPicker = FluentColorPickerFile.FluentUI.Blazor.Components.ColorPicker;
     (window as any).Microsoft.FluentUI.Blazor.Components.KeyCode = FluentKeyCodeFile.FluentUI.Blazor.Components.KeyCode;
+    (window as any).Microsoft.FluentUI.Blazor.Components.Overflow = FluentOverflowFile.FluentUI.Blazor.Components.Overflow;
 
     // [^^^ Add your other exported methods before this line ^^^]
   }

--- a/src/Core/Components/Tabs/FluentTab.razor.cs
+++ b/src/Core/Components/Tabs/FluentTab.razor.cs
@@ -117,6 +117,11 @@ public partial class FluentTab : FluentComponentBase, ITooltipComponent
     /// <summary />
     protected override async Task OnInitializedAsync()
     {
+        if (string.IsNullOrEmpty(Id))
+        {
+            throw new InvalidOperationException($"{nameof(Id)} must be set for {nameof(FluentTab)}.");
+        }
+
         await base.RenderTooltipAsync(Tooltip);
 
         if (Owner is not null)

--- a/src/Core/Components/Tabs/FluentTabs.razor
+++ b/src/Core/Components/Tabs/FluentTabs.razor
@@ -99,7 +99,7 @@
                                 disabled="@Disabled"
                                 size="@Size.ToAttributeValue(isNull: TabsSize.Medium, returnEmptyAsNull: true)"
                                 orientation="@Orientation.ToAttributeValue()"
-                                activeid="@(ActiveTabId ?? ActiveTab?.Id)"
+                                activeid="@ActiveTabIdAttribute"
                                 ontabchange="@TabChangeHandlerAsync"
                                 @onoverflowchange="@OverflowChangedHandler">
             @ChildContent

--- a/src/Core/Components/Tabs/FluentTabs.razor
+++ b/src/Core/Components/Tabs/FluentTabs.razor
@@ -6,15 +6,68 @@
     <div id="@Id" class="@ClassValue" style="@StyleValue" @attributes="@AdditionalAttributes">
 
         @* List of tab headers *@
-        <fluent-tablist id="@TabListId"
-                        appearance="@Appearance.ToAttributeValue(isNull: TabsAppearance.Transparent, returnEmptyAsNull: true)"
-                        disabled="@Disabled"
-                        size="@Size.ToAttributeValue(isNull: TabsSize.Medium, returnEmptyAsNull: true)"
-                        orientation="@Orientation.ToAttributeValue()"
-                        activeid="@(ActiveTabId ?? ActiveTab?.Id)"
-                        ontabchange="@TabChangeHandlerAsync">
-            @ChildContent
-        </fluent-tablist>
+        @if (Overflow)
+        {
+            <div class="fluent-tabs-overflow-header">
+                <fluent-tablist id="@TabListId"
+                                appearance="@Appearance.ToAttributeValue(isNull: TabsAppearance.Transparent, returnEmptyAsNull: true)"
+                                disabled="@Disabled"
+                                size="@Size.ToAttributeValue(isNull: TabsSize.Medium, returnEmptyAsNull: true)"
+                                orientation="@Orientation.ToAttributeValue()"
+                                activeid="@(ActiveTabId ?? ActiveTab?.Id)"
+                                ontabchange="@TabChangeHandlerAsync"
+                                @onoverflowchange="@OverflowChangedHandler">
+                    @ChildContent
+                </fluent-tablist>
+                <FluentButton Id="@IdMoreButton"
+                              Style="@MoreButtonStyleValue"
+                              Appearance="ButtonAppearance.Transparent"
+                              Disabled="@Disabled"
+                              IconOnly="@(MoreTemplate is null)"
+                              IconStart="@(MoreTemplate is null ? new CoreIcons.Regular.Size20.MoreHorizontal() : null)"
+                              Title="@MoreButtonLabel"
+                              aria-haspopup="menu"
+                              aria-controls="@OverflowMenuId">
+                    @if (MoreTemplate is not null)
+                    {
+                        @MoreTemplate(this)
+                    }
+                </FluentButton>
+            </div>
+
+            @if (OverflowTemplate is not null)
+            {
+                @OverflowTemplate(this)
+            }
+            else
+            {
+                <FluentMenu Id="@OverflowMenuId" Trigger="@IdMoreButton">
+                    <FluentMenuList>
+                        @foreach (var tab in OverflowTabs)
+                        {
+                            <FluentMenuItem Disabled="@(Disabled || tab.Disabled)"
+                                            IconStart="@tab.IconStart"
+                                            OnClick="@(_ => SelectTabAsync(tab.Id!))">
+                                @tab.Header
+                                @tab.HeaderTemplate
+                            </FluentMenuItem>
+                        }
+                    </FluentMenuList>
+                </FluentMenu>
+            }
+        }
+        else
+        {
+            <fluent-tablist id="@TabListId"
+                            appearance="@Appearance.ToAttributeValue(isNull: TabsAppearance.Transparent, returnEmptyAsNull: true)"
+                            disabled="@Disabled"
+                            size="@Size.ToAttributeValue(isNull: TabsSize.Medium, returnEmptyAsNull: true)"
+                            orientation="@Orientation.ToAttributeValue()"
+                            activeid="@(ActiveTabId ?? ActiveTab?.Id)"
+                            ontabchange="@TabChangeHandlerAsync">
+                @ChildContent
+            </fluent-tablist>
+        }
 
         @* List of tab contents (need to be added outside of the fluent-tablist *@
         @foreach (var tab in Tabs.OrderBy(i => i.Index))

--- a/src/Core/Components/Tabs/FluentTabs.razor
+++ b/src/Core/Components/Tabs/FluentTabs.razor
@@ -2,23 +2,20 @@
 @using Microsoft.FluentUI.AspNetCore.Components.Extensions
 @inherits FluentComponentBase
 
-<CascadingValue Value="this" IsFixed="true">
-    <div id="@Id" class="@ClassValue" style="@StyleValue" @attributes="@AdditionalAttributes">
+<CascadingValue Value="this"
+                IsFixed="true">
+    <div id="@Id"
+         class="@ClassValue"
+         style="@StyleValue"
+         @attributes="@AdditionalAttributes">
 
         @* List of tab headers *@
         @if (Overflow)
         {
-            <div class="fluent-tabs-overflow-header">
-                <fluent-tablist id="@TabListId"
-                                appearance="@Appearance.ToAttributeValue(isNull: TabsAppearance.Transparent, returnEmptyAsNull: true)"
-                                disabled="@Disabled"
-                                size="@Size.ToAttributeValue(isNull: TabsSize.Medium, returnEmptyAsNull: true)"
-                                orientation="@Orientation.ToAttributeValue()"
-                                activeid="@(ActiveTabId ?? ActiveTab?.Id)"
-                                ontabchange="@TabChangeHandlerAsync"
-                                @onoverflowchange="@OverflowChangedHandler">
-                    @ChildContent
-                </fluent-tablist>
+            <div slot="overflow-header">
+
+                @RenderFluentDatalist()
+
                 <FluentMenu Id="@OverflowMenuId">
                     <FluentMenuButton Id="@IdMoreButton"
                                       Style="@MoreButtonStyleValue"
@@ -28,6 +25,7 @@
                                       IconStart="@(MoreTemplate is null ? new CoreIcons.Regular.Size20.MoreHorizontal() : null)"
                                       Title="@MoreButtonLabel"
                                       aria-controls="@OverflowMenuId">
+                        <span slot="@FluentSlot.End" hidden></span>
                         @if (MoreTemplate is not null)
                         {
                             @MoreTemplate(this)
@@ -57,15 +55,7 @@
         }
         else
         {
-            <fluent-tablist id="@TabListId"
-                            appearance="@Appearance.ToAttributeValue(isNull: TabsAppearance.Transparent, returnEmptyAsNull: true)"
-                            disabled="@Disabled"
-                            size="@Size.ToAttributeValue(isNull: TabsSize.Medium, returnEmptyAsNull: true)"
-                            orientation="@Orientation.ToAttributeValue()"
-                            activeid="@(ActiveTabId ?? ActiveTab?.Id)"
-                            ontabchange="@TabChangeHandlerAsync">
-                @ChildContent
-            </fluent-tablist>
+            @RenderFluentDatalist()
         }
 
         @* List of tab contents (need to be added outside of the fluent-tablist *@
@@ -73,7 +63,12 @@
         {
             @if (tab.Visible)
             {
-                <div id="@tab.TabPanelId" index="@tab.Index" style="@tab.StyleValue" class="@tab.ClassValue" @attributes="@tab.AdditionalAttributes" role="tabpanel">
+                <div id="@tab.TabPanelId"
+                     index="@tab.Index"
+                     style="@tab.StyleValue"
+                     class="@tab.ClassValue"
+                     @attributes="@tab.AdditionalAttributes"
+                     role="tabpanel">
                     @if (tab.DeferredLoading && ActiveTabId != tab.Id)
                     {
                         if (tab.LoadingTemplate is null)
@@ -94,3 +89,20 @@
         }
     </div>
 </CascadingValue>
+
+@code
+{
+    private RenderFragment RenderFluentDatalist()
+    {
+        return @<fluent-tablist id="@TabListId"
+                                appearance="@Appearance.ToAttributeValue(isNull: TabsAppearance.Transparent, returnEmptyAsNull: true)"
+                                disabled="@Disabled"
+                                size="@Size.ToAttributeValue(isNull: TabsSize.Medium, returnEmptyAsNull: true)"
+                                orientation="@Orientation.ToAttributeValue()"
+                                activeid="@(ActiveTabId ?? ActiveTab?.Id)"
+                                ontabchange="@TabChangeHandlerAsync"
+                                @onoverflowchange="@OverflowChangedHandler">
+            @ChildContent
+        </fluent-tablist>;
+    }
+}

--- a/src/Core/Components/Tabs/FluentTabs.razor
+++ b/src/Core/Components/Tabs/FluentTabs.razor
@@ -19,41 +19,40 @@
                                 @onoverflowchange="@OverflowChangedHandler">
                     @ChildContent
                 </fluent-tablist>
-                <FluentButton Id="@IdMoreButton"
-                              Style="@MoreButtonStyleValue"
-                              Appearance="ButtonAppearance.Transparent"
-                              Disabled="@Disabled"
-                              IconOnly="@(MoreTemplate is null)"
-                              IconStart="@(MoreTemplate is null ? new CoreIcons.Regular.Size20.MoreHorizontal() : null)"
-                              Title="@MoreButtonLabel"
-                              aria-haspopup="menu"
-                              aria-controls="@OverflowMenuId">
-                    @if (MoreTemplate is not null)
+                <FluentMenu Id="@OverflowMenuId">
+                    <FluentMenuButton Id="@IdMoreButton"
+                                      Style="@MoreButtonStyleValue"
+                                      Appearance="ButtonAppearance.Transparent"
+                                      Disabled="@Disabled"
+                                      IconOnly="@(MoreTemplate is null)"
+                                      IconStart="@(MoreTemplate is null ? new CoreIcons.Regular.Size20.MoreHorizontal() : null)"
+                                      Title="@MoreButtonLabel"
+                                      aria-controls="@OverflowMenuId">
+                        @if (MoreTemplate is not null)
+                        {
+                            @MoreTemplate(this)
+                        }
+                    </FluentMenuButton>
+                    @if (OverflowTemplate is null)
                     {
-                        @MoreTemplate(this)
+                        <FluentMenuList>
+                            @foreach (var tab in OverflowTabs)
+                            {
+                                <FluentMenuItem Disabled="@(Disabled || tab.Disabled)"
+                                                IconStart="@tab.IconStart"
+                                                OnClick="@(_ => SelectTabAsync(tab.Id!))">
+                                    @tab.Header
+                                    @tab.HeaderTemplate
+                                </FluentMenuItem>
+                            }
+                        </FluentMenuList>
                     }
-                </FluentButton>
+                </FluentMenu>
             </div>
 
             @if (OverflowTemplate is not null)
             {
                 @OverflowTemplate(this)
-            }
-            else
-            {
-                <FluentMenu Id="@OverflowMenuId" Trigger="@IdMoreButton">
-                    <FluentMenuList>
-                        @foreach (var tab in OverflowTabs)
-                        {
-                            <FluentMenuItem Disabled="@(Disabled || tab.Disabled)"
-                                            IconStart="@tab.IconStart"
-                                            OnClick="@(_ => SelectTabAsync(tab.Id!))">
-                                @tab.Header
-                                @tab.HeaderTemplate
-                            </FluentMenuItem>
-                        }
-                    </FluentMenuList>
-                </FluentMenu>
             }
         }
         else

--- a/src/Core/Components/Tabs/FluentTabs.razor
+++ b/src/Core/Components/Tabs/FluentTabs.razor
@@ -16,23 +16,24 @@
 
                 @RenderFluentDatalist()
 
-                <FluentMenu Id="@OverflowMenuId">
-                    <FluentMenuButton Id="@IdMoreButton"
-                                      Style="@MoreButtonStyleValue"
-                                      Appearance="ButtonAppearance.Transparent"
-                                      Disabled="@Disabled"
-                                      IconOnly="@(MoreTemplate is null)"
-                                      IconStart="@(MoreTemplate is null ? new CoreIcons.Regular.Size20.MoreHorizontal() : null)"
-                                      Title="@MoreButtonLabel"
-                                      aria-controls="@OverflowMenuId">
-                        <span slot="@FluentSlot.End" hidden></span>
-                        @if (MoreTemplate is not null)
-                        {
-                            @MoreTemplate(this)
-                        }
-                    </FluentMenuButton>
-                    @if (OverflowTemplate is null)
-                    {
+                @if (OverflowTemplate is null)
+                {
+                    <FluentMenu Id="@OverflowMenuId">
+                        <FluentMenuButton Id="@IdMoreButton"
+                                          Style="@MoreButtonStyleValue"
+                                          Appearance="ButtonAppearance.Transparent"
+                                          Disabled="@Disabled"
+                                          IconOnly="@(MoreTemplate is null)"
+                                          IconStart="@(MoreTemplate is null ? new CoreIcons.Regular.Size20.MoreHorizontal() : null)"
+                                          Title="@MoreButtonLabel"
+                                          aria-controls="@OverflowMenuId">
+                            <span slot="@FluentSlot.End"
+                                  hidden></span>
+                            @if (MoreTemplate is not null)
+                            {
+                                @MoreTemplate(this)
+                            }
+                        </FluentMenuButton>
                         <FluentMenuList>
                             @foreach (var tab in OverflowTabs)
                             {
@@ -44,14 +45,13 @@
                                 </FluentMenuItem>
                             }
                         </FluentMenuList>
-                    }
-                </FluentMenu>
+                    </FluentMenu>
+                }
+                else
+                {
+                    @OverflowTemplate(this)
+                }
             </div>
-
-            @if (OverflowTemplate is not null)
-            {
-                @OverflowTemplate(this)
-            }
         }
         else
         {

--- a/src/Core/Components/Tabs/FluentTabs.razor.cs
+++ b/src/Core/Components/Tabs/FluentTabs.razor.cs
@@ -14,11 +14,19 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// </summary>
 public partial class FluentTabs : FluentComponentBase
 {
+    private bool _overflowInitialized;
+    private bool? _observedOverflow;
+    private IReadOnlyList<FluentTab> _overflowTabs = [];
+    private bool _refreshOverflowAfterRender;
+    private bool _tabsObserverInitialized;
+
     private List<FluentTab> Tabs { get; } = [];
 
     /// <summary />
     [DynamicDependency(nameof(TabChangeHandlerAsync))]
+    [DynamicDependency(nameof(OverflowChangedHandler))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(TabChangeEventArgs))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(OverflowChangedEventArgs))]
     public FluentTabs(LibraryConfiguration configuration) : base(configuration)
     {
         Id = Identifier.NewId();
@@ -34,6 +42,19 @@ public partial class FluentTabs : FluentComponentBase
         .AddStyle("width", Width, when: !string.IsNullOrEmpty(Width))
         .AddStyle("height", Height, when: !string.IsNullOrEmpty(Height))
         .Build();
+
+    /// <summary />
+    protected string? MoreButtonStyleValue => new StyleBuilder()
+        .AddStyle("flex", "0 0 auto")
+        .AddStyle("padding", "0")
+        .AddStyle("visibility", "hidden", when: OverflowCount == 0)
+        .Build();
+
+    /// <summary />
+    protected string MoreButtonLabel => Localizer[Localization.LanguageResource.Tabs_MoreItems, OverflowCount];
+
+    /// <summary />
+    protected string OverflowMenuId => $"{Id}-overflow-menu";
 
     /// <summary>
     /// Gets or sets the visual appearance applied to each contained tab (e.g., <c>Appearance="TabsAppearance.Subtle"</c>).
@@ -58,6 +79,12 @@ public partial class FluentTabs : FluentComponentBase
     /// </summary>
     [Parameter]
     public Orientation? Orientation { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether tabs that do not fit in the available space are displayed in an overflow menu.
+    /// </summary>
+    [Parameter]
+    public bool Overflow { get; set; }
 
     /// <summary>
     /// Gets or sets the height of the tabs.
@@ -103,13 +130,73 @@ public partial class FluentTabs : FluentComponentBase
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
 
+    /// <summary>
+    /// Gets or sets the content rendered inside the overflow menu trigger.
+    /// </summary>
+    [Parameter]
+    public RenderFragment<FluentTabs>? MoreTemplate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the content rendered in place of the default overflow menu.
+    /// </summary>
+    [Parameter]
+    public RenderFragment<FluentTabs>? OverflowTemplate { get; set; }
+
+    /// <summary>
+    /// Gets the tabs that are currently displayed in the overflow menu.
+    /// </summary>
+    public IReadOnlyList<FluentTab> OverflowTabs => _overflowTabs;
+
+    /// <summary>
+    /// Gets the number of tabs that are currently displayed in the overflow menu.
+    /// </summary>
+    public int OverflowCount { get; private set; }
+
+    /// <summary>
+    /// Gets the identifier of the overflow menu trigger.
+    /// </summary>
+    public string IdMoreButton => $"{Id}-more-button";
+
     /// <summary />
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (firstRender)
+        var overflowModeChanged = _observedOverflow != Overflow;
+
+        if (!Overflow && _overflowInitialized)
+        {
+            await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Components.Overflow.Dispose", TabListId);
+            _overflowInitialized = false;
+            _overflowTabs = [];
+            OverflowCount = 0;
+        }
+
+        if (firstRender || overflowModeChanged)
         {
             await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Components.Tabs.ObserveTabsChanged", Id);
+            _tabsObserverInitialized = true;
         }
+
+        if (Overflow && !_overflowInitialized)
+        {
+            await JSRuntime.InvokeVoidAsync(
+                "Microsoft.FluentUI.Blazor.Components.Overflow.Initialize",
+                TabListId,
+                "fluent-tab",
+                0,
+                0,
+                "activeid",
+                true,
+                true);
+            _overflowInitialized = true;
+        }
+
+        if (_overflowInitialized && _refreshOverflowAfterRender)
+        {
+            _refreshOverflowAfterRender = false;
+            await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Components.Overflow.Refresh", TabListId);
+        }
+
+        _observedOverflow = Overflow;
     }
 
     /// <summary />
@@ -196,23 +283,111 @@ public partial class FluentTabs : FluentComponentBase
 
         // Search for the tab
         var tab = Tabs.FirstOrDefault(t => string.Equals(t.Id, args.ActiveId, StringComparison.Ordinal));
-        if (tab is not null)
+        await SetActiveTabAsync(tab);
+    }
+
+    /// <summary>
+    /// Selects a tab by its identifier.
+    /// </summary>
+    /// <param name="tabId">The identifier of the tab to select.</param>
+    public async Task SelectTabAsync(string tabId)
+    {
+        var tab = Tabs.FirstOrDefault(t => t.Visible && !t.Disabled && string.Equals(t.Id, tabId, StringComparison.Ordinal));
+        if (await SetActiveTabAsync(tab))
         {
-            ActiveTabId = args.ActiveId;
-            ActiveTab = tab;
-
-            if (ActiveTabIdChanged.HasDelegate)
-            {
-                await ActiveTabIdChanged.InvokeAsync(ActiveTabId);
-            }
-
-            if (ActiveTabChanged.HasDelegate)
-            {
-                await ActiveTabChanged.InvokeAsync(ActiveTab);
-            }
+            await InvokeAsync(StateHasChanged);
         }
+    }
+
+    /// <summary>
+    /// Recalculates which tabs fit in the available space.
+    /// </summary>
+    public async Task RefreshOverflowAsync()
+    {
+        if (_overflowInitialized)
+        {
+            await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Components.Overflow.Refresh", TabListId);
+        }
+        else if (Overflow)
+        {
+            _refreshOverflowAfterRender = true;
+        }
+    }
+
+    /// <inheritdoc />
+    public override async ValueTask DisposeAsync()
+    {
+        if (_overflowInitialized)
+        {
+            await JSRuntime.InvokeFluentVoidAsync("Microsoft.FluentUI.Blazor.Components.Overflow.Dispose", TabListId);
+            _overflowInitialized = false;
+        }
+
+        if (_tabsObserverInitialized)
+        {
+            await JSRuntime.InvokeFluentVoidAsync("Microsoft.FluentUI.Blazor.Components.Tabs.Dispose", Id);
+            _tabsObserverInitialized = false;
+        }
+
+        await base.DisposeAsync();
     }
 
     /// <summary />
     internal string TabListId => $"{Id}-tablist";
+
+    private async Task<bool> SetActiveTabAsync(FluentTab? tab)
+    {
+        if (tab is null || Disabled || tab.Disabled || !tab.Visible)
+        {
+            return false;
+        }
+
+        var activeTabIdChanged = !string.Equals(ActiveTabId, tab.Id, StringComparison.Ordinal);
+        var activeTabChanged = !ReferenceEquals(ActiveTab, tab);
+        if (!activeTabIdChanged && !activeTabChanged)
+        {
+            return false;
+        }
+
+        ActiveTabId = tab.Id;
+        ActiveTab = tab;
+        _refreshOverflowAfterRender = Overflow;
+
+        if (activeTabIdChanged && ActiveTabIdChanged.HasDelegate)
+        {
+            await ActiveTabIdChanged.InvokeAsync(ActiveTabId);
+        }
+
+        if (activeTabChanged && ActiveTabChanged.HasDelegate)
+        {
+            await ActiveTabChanged.InvokeAsync(ActiveTab);
+        }
+
+        return true;
+    }
+
+    private void OverflowChangedHandler(OverflowChangedEventArgs args)
+    {
+        if (!string.Equals(args.Id, TabListId, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var overflowTabIds = args.Items?
+            .Where(item => item.Overflow && !string.IsNullOrEmpty(item.Id))
+            .Select(item => item.Id!)
+            .ToHashSet(StringComparer.Ordinal) ?? [];
+        var overflowTabs = Tabs
+            .OrderBy(tab => tab.Index)
+            .Where(tab => tab.Id is not null && overflowTabIds.Contains(tab.Id))
+            .ToArray();
+
+        if (OverflowCount == args.OverflowCount && _overflowTabs.SequenceEqual(overflowTabs))
+        {
+            return;
+        }
+
+        OverflowCount = args.OverflowCount;
+        _overflowTabs = overflowTabs;
+    }
 }

--- a/src/Core/Components/Tabs/FluentTabs.razor.cs
+++ b/src/Core/Components/Tabs/FluentTabs.razor.cs
@@ -45,8 +45,6 @@ public partial class FluentTabs : FluentComponentBase
 
     /// <summary />
     protected string? MoreButtonStyleValue => new StyleBuilder()
-        .AddStyle("flex", "0 0 auto")
-        .AddStyle("padding", "0")
         .AddStyle("visibility", "hidden", when: OverflowCount == 0)
         .Build();
 
@@ -368,6 +366,11 @@ public partial class FluentTabs : FluentComponentBase
 
     private void OverflowChangedHandler(OverflowChangedEventArgs args)
     {
+        if (Overflow is false)
+        {
+            return;
+        }
+
         if (!string.Equals(args.Id, TabListId, StringComparison.Ordinal))
         {
             return;

--- a/src/Core/Components/Tabs/FluentTabs.razor.cs
+++ b/src/Core/Components/Tabs/FluentTabs.razor.cs
@@ -16,7 +16,6 @@ public partial class FluentTabs : FluentComponentBase
 {
     private bool _overflowInitialized;
     private bool? _observedOverflow;
-    private IReadOnlyList<FluentTab> _overflowTabs = [];
     private bool _refreshOverflowAfterRender;
     private bool _tabsObserverInitialized;
 
@@ -31,6 +30,12 @@ public partial class FluentTabs : FluentComponentBase
     {
         Id = Identifier.NewId();
     }
+
+    /// <summary />
+    internal string TabListId => $"{Id}-tablist";
+
+    /// <summary />
+    internal string IdMoreButton => $"{Id}-more-button";
 
     /// <summary />
     protected string? ClassValue => DefaultClassBuilder
@@ -143,17 +148,12 @@ public partial class FluentTabs : FluentComponentBase
     /// <summary>
     /// Gets the tabs that are currently displayed in the overflow menu.
     /// </summary>
-    public IReadOnlyList<FluentTab> OverflowTabs => _overflowTabs;
+    public IReadOnlyList<FluentTab> OverflowTabs { get; private set; } = [];
 
     /// <summary>
     /// Gets the number of tabs that are currently displayed in the overflow menu.
     /// </summary>
     public int OverflowCount { get; private set; }
-
-    /// <summary>
-    /// Gets the identifier of the overflow menu trigger.
-    /// </summary>
-    public string IdMoreButton => $"{Id}-more-button";
 
     /// <summary />
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -164,7 +164,7 @@ public partial class FluentTabs : FluentComponentBase
         {
             await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Components.Overflow.Dispose", TabListId);
             _overflowInitialized = false;
-            _overflowTabs = [];
+            OverflowTabs = [];
             OverflowCount = 0;
         }
 
@@ -330,9 +330,6 @@ public partial class FluentTabs : FluentComponentBase
         await base.DisposeAsync();
     }
 
-    /// <summary />
-    internal string TabListId => $"{Id}-tablist";
-
     private async Task<bool> SetActiveTabAsync(FluentTab? tab)
     {
         if (tab is null || Disabled || tab.Disabled || !tab.Visible)
@@ -379,18 +376,19 @@ public partial class FluentTabs : FluentComponentBase
         var overflowTabIds = args.Items?
             .Where(item => item.Overflow && !string.IsNullOrEmpty(item.Id))
             .Select(item => item.Id!)
-            .ToHashSet(StringComparer.Ordinal) ?? [];
+            .ToHashSet(StringComparer.Ordinal) ?? new HashSet<string>(StringComparer.Ordinal);
+
         var overflowTabs = Tabs
             .OrderBy(tab => tab.Index)
             .Where(tab => tab.Id is not null && overflowTabIds.Contains(tab.Id))
             .ToArray();
 
-        if (OverflowCount == args.OverflowCount && _overflowTabs.SequenceEqual(overflowTabs))
+        if (OverflowCount == args.OverflowCount && OverflowTabs.SequenceEqual(overflowTabs))
         {
             return;
         }
 
         OverflowCount = args.OverflowCount;
-        _overflowTabs = overflowTabs;
+        OverflowTabs = overflowTabs;
     }
 }

--- a/src/Core/Components/Tabs/FluentTabs.razor.cs
+++ b/src/Core/Components/Tabs/FluentTabs.razor.cs
@@ -14,6 +14,7 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// </summary>
 public partial class FluentTabs : FluentComponentBase
 {
+    private string? _clientActiveTabId;
     private bool _overflowInitialized;
     private bool? _previousOverflowValue;
     private bool _refreshOverflowAfterRender;
@@ -36,6 +37,9 @@ public partial class FluentTabs : FluentComponentBase
 
     /// <summary />
     internal string IdMoreButton => $"{Id}-more";
+
+    /// <summary />
+    private string? ActiveTabIdAttribute { get; set; }
 
     /// <summary />
     protected string? ClassValue => DefaultClassBuilder
@@ -156,6 +160,19 @@ public partial class FluentTabs : FluentComponentBase
     public int OverflowCount => OverflowTabs.Count;
 
     /// <summary />
+    protected override void OnParametersSet()
+    {
+        var activeTabId = ActiveTabId ?? ActiveTab?.Id;
+        if (string.Equals(activeTabId, _clientActiveTabId, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        ActiveTabIdAttribute = activeTabId;
+        _clientActiveTabId = null;
+    }
+
+    /// <summary />
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         // Check if the overflow mode has changed since the last render
@@ -245,6 +262,8 @@ public partial class FluentTabs : FluentComponentBase
                 {
                     ActiveTab = firstTab;
                     ActiveTabId = firstTabId;
+                    ActiveTabIdAttribute = firstTabId;
+                    _clientActiveTabId = null;
 
                     if (ActiveTabChanged.HasDelegate)
                     {
@@ -277,7 +296,7 @@ public partial class FluentTabs : FluentComponentBase
 
         // Search for the tab
         var tab = Tabs.FirstOrDefault(t => string.Equals(t.Id, args.ActiveId, StringComparison.Ordinal));
-        await SetActiveTabAsync(tab);
+        await SetActiveTabAsync(tab, updateActiveIdAttribute: false);
     }
 
     /// <summary>
@@ -329,7 +348,7 @@ public partial class FluentTabs : FluentComponentBase
     /// <summary>
     /// Sets the specified tab as the active tab.
     /// </summary>
-    private async Task<bool> SetActiveTabAsync(FluentTab? tab)
+    private async Task<bool> SetActiveTabAsync(FluentTab? tab, bool updateActiveIdAttribute = true)
     {
         if (tab is null || Disabled || tab.Disabled || !tab.Visible)
         {
@@ -346,6 +365,16 @@ public partial class FluentTabs : FluentComponentBase
         ActiveTabId = tab.Id;
         ActiveTab = tab;
         _refreshOverflowAfterRender = Overflow;
+
+        if (updateActiveIdAttribute)
+        {
+            ActiveTabIdAttribute = tab.Id;
+            _clientActiveTabId = null;
+        }
+        else
+        {
+            _clientActiveTabId = tab.Id;
+        }
 
         if (activeTabIdChanged && ActiveTabIdChanged.HasDelegate)
         {

--- a/src/Core/Components/Tabs/FluentTabs.razor.cs
+++ b/src/Core/Components/Tabs/FluentTabs.razor.cs
@@ -153,7 +153,7 @@ public partial class FluentTabs : FluentComponentBase
     /// <summary>
     /// Gets the number of tabs that are currently displayed in the overflow menu.
     /// </summary>
-    public int OverflowCount { get; private set; }
+    public int OverflowCount => OverflowTabs.Count;
 
     /// <summary />
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -165,7 +165,6 @@ public partial class FluentTabs : FluentComponentBase
             await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Components.Overflow.Dispose", TabListId);
             _overflowInitialized = false;
             OverflowTabs = [];
-            OverflowCount = 0;
         }
 
         if (firstRender || overflowModeChanged)
@@ -383,12 +382,11 @@ public partial class FluentTabs : FluentComponentBase
             .Where(tab => tab.Id is not null && overflowTabIds.Contains(tab.Id))
             .ToArray();
 
-        if (OverflowCount == args.OverflowCount && OverflowTabs.SequenceEqual(overflowTabs))
+        if (OverflowTabs.SequenceEqual(overflowTabs))
         {
             return;
         }
 
-        OverflowCount = args.OverflowCount;
         OverflowTabs = overflowTabs;
     }
 }

--- a/src/Core/Components/Tabs/FluentTabs.razor.cs
+++ b/src/Core/Components/Tabs/FluentTabs.razor.cs
@@ -15,7 +15,7 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 public partial class FluentTabs : FluentComponentBase
 {
     private bool _overflowInitialized;
-    private bool? _observedOverflow;
+    private bool? _previousOverflowValue;
     private bool _refreshOverflowAfterRender;
     private bool _tabsObserverInitialized;
 
@@ -158,8 +158,10 @@ public partial class FluentTabs : FluentComponentBase
     /// <summary />
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        var overflowModeChanged = _observedOverflow != Overflow;
+        // Check if the overflow mode has changed since the last render
+        var overflowModeChanged = _previousOverflowValue != Overflow;
 
+        // Dispose the overflow observer if the Overflow property is false and it was previously initialized
         if (!Overflow && _overflowInitialized)
         {
             await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Components.Overflow.Dispose", TabListId);
@@ -167,33 +169,28 @@ public partial class FluentTabs : FluentComponentBase
             OverflowTabs = [];
         }
 
+        // Observe the tabs for changes
         if (firstRender || overflowModeChanged)
         {
             await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Components.Tabs.ObserveTabsChanged", Id);
             _tabsObserverInitialized = true;
         }
 
+        // Initialize the overflow observer
         if (Overflow && !_overflowInitialized)
         {
-            await JSRuntime.InvokeVoidAsync(
-                "Microsoft.FluentUI.Blazor.Components.Overflow.Initialize",
-                TabListId,
-                "fluent-tab",
-                0,
-                0,
-                "activeid",
-                true,
-                true);
+            await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Components.Overflow.Initialize", TabListId, "fluent-tab", 0, 0, "activeid", true, true);
             _overflowInitialized = true;
         }
 
+        // Refresh the overflow after render if needed
         if (_overflowInitialized && _refreshOverflowAfterRender)
         {
             _refreshOverflowAfterRender = false;
             await JSRuntime.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Components.Overflow.Refresh", TabListId);
         }
 
-        _observedOverflow = Overflow;
+        _previousOverflowValue = Overflow;
     }
 
     /// <summary />
@@ -329,6 +326,9 @@ public partial class FluentTabs : FluentComponentBase
         await base.DisposeAsync();
     }
 
+    /// <summary>
+    /// Sets the specified tab as the active tab.
+    /// </summary>
     private async Task<bool> SetActiveTabAsync(FluentTab? tab)
     {
         if (tab is null || Disabled || tab.Disabled || !tab.Visible)
@@ -360,6 +360,10 @@ public partial class FluentTabs : FluentComponentBase
         return true;
     }
 
+    /// <summary>
+    /// Handles the event when the overflow state of the tabs changes.
+    /// </summary>
+    /// <param name="args"></param>
     private void OverflowChangedHandler(OverflowChangedEventArgs args)
     {
         if (Overflow is false)

--- a/src/Core/Components/Tabs/FluentTabs.razor.cs
+++ b/src/Core/Components/Tabs/FluentTabs.razor.cs
@@ -35,7 +35,7 @@ public partial class FluentTabs : FluentComponentBase
     internal string TabListId => $"{Id}-tablist";
 
     /// <summary />
-    internal string IdMoreButton => $"{Id}-more-button";
+    internal string IdMoreButton => $"{Id}-more";
 
     /// <summary />
     protected string? ClassValue => DefaultClassBuilder

--- a/src/Core/Components/Tabs/FluentTabs.razor.css
+++ b/src/Core/Components/Tabs/FluentTabs.razor.css
@@ -17,7 +17,8 @@
 .fluent-tabs>div[slot="overflow-header"]>fluent-tablist {
   flex: 1 1 auto;
   min-width: 0;
-  overflow: hidden;
+  overflow: clip;
+  overflow-clip-margin: 3px;
 }
 
 .fluent-tabs>div[slot="overflow-header"]>fluent-menu>fluent-menu-button {

--- a/src/Core/Components/Tabs/FluentTabs.razor.css
+++ b/src/Core/Components/Tabs/FluentTabs.razor.css
@@ -20,6 +20,10 @@
     overflow: hidden;
   }
 
+  .fluent-tabs-overflow-header > fluent-menu {
+    flex: 0 0 auto;
+  }
+
   .fluent-tabs-overflow-header:has(> fluent-tablist[orientation="vertical"]) {
     flex: 0 1 auto;
     flex-direction: column;

--- a/src/Core/Components/Tabs/FluentTabs.razor.css
+++ b/src/Core/Components/Tabs/FluentTabs.razor.css
@@ -2,39 +2,45 @@
   width: 100%;
 }
 
-  .fluent-tabs:has(fluent-tablist[orientation="vertical"]) {
-    display: flex;
-    flex-direction: row;
-  }
+.fluent-tabs:has(fluent-tablist[orientation="vertical"]) {
+  display: flex;
+  flex-direction: row;
+}
 
-.fluent-tabs-overflow-header {
+.fluent-tabs>div[slot="overflow-header"] {
   align-items: stretch;
   display: flex;
   min-width: 0;
   width: 100%;
+  align-items: center;
 }
 
-  .fluent-tabs-overflow-header > fluent-tablist {
-    flex: 1 1 auto;
-    min-width: 0;
-    overflow: hidden;
-  }
+.fluent-tabs>div[slot="overflow-header"]>fluent-tablist {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+}
 
-  .fluent-tabs-overflow-header > fluent-menu {
-    flex: 0 0 auto;
-  }
+.fluent-tabs>div[slot="overflow-header"]>fluent-menu>fluent-menu-button {
+  min-width: 32px;
+  padding: 0;
+}
 
-  .fluent-tabs-overflow-header:has(> fluent-tablist[orientation="vertical"]) {
-    flex: 0 1 auto;
-    flex-direction: column;
-    height: 100%;
-    min-height: 0;
-    width: auto;
-  }
+.fluent-tabs>div[slot="overflow-header"]>fluent-menu {
+  flex: 0 0 auto;
+}
 
-    .fluent-tabs-overflow-header > fluent-tablist[orientation="vertical"] {
-      min-height: 0;
-    }
+.fluent-tabs>div[slot="overflow-header"]:has(> fluent-tablist[orientation="vertical"]) {
+  flex: 0 1 auto;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  width: auto;
+}
+
+.fluent-tabs>div[slot="overflow-header"]>fluent-tablist[orientation="vertical"] {
+  min-height: 0;
+}
 
 .fluent-tab-panel {
   padding: var(--spacingVerticalS) var(--spacingHorizontalS);

--- a/src/Core/Components/Tabs/FluentTabs.razor.css
+++ b/src/Core/Components/Tabs/FluentTabs.razor.css
@@ -8,7 +8,6 @@
 }
 
 .fluent-tabs>div[slot="overflow-header"] {
-  align-items: stretch;
   display: flex;
   min-width: 0;
   width: 100%;

--- a/src/Core/Components/Tabs/FluentTabs.razor.css
+++ b/src/Core/Components/Tabs/FluentTabs.razor.css
@@ -7,6 +7,31 @@
     flex-direction: row;
   }
 
+.fluent-tabs-overflow-header {
+  align-items: stretch;
+  display: flex;
+  min-width: 0;
+  width: 100%;
+}
+
+  .fluent-tabs-overflow-header > fluent-tablist {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+  }
+
+  .fluent-tabs-overflow-header:has(> fluent-tablist[orientation="vertical"]) {
+    flex: 0 1 auto;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+    width: auto;
+  }
+
+    .fluent-tabs-overflow-header > fluent-tablist[orientation="vertical"] {
+      min-height: 0;
+    }
+
 .fluent-tab-panel {
   padding: var(--spacingVerticalS) var(--spacingHorizontalS);
   width: 100%;

--- a/src/Core/Localization/LanguageResource.resx
+++ b/src/Core/Localization/LanguageResource.resx
@@ -396,4 +396,7 @@
   <data name="DataGrid_LoadingContent" xml:space="preserve">
     <value>Loading...</value>
   </data>
+  <data name="Tabs_MoreItems" xml:space="preserve">
+    <value>View {0} more tabs</value>
+  </data>
 </root>

--- a/tests/Core/Components/Tabs/FluentTabsTests.razor
+++ b/tests/Core/Components/Tabs/FluentTabsTests.razor
@@ -75,6 +75,56 @@
         Assert.Equal(expectedActiveId, activeTabId);
     }
 
+    [Fact]
+    public async Task FluentTabs_UserSelection_DoesNotRewriteActiveId()
+    {
+        string? activeTabId = "tab1";
+
+        // Arrange
+        var cut = Render(@<FluentTabs Id="MyTabsId" @bind-ActiveTabId="@activeTabId">
+            <FluentTab Id="tab1" Header="Chat" />
+            <FluentTab Id="tab2" Header="Files" />
+        </FluentTabs>);
+        var tabList = cut.Find("fluent-tablist");
+
+        // Act
+        await tabList.TriggerEventAsync("ontabchange", new TabChangeEventArgs
+        {
+            Id = "MyTabsId-tablist",
+            ActiveId = "tab2",
+        });
+
+        // Assert
+        Assert.Equal("tab2", activeTabId);
+        Assert.Equal("tab1", tabList.GetAttribute("activeid"));
+    }
+
+    [Fact]
+    public async Task FluentTabs_ParameterSelection_RewritesActiveIdAfterUserSelection()
+    {
+        string? activeTabId = "tab1";
+
+        // Arrange
+        var cut = Render(@<FluentTabs Id="MyTabsId" @bind-ActiveTabId="@activeTabId">
+            <FluentTab Id="tab1" Header="Chat" />
+            <FluentTab Id="tab2" Header="Files" />
+            <FluentTab Id="tab3" Header="Settings" />
+        </FluentTabs>);
+        var tabs = cut.FindComponent<FluentTabs>();
+        var tabList = cut.Find("fluent-tablist");
+        await tabList.TriggerEventAsync("ontabchange", new TabChangeEventArgs
+        {
+            Id = "MyTabsId-tablist",
+            ActiveId = "tab2",
+        });
+
+        // Act
+        tabs.Render(parameters => parameters.Add(component => component.ActiveTabId, "tab3"));
+
+        // Assert
+        Assert.Equal("tab3", tabList.GetAttribute("activeid"));
+    }
+
     [Theory]
     [InlineData("MyTabsId", "tab2", "tab2")]          // Normal case
     [InlineData("INVALID_TABS_ID", "tab2", null)]     // Main TabsID is unknown => no change (stay on tab1)

--- a/tests/Core/Components/Tabs/FluentTabsTests.razor
+++ b/tests/Core/Components/Tabs/FluentTabsTests.razor
@@ -126,6 +126,145 @@
     }
 
     [Theory]
+    [InlineData(true, false, true)]
+    [InlineData(false, true, true)]
+    [InlineData(false, false, false)]
+    public async Task FluentTabs_TabChange_InvalidTarget_DoesNotChangeSelection(
+        bool tabsDisabled,
+        bool tabDisabled,
+        bool tabVisible)
+    {
+        // Arrange
+        var cut = Render(@<FluentTabs Id="MyTabs" ActiveTabId="tab1" Disabled="@tabsDisabled">
+            <FluentTab Id="tab1" Header="Chat" />
+            <FluentTab Id="tab2" Header="Files" Disabled="@tabDisabled" Visible="@tabVisible" />
+        </FluentTabs>);
+        var tabs = cut.FindComponent<FluentTabs>().Instance;
+
+        // Act
+        await tabs.TabChangeHandlerAsync(new()
+        {
+            Id = "MyTabs-tablist",
+            ActiveId = "tab2",
+        });
+
+        // Assert
+        Assert.Equal("tab1", tabs.ActiveTabId);
+    }
+
+    [Fact]
+    public async Task FluentTabs_SelectActiveTab_DoesNotRefreshOverflow()
+    {
+        // Arrange
+        var cut = Render(@<FluentTabs Id="MyTabs" ActiveTabId="tab1" Overflow="true">
+            <FluentTab Id="tab1" Header="Chat" />
+        </FluentTabs>);
+        var tabs = cut.FindComponent<FluentTabs>().Instance;
+        var refreshCount = JSInterop.Invocations.Count(invocation =>
+            invocation.Identifier == "Microsoft.FluentUI.Blazor.Components.Overflow.Refresh");
+
+        // Act
+        await tabs.SelectTabAsync("tab1");
+
+        // Assert
+        Assert.Equal(refreshCount, JSInterop.Invocations.Count(invocation =>
+            invocation.Identifier == "Microsoft.FluentUI.Blazor.Components.Overflow.Refresh"));
+    }
+
+    [Theory]
+    [InlineData("unknown", false, true)]
+    [InlineData("tab2", true, true)]
+    [InlineData("tab2", false, false)]
+    public async Task FluentTabs_SelectTabAsync_InvalidTarget_DoesNotChangeSelection(
+        string tabId,
+        bool tabDisabled,
+        bool tabVisible)
+    {
+        // Arrange
+        var cut = Render(@<FluentTabs ActiveTabId="tab1">
+            <FluentTab Id="tab1" Header="Chat" />
+            <FluentTab Id="tab2" Header="Files" Disabled="@tabDisabled" Visible="@tabVisible" />
+        </FluentTabs>);
+        var tabs = cut.FindComponent<FluentTabs>().Instance;
+
+        // Act
+        await tabs.SelectTabAsync(tabId);
+
+        // Assert
+        Assert.Equal("tab1", tabs.ActiveTabId);
+    }
+
+    [Fact]
+    public async Task FluentTabs_SelectTabAsync_WithoutCallbacks_UpdatesSelection()
+    {
+        // Arrange
+        var cut = Render(@<FluentTabs ActiveTabId="tab1">
+            <FluentTab Id="tab1" Header="Chat" />
+            <FluentTab Id="tab2" Header="Files" />
+        </FluentTabs>);
+        var tabs = cut.FindComponent<FluentTabs>().Instance;
+
+        // Act
+        await tabs.SelectTabAsync("tab2");
+
+        // Assert
+        Assert.Equal("tab2", tabs.ActiveTabId);
+        Assert.Equal("tab2", tabs.ActiveTab?.Id);
+    }
+
+    [Fact]
+    public async Task FluentTabs_SelectTabAsync_SameIdDifferentTab_OnlyRaisesActiveTabChanged()
+    {
+        string? changedId = null;
+        FluentTab? changedTab = null;
+
+        // Arrange
+        var cut = Render(@<FluentTabs ActiveTabIdChanged="@(id => changedId = id)"
+                                      ActiveTabChanged="@(tab => changedTab = tab)">
+            <FluentTab Id="tab1" Header="Chat" />
+            <FluentTab Id="tab2" Header="Files" />
+        </FluentTabs>);
+        var tabs = cut.FindComponent<FluentTabs>();
+        var tab1 = cut.FindComponents<FluentTab>()[0].Instance;
+        tabs.Render(parameters => parameters
+            .Add(component => component.ActiveTabId, "tab2")
+            .Add(component => component.ActiveTab, tab1));
+
+        // Act
+        await tabs.Instance.SelectTabAsync("tab2");
+
+        // Assert
+        Assert.Null(changedId);
+        Assert.Equal("tab2", changedTab?.Id);
+    }
+
+    [Fact]
+    public async Task FluentTabs_SelectTabAsync_DifferentIdSameTab_OnlyRaisesActiveTabIdChanged()
+    {
+        string? changedId = null;
+        FluentTab? changedTab = null;
+
+        // Arrange
+        var cut = Render(@<FluentTabs ActiveTabIdChanged="@(id => changedId = id)"
+                                      ActiveTabChanged="@(tab => changedTab = tab)">
+            <FluentTab Id="tab1" Header="Chat" />
+            <FluentTab Id="tab2" Header="Files" />
+        </FluentTabs>);
+        var tabs = cut.FindComponent<FluentTabs>();
+        var tab2 = cut.FindComponents<FluentTab>()[1].Instance;
+        tabs.Render(parameters => parameters
+            .Add(component => component.ActiveTabId, "tab1")
+            .Add(component => component.ActiveTab, tab2));
+
+        // Act
+        await tabs.Instance.SelectTabAsync("tab2");
+
+        // Assert
+        Assert.Equal("tab2", changedId);
+        Assert.Null(changedTab);
+    }
+
+    [Theory]
     [InlineData("MyTabsId", "tab2", "tab2")]          // Normal case
     [InlineData("INVALID_TABS_ID", "tab2", null)]     // Main TabsID is unknown => no change (stay on tab1)
     [InlineData("MyTabsId", "INVALID_TAB", null)]     // Try to go to an unknow Tab => no change (stay on tab1)
@@ -258,6 +397,314 @@
 
         // Assert
         cut.Verify();
+    }
+
+    [Fact]
+    public void FluentTabs_Overflow_RendersDefaultMenu()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentTabs Id="MyTabs" Overflow="true">
+            <FluentTab Id="tab1" Header="Chat" />
+        </FluentTabs>);
+
+        // Assert
+        Assert.NotNull(cut.Find("[slot='overflow-header']"));
+        Assert.NotNull(cut.Find("#MyTabs-overflow-menu"));
+        Assert.NotNull(cut.Find("#MyTabs-more"));
+    }
+
+    [Fact]
+    public void FluentTabs_MoreTemplate_RendersCustomTriggerContent()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentTabs Id="MyTabs" Overflow="true">
+            <MoreTemplate Context="tabs">
+                <span class="custom-more">@tabs.OverflowCount more</span>
+            </MoreTemplate>
+            <ChildContent>
+                <FluentTab Id="tab1" Header="Chat" />
+            </ChildContent>
+        </FluentTabs>);
+
+        // Assert
+        Assert.Equal("0 more", cut.Find(".custom-more").TextContent);
+        Assert.NotNull(cut.Find("#MyTabs-overflow-menu"));
+    }
+
+    [Fact]
+    public void FluentTabs_OverflowTemplate_ReplacesDefaultMenu()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentTabs Id="MyTabs" Overflow="true">
+            <OverflowTemplate Context="tabs">
+                <span class="custom-overflow">@tabs.OverflowCount overflowed</span>
+            </OverflowTemplate>
+            <ChildContent>
+                <FluentTab Id="tab1" Header="Chat" />
+            </ChildContent>
+        </FluentTabs>);
+
+        // Assert
+        Assert.Equal("0 overflowed", cut.Find(".custom-overflow").TextContent);
+        Assert.Empty(cut.FindAll("#MyTabs-overflow-menu"));
+    }
+
+    [Theory]
+    [InlineData(false, "MyTabs-tablist")]
+    [InlineData(true, "OtherTabs-tablist")]
+    public async Task FluentTabs_OverflowChange_InvalidSource_IsIgnored(bool overflow, string eventId)
+    {
+        // Arrange
+        var cut = Render(@<FluentTabs Id="MyTabs" Overflow="@overflow">
+            <FluentTab Id="tab1" Header="Chat" />
+        </FluentTabs>);
+        var tabs = cut.FindComponent<FluentTabs>().Instance;
+
+        // Act
+        await cut.Find("fluent-tablist").TriggerEventAsync("onoverflowchange", new OverflowChangedEventArgs
+        {
+            Id = eventId,
+            Items = [new OverflowChangedItem { Id = "tab1", Overflow = true }],
+        });
+
+        // Assert
+        Assert.Empty(tabs.OverflowTabs);
+    }
+
+    [Fact]
+    public async Task FluentTabs_OverflowChange_UpdatesOrderedOverflowTabs()
+    {
+        // Arrange
+        var cut = Render(@<FluentTabs Id="MyTabs" Overflow="true">
+            <FluentTab Id="tab1" Header="Chat" />
+            <FluentTab Id="tab2" Header="Files" />
+        </FluentTabs>);
+        var tabs = cut.FindComponent<FluentTabs>().Instance;
+
+        // Act
+        await cut.Find("fluent-tablist").TriggerEventAsync("onoverflowchange", new OverflowChangedEventArgs
+        {
+            Id = "MyTabs-tablist",
+            Items =
+            [
+                new OverflowChangedItem { Id = "tab2", Overflow = true },
+                new OverflowChangedItem { Id = "tab1", Overflow = true },
+                new OverflowChangedItem { Id = "unknown", Overflow = true },
+                new OverflowChangedItem { Id = "", Overflow = true },
+                new OverflowChangedItem { Id = "tab1", Overflow = false },
+            ],
+        });
+
+        // Assert
+        Assert.Equal(["tab1", "tab2"], tabs.OverflowTabs.Select(tab => tab.Id));
+        Assert.Equal(2, tabs.OverflowCount);
+        Assert.Equal(2, cut.FindAll("fluent-menu-item").Count);
+    }
+
+    [Fact]
+    public async Task FluentTabs_OverflowChange_UnchangedItems_PreservesCollection()
+    {
+        // Arrange
+        var cut = Render(@<FluentTabs Id="MyTabs" Overflow="true">
+            <FluentTab Id="tab1" Header="Chat" />
+        </FluentTabs>);
+        var tabList = cut.Find("fluent-tablist");
+        var args = new OverflowChangedEventArgs
+        {
+            Id = "MyTabs-tablist",
+            Items = [new OverflowChangedItem { Id = "tab1", Overflow = true }],
+        };
+        await tabList.TriggerEventAsync("onoverflowchange", args);
+        var overflowTabs = cut.FindComponent<FluentTabs>().Instance.OverflowTabs;
+
+        // Act
+        await tabList.TriggerEventAsync("onoverflowchange", args);
+
+        // Assert
+        Assert.Same(overflowTabs, cut.FindComponent<FluentTabs>().Instance.OverflowTabs);
+    }
+
+    [Fact]
+    public async Task FluentTabs_OverflowChange_NullItems_ClearsOverflowTabs()
+    {
+        // Arrange
+        var cut = Render(@<FluentTabs Id="MyTabs" Overflow="true">
+            <FluentTab Id="tab1" Header="Chat" />
+        </FluentTabs>);
+        var tabList = cut.Find("fluent-tablist");
+        await tabList.TriggerEventAsync("onoverflowchange", new OverflowChangedEventArgs
+        {
+            Id = "MyTabs-tablist",
+            Items = [new OverflowChangedItem { Id = "tab1", Overflow = true }],
+        });
+
+        // Act
+        await tabList.TriggerEventAsync("onoverflowchange", new OverflowChangedEventArgs
+        {
+            Id = "MyTabs-tablist",
+            Items = null,
+        });
+
+        // Assert
+        Assert.Empty(cut.FindComponent<FluentTabs>().Instance.OverflowTabs);
+    }
+
+    [Fact]
+    public async Task FluentTabs_OverflowChange_TabWithNullId_IsIgnored()
+    {
+        // Arrange
+        var cut = Render(@<FluentTabs Id="MyTabs" Overflow="true">
+            <FluentTab Id="tab1" Header="Chat" />
+        </FluentTabs>);
+        var tab = cut.FindComponent<FluentTab>().Instance;
+        typeof(FluentComponentBase).GetProperty(nameof(FluentComponentBase.Id))!.SetValue(tab, null);
+
+        // Act
+        await cut.Find("fluent-tablist").TriggerEventAsync("onoverflowchange", new OverflowChangedEventArgs
+        {
+            Id = "MyTabs-tablist",
+            Items = [new OverflowChangedItem { Id = "tab1", Overflow = true }],
+        });
+
+        // Assert
+        Assert.Empty(cut.FindComponent<FluentTabs>().Instance.OverflowTabs);
+    }
+
+    [Fact]
+    public async Task FluentTabs_OverflowMenuItemClick_SelectsTabAndRefreshesOverflow()
+    {
+        string? activeTabId = "tab1";
+        FluentTab? activeTab = null;
+
+        // Arrange
+        var cut = Render(@<FluentTabs Id="MyTabs"
+                                      Overflow="true"
+                                      @bind-ActiveTabId="@activeTabId"
+                                      @bind-ActiveTab="@activeTab">
+            <FluentTab Id="tab1" Header="Chat" />
+            <FluentTab Id="tab2" Header="Files" />
+        </FluentTabs>);
+        await cut.Find("fluent-tablist").TriggerEventAsync("onoverflowchange", new OverflowChangedEventArgs
+        {
+            Id = "MyTabs-tablist",
+            Items = [new OverflowChangedItem { Id = "tab2", Overflow = true }],
+        });
+        var refreshCount = JSInterop.Invocations.Count(invocation =>
+            invocation.Identifier == "Microsoft.FluentUI.Blazor.Components.Overflow.Refresh");
+        var menuItem = cut.Find("fluent-menu-item");
+
+        // Act
+        menuItem.TriggerEvent("onmenuitemchange", new MenuItemEventArgs { Id = menuItem.Id });
+
+        // Assert
+        Assert.Equal("tab2", activeTabId);
+        Assert.Equal("tab2", activeTab?.Id);
+        Assert.Equal(refreshCount + 1, JSInterop.Invocations.Count(invocation =>
+            invocation.Identifier == "Microsoft.FluentUI.Blazor.Components.Overflow.Refresh"));
+    }
+
+    [Fact]
+    public async Task FluentTabs_RefreshOverflowAsync_InitializedObserver_InvokesRefresh()
+    {
+        // Arrange
+        var cut = Render(@<FluentTabs Id="MyTabs" Overflow="true">
+            <FluentTab Id="tab1" Header="Chat" />
+        </FluentTabs>);
+        var refreshCount = JSInterop.Invocations.Count(invocation =>
+            invocation.Identifier == "Microsoft.FluentUI.Blazor.Components.Overflow.Refresh");
+
+        // Act
+        await cut.FindComponent<FluentTabs>().Instance.RefreshOverflowAsync();
+
+        // Assert
+        Assert.Equal(refreshCount + 1, JSInterop.Invocations.Count(invocation =>
+            invocation.Identifier == "Microsoft.FluentUI.Blazor.Components.Overflow.Refresh"));
+    }
+
+    [Fact]
+    public async Task FluentTabs_RefreshOverflowAsync_BeforeInitialization_RefreshesAfterRender()
+    {
+        // Arrange
+        var cut = Render(@<FluentTabs Id="MyTabs">
+            <FluentTab Id="tab1" Header="Chat" />
+        </FluentTabs>);
+        var tabs = cut.FindComponent<FluentTabs>();
+        typeof(FluentTabs).GetProperty(nameof(FluentTabs.Overflow))!.SetValue(tabs.Instance, true);
+
+        // Act
+        await tabs.Instance.RefreshOverflowAsync();
+        tabs.Render(parameters => parameters.Add(component => component.Overflow, true));
+
+        // Assert
+        JSInterop.VerifyInvoke("Microsoft.FluentUI.Blazor.Components.Overflow.Refresh");
+    }
+
+    [Fact]
+    public async Task FluentTabs_RefreshOverflowAsync_OverflowDisabled_DoesNotRefresh()
+    {
+        // Arrange
+        var cut = Render(@<FluentTabs Id="MyTabs">
+            <FluentTab Id="tab1" Header="Chat" />
+        </FluentTabs>);
+        var refreshCount = JSInterop.Invocations.Count(invocation =>
+            invocation.Identifier == "Microsoft.FluentUI.Blazor.Components.Overflow.Refresh");
+
+        // Act
+        await cut.FindComponent<FluentTabs>().Instance.RefreshOverflowAsync();
+
+        // Assert
+        Assert.Equal(refreshCount, JSInterop.Invocations.Count(invocation =>
+            invocation.Identifier == "Microsoft.FluentUI.Blazor.Components.Overflow.Refresh"));
+    }
+
+    [Fact]
+    public async Task FluentTabs_DisableOverflow_DisposesObserverAndClearsItems()
+    {
+        // Arrange
+        var cut = Render(@<FluentTabs Id="MyTabs" Overflow="true">
+            <FluentTab Id="tab1" Header="Chat" />
+        </FluentTabs>);
+        await cut.Find("fluent-tablist").TriggerEventAsync("onoverflowchange", new OverflowChangedEventArgs
+        {
+            Id = "MyTabs-tablist",
+            Items = [new OverflowChangedItem { Id = "tab1", Overflow = true }],
+        });
+        var tabs = cut.FindComponent<FluentTabs>();
+
+        // Act
+        tabs.Render(parameters => parameters.Add(component => component.Overflow, false));
+
+        // Assert
+        Assert.Empty(tabs.Instance.OverflowTabs);
+        JSInterop.VerifyInvoke("Microsoft.FluentUI.Blazor.Components.Overflow.Dispose");
+        JSInterop.VerifyInvoke("Microsoft.FluentUI.Blazor.Components.Tabs.ObserveTabsChanged", 2);
+    }
+
+    [Fact]
+    public async Task FluentTabs_DisposeAsync_InitializedObservers_DisposesObservers()
+    {
+        // Arrange
+        var cut = Render(@<FluentTabs Id="MyTabs" Overflow="true">
+            <FluentTab Id="tab1" Header="Chat" />
+        </FluentTabs>);
+        var tabs = cut.FindComponent<FluentTabs>().Instance;
+
+        // Act
+        await tabs.DisposeAsync();
+
+        // Assert
+        JSInterop.VerifyInvoke("Microsoft.FluentUI.Blazor.Components.Overflow.Dispose");
+        JSInterop.VerifyInvoke("Microsoft.FluentUI.Blazor.Components.Tabs.Dispose");
+    }
+
+    [Fact]
+    public void FluentTab_EmptyId_ThrowsInvalidOperationException()
+    {
+        // Arrange && Act
+        var exception = Assert.Throws<InvalidOperationException>(() => Render(@<FluentTab Id="" />));
+
+        // Assert
+        Assert.Equal("Id must be set for FluentTab.", exception.Message);
     }
 
     [Fact]


### PR DESCRIPTION
# [dev-v5] Implement overflow functionality for FluentTabs component

Enhance the **FluentTabs** component to support overflow functionality, improving accessibility and structure by utilizing **FluentMenu**. This change allows tabs that exceed the available space to be moved into a menu, ensuring a better user experience.

## Add the Overflow parameter

```razor
<FluentTabs Overflow="true">
    <FluentTab Header="Overview">Overview content</FluentTab>
    <FluentTab Header="Activity">Activity content</FluentTab>
    <FluentTab Header="Messages">Messages content</FluentTab>
    <FluentTab Header="Files">Files content</FluentTab>
    <FluentTab Header="Shared links">Shared links content</FluentTab>
    <FluentTab Header="Members">Members content</FluentTab>
    <FluentTab Header="Permissions">Permissions content</FluentTab>
    <FluentTab Header="Settings">Settings content</FluentTab>
</FluentTabs>
```

https://github.com/user-attachments/assets/bc47a390-86f5-4154-9684-00d9783b4e1e

## Fix the "switching infinitely"


https://github.com/user-attachments/assets/c8f002f0-c638-417b-bca8-a64859c4bcb9



## Unit Tests

Added.

<img width="1248" height="85" alt="image" src="https://github.com/user-attachments/assets/72d5ce16-8263-4931-a21f-7356567a786e" />
