### PR TITLE
[dev-v5] Add FieldStartTemplate and FieldEndTemplate to FluentField 

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Field/DebugPages/FieldStartTemplate.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Field/DebugPages/FieldStartTemplate.razor
@@ -1,0 +1,140 @@
+@page "/Field/Debug/StartTemplate"
+
+<FluentSelect Label="Width"
+			  Items="@WidthOptions"
+			  Width="200px"
+			  @bind-Value="@_width" />
+
+<FluentDivider Margin="@Margin.Vertical4" />
+
+<FluentStack Orientation="Orientation.Vertical" VerticalGap="24px">
+	<FluentAutocomplete TOption="string"
+						TValue="string"
+						Label="FluentAutocomplete"
+						Items="@Options"
+						Width="@_width"
+						FieldStartTemplate="@StartTemplate"
+						FieldEndTemplate="@EndTemplate"
+						@bind-Value="@_selectedOption" />
+
+	<FluentCalendar TValue="DateTime?"
+					Label="FluentCalendar"
+					Style="@($"width: {_width};")"
+					FieldStartTemplate="@StartTemplate"
+					FieldEndTemplate="@EndTemplate"
+					@bind-Value="@_date" />
+
+	<FluentCheckbox Label="FluentCheckbox"
+					Width="@_width"
+					FieldStartTemplate="@StartTemplate"
+					FieldEndTemplate="@EndTemplate"
+					@bind-Value="@_isChecked" />
+
+	<FluentColorPickerInput Label="FluentColorPickerInput"
+							Width="@_width"
+							FieldStartTemplate="@StartTemplate"
+							FieldEndTemplate="@EndTemplate"
+							@bind-Value="@_color" />
+
+	<FluentCombobox TOption="string"
+					TValue="string"
+					Label="FluentCombobox"
+					Items="@Options"
+					Width="@_width"
+					FieldStartTemplate="@StartTemplate"
+					FieldEndTemplate="@EndTemplate"
+					@bind-Value="@_selectedOption" />
+
+	<FluentDatePicker TValue="DateTime?"
+					  Label="FluentDatePicker"
+					  Width="@_width"
+					  FieldStartTemplate="@StartTemplate"
+					  FieldEndTemplate="@EndTemplate"
+					  @bind-Value="@_date" />
+
+	<FluentListbox TOption="string"
+				   TValue="string"
+				   Label="FluentListbox"
+				   Items="@Options"
+				   Width="@_width"
+				   FieldStartTemplate="@StartTemplate"
+				   FieldEndTemplate="@EndTemplate"
+				   @bind-Value="@_selectedOption" />
+
+	<FluentNumberInput TValue="int"
+					   Label="FluentNumberInput"
+					   Width="@_width"
+					   FieldStartTemplate="@StartTemplate"
+					   FieldEndTemplate="@EndTemplate"
+					   @bind-Value="@_number" />
+
+	<FluentRadioGroup TValue="string"
+					  Label="FluentRadioGroup"
+					  Items="@Options"
+					  Width="@_width"
+					  FieldStartTemplate="@StartTemplate"
+					  FieldEndTemplate="@EndTemplate"
+					  @bind-Value="@_selectedOption" />
+
+	<FluentSelect TOption="string"
+				  TValue="string"
+				  Label="FluentSelect"
+				  Items="@Options"
+				  Width="@_width"
+				  FieldStartTemplate="@StartTemplate"
+				  FieldEndTemplate="@EndTemplate"
+				  @bind-Value="@_selectedOption" />
+
+	<FluentSlider TValue="int"
+				  Label="FluentSlider"
+				  Width="@_width"
+				  FieldStartTemplate="@StartTemplate"
+				  FieldEndTemplate="@EndTemplate"
+				  @bind-Value="@_number" />
+
+	<FluentSwitch Label="FluentSwitch"
+				  Width="@_width"
+				  FieldStartTemplate="@StartTemplate"
+				  FieldEndTemplate="@EndTemplate"
+				  @bind-Value="@_isChecked" />
+
+	<FluentTextArea Label="FluentTextArea"
+					Width="@_width"
+					FieldStartTemplate="@StartTemplate"
+					FieldEndTemplate="@EndTemplate"
+					@bind-Value="@_text" />
+
+	<FluentTextInput Label="FluentTextInput"
+					 Width="@_width"
+					 FieldStartTemplate="@StartTemplate"
+					 FieldEndTemplate="@EndTemplate"
+					 @bind-Value="@_text" />
+
+	<FluentTimePicker TValue="DateTime?"
+					  Label="FluentTimePicker"
+					  Width="@_width"
+					  FieldStartTemplate="@StartTemplate"
+					  FieldEndTemplate="@EndTemplate"
+					  @bind-Value="@_date" />
+</FluentStack>
+
+@code
+{
+	private static readonly string[] Options = ["One", "Two", "Three"];
+	private static readonly string[] WidthOptions = ["200px", "320px", "100%"];
+
+	private bool _isChecked;
+	private DateTime? _date = DateTime.Today;
+	private int _number = 25;
+	private string? _color = "#0078D4";
+	private string? _selectedOption = Options[0];
+	private string? _text;
+	private string? _width = WidthOptions[1];
+
+	private RenderFragment StartTemplate =>
+		@<FluentButton IconStart="@(new Icons.Regular.Size20.ChevronLeft())" IconOnly="true" />;
+
+	private RenderFragment EndTemplate =>
+		@<FluentButton IconStart="@(new Icons.Regular.Size20.ChevronRight())" IconOnly="true" />;
+}
+

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextInput/Examples/TextInputFieldTemplate.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextInput/Examples/TextInputFieldTemplate.razor
@@ -29,3 +29,20 @@
     </FluentTextInput>
 
 </FluentStack>
