### PR TITLE
[dev-v5] Enhance FluentSelect for multiple selections

### DIFF
--- a/src/Core/Components/List/FluentListBase.razor.cs
+++ b/src/Core/Components/List/FluentListBase.razor.cs
@@ -376,7 +376,7 @@ public abstract partial class FluentListBase<TOption, TValue> : FluentInputBase<
 
             if (IsOptionTypeCompatibleWithValue())
             {
-                SelectedItems = selectedValues.Select(value => (TOption)(object)value!).ToList();
+                SelectedItems = selectedValues.Cast<TOption>().ToList();
 
                 if (SelectedItemsChanged.HasDelegate)
                 {

--- a/src/Core/Components/List/FluentListBase.razor.cs
+++ b/src/Core/Components/List/FluentListBase.razor.cs
@@ -370,13 +370,23 @@ public abstract partial class FluentListBase<TOption, TValue> : FluentInputBase<
         // Manual FluentOptions
         if (InternalValues.Count > 0)
         {
-            var SelectedValue = selectedIds.Length > 0
-                              ? InternalValues.Where(kvp => selectedIds.Contains(kvp.Key, StringComparer.Ordinal)).Select(kvp => kvp.Value).FirstOrDefault()
-                              : default;
+            var selectedValues = selectedIds.Length > 0
+                               ? InternalValues.Where(kvp => selectedIds.Contains(kvp.Key, StringComparer.Ordinal)).Select(kvp => kvp.Value).ToList()
+                               : [];
+
+            if (IsOptionTypeCompatibleWithValue())
+            {
+                SelectedItems = selectedValues.Select(value => (TOption)(object)value!).ToList();
+
+                if (SelectedItemsChanged.HasDelegate)
+                {
+                    await SelectedItemsChanged.InvokeAsync(SelectedItems);
+                }
+            }
 
             if (ValueChanged.HasDelegate)
             {
-                await ValueChanged.InvokeAsync(SelectedValue);
+                await ValueChanged.InvokeAsync(selectedValues.FirstOrDefault());
             }
 
             NotifyValidationFieldChanged();

--- a/tests/Core/Components/List/FluentSelectTests.razor
+++ b/tests/Core/Components/List/FluentSelectTests.razor
@@ -438,6 +438,28 @@
     }
 
     [Fact]
+    public async Task FluentSelect_Manual_Multiple_OnDropdownChange()
+    {
+        IEnumerable<string> selectedItems = [];
+
+        var cut = Render(@<FluentSelect TOption="string" TValue="string" Multiple="true" @bind-SelectedItems="@selectedItems">
+            <FluentOptionString Value="One">One</FluentOptionString>
+            <FluentOptionString Value="Two">Two</FluentOptionString>
+            <FluentOptionString Value="Three">Three</FluentOptionString>
+        </FluentSelect>);
+        var selectedIds = cut.FindAll("fluent-option")
+                             .Where(option => option.GetAttribute("value") is "One" or "Two")
+                             .Select(option => option.GetAttribute("id"));
+
+        await cut.FindComponent<FluentSelect<string, string>>().Instance.OnDropdownChangeHandlerAsync(new DropdownEventArgs
+        {
+            SelectedOptions = string.Join(';', selectedIds),
+        });
+
+        Assert.Equal(new[] { "One", "Two" }, selectedItems);
+    }
+
+    [Fact]
     public async Task FluentSelect_Manual_OnDropdownChange_EmptySelection()
     {
         string? selectedValue = "One";


### PR DESCRIPTION
# [dev-v5] Enhance FluentSelect for multiple selections

Support multiple selections in **FluentSelect** to handle selected items appropriately. 
This change improves the component's functionality and usability.

## example

```razor
<FluentSelect TOption="string"
              TValue="string"
              @bind-Value="@Value">
    <FluentOptionString Value="ff0000">Red</FluentOptionString>
    <FluentOptionString Value="00ff00">Green</FluentOptionString>
    <FluentOptionString Value="0000ff">Blue</FluentOptionString>
</FluentSelect>

<FluentSelect TOption="string"
              TValue="string"
              Multiple="true"
              @bind-SelectedItems="@SelectedItems">
    <FluentOptionString Value="ff0000">Red</FluentOptionString>
    <FluentOptionString Value="00ff00">Green</FluentOptionString>
    <FluentOptionString Value="0000ff">Blue</FluentOptionString>
</FluentSelect>

@code {
    string? Value;
    IEnumerable<string> SelectedItems = new List<string>();
}
```

https://github.com/user-attachments/assets/6b150720-dacb-4847-9e52-a8e60b8411c9

## Unit Tests

Added


