### PR TITLE
[Autocomplete] Add Size parameter

### DIFF
--- a/src/Core/Components/List/FluentAutocomplete.razor
+++ b/src/Core/Components/List/FluentAutocomplete.razor
@@ -37,6 +37,7 @@
                          MessageIcon="@MessageIcon"
                          MessageState="@MessageState"
                          Placeholder="@(_internalSelectedItems.Any() ? null : Placeholder)"
+                         Size="Size"
                          Style="@StyleValue"
                          Name="@Name"
                          auto-complete="true"

--- a/src/Core/Components/List/FluentAutocomplete.razor
+++ b/src/Core/Components/List/FluentAutocomplete.razor
@@ -37,7 +37,7 @@
                          MessageIcon="@MessageIcon"
                          MessageState="@MessageState"
                          Placeholder="@(_internalSelectedItems.Any() ? null : Placeholder)"
-                         Size="Size"
+                         Size="@Size"
                          Style="@StyleValue"
                          Name="@Name"
                          auto-complete="true"

--- a/src/Core/Components/List/FluentAutocomplete.razor.cs
+++ b/src/Core/Components/List/FluentAutocomplete.razor.cs
@@ -83,6 +83,12 @@ public partial class FluentAutocomplete<TOption, TValue> : FluentListBase<TOptio
     public int ImmediateDelay { get; set; } = 400;
 
     /// <summary>
+    /// Gets or sets the size of the input. See <see cref="Components.TextInputSize"/>
+    /// </summary>
+    [Parameter]
+    public TextInputSize? Size { get; set; }
+
+    /// <summary>
     /// Filter the list of options (items) using the text written by the user.
     /// </summary>
     [Parameter]

--- a/tests/Core/Components/List/FluentAutocompleteTests.razor
+++ b/tests/Core/Components/List/FluentAutocompleteTests.razor
@@ -1,4 +1,5 @@
 ﻿@using System.ComponentModel.DataAnnotations
+@using Microsoft.FluentUI.AspNetCore.Components.Extensions
 @using Xunit;
 @inherits FluentUITestContext
 @code
@@ -1376,6 +1377,22 @@
 
         // Assert that the component updates the value to null
         Assert.Null(selectedId);
+    }
+
+    [Theory]
+    [InlineData(TextInputSize.Small)]
+    [InlineData(TextInputSize.Medium)]
+    [InlineData(TextInputSize.Large)]
+    [InlineData((TextInputSize)999)]
+    [InlineData(null)]
+    public void FluentAutocomplete_Size(TextInputSize? size)
+    {
+        // Arrange & Act
+        var cut = Render(@<FluentAutocomplete Id="my-list" TOption="string" TValue="string" Size="@size" Items="@Digits" />);
+
+        // Assert - the underlying fluent-text-input control-size attribute should match the enum attribute value
+        var input = cut.Find("fluent-text-input");
+        Assert.Equal(size.ToAttributeValue(), input.GetAttribute("control-size"));
     }
 
     public class Person : IEqualityComparer<Person>


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

This PR adds the missing `Size` parameter to the `FluentAutocomplete` component as well as an additional unit test for the parameter.

<img width="707" height="317" alt="grafik" src="https://github.com/user-attachments/assets/3a7b2408-b519-49c9-8632-bcc77432d468" />


### 🎫 Issues

Fix #5226 

## 👩‍💻 Reviewer Notes



## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