+
+<hr />
+
+<!-- Width: 1000px -->
+<FluentTextInput Label="First name"
+                 Width="1000px"
+                 Style="border: 1px solid red;"
+                 Placeholder="First name">
+    <FieldStartTemplate>
+        <FluentButton Margin="@Margin.Right2">Default</FluentButton>
+    </FieldStartTemplate>
+    <FieldEndTemplate>
+        <FluentButton Appearance="ButtonAppearance.Primary"
+                      Margin="@Margin.Left2"
+                      Label="Search" />
+    </FieldEndTemplate>
+</FluentTextInput>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextInput/Examples/TextInputFieldTemplate.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextInput/Examples/TextInputFieldTemplate.razor
@@ -1,5 +1,6 @@
 ﻿<FluentStack HorizontalGap="20px">
 
+    <!-- FieldStartTemplate and FieldEndTemplate -->
     <FluentTextInput Label="First name"
                      Placeholder="First name">
         <FieldStartTemplate>
@@ -7,10 +8,12 @@
         </FieldStartTemplate>
         <FieldEndTemplate>
             <FluentButton Appearance="ButtonAppearance.Primary"
+                          Margin="@Margin.Left2"
                           Label="Search" />
         </FieldEndTemplate>
     </FluentTextInput>
 
+    <!-- Size=Large -->
     <FluentTextInput Label="Last name"
                      Size="@TextInputSize.Large"
                      Placeholder="Last name">
@@ -19,6 +22,7 @@
         </FieldStartTemplate>
         <FieldEndTemplate>
             <FluentButton Appearance="ButtonAppearance.Primary"
+                          Margin="@Margin.Left2"
                           Label="Search"
                           Size="@ButtonSize.Large" />
         </FieldEndTemplate>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextInput/Examples/TextInputFieldTemplate.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextInput/Examples/TextInputFieldTemplate.razor
@@ -1,0 +1,27 @@
+﻿<FluentStack HorizontalGap="20px">
+
+    <FluentTextInput Label="First name"
+                     Placeholder="First name">
+        <FieldStartTemplate>
+            <FluentIcon Value="@(new Icons.Regular.Size24.Accessibility())" />
+        </FieldStartTemplate>
+        <FieldEndTemplate>
+            <FluentButton Appearance="ButtonAppearance.Primary"
+                          Label="Search" />
+        </FieldEndTemplate>
+    </FluentTextInput>
+
+    <FluentTextInput Label="Last name"
+                     Size="@TextInputSize.Large"
+                     Placeholder="Last name">
+        <FieldStartTemplate>
+            <FluentIcon Value="@(new Icons.Regular.Size24.Accessibility())" />
+        </FieldStartTemplate>
+        <FieldEndTemplate>
+            <FluentButton Appearance="ButtonAppearance.Primary"
+                          Label="Search"
+                          Size="@ButtonSize.Large" />
+        </FieldEndTemplate>
+    </FluentTextInput>
+
+</FluentStack>

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextInput/Examples/TextInputFieldTemplate.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextInput/Examples/TextInputFieldTemplate.razor
@@ -1,10 +1,11 @@
-﻿<FluentStack HorizontalGap="20px">
+<FluentStack HorizontalGap="20px">
 
     <!-- FieldStartTemplate and FieldEndTemplate -->
     <FluentTextInput Label="First name"
                      Placeholder="First name">
         <FieldStartTemplate>
-            <FluentIcon Value="@(new Icons.Regular.Size24.Accessibility())" />
+            <FluentIcon Margin="@Margin.Right1"
+                        Value="@(new Icons.Regular.Size24.Accessibility())" />
         </FieldStartTemplate>
         <FieldEndTemplate>
             <FluentButton Appearance="ButtonAppearance.Primary"
@@ -18,7 +19,8 @@
                      Size="@TextInputSize.Large"
                      Placeholder="Last name">
         <FieldStartTemplate>
-            <FluentIcon Value="@(new Icons.Regular.Size24.Accessibility())" />
+            <FluentIcon Margin="@Margin.Right1"
+                        Value="@(new Icons.Regular.Size24.Accessibility())" />
         </FieldStartTemplate>
         <FieldEndTemplate>
             <FluentButton Appearance="ButtonAppearance.Primary"

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextInput/FluentTextInput.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextInput/FluentTextInput.md
@@ -165,6 +165,12 @@ There are certain placeholder values which you should avoid to prevent the brows
 
 If you still want to use these placeholder values, then you need to disable autofill in your browser settings completely.
 
+## Input adornments
+
+Use `FieldStartTemplate` and `FieldEndTemplate` to render custom content immediately before or after the input control. These templates are intended for adornments such as icons, status indicators, or action buttons. They accept arbitrary Razor content and can be used independently or together.
+
+{{ TextInputFieldTemplate }}
+
 ## API FluentTextInput
 
 {{ API Type=FluentTextInput }}

--- a/src/Core/Components/Base/FluentInputBase.cs
+++ b/src/Core/Components/Base/FluentInputBase.cs
@@ -112,6 +112,14 @@ public abstract partial class FluentInputBase<TValue> : InputBase<TValue>, IFlue
     [Parameter]
     public virtual RenderFragment? LabelTemplate { get; set; }
 
+    /// <inheritdoc cref="IFluentField.FieldStartTemplate" />
+    [Parameter]
+    public virtual RenderFragment? FieldStartTemplate { get; set; }
+
+    /// <inheritdoc cref="IFluentField.FieldEndTemplate" />
+    [Parameter]
+    public virtual RenderFragment? FieldEndTemplate { get; set; }
+
     /// <inheritdoc cref="IFluentField.LabelPosition" />
     [Parameter]
     public virtual LabelPosition? LabelPosition { get; set; }

--- a/src/Core/Components/ColorPicker/FluentColorPickerInput.razor
+++ b/src/Core/Components/ColorPicker/FluentColorPickerInput.razor
@@ -22,6 +22,8 @@
                  Appearance="@Appearance"
                  Immediate="@Immediate"
                  ImmediateDelay="@ImmediateDelay"
+                 FieldStartTemplate="@FieldStartTemplate"
+                 FieldEndTemplate="@FieldEndTemplate"
                  Message="@Message"
                  MessageTemplate="@MessageTemplate"
                  MessageCondition="@MessageCondition"

--- a/src/Core/Components/ColorPicker/FluentColorPickerInput.razor
+++ b/src/Core/Components/ColorPicker/FluentColorPickerInput.razor
@@ -24,6 +24,7 @@
                  ImmediateDelay="@ImmediateDelay"
                  FieldStartTemplate="@FieldStartTemplate"
                  FieldEndTemplate="@FieldEndTemplate"
+                 LabelInfo="@LabelInfo"
                  Message="@Message"
                  MessageTemplate="@MessageTemplate"
                  MessageCondition="@MessageCondition"

--- a/src/Core/Components/DateTime/FluentDatePicker.razor
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor
@@ -22,6 +22,8 @@
                  Required="@Required"
                  type="@GetInputType()"
                  InputMode="@GetInputMode()"
+                 FieldStartTemplate="@FieldStartTemplate"
+                 FieldEndTemplate="@FieldEndTemplate"
                  Message="@Message"
                  MessageIcon="@MessageIcon"
                  MessageCondition="@MessageCondition"

--- a/src/Core/Components/DateTime/FluentDatePicker.razor
+++ b/src/Core/Components/DateTime/FluentDatePicker.razor
@@ -22,6 +22,7 @@
                  Required="@Required"
                  type="@GetInputType()"
                  InputMode="@GetInputMode()"
+                 LabelInfo="@LabelInfo"
                  FieldStartTemplate="@FieldStartTemplate"
                  FieldEndTemplate="@FieldEndTemplate"
                  Message="@Message"

--- a/src/Core/Components/DateTime/FluentTimePicker.razor
+++ b/src/Core/Components/DateTime/FluentTimePicker.razor
@@ -25,6 +25,8 @@
                     OptionValueToString="@(i => FormatValueAsString(i))"
                     OptionSelectedComparer="@TimeComparer"
                     OptionDisabled="@DisableHourHandler"
+                    FieldStartTemplate="@FieldStartTemplate"
+                    FieldEndTemplate="@FieldEndTemplate"
                     Required="@Required"
                     Indicator="@(new CoreIcons.Regular.Size20.Clock().WithColor("var(--colorNeutralForeground3)"))"
                     Items="@Items"

--- a/src/Core/Components/DateTime/FluentTimePicker.razor
+++ b/src/Core/Components/DateTime/FluentTimePicker.razor
@@ -27,6 +27,7 @@
                     OptionDisabled="@DisableHourHandler"
                     FieldStartTemplate="@FieldStartTemplate"
                     FieldEndTemplate="@FieldEndTemplate"
+                    LabelInfo="@LabelInfo"
                     Required="@Required"
                     Indicator="@(new CoreIcons.Regular.Size20.Clock().WithColor("var(--colorNeutralForeground3)"))"
                     Items="@Items"

--- a/src/Core/Components/Field/FluentField.razor
+++ b/src/Core/Components/Field/FluentField.razor
@@ -49,7 +49,9 @@ else
             {
                 @if (Parameters.FieldStartTemplate is not null || Parameters.FieldEndTemplate is not null)
                 {
-                    <div part="input-adornments" slot="@FluentSlot.FieldInput">
+                    <div part="input-adornments"
+                         slot="@FluentSlot.FieldInput"
+                         id="@(!Parameters.HasInputComponent && IncludeInputSlot ? GetId("input") : null)">
                         @Parameters.FieldStartTemplate
                         @ChildContent
                         @Parameters.FieldEndTemplate

--- a/src/Core/Components/Field/FluentField.razor
+++ b/src/Core/Components/Field/FluentField.razor
@@ -47,7 +47,15 @@ else
 
             @if (ChildContent is not null)
             {
-                @if (Parameters.HasInputComponent || !IncludeInputSlot)
+                @if (Parameters.FieldStartTemplate is not null || Parameters.FieldEndTemplate is not null)
+                {
+                    <div part="input-adornments" slot="@FluentSlot.FieldInput">
+                        @Parameters.FieldStartTemplate
+                        @ChildContent
+                        @Parameters.FieldEndTemplate
+                    </div>
+                }
+                else if (Parameters.HasInputComponent || !IncludeInputSlot)
                 {
                     @ChildContent
                 }

--- a/src/Core/Components/Field/FluentField.razor.cs
+++ b/src/Core/Components/Field/FluentField.razor.cs
@@ -59,7 +59,7 @@ public partial class FluentField : FluentComponentBase, IFluentField
     /// <summary>
     /// Gets or sets an existing FieldInput component to use in the field.
     /// Setting this parameter will define the parameters
-    /// Label, LabelTemplate, LabelPosition, LabelWidth,
+    /// Label, LabelTemplate, FieldStartTemplate, FieldEndTemplate, LabelPosition, LabelWidth,
     /// Required, Disabled,
     /// Message, MessageIcon, MessageTemplate, and MessageCondition.
     /// </summary>
@@ -91,6 +91,14 @@ public partial class FluentField : FluentComponentBase, IFluentField
     /// <inheritdoc cref="IFluentField.LabelTemplate"/>
     [Parameter]
     public RenderFragment? LabelTemplate { get; set; }
+
+    /// <inheritdoc cref="IFluentField.FieldStartTemplate"/>
+    [Parameter]
+    public RenderFragment? FieldStartTemplate { get; set; }
+
+    /// <inheritdoc cref="IFluentField.FieldEndTemplate"/>
+    [Parameter]
+    public RenderFragment? FieldEndTemplate { get; set; }
 
     /// <inheritdoc cref="IFluentField.LabelPosition"/>
     [Parameter]

--- a/src/Core/Components/Field/FluentField.razor.css
+++ b/src/Core/Components/Field/FluentField.razor.css
@@ -34,3 +34,8 @@ fluent-field label[disabled] {
 fluent-field.invalid div::part('root') {
   border-color: var(--colorPaletteRedBorder2);
 }
+
+fluent-field div[part="input-adornments"] {
+  display: flex;
+  align-items: center;
+}

--- a/src/Core/Components/Field/FluentField.razor.css
+++ b/src/Core/Components/Field/FluentField.razor.css
@@ -38,4 +38,5 @@ fluent-field.invalid div::part('root') {
 fluent-field div[part="input-adornments"] {
   display: flex;
   align-items: center;
+  width: 100%;
 }

--- a/src/Core/Components/Field/FluentFieldParameterSelector.cs
+++ b/src/Core/Components/Field/FluentFieldParameterSelector.cs
@@ -55,6 +55,20 @@ internal class FluentFieldParameterSelector : IFluentField
     }
 
     /// <summary />
+    public RenderFragment? FieldStartTemplate
+    {
+        get => _component.FieldStartTemplate ?? _component.InputComponent?.FieldStartTemplate;
+        set => throw new NotSupportedException();
+    }
+
+    /// <summary />
+    public RenderFragment? FieldEndTemplate
+    {
+        get => _component.FieldEndTemplate ?? _component.InputComponent?.FieldEndTemplate;
+        set => throw new NotSupportedException();
+    }
+
+    /// <summary />
     public LabelPosition? LabelPosition
     {
         get => _component.LabelPosition ?? _component.InputComponent?.LabelPosition ?? Components.LabelPosition.Above;

--- a/src/Core/Components/Field/IFluentField.cs
+++ b/src/Core/Components/Field/IFluentField.cs
@@ -36,6 +36,16 @@ public interface IFluentField
     RenderFragment? LabelTemplate { get; set; }
 
     /// <summary>
+    /// Gets or sets the content to display before the input component.
+    /// </summary>
+    RenderFragment? FieldStartTemplate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the content to display after the input component.
+    /// </summary>
+    RenderFragment? FieldEndTemplate { get; set; }
+
+    /// <summary>
     /// Gets or sets the position of the label relative to the input.
     /// </summary>
     LabelPosition? LabelPosition { get; set; }

--- a/src/Core/Components/List/FluentAutocomplete.razor
+++ b/src/Core/Components/List/FluentAutocomplete.razor
@@ -38,6 +38,7 @@
                          MessageState="@MessageState"
                          FieldStartTemplate="@FieldStartTemplate"
                          FieldEndTemplate="@FieldEndTemplate"
+                         LabelInfo="@LabelInfo"
                          Placeholder="@(_internalSelectedItems.Any() ? null : Placeholder)"
                          Size="@Size"
                          Style="@StyleValue"

--- a/src/Core/Components/List/FluentAutocomplete.razor
+++ b/src/Core/Components/List/FluentAutocomplete.razor
@@ -36,6 +36,8 @@
                          MessageCondition="@MessageCondition"
                          MessageIcon="@MessageIcon"
                          MessageState="@MessageState"
+                         FieldStartTemplate="@FieldStartTemplate"
+                         FieldEndTemplate="@FieldEndTemplate"
                          Placeholder="@(_internalSelectedItems.Any() ? null : Placeholder)"
                          Size="@Size"
                          Style="@StyleValue"

--- a/tests/Core/Components/Base/ComponentBaseTests.cs
+++ b/tests/Core/Components/Base/ComponentBaseTests.cs
@@ -2,6 +2,7 @@
 // This file is licensed to you under the MIT License.
 // ------------------------------------------------------------------------
 
+using System.Globalization;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -226,6 +227,78 @@ public class ComponentBaseTests : Bunit.BunitContext
     }
 
     [Fact]
+    public void ComponentBase_FluentFieldInterface_CorrectRendering()
+    {
+        var errors = new StringBuilder();
+        var fieldParameters = typeof(IFluentField)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(property => property.SetMethod is not null)
+            .ToArray();
+        var fieldParameterValues = fieldParameters.ToDictionary(
+            property => property.Name,
+            CreateFieldParameterValue);
+
+        using var context = new DateTimeProviderContext(DateTime.Now);
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        foreach (var componentType in BaseHelpers.GetDerivedTypes<IFluentField>(except: [])
+                     .Where(type => typeof(IComponent).IsAssignableFrom(type)))
+        {
+            var type = ComponentInitializer.TryGetValue(componentType, out var value)
+                     ? value.ComponentType(componentType)
+                     : componentType;
+
+            try
+            {
+                var renderedComponent = Render<DynamicComponent>(parameters =>
+                {
+                    parameters.Add(p => p.Type, type);
+                    parameters.Add(p => p.Parameters, DictionaryExtensions.Union(
+                        fieldParameterValues,
+                        ComponentInitializer.TryGetValue(componentType, out var valueRequired) ? valueRequired.RequiredParameters : null
+                    ));
+
+                    if (ComponentInitializer.TryGetValue(componentType, out var valueCascading))
+                    {
+                        foreach (var (Name, Value) in valueCascading.CascadingValues)
+                        {
+                            if (string.IsNullOrEmpty(Name))
+                            {
+                                parameters.AddCascadingValue(Value);
+                            }
+                            else
+                            {
+                                parameters.AddCascadingValue(Name, Value);
+                            }
+                        }
+                    }
+                });
+
+                var renderedField = renderedComponent.FindComponent<FluentField>().Instance;
+                var effectiveField = renderedField.InputComponent ?? renderedField;
+                var incorrectlyRenderedParameters = fieldParameters
+                    .Where(property => !Equals(fieldParameterValues[property.Name], property.GetValue(effectiveField)))
+                    .Select(property => property.Name)
+                    .ToArray();
+
+                var isValid = incorrectlyRenderedParameters.Length == 0;
+                Output.WriteLine($"{(isValid ? "✅" : "❌")} {componentType.Name}");
+
+                if (!isValid)
+                {
+                    errors.AppendLine(CultureInfo.InvariantCulture, $"\"{componentType.Name}\" does not correctly render the following \"IFluentField\" parameters: {string.Join(", ", incorrectlyRenderedParameters)}.");
+                }
+            }
+            catch (Exception ex)
+            {
+                errors.AppendLine(CultureInfo.InvariantCulture, $"Error rendering component {componentType.Name}: {ex.Message}");
+            }
+        }
+
+        Assert.True(errors.Length == 0, errors.ToString());
+    }
+
+    [Fact]
     public void ComponentBase_TooltipInterface_NotImplemented()
     {
         var errors = new StringBuilder();
@@ -322,6 +395,52 @@ public class ComponentBaseTests : Bunit.BunitContext
         var value = parts[1].Trim(' ', '"', '\'');
 
         return (name, value);
+    }
+
+    private static object CreateFieldParameterValue(PropertyInfo property)
+    {
+        var propertyType = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
+
+        if (propertyType == typeof(string))
+        {
+            return $"field-{property.Name}";
+        }
+
+        if (propertyType == typeof(bool))
+        {
+            return true;
+        }
+
+        if (propertyType == typeof(RenderFragment))
+        {
+            return (RenderFragment)(builder => builder.AddContent(0, $"field-{property.Name}"));
+        }
+
+        if (propertyType == typeof(Func<IFluentField, bool>))
+        {
+            return (Func<IFluentField, bool>)(_ => true);
+        }
+
+        if (propertyType == typeof(Icon))
+        {
+            return FluentStatus.InfoIcon;
+        }
+
+        if (propertyType == typeof(ILabelInfo))
+        {
+            return new LabelInfo($"field-{property.Name}");
+        }
+
+        if (propertyType.IsEnum)
+        {
+            var defaultValue = Activator.CreateInstance(propertyType);
+            return Enum.GetValues(propertyType)
+                .Cast<object>()
+                .FirstOrDefault(value => !Equals(value, defaultValue))
+                ?? throw new InvalidOperationException($"The enum parameter {property.Name} must define a non-default value for this test.");
+        }
+
+        throw new NotSupportedException($"No test value can be created for the {property.Name} parameter of type {property.PropertyType}.");
     }
 
     // Class used by the "ComponentBase_JsModule" test

--- a/tests/Core/Components/ColorPicker/FluentColorPickerInputTests.razor
+++ b/tests/Core/Components/ColorPicker/FluentColorPickerInputTests.razor
@@ -414,6 +414,8 @@
         public bool FocusLost { get; set; }
         public string? Label { get; set; }
         public RenderFragment? LabelTemplate { get; set; }
+        public RenderFragment? FieldStartTemplate { get; set; }
+        public RenderFragment? FieldEndTemplate { get; set; }
         public LabelPosition? LabelPosition { get; set; }
         public string? LabelWidth { get; set; }
         public bool? Required { get; set; }

--- a/tests/Core/Components/Field/FluentFieldParameterSelectorTests.razor
+++ b/tests/Core/Components/Field/FluentFieldParameterSelectorTests.razor
@@ -17,6 +17,8 @@
         // Predefined values
         yield return new object?[] { "Label", "my-label", "my-label", null };
         yield return new object?[] { "LabelTemplate", TemplateWithDiv, TemplateWithDiv, null };
+        yield return new object?[] { "FieldStartTemplate", TemplateWithDiv, TemplateWithDiv, null };
+        yield return new object?[] { "FieldEndTemplate", TemplateWithDiv, TemplateWithDiv, null };
         yield return new object?[] { "LabelPosition", LabelPosition.Before, LabelPosition.Before, null };
         yield return new object?[] { "LabelWidth", "10px", "10px", null };
         yield return new object?[] { "Required", true, true, null };
@@ -30,6 +32,8 @@
         // Default values
         yield return new object?[] { "Label", null, null, null };
         yield return new object?[] { "LabelTemplate", null, null, null };
+        yield return new object?[] { "FieldStartTemplate", null, null, null };
+        yield return new object?[] { "FieldEndTemplate", null, null, null };
         yield return new object?[] { "LabelPosition", null, LabelPosition.Above, null };
         yield return new object?[] { "LabelWidth", null, null, null };
         yield return new object?[] { "Required", null, false, null };

--- a/tests/Core/Components/Field/FluentFieldParameterSelectorTests.razor
+++ b/tests/Core/Components/Field/FluentFieldParameterSelectorTests.razor
@@ -167,6 +167,8 @@
         public bool FocusLost { get; }
         public string? Label { get; set; }
         public RenderFragment? LabelTemplate { get; set; }
+        public RenderFragment? FieldStartTemplate { get; set; }
+        public RenderFragment? FieldEndTemplate { get; set; }
         public LabelPosition? LabelPosition { get; set; }
         public string? LabelWidth { get; set; }
         public bool? Required { get; set; }

--- a/tests/Core/Components/Field/FluentFieldTests.razor
+++ b/tests/Core/Components/Field/FluentFieldTests.razor
@@ -288,6 +288,24 @@
         Assert.Equal(withInputSlot, hasSlot);
     }
 
+    [Theory]
+    [InlineData(true, false, "StartField content")]
+    [InlineData(false, true, "Field contentEnd")]
+    [InlineData(true, true, "StartField contentEnd")]
+    public void FluentField_FieldTemplates_RenderAroundChildContent(bool hasStartTemplate, bool hasEndTemplate, string expectedContent)
+    {
+        // Arrange & Act
+        var cut = Render<FluentField>(parameters => parameters
+            .Add(p => p.FieldStartTemplate, hasStartTemplate ? CreateContent("Start") : null)
+            .Add(p => p.ChildContent, CreateContent("Field content"))
+            .Add(p => p.FieldEndTemplate, hasEndTemplate ? CreateContent("End") : null));
+
+        // Assert
+        var wrapper = cut.Find("div[part='input-adornments']");
+
+        Assert.Equal(expectedContent, wrapper.TextContent);
+    }
+
     [Fact]
     public void FluentField_FieldTemplate_StandaloneWrapperOwnsInputId()
     {
@@ -424,4 +442,7 @@
 
         public int Number { get; set; }
     }
+
+    private static RenderFragment CreateContent(string content)
+        => builder => builder.AddContent(0, content);
 }

--- a/tests/Core/Components/Field/FluentFieldTests.razor
+++ b/tests/Core/Components/Field/FluentFieldTests.razor
@@ -289,6 +289,59 @@
     }
 
     [Fact]
+    public void FluentField_FieldTemplate_StandaloneWrapperOwnsInputId()
+    {
+        // Arrange & Act
+        var cut = Render(
+            @<FluentField Id="MyField" Label="My label">
+                <FieldStartTemplate>Start</FieldStartTemplate>
+                <ChildContent>Field content</ChildContent>
+            </FluentField>);
+
+        // Assert
+        var wrapper = cut.Find("div[part='input-adornments']");
+
+        Assert.Equal("MyField-input", wrapper.GetAttribute("id"));
+        Assert.Equal("MyField-input", cut.Find("label").GetAttribute("for"));
+    }
+
+    [Fact]
+    public void FluentField_FieldTemplate_InputComponentOwnsInputId()
+    {
+        // Arrange & Act
+        using var context = new IdentifierContext(_ => "myId");
+        var cut = Render(
+            @<FluentTextInput Label="My label">
+                <FieldStartTemplate>Start</FieldStartTemplate>
+            </FluentTextInput>);
+
+        // Assert
+        var wrapper = cut.Find("div[part='input-adornments']");
+
+        Assert.False(wrapper.HasAttribute("id"));
+        Assert.Equal("myId", cut.Find("fluent-text-input").GetAttribute("id"));
+        Assert.Single(cut.FindAll("#myId"));
+    }
+
+    [Fact]
+    public void FluentField_FieldTemplate_WithoutInputSlot_ChildOwnsInputId()
+    {
+        // Arrange & Act
+        var cut = Render(
+            @<FluentField Label="My label" ForId="custom-input" IncludeInputSlot="false">
+                <FieldStartTemplate>Start</FieldStartTemplate>
+                <ChildContent><input id="custom-input" /></ChildContent>
+            </FluentField>);
+
+        // Assert
+        var wrapper = cut.Find("div[part='input-adornments']");
+
+        Assert.False(wrapper.HasAttribute("id"));
+        Assert.Equal("custom-input", cut.Find("label").GetAttribute("for"));
+        Assert.Single(cut.FindAll("#custom-input"));
+    }
+
+    [Fact]
     public void FluentField_HideFluentField()
     {
         // Arrange & Act

--- a/tests/Core/Components/Field/FluentFieldTests.razor
+++ b/tests/Core/Components/Field/FluentFieldTests.razor
@@ -289,9 +289,9 @@
     }
 
     [Theory]
-    [InlineData(true, false, "StartField content")]
-    [InlineData(false, true, "Field contentEnd")]
-    [InlineData(true, true, "StartField contentEnd")]
+    [InlineData(true, false, "StartFieldcontent")]
+    [InlineData(false, true, "FieldcontentEnd")]
+    [InlineData(true, true, "StartFieldcontentEnd")]
     public void FluentField_FieldTemplates_RenderAroundChildContent(bool hasStartTemplate, bool hasEndTemplate, string expectedContent)
     {
         // Arrange & Act
@@ -302,8 +302,9 @@
 
         // Assert
         var wrapper = cut.Find("div[part='input-adornments']");
+        var content = string.Concat(wrapper.TextContent.Where(character => !char.IsWhiteSpace(character)));
 
-        Assert.Equal(expectedContent, wrapper.TextContent);
+        Assert.Equal(expectedContent, content);
     }
 
     [Fact]

--- a/tests/_StartCodeCoverage.ps1
+++ b/tests/_StartCodeCoverage.ps1
@@ -39,6 +39,11 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+# Configuration: Release or Debug
+$configuration = 'Debug'
+# Target .NET versions for test projects. Separate multiple versions with a semicolon.
+$targetNetVersionsArgument = "-p:TargetNetVersions=`"net8.0;net9.0;net10.0`""
+
 foreach ($arg in $RemainingArgs) {
     switch ($arg.ToLowerInvariant()) {
         '/force' { $Force = $true }
@@ -135,7 +140,8 @@ else {
 
         & dotnet test (Join-Path $scriptDir 'Core\Components.Tests.csproj') `
             --results-directory $coreResults `
-            --configuration Release `
+            --configuration $configuration `
+            $targetNetVersionsArgument `
             --coverage `
             --coverage-output-format cobertura `
             --coverage-output Components.Tests.cobertura.xml `
@@ -157,7 +163,8 @@ else {
 
         & dotnet test (Join-Path $scriptDir 'Charts\Components.Charts.Tests.csproj') `
             --results-directory $chartsResults `
-            --configuration Release `
+            --configuration $configuration `
+            $targetNetVersionsArgument `
             --coverage `
             --coverage-output-format cobertura `
             --coverage-output Components.Charts.Tests.cobertura.xml `


### PR DESCRIPTION
# [dev-v5] Add FieldStartTemplate and FieldEndTemplate to FluentField 

Introduce `FieldStartTemplate` and `FieldEndTemplate` parameters to enhance the `FluentField` and `FluentInput` components, allowing for custom content before and after input fields. Refactor `TextInputFieldTemplate` for improved layout and consistency in utilizing these new templates. This change enhances flexibility in rendering adornments like icons and buttons.

This feature is available for all components that use **FluentField**: that is, all input components.

## Example

```razor
<FluentTextInput>
    <FieldStartTemplate>
        <FluentIcon Value="@(new Icons.Regular.Size24.Accessibility())" />
    </FieldStartTemplate>
    <FieldEndTemplate>
        <FluentButton Label="Search" />
    </FieldEndTemplate>
</FluentTextInput>

<FluentTextInput Size="@TextInputSize.Large">
    <FieldStartTemplate>
        <FluentIcon Value="@(new Icons.Regular.Size24.Accessibility())" />
    </FieldStartTemplate>
    <FieldEndTemplate>
        <FluentButton Label="Search"
                        Size="@ButtonSize.Large" />
    </FieldEndTemplate>
</FluentTextInput>
```

<img width="850" height="112" alt="image" src="https://github.com/user-attachments/assets/37a939ea-6d2a-4012-a3f7-0261fe06025e" />

## Unit Tests

Added

Added a general test that verifies that all IFluentField parameters are correctly rendered in the components