### PR TITLE
feat(Charts): implement missing chart Blazor wrappers

### DIFF
--- a/src/Charts/Charts/FluentCartesianChartBase.cs
+++ b/src/Charts/Charts/FluentCartesianChartBase.cs
@@ -233,6 +233,103 @@ public abstract partial class FluentCartesianChartBase : FluentChartBase
     [Parameter]
     public IDictionary<string, string>? DateLocalizeOptions { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether date axes display values in UTC instead of the
+    /// user's local timezone.
+    /// </summary>
+    [Parameter]
+    public bool UseUTC { get; set; }
+
+    /// <summary>
+    /// Gets or sets the sort order applied to a categorical X axis domain.
+    /// Charts with non-categorical x-axes ignore this. Defaults to <see cref="ChartCategoryOrder.Default"/>.
+    /// </summary>
+    [Parameter]
+    public ChartCategoryOrder XAxisCategoryOrder { get; set; } = ChartCategoryOrder.Default;
+
+    /// <summary>
+    /// Gets or sets the scale type applied to a continuous numeric X axis.
+    /// </summary>
+    [Parameter]
+    public ChartAxisScaleType XAxisScaleType { get; set; } = ChartAxisScaleType.Default;
+
+    /// <summary>
+    /// Gets or sets the scale type applied to the primary numeric Y axis.
+    /// </summary>
+    [Parameter]
+    public ChartAxisScaleType YAxisScaleType { get; set; } = ChartAxisScaleType.Default;
+
+    /// <summary>
+    /// Gets or sets the scale type applied to a secondary numeric Y axis, when present.
+    /// </summary>
+    [Parameter]
+    public ChartAxisScaleType SecondaryYAxisScaleType { get; set; } = ChartAxisScaleType.Default;
+
+    /// <summary>
+    /// Gets or sets the fractional inner padding (0–1) between bands on a categorical X axis.
+    /// Applies to categorical bar charts.
+    /// </summary>
+    [Parameter]
+    public double? XAxisInnerPadding { get; set; }
+
+    /// <summary>
+    /// Gets or sets the fractional outer padding (0–1) around the first and last bands on a
+    /// categorical X axis. Applies to categorical bar charts.
+    /// </summary>
+    [Parameter]
+    public double? XAxisOuterPadding { get; set; }
+
+    /// <summary>
+    /// Gets or sets the explicit set of y-axis tick values to render.
+    /// When set, only the specified values appear as tick marks instead of the auto-generated ones.
+    /// </summary>
+    [Parameter]
+    public IEnumerable<double>? YAxisTickValues { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of characters shown in x-axis labels when
+    /// <see cref="ShowXAxisLabelsTooltip"/> is enabled. Longer labels are truncated and the full
+    /// text is available on hover.
+    /// </summary>
+    [Parameter]
+    public int? NoOfCharsToTruncate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the pixel width of an overlaid line stroke, when the chart renders one.
+    /// </summary>
+    [Parameter]
+    public double? LineStrokeWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets the dash pattern applied to an overlaid line stroke.
+    /// </summary>
+    [Parameter]
+    public string? LineStrokeDasharray { get; set; }
+
+    /// <summary>
+    /// Gets or sets the dash offset applied to an overlaid line stroke.
+    /// </summary>
+    [Parameter]
+    public string? LineStrokeDashoffset { get; set; }
+
+    /// <summary>
+    /// Gets or sets the line cap style applied to an overlaid line stroke.
+    /// </summary>
+    [Parameter]
+    public ChartStrokeLinecap? LineStrokeLinecap { get; set; }
+
+    /// <summary>
+    /// Gets or sets the pixel width of the border drawn around an overlaid line.
+    /// </summary>
+    [Parameter]
+    public double? LineBorderWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets the color of the border drawn around an overlaid line.
+    /// </summary>
+    [Parameter]
+    public string? LineBorderColor { get; set; }
+
     // ── Computed JSON helpers ─────────────────────────────────────────────────
 
     /// <summary>
@@ -241,6 +338,12 @@ public abstract partial class FluentCartesianChartBase : FluentChartBase
     /// </summary>
     internal virtual string? TickValuesJson =>
         TickValues is not null ? JsonSerializer.Serialize(TickValues, ChartJsonSerializerContext.Default.IEnumerableDouble) : null;
+
+    /// <summary>
+    /// Serializes <see cref="YAxisTickValues"/> to a JSON array string for the web component attribute.
+    /// </summary>
+    internal string? YAxisTickValuesJson =>
+        YAxisTickValues is not null ? JsonSerializer.Serialize(YAxisTickValues, ChartJsonSerializerContext.Default.IEnumerableDouble) : null;
 
     /// <summary>
     /// Serializes <see cref="DateLocalizeOptions"/> to a JSON object string for the web component attribute.
@@ -252,6 +355,9 @@ public abstract partial class FluentCartesianChartBase : FluentChartBase
 [JsonSerializable(typeof(IEnumerable<double>))]
 [JsonSerializable(typeof(double[]))]
 [JsonSerializable(typeof(List<double>))]
+[JsonSerializable(typeof(IEnumerable<string>))]
+[JsonSerializable(typeof(string[]))]
+[JsonSerializable(typeof(List<string>))]
 [JsonSerializable(typeof(IDictionary<string, string>))]
 [JsonSerializable(typeof(Dictionary<string, string>))]
 [JsonSourceGenerationOptions(WriteIndented = false)]

--- a/src/Charts/Charts/GaugeChart/FluentGaugeChart.razor
+++ b/src/Charts/Charts/GaugeChart/FluentGaugeChart.razor
@@ -1,0 +1,34 @@
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components.Charts
+@using Microsoft.FluentUI.AspNetCore.Components.Extensions
+@inherits FluentChartBase
+
+<fluent-gauge-chart id="@Id"
+                    class="@ClassValue"
+                    style="@StyleValue"
+                    chart-title="@ChartTitle"
+                    segments="@ChartJson.Serialize(Segments)"
+                    chart-value="@ChartValue"
+                    min-value="@MinValue"
+                    max-value="@MaxValue"
+                    sublabel="@Sublabel"
+                    hide-min-max="@(HideMinMax ? "true" : null)"
+                    chart-value-format="@ChartValueFormat?.ToAttributeValue()"
+                    chart-value-format-template="@ChartValueFormatTemplate"
+                    variant="@Variant?.ToAttributeValue()"
+                    enable-gradient="@(EnableGradient ? "true" : null)"
+                    width="@Width"
+                    height="@Height"
+                    hide-tooltip="@(HideTooltip ? "true" : null)"
+                    hide-labels="@(HideLabels ? "true" : null)"
+                    hide-legends="@(HideLegends ? "true" : null)"
+                    legend-list-label="@LegendListLabel"
+                    round-corners="@(RoundedCorners ? "true" : null)"
+                    allow-multiple-legend-selection="@(AllowMultipleLegendSelection ? "true" : null)"
+                    culture="@Culture?.Name"
+                    @attributes="@AdditionalAttributes">
+</fluent-gauge-chart>
+
+@if (TooltipTemplate is not null)
+{
+    <div id="@_tooltipPortalId" style="display:none;position:absolute;">@TooltipTemplate(_tooltipContext)</div>
+}

--- a/src/Charts/Charts/GaugeChart/FluentGaugeChart.razor.cs
+++ b/src/Charts/Charts/GaugeChart/FluentGaugeChart.razor.cs
@@ -1,0 +1,83 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Components;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// FluentGaugeChart displays progress or ranges on a semicircular gauge.
+/// </summary>
+public partial class FluentGaugeChart : FluentChartBase
+{
+    /// <summary />
+    public FluentGaugeChart(LibraryConfiguration configuration) : base(configuration)
+    {
+    }
+
+    /// <summary />
+    internal string? ClassValue => DefaultClassBuilder
+        .AddClass("fluent-gauge-chart")
+        .Build();
+
+    /// <summary>
+    /// Gets or sets the segments rendered by the gauge chart.
+    /// </summary>
+    [Parameter, EditorRequired]
+    public IReadOnlyList<GaugeChartSegment> Segments { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the current gauge value.
+    /// </summary>
+    [Parameter]
+    public double ChartValue { get; set; }
+
+    /// <summary>
+    /// Gets or sets the minimum value shown on the gauge scale.
+    /// </summary>
+    [Parameter]
+    public double MinValue { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional maximum value shown on the gauge scale.
+    /// </summary>
+    [Parameter]
+    public double? MaxValue { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional label rendered below the center value.
+    /// </summary>
+    [Parameter]
+    public string? Sublabel { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the min and max labels are hidden.
+    /// </summary>
+    [Parameter]
+    public bool HideMinMax { get; set; }
+
+    /// <summary>
+    /// Gets or sets the format used for the center value label.
+    /// </summary>
+    [Parameter]
+    public GaugeValueFormat? ChartValueFormat { get; set; }
+
+    /// <summary>
+    /// Gets or sets the template used to format the center value label.
+    /// </summary>
+    [Parameter]
+    public string? ChartValueFormatTemplate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the visual variant of the gauge chart.
+    /// </summary>
+    [Parameter]
+    public GaugeChartVariant? Variant { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether gradient fills are enabled for the segments.
+    /// </summary>
+    [Parameter]
+    public bool EnableGradient { get; set; }
+}

--- a/src/Charts/Charts/GroupedVerticalBarChart/FluentGroupedVerticalBarChart.razor
+++ b/src/Charts/Charts/GroupedVerticalBarChart/FluentGroupedVerticalBarChart.razor
@@ -1,0 +1,63 @@
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components.Charts
+@using Microsoft.FluentUI.AspNetCore.Components.Extensions
+@inherits FluentCartesianChartBase
+
+<fluent-grouped-vertical-bar-chart id="@Id"
+                                   class="@ClassValue"
+                                   style="@StyleValue"
+                                   chart-title="@ChartTitle"
+                                   data="@ChartJson.Serialize(ChartData)"
+                                   width="@Width"
+                                   height="@Height"
+                                   hide-tooltip="@(HideTooltip ? "true" : null)"
+                                   hide-labels="@(HideLabels ? "true" : null)"
+                                   hide-legends="@(HideLegends ? "true" : null)"
+                                   legend-list-label="@LegendListLabel"
+                                   show-y-axis-labels="@(ShowYAxisLabels ? "true" : null)"
+                                   show-y-axis-labels-tooltip="@(ShowYAxisLabelsTooltip ? "true" : null)"
+                                   use-single-color="@(UseSingleColor ? "true" : null)"
+                                   enable-gradient="@(EnableGradient ? "true" : null)"
+                                   round-corners="@(RoundedCorners ? "true" : null)"
+                                   allow-multiple-legend-selection="@(AllowMultipleLegendSelection ? "true" : null)"
+                                   bar-width="@BarWidth"
+                                   max-bar-width="@MaxBarWidth"
+                                   colors="@ColorsJson"
+                                   is-callout-for-stack="@(IsCalloutForStack ? "true" : null)"
+                                   x-axis-category-order="@XAxisCategoryOrder.ToAttributeValue()"
+                                   x-axis-inner-padding="@XAxisInnerPadding"
+                                   x-axis-outer-padding="@XAxisOuterPadding"
+                                   x-axis-tick-count="@XAxisTickCount"
+                                   y-axis-tick-count="@YAxisTickCount"
+                                   y-axis-tick-values="@YAxisTickValuesJson"
+                                   x-min-value="@XMinValue"
+                                   x-max-value="@XMaxValue"
+                                   y-min-value="@YMinValue"
+                                   y-max-value="@YMaxValue"
+                                   y-scale-type="@YAxisScaleType.ToAttributeValue()"
+                                   x-axis-title="@XAxisTitle"
+                                   y-axis-title="@YAxisTitle"
+                                   x-axis-tick-format="@XAxisTickFormat"
+                                   y-axis-tick-format="@YAxisTickFormat"
+                                   tick-padding="@TickPadding"
+                                   wrap-x-axis-labels="@(WrapXAxisLabels ? "true" : null)"
+                                   rotate-x-axis-labels="@(RotateXAxisLabels ? "true" : null)"
+                                   support-negative-data="@(SupportNegativeData ? "true" : null)"
+                                   rounded-ticks="@(RoundedTicks ? "true" : null)"
+                                   culture="@Culture?.Name"
+                                   stroke-width="@StrokeWidth"
+                                   no-of-chars-to-truncate="@NoOfCharsToTruncate"
+                                   show-x-axis-labels-tooltip="@(ShowXAxisLabelsTooltip ? "true" : null)"
+                                   hide-tick-overlap="@(HideTickOverlap ? "true" : null)"
+                                   date-localize-options="@DateLocalizeOptionsJson"
+                                   use-utc="@(UseUTC ? "true" : null)"
+                                   @attributes="@AdditionalAttributes">
+</fluent-grouped-vertical-bar-chart>
+
+@if (CartesianTooltipTemplate is not null)
+{
+    <div id="@_tooltipPortalId" style="display:none;position:absolute;">@CartesianTooltipTemplate((CartesianTooltipContext)_tooltipContext)</div>
+}
+else if (TooltipTemplate is not null)
+{
+    <div id="@_tooltipPortalId" style="display:none;position:absolute;">@TooltipTemplate(_tooltipContext)</div>
+}

--- a/src/Charts/Charts/GroupedVerticalBarChart/FluentGroupedVerticalBarChart.razor.cs
+++ b/src/Charts/Charts/GroupedVerticalBarChart/FluentGroupedVerticalBarChart.razor.cs
@@ -1,0 +1,74 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json;
+using Microsoft.AspNetCore.Components;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// FluentGroupedVerticalBarChart displays data as clusters of vertical bars grouped by category,
+/// allowing comparison of multiple series side by side within each category.
+/// </summary>
+public partial class FluentGroupedVerticalBarChart : FluentCartesianChartBase
+{
+    /// <summary />
+    public FluentGroupedVerticalBarChart(LibraryConfiguration configuration) : base(configuration)
+    {
+    }
+
+    /// <summary />
+    internal string? ClassValue => DefaultClassBuilder
+        .AddClass("fluent-grouped-vertical-bar-chart")
+        .Build();
+
+    /// <summary>
+    /// Gets or sets the data for the grouped vertical bar chart.
+    /// </summary>
+    [Parameter, EditorRequired]
+    public IReadOnlyList<GroupedVerticalBarChartSeries> ChartData { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the width of each bar. Use <see langword="null"/> to fill the available band automatically.
+    /// </summary>
+    [Parameter]
+    public string? BarWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum width of each bar when its width is calculated automatically.
+    /// </summary>
+    [Parameter]
+    public string? MaxBarWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the first resolved series color is used for every bar.
+    /// </summary>
+    [Parameter]
+    public bool UseSingleColor { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether a gradient fill is applied to the bars.
+    /// </summary>
+    [Parameter]
+    public bool EnableGradient { get; set; }
+
+    /// <summary>
+    /// Gets or sets the ordered color palette used when a data point does not provide a color.
+    /// </summary>
+    [Parameter]
+    public IReadOnlyList<string>? Colors { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the tooltip aggregates all values in the group (stack)
+    /// rather than showing only the hovered bar.
+    /// </summary>
+    [Parameter]
+    public bool IsCalloutForStack { get; set; }
+
+    /// <summary>
+    /// Serializes <see cref="Colors"/> to a JSON array string for the web component attribute.
+    /// </summary>
+    internal string? ColorsJson =>
+        Colors is not null ? JsonSerializer.Serialize(Colors, ChartJsonSerializerContext.Default.IEnumerableString) : null;
+}

--- a/src/Charts/Charts/HeatMapChart/FluentHeatMapChart.razor
+++ b/src/Charts/Charts/HeatMapChart/FluentHeatMapChart.razor
@@ -1,0 +1,69 @@
+@namespace Microsoft.FluentUI.AspNetCore.Components.Charts
+@using Microsoft.FluentUI.AspNetCore.Components.Extensions
+@inherits FluentCartesianChartBase
+
+<fluent-heat-map-chart id="@Id"
+                       class="@ClassValue"
+                       style="@StyleValue"
+                       chart-title="@ChartTitle"
+                       data="@ChartJson.Serialize(ChartData)"
+                       width="@Width"
+                       height="@Height"
+                       hide-tooltip="@(HideTooltip ? "true" : null)"
+                       hide-labels="@(HideLabels ? "true" : null)"
+                       hide-legends="@(HideLegends ? "true" : null)"
+                       legend-list-label="@LegendListLabel"
+                       round-corners="@(RoundedCorners ? "true" : null)"
+                       allow-multiple-legend-selection="@(AllowMultipleLegendSelection ? "true" : null)"
+                       domain-values-for-color-scale="@DomainValuesForColorScaleJson"
+                       range-values-for-color-scale="@RangeValuesForColorScaleJson"
+                       x-axis-date-format-string="@XAxisDateFormatString"
+                       y-axis-date-format-string="@YAxisDateFormatString"
+                       x-axis-number-format-string="@XAxisNumberFormatString"
+                       y-axis-number-format-string="@YAxisNumberFormatString"
+                       y-axis-tick-label-max-width="@YAxisTickLabelMaxWidth"
+                       sort-order="@SortOrder.ToAttributeValue()"
+                       x-axis-string-labels="@XAxisStringLabelsJson"
+                       y-axis-string-labels="@YAxisStringLabelsJson"
+                       x-axis-tick-count="@XAxisTickCount"
+                       y-axis-tick-count="@YAxisTickCount"
+                       y-axis-tick-values="@YAxisTickValuesJson"
+                       x-min-value="@XMinValue"
+                       x-max-value="@XMaxValue"
+                       y-min-value="@YMinValue"
+                       y-max-value="@YMaxValue"
+                       x-axis-category-order="@XAxisCategoryOrder.ToAttributeValue()"
+                       y-axis-category-order="@YAxisCategoryOrder.ToAttributeValue()"
+                       x-scale-type="@XAxisScaleType.ToAttributeValue()"
+                       y-scale-type="@YAxisScaleType.ToAttributeValue()"
+                       x-axis-inner-padding="@XAxisInnerPadding"
+                       x-axis-outer-padding="@XAxisOuterPadding"
+                       x-axis-title="@XAxisTitle"
+                       y-axis-title="@YAxisTitle"
+                       x-axis-tick-format="@XAxisTickFormat"
+                       y-axis-tick-format="@YAxisTickFormat"
+                       tick-padding="@TickPadding"
+                       wrap-x-axis-labels="@(WrapXAxisLabels ? "true" : null)"
+                       rotate-x-axis-labels="@(RotateXAxisLabels ? "true" : null)"
+                       support-negative-data="@(SupportNegativeData ? "true" : null)"
+                       rounded-ticks="@(RoundedTicks ? "true" : null)"
+                       culture="@Culture?.Name"
+                       tick-values="@TickValuesJson"
+                       tick-format="@TickFormat"
+                       hide-tick-overlap="@(HideTickOverlap ? "true" : null)"
+                       stroke-width="@StrokeWidth"
+                       no-of-chars-to-truncate="@NoOfCharsToTruncate"
+                       show-x-axis-labels-tooltip="@(ShowXAxisLabelsTooltip ? "true" : null)"
+                       date-localize-options="@DateLocalizeOptionsJson"
+                       use-utc="@(UseUTC ? "true" : null)"
+                       @attributes="@AdditionalAttributes">
+</fluent-heat-map-chart>
+
+@if (CartesianTooltipTemplate is not null)
+{
+    <div id="@_tooltipPortalId" style="display:none;position:absolute;">@CartesianTooltipTemplate((CartesianTooltipContext)_tooltipContext)</div>
+}
+else if (TooltipTemplate is not null)
+{
+    <div id="@_tooltipPortalId" style="display:none;position:absolute;">@TooltipTemplate(_tooltipContext)</div>
+}

--- a/src/Charts/Charts/HeatMapChart/FluentHeatMapChart.razor.cs
+++ b/src/Charts/Charts/HeatMapChart/FluentHeatMapChart.razor.cs
@@ -1,0 +1,122 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json;
+using Microsoft.AspNetCore.Components;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// FluentHeatMapChart displays data as a colored Cartesian grid.
+/// </summary>
+public partial class FluentHeatMapChart
+{
+    /// <summary />
+    public FluentHeatMapChart(LibraryConfiguration configuration) : base(configuration)
+    {
+    }
+
+    /// <summary />
+    internal string? ClassValue => DefaultClassBuilder
+        .AddClass("fluent-heat-map-chart")
+        .Build();
+
+    /// <summary>
+    /// Gets or sets the data for the heat map chart.
+    /// </summary>
+    [Parameter, EditorRequired]
+    public IReadOnlyList<HeatMapChartData> ChartData { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the control points used for the color scale domain.
+    /// </summary>
+    [Parameter]
+    public IEnumerable<double>? DomainValuesForColorScale { get; set; }
+
+    /// <summary>
+    /// Gets or sets the colors mapped to <see cref="DomainValuesForColorScale"/>.
+    /// </summary>
+    [Parameter]
+    public IEnumerable<string>? RangeValuesForColorScale { get; set; }
+
+    /// <summary>
+    /// Gets or sets the d3 time-format string used for x-axis date labels.
+    /// </summary>
+    [Parameter]
+    public string? XAxisDateFormatString { get; set; }
+
+    /// <summary>
+    /// Gets or sets the d3 time-format string used for y-axis date labels.
+    /// </summary>
+    [Parameter]
+    public string? YAxisDateFormatString { get; set; }
+
+    /// <summary>
+    /// Gets or sets the d3 number-format string used for x-axis numeric labels.
+    /// </summary>
+    [Parameter]
+    public string? XAxisNumberFormatString { get; set; }
+
+    /// <summary>
+    /// Gets or sets the d3 number-format string used for y-axis numeric labels.
+    /// </summary>
+    [Parameter]
+    public string? YAxisNumberFormatString { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum width for y-axis tick labels before truncation.
+    /// </summary>
+    [Parameter]
+    public string? YAxisTickLabelMaxWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default sort order applied to string axis labels.
+    /// </summary>
+    [Parameter]
+    public HeatMapSortOrder SortOrder { get; set; } = HeatMapSortOrder.Alphabetical;
+
+    /// <summary>
+    /// Gets or sets the dictionary of x-axis string keys to display labels.
+    /// </summary>
+    [Parameter]
+    public IDictionary<string, string>? XAxisStringLabels { get; set; }
+
+    /// <summary>
+    /// Gets or sets the dictionary of y-axis string keys to display labels.
+    /// </summary>
+    [Parameter]
+    public IDictionary<string, string>? YAxisStringLabels { get; set; }
+
+    /// <summary>
+    /// Serializes <see cref="DomainValuesForColorScale"/> to a JSON array string for the web component attribute.
+    /// </summary>
+    internal string? DomainValuesForColorScaleJson =>
+        DomainValuesForColorScale is not null
+            ? JsonSerializer.Serialize(DomainValuesForColorScale, ChartJsonSerializerContext.Default.IEnumerableDouble)
+            : null;
+
+    /// <summary>
+    /// Serializes <see cref="RangeValuesForColorScale"/> to a JSON array string for the web component attribute.
+    /// </summary>
+    internal string? RangeValuesForColorScaleJson =>
+        RangeValuesForColorScale is not null
+            ? JsonSerializer.Serialize(RangeValuesForColorScale, ChartJsonSerializerContext.Default.IEnumerableString)
+            : null;
+
+    /// <summary>
+    /// Serializes <see cref="XAxisStringLabels"/> to a JSON object string for the web component attribute.
+    /// </summary>
+    internal string? XAxisStringLabelsJson =>
+        XAxisStringLabels is not null
+            ? JsonSerializer.Serialize(XAxisStringLabels, ChartJsonSerializerContext.Default.IDictionaryStringString)
+            : null;
+
+    /// <summary>
+    /// Serializes <see cref="YAxisStringLabels"/> to a JSON object string for the web component attribute.
+    /// </summary>
+    internal string? YAxisStringLabelsJson =>
+        YAxisStringLabels is not null
+            ? JsonSerializer.Serialize(YAxisStringLabels, ChartJsonSerializerContext.Default.IDictionaryStringString)
+            : null;
+}

--- a/src/Charts/Charts/LineChart/FluentLineChart.razor
+++ b/src/Charts/Charts/LineChart/FluentLineChart.razor
@@ -1,0 +1,72 @@
+@namespace Microsoft.FluentUI.AspNetCore.Components.Charts
+@using Microsoft.FluentUI.AspNetCore.Components.Extensions
+@inherits FluentCartesianChartBase
+
+<fluent-line-chart id="@Id"
+                   class="@ClassValue"
+                   style="@StyleValue"
+                   chart-title="@ChartTitle"
+                   data="@ChartJson.Serialize(ChartData)"
+                   width="@Width"
+                   height="@Height"
+                   hide-tooltip="@(HideTooltip ? "true" : null)"
+                   hide-labels="@(HideLabels ? "true" : null)"
+                   hide-legends="@(HideLegends ? "true" : null)"
+                   legend-list-label="@LegendListLabel"
+                   round-corners="@(RoundedCorners ? "true" : null)"
+                   allow-multiple-legend-selection="@(AllowMultipleLegendSelection ? "true" : null)"
+                   show-markers="@(ShowMarkers ? "true" : null)"
+                   allow-multiple-shapes-for-points="@(AllowMultipleShapesForPoints ? "true" : null)"
+                   is-callout-for-stack="@(IsCalloutForStack ? "true" : null)"
+                   color-fill-bars="@ColorFillBarsJson"
+                   y-axis-tick-label-max-width="@YAxisTickLabelMaxWidth"
+                   event-annotation-props="@EventAnnotationProps"
+                   x-axis-tick-count="@XAxisTickCount"
+                   y-axis-tick-count="@YAxisTickCount"
+                   y-axis-tick-values="@YAxisTickValuesJson"
+                   x-min-value="@XMinValue"
+                   x-max-value="@XMaxValue"
+                   y-min-value="@YMinValue"
+                   y-max-value="@YMaxValue"
+                   x-axis-category-order="@XAxisCategoryOrder.ToAttributeValue()"
+                   x-scale-type="@XAxisScaleType.ToAttributeValue()"
+                   y-scale-type="@YAxisScaleType.ToAttributeValue()"
+                   secondary-y-scale-type="@SecondaryYAxisScaleType.ToAttributeValue()"
+                   x-axis-inner-padding="@XAxisInnerPadding"
+                   x-axis-outer-padding="@XAxisOuterPadding"
+                   x-axis-title="@XAxisTitle"
+                   y-axis-title="@YAxisTitle"
+                   secondary-y-axis-title="@SecondaryYAxisTitle"
+                   x-axis-tick-format="@XAxisTickFormat"
+                   y-axis-tick-format="@YAxisTickFormat"
+                   tick-padding="@TickPadding"
+                   wrap-x-axis-labels="@(WrapXAxisLabels ? "true" : null)"
+                   rotate-x-axis-labels="@(RotateXAxisLabels ? "true" : null)"
+                   support-negative-data="@(SupportNegativeData ? "true" : null)"
+                   rounded-ticks="@(RoundedTicks ? "true" : null)"
+                   culture="@Culture?.Name"
+                   tick-values="@TickValuesJson"
+                   tick-format="@TickFormat"
+                   hide-tick-overlap="@(HideTickOverlap ? "true" : null)"
+                   stroke-width="@StrokeWidth"
+                   line-stroke-width="@LineStrokeWidth"
+                   line-stroke-dasharray="@LineStrokeDasharray"
+                   line-stroke-dashoffset="@LineStrokeDashoffset"
+                   line-stroke-linecap="@(LineStrokeLinecap is null ? null : LineStrokeLinecap.Value.ToAttributeValue())"
+                   line-border-width="@LineBorderWidth"
+                   line-border-color="@LineBorderColor"
+                   no-of-chars-to-truncate="@NoOfCharsToTruncate"
+                   show-x-axis-labels-tooltip="@(ShowXAxisLabelsTooltip ? "true" : null)"
+                   date-localize-options="@DateLocalizeOptionsJson"
+                   use-utc="@(UseUTC ? "true" : null)"
+                   @attributes="@AdditionalAttributes">
+</fluent-line-chart>
+
+@if (CartesianTooltipTemplate is not null)
+{
+    <div id="@_tooltipPortalId" style="display:none;position:absolute;">@CartesianTooltipTemplate((CartesianTooltipContext)_tooltipContext)</div>
+}
+else if (TooltipTemplate is not null)
+{
+    <div id="@_tooltipPortalId" style="display:none;position:absolute;">@TooltipTemplate(_tooltipContext)</div>
+}

--- a/src/Charts/Charts/LineChart/FluentLineChart.razor.cs
+++ b/src/Charts/Charts/LineChart/FluentLineChart.razor.cs
@@ -1,0 +1,83 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json;
+using Microsoft.AspNetCore.Components;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// FluentLineChart displays data as one or more connected line series on Cartesian axes.
+/// </summary>
+public partial class FluentLineChart
+{
+    /// <summary />
+    public FluentLineChart(LibraryConfiguration configuration) : base(configuration)
+    {
+    }
+
+    /// <summary />
+    internal string? ClassValue => DefaultClassBuilder
+        .AddClass("fluent-line-chart")
+        .Build();
+
+    /// <summary>
+    /// Gets or sets the data for the line chart.
+    /// </summary>
+    [Parameter, EditorRequired]
+    public IReadOnlyList<LineChartSeries> ChartData { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets a value indicating whether markers are rendered for individual points.
+    /// </summary>
+    [Parameter]
+    public bool ShowMarkers { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether multiple point shapes may be used across series.
+    /// </summary>
+    [Parameter]
+    public bool AllowMultipleShapesForPoints { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the callout is rendered using stacked content.
+    /// </summary>
+    [Parameter]
+    public bool IsCalloutForStack { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional colored bars rendered behind x-axis ranges.
+    /// </summary>
+    [Parameter]
+    public IReadOnlyList<LineChartColorFillBar>? ColorFillBars { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum width for the primary y-axis tick labels.
+    /// </summary>
+    [Parameter]
+    public string? YAxisTickLabelMaxWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets the label rendered beside the secondary y-axis when one or more series use
+    /// <see cref="LineChartSeries.UseSecondaryYScale"/>.
+    /// </summary>
+    [Parameter]
+    public string? SecondaryYAxisTitle { get; set; }
+
+    /// <summary>
+    /// Gets or sets the pre-serialized JSON payload passed to the web component's
+    /// <c>event-annotation-props</c> attribute.
+    /// The value must match the TypeScript <c>LineChartEventAnnotationProps</c> shape.
+    /// </summary>
+    [Parameter]
+    public string? EventAnnotationProps { get; set; }
+
+    /// <summary>
+    /// Serializes <see cref="ColorFillBars"/> to a JSON array string for the web component attribute.
+    /// </summary>
+    internal string? ColorFillBarsJson =>
+        ColorFillBars is not null
+            ? JsonSerializer.Serialize(ColorFillBars, LineChartDataJsonSerializerContext.Default.IReadOnlyListLineChartColorFillBar)
+            : null;
+}

--- a/src/Charts/Charts/PolarChart/FluentPolarChart.razor
+++ b/src/Charts/Charts/PolarChart/FluentPolarChart.razor
@@ -1,0 +1,35 @@
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components.Charts
+@using Microsoft.FluentUI.AspNetCore.Components.Extensions
+@inherits FluentChartBase
+
+<fluent-polar-chart id="@Id"
+                    class="@ClassValue"
+                    style="@StyleValue"
+                    chart-title="@ChartTitle"
+                    data="@ChartJson.Serialize(ChartData)"
+                    width="@Width"
+                    height="@Height"
+                    hide-tooltip="@(HideTooltip ? "true" : null)"
+                    hide-labels="@(HideLabels ? "true" : null)"
+                    hide-legends="@(HideLegends ? "true" : null)"
+                    legend-list-label="@LegendListLabel"
+                    round-corners="@(RoundedCorners ? "true" : null)"
+                    allow-multiple-legend-selection="@(AllowMultipleLegendSelection ? "true" : null)"
+                    culture="@Culture?.Name"
+                    show-markers="@(ShowMarkers ? "true" : null)"
+                    enable-multi-value-callout="@(EnableMultiValueCallout ? "true" : null)"
+                    shape="@(Shape?.ToAttributeValue())"
+                    direction="@(Direction?.ToAttributeValue())"
+                    hole="@Hole"
+                    radial-axis="@RadialAxisJson"
+                    angular-axis="@AngularAxisJson"
+                    margins="@MarginsJson"
+                    date-localize-options="@DateLocalizeOptionsJson"
+                    use-utc="@(UseUTC ? "true" : null)"
+                    @attributes="@AdditionalAttributes">
+</fluent-polar-chart>
+
+@if (TooltipTemplate is not null)
+{
+    <div id="@_tooltipPortalId" style="display:none;position:absolute;">@TooltipTemplate(_tooltipContext)</div>
+}

--- a/src/Charts/Charts/PolarChart/FluentPolarChart.razor.cs
+++ b/src/Charts/Charts/PolarChart/FluentPolarChart.razor.cs
@@ -1,0 +1,122 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json;
+using Microsoft.AspNetCore.Components;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// FluentPolarChart displays data using radial and angular axes.
+/// </summary>
+public partial class FluentPolarChart : FluentChartBase
+{
+    /// <summary />
+    public FluentPolarChart(LibraryConfiguration configuration) : base(configuration)
+    {
+    }
+
+    /// <summary />
+    internal string? ClassValue => DefaultClassBuilder
+        .AddClass("fluent-polar-chart")
+        .Build();
+
+    /// <summary>
+    /// Gets or sets the data for the polar chart.
+    /// </summary>
+    [Parameter, EditorRequired]
+    public IReadOnlyList<PolarChartSeries> ChartData { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets a value indicating whether markers are shown for each point.
+    /// </summary>
+    [Parameter]
+    public bool ShowMarkers { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether grouped multi-value tooltips are enabled.
+    /// </summary>
+    [Parameter]
+    public bool EnableMultiValueCallout { get; set; }
+
+    /// <summary>
+    /// Gets or sets the grid outline shape.
+    /// </summary>
+    [Parameter]
+    public PolarChartShape? Shape { get; set; }
+
+    /// <summary>
+    /// Gets or sets the angular rendering direction.
+    /// </summary>
+    [Parameter]
+    public PolarChartDirection? Direction { get; set; }
+
+    /// <summary>
+    /// Gets or sets the size of the inner hole as a ratio from 0 to 1.
+    /// </summary>
+    [Parameter]
+    public double? Hole { get; set; }
+
+    /// <summary>
+    /// Gets or sets the radial axis options.
+    /// </summary>
+    [Parameter]
+    public PolarAxisOptions? RadialAxis { get; set; }
+
+    /// <summary>
+    /// Gets or sets the angular axis options.
+    /// </summary>
+    [Parameter]
+    public PolarAxisOptions? AngularAxis { get; set; }
+
+    /// <summary>
+    /// Gets or sets explicit chart margins in pixels.
+    /// </summary>
+    [Parameter]
+    public PolarChartMargins? Margins { get; set; }
+
+    /// <summary>
+    /// Gets or sets the locale-aware date formatting options for date axis values.
+    /// </summary>
+    [Parameter]
+    public IDictionary<string, string>? DateLocalizeOptions { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether date axis values are formatted in UTC.
+    /// </summary>
+    [Parameter]
+    public bool UseUTC { get; set; }
+
+    /// <summary>
+    /// Serializes <see cref="RadialAxis"/> to a JSON object string for the web component attribute.
+    /// </summary>
+    internal string? RadialAxisJson =>
+        RadialAxis is not null
+            ? JsonSerializer.Serialize(RadialAxis, PolarChartDataJsonSerializerContext.Default.PolarAxisOptions)
+            : null;
+
+    /// <summary>
+    /// Serializes <see cref="AngularAxis"/> to a JSON object string for the web component attribute.
+    /// </summary>
+    internal string? AngularAxisJson =>
+        AngularAxis is not null
+            ? JsonSerializer.Serialize(AngularAxis, PolarChartDataJsonSerializerContext.Default.PolarAxisOptions)
+            : null;
+
+    /// <summary>
+    /// Serializes <see cref="Margins"/> to a JSON object string for the web component attribute.
+    /// </summary>
+    internal string? MarginsJson =>
+        Margins is not null
+            ? JsonSerializer.Serialize(Margins, PolarChartDataJsonSerializerContext.Default.PolarChartMargins)
+            : null;
+
+    /// <summary>
+    /// Serializes <see cref="DateLocalizeOptions"/> to a JSON object string for the web component attribute.
+    /// </summary>
+    internal string? DateLocalizeOptionsJson =>
+        DateLocalizeOptions is not null
+            ? JsonSerializer.Serialize(DateLocalizeOptions, PolarChartDataJsonSerializerContext.Default.IDictionaryStringString)
+            : null;
+}

--- a/src/Charts/Charts/SankeyChart/FluentSankeyChart.razor
+++ b/src/Charts/Charts/SankeyChart/FluentSankeyChart.razor
@@ -1,0 +1,25 @@
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components.Charts
+@inherits FluentChartBase
+
+<fluent-sankey-chart id="@Id"
+                     class="@ClassValue"
+                     style="@StyleValue"
+                     chart-title="@ChartTitle"
+                     data="@ChartJson.Serialize(ChartData)"
+                     width="@Width"
+                     height="@Height"
+                     hide-tooltip="@(HideTooltip ? "true" : null)"
+                     hide-labels="@(HideLabels ? "true" : null)"
+                     hide-legends="@(HideLegends ? "true" : null)"
+                     legend-list-label="@LegendListLabel"
+                     round-corners="@(RoundedCorners ? "true" : null)"
+                     allow-multiple-legend-selection="@(AllowMultipleLegendSelection ? "true" : null)"
+                     culture="@Culture?.Name"
+                     path-color="@PathColor"
+                     @attributes="@AdditionalAttributes">
+</fluent-sankey-chart>
+
+@if (TooltipTemplate is not null)
+{
+    <div id="@_tooltipPortalId" style="display:none;position:absolute;">@TooltipTemplate(_tooltipContext)</div>
+}

--- a/src/Charts/Charts/SankeyChart/FluentSankeyChart.razor.cs
+++ b/src/Charts/Charts/SankeyChart/FluentSankeyChart.razor.cs
@@ -1,0 +1,35 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Components;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// FluentSankeyChart displays flow values between linked nodes.
+/// </summary>
+public partial class FluentSankeyChart : FluentChartBase
+{
+    /// <summary />
+    public FluentSankeyChart(LibraryConfiguration configuration) : base(configuration)
+    {
+    }
+
+    /// <summary />
+    internal string? ClassValue => DefaultClassBuilder
+        .AddClass("fluent-sankey-chart")
+        .Build();
+
+    /// <summary>
+    /// Gets or sets the data for the sankey chart.
+    /// </summary>
+    [Parameter, EditorRequired]
+    public SankeyChartData ChartData { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the optional stroke color applied to chart paths.
+    /// </summary>
+    [Parameter]
+    public string? PathColor { get; set; }
+}

--- a/src/Charts/Charts/ScatterChart/FluentScatterChart.razor
+++ b/src/Charts/Charts/ScatterChart/FluentScatterChart.razor
@@ -1,0 +1,58 @@
+@namespace Microsoft.FluentUI.AspNetCore.Components.Charts
+@using Microsoft.FluentUI.AspNetCore.Components.Extensions
+@inherits FluentCartesianChartBase
+
+<fluent-scatter-chart id="@Id"
+                      class="@ClassValue"
+                      style="@StyleValue"
+                      chart-title="@ChartTitle"
+                      data="@ChartJson.Serialize(ChartData)"
+                      width="@Width"
+                      height="@Height"
+                      hide-tooltip="@(HideTooltip ? "true" : null)"
+                      hide-labels="@(HideLabels ? "true" : null)"
+                      hide-legends="@(HideLegends ? "true" : null)"
+                      legend-list-label="@LegendListLabel"
+                      round-corners="@(RoundedCorners ? "true" : null)"
+                      allow-multiple-legend-selection="@(AllowMultipleLegendSelection ? "true" : null)"
+                      x-axis-tick-count="@XAxisTickCount"
+                      y-axis-tick-count="@YAxisTickCount"
+                      y-axis-tick-values="@YAxisTickValuesJson"
+                      x-min-value="@XMinValue"
+                      x-max-value="@XMaxValue"
+                      y-min-value="@YMinValue"
+                      y-max-value="@YMaxValue"
+                      x-axis-category-order="@XAxisCategoryOrder.ToAttributeValue()"
+                      x-scale-type="@XAxisScaleType.ToAttributeValue()"
+                      y-scale-type="@YAxisScaleType.ToAttributeValue()"
+                      x-axis-inner-padding="@XAxisInnerPadding"
+                      x-axis-outer-padding="@XAxisOuterPadding"
+                      x-axis-title="@XAxisTitle"
+                      y-axis-title="@YAxisTitle"
+                      x-axis-tick-format="@XAxisTickFormat"
+                      y-axis-tick-format="@YAxisTickFormat"
+                      tick-padding="@TickPadding"
+                      wrap-x-axis-labels="@(WrapXAxisLabels ? "true" : null)"
+                      rotate-x-axis-labels="@(RotateXAxisLabels ? "true" : null)"
+                      support-negative-data="@(SupportNegativeData ? "true" : null)"
+                      rounded-ticks="@(RoundedTicks ? "true" : null)"
+                      culture="@Culture?.Name"
+                      tick-values="@TickValuesJson"
+                      tick-format="@TickFormat"
+                      hide-tick-overlap="@(HideTickOverlap ? "true" : null)"
+                      stroke-width="@StrokeWidth"
+                      no-of-chars-to-truncate="@NoOfCharsToTruncate"
+                      show-x-axis-labels-tooltip="@(ShowXAxisLabelsTooltip ? "true" : null)"
+                      date-localize-options="@DateLocalizeOptionsJson"
+                      use-utc="@(UseUTC ? "true" : null)"
+                      @attributes="@AdditionalAttributes">
+</fluent-scatter-chart>
+
+@if (CartesianTooltipTemplate is not null)
+{
+    <div id="@_tooltipPortalId" style="display:none;position:absolute;">@CartesianTooltipTemplate((CartesianTooltipContext)_tooltipContext)</div>
+}
+else if (TooltipTemplate is not null)
+{
+    <div id="@_tooltipPortalId" style="display:none;position:absolute;">@TooltipTemplate(_tooltipContext)</div>
+}

--- a/src/Charts/Charts/ScatterChart/FluentScatterChart.razor.cs
+++ b/src/Charts/Charts/ScatterChart/FluentScatterChart.razor.cs
@@ -1,0 +1,29 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Components;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// FluentScatterChart displays data as one or more scatter series on Cartesian axes.
+/// </summary>
+public partial class FluentScatterChart
+{
+    /// <summary />
+    public FluentScatterChart(LibraryConfiguration configuration) : base(configuration)
+    {
+    }
+
+    /// <summary />
+    internal string? ClassValue => DefaultClassBuilder
+        .AddClass("fluent-scatter-chart")
+        .Build();
+
+    /// <summary>
+    /// Gets or sets the data for the scatter chart.
+    /// </summary>
+    [Parameter, EditorRequired]
+    public IReadOnlyList<ScatterChartSeries> ChartData { get; set; } = [];
+}

--- a/src/Charts/Charts/SparklineChart/FluentSparklineChart.razor
+++ b/src/Charts/Charts/SparklineChart/FluentSparklineChart.razor
@@ -1,0 +1,29 @@
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components.Charts
+@using Microsoft.FluentUI.AspNetCore.Components.Extensions
+@inherits FluentChartBase
+
+<fluent-sparkline-chart id="@Id"
+                        class="@ClassValue"
+                        style="@StyleValue"
+                        chart-title="@ChartTitle"
+                        data="@ChartJson.Serialize(ChartData)"
+                        variant="@Variant?.ToAttributeValue()"
+                        color="@Color"
+                        show-legend="@(ShowLegend ? "true" : null)"
+                        value-text-width="@ValueTextWidth"
+                        width="@Width"
+                        height="@Height"
+                        hide-tooltip="@(HideTooltip ? "true" : null)"
+                        hide-labels="@(HideLabels ? "true" : null)"
+                        hide-legends="@(HideLegends ? "true" : null)"
+                        legend-list-label="@LegendListLabel"
+                        round-corners="@(RoundedCorners ? "true" : null)"
+                        allow-multiple-legend-selection="@(AllowMultipleLegendSelection ? "true" : null)"
+                        culture="@Culture?.Name"
+                        @attributes="@AdditionalAttributes">
+</fluent-sparkline-chart>
+
+@if (TooltipTemplate is not null)
+{
+    <div id="@_tooltipPortalId" style="display:none;position:absolute;">@TooltipTemplate(_tooltipContext)</div>
+}

--- a/src/Charts/Charts/SparklineChart/FluentSparklineChart.razor.cs
+++ b/src/Charts/Charts/SparklineChart/FluentSparklineChart.razor.cs
@@ -1,0 +1,53 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Components;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// FluentSparklineChart displays compact trend data as a sparkline.
+/// </summary>
+public partial class FluentSparklineChart : FluentChartBase
+{
+    /// <summary />
+    public FluentSparklineChart(LibraryConfiguration configuration) : base(configuration)
+    {
+    }
+
+    /// <summary />
+    internal string? ClassValue => DefaultClassBuilder
+        .AddClass("fluent-sparkline-chart")
+        .Build();
+
+    /// <summary>
+    /// Gets or sets the data for the sparkline chart.
+    /// </summary>
+    [Parameter, EditorRequired]
+    public SparklineChartData ChartData { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the rendering variant used by the sparkline chart.
+    /// </summary>
+    [Parameter]
+    public SparklineVariant? Variant { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional chart color override.
+    /// </summary>
+    [Parameter]
+    public string? Color { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the legend is shown.
+    /// </summary>
+    [Parameter]
+    public bool ShowLegend { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional width reserved for the value text.
+    /// </summary>
+    [Parameter]
+    public double? ValueTextWidth { get; set; }
+}

--- a/src/Charts/Charts/VerticalBarChart/FluentVerticalBarChart.razor
+++ b/src/Charts/Charts/VerticalBarChart/FluentVerticalBarChart.razor
@@ -1,0 +1,64 @@
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components.Charts
+@using Microsoft.FluentUI.AspNetCore.Components.Extensions
+@inherits FluentCartesianChartBase
+
+<fluent-vertical-bar-chart id="@Id"
+                           class="@ClassValue"
+                           style="@StyleValue"
+                           chart-title="@ChartTitle"
+                           data="@ChartJson.Serialize(ChartData)"
+                           width="@Width"
+                           height="@Height"
+                           hide-tooltip="@(HideTooltip ? "true" : null)"
+                           hide-labels="@(HideLabels ? "true" : null)"
+                           hide-legends="@(HideLegends ? "true" : null)"
+                           legend-list-label="@LegendListLabel"
+                           show-y-axis-labels="@(ShowYAxisLabels ? "true" : null)"
+                           show-y-axis-labels-tooltip="@(ShowYAxisLabelsTooltip ? "true" : null)"
+                           use-single-color="@(UseSingleColor ? "true" : null)"
+                           enable-gradient="@(EnableGradient ? "true" : null)"
+                           round-corners="@(RoundedCorners ? "true" : null)"
+                           allow-multiple-legend-selection="@(AllowMultipleLegendSelection ? "true" : null)"
+                           bar-width="@BarWidth"
+                           max-bar-width="@MaxBarWidth"
+                           colors="@ColorsJson"
+                           line-legend-text="@LineLegendText"
+                           line-legend-color="@LineLegendColor"
+                           x-axis-category-order="@XAxisCategoryOrder.ToAttributeValue()"
+                           x-axis-inner-padding="@XAxisInnerPadding"
+                           x-axis-outer-padding="@XAxisOuterPadding"
+                           x-axis-tick-count="@XAxisTickCount"
+                           y-axis-tick-count="@YAxisTickCount"
+                           y-axis-tick-values="@YAxisTickValuesJson"
+                           x-min-value="@XMinValue"
+                           x-max-value="@XMaxValue"
+                           y-min-value="@YMinValue"
+                           y-max-value="@YMaxValue"
+                           y-scale-type="@YAxisScaleType.ToAttributeValue()"
+                           x-axis-title="@XAxisTitle"
+                           y-axis-title="@YAxisTitle"
+                           x-axis-tick-format="@XAxisTickFormat"
+                           y-axis-tick-format="@YAxisTickFormat"
+                           tick-padding="@TickPadding"
+                           wrap-x-axis-labels="@(WrapXAxisLabels ? "true" : null)"
+                           rotate-x-axis-labels="@(RotateXAxisLabels ? "true" : null)"
+                           support-negative-data="@(SupportNegativeData ? "true" : null)"
+                           rounded-ticks="@(RoundedTicks ? "true" : null)"
+                           culture="@Culture?.Name"
+                           stroke-width="@StrokeWidth"
+                           no-of-chars-to-truncate="@NoOfCharsToTruncate"
+                           show-x-axis-labels-tooltip="@(ShowXAxisLabelsTooltip ? "true" : null)"
+                           hide-tick-overlap="@(HideTickOverlap ? "true" : null)"
+                           date-localize-options="@DateLocalizeOptionsJson"
+                           use-utc="@(UseUTC ? "true" : null)"
+                           @attributes="@AdditionalAttributes">
+</fluent-vertical-bar-chart>
+
+@if (CartesianTooltipTemplate is not null)
+{
+    <div id="@_tooltipPortalId" style="display:none;position:absolute;">@CartesianTooltipTemplate((CartesianTooltipContext)_tooltipContext)</div>
+}
+else if (TooltipTemplate is not null)
+{
+    <div id="@_tooltipPortalId" style="display:none;position:absolute;">@TooltipTemplate(_tooltipContext)</div>
+}

--- a/src/Charts/Charts/VerticalBarChart/FluentVerticalBarChart.razor.cs
+++ b/src/Charts/Charts/VerticalBarChart/FluentVerticalBarChart.razor.cs
@@ -1,0 +1,79 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json;
+using Microsoft.AspNetCore.Components;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// FluentVerticalBarChart displays data as a series of vertical bars, optionally overlaid with a line series.
+/// </summary>
+public partial class FluentVerticalBarChart : FluentCartesianChartBase
+{
+    /// <summary />
+    public FluentVerticalBarChart(LibraryConfiguration configuration) : base(configuration)
+    {
+    }
+
+    /// <summary />
+    internal string? ClassValue => DefaultClassBuilder
+        .AddClass("fluent-vertical-bar-chart")
+        .Build();
+
+    /// <summary>
+    /// Gets or sets the data for the vertical bar chart.
+    /// </summary>
+    [Parameter, EditorRequired]
+    public IReadOnlyList<VerticalBarChartSeries> ChartData { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the width of each bar. Use <see langword="null"/> to fill the available band automatically.
+    /// </summary>
+    [Parameter]
+    public string? BarWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum width of each bar when its width is calculated automatically.
+    /// </summary>
+    [Parameter]
+    public string? MaxBarWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the first resolved series color is used for every bar.
+    /// </summary>
+    [Parameter]
+    public bool UseSingleColor { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether a gradient fill is applied to the bars.
+    /// </summary>
+    [Parameter]
+    public bool EnableGradient { get; set; }
+
+    /// <summary>
+    /// Gets or sets the ordered color palette used when a data point does not provide a color.
+    /// </summary>
+    [Parameter]
+    public IReadOnlyList<string>? Colors { get; set; }
+
+    /// <summary>
+    /// Gets or sets the legend text for the overlaid line series, when <see cref="VerticalBarChartSeries.BenchmarkData"/>
+    /// values are supplied.
+    /// </summary>
+    [Parameter]
+    public string? LineLegendText { get; set; }
+
+    /// <summary>
+    /// Gets or sets the color of the overlaid line series.
+    /// </summary>
+    [Parameter]
+    public string? LineLegendColor { get; set; }
+
+    /// <summary>
+    /// Serializes <see cref="Colors"/> to a JSON array string for the web component attribute.
+    /// </summary>
+    internal string? ColorsJson =>
+        Colors is not null ? JsonSerializer.Serialize(Colors, ChartJsonSerializerContext.Default.IEnumerableString) : null;
+}

--- a/src/Charts/Charts/VerticalStackedBarChart/FluentVerticalStackedBarChart.razor
+++ b/src/Charts/Charts/VerticalStackedBarChart/FluentVerticalStackedBarChart.razor
@@ -1,0 +1,64 @@
+﻿@namespace Microsoft.FluentUI.AspNetCore.Components.Charts
+@using Microsoft.FluentUI.AspNetCore.Components.Extensions
+@inherits FluentCartesianChartBase
+
+<fluent-vertical-stacked-bar-chart id="@Id"
+                                   class="@ClassValue"
+                                   style="@StyleValue"
+                                   chart-title="@ChartTitle"
+                                   data="@ChartJson.Serialize(ChartData)"
+                                   width="@Width"
+                                   height="@Height"
+                                   hide-tooltip="@(HideTooltip ? "true" : null)"
+                                   hide-labels="@(HideLabels ? "true" : null)"
+                                   hide-legends="@(HideLegends ? "true" : null)"
+                                   legend-list-label="@LegendListLabel"
+                                   show-y-axis-labels="@(ShowYAxisLabels ? "true" : null)"
+                                   show-y-axis-labels-tooltip="@(ShowYAxisLabelsTooltip ? "true" : null)"
+                                   use-single-color="@(UseSingleColor ? "true" : null)"
+                                   enable-gradient="@(EnableGradient ? "true" : null)"
+                                   round-corners="@(RoundedCorners ? "true" : null)"
+                                   allow-multiple-legend-selection="@(AllowMultipleLegendSelection ? "true" : null)"
+                                   bar-width="@BarWidth"
+                                   max-bar-width="@MaxBarWidth"
+                                   bar-gap-max="@BarGapMax"
+                                   colors="@ColorsJson"
+                                   is-callout-for-stack="@(IsCalloutForStack ? "true" : null)"
+                                   x-axis-category-order="@XAxisCategoryOrder.ToAttributeValue()"
+                                   x-axis-inner-padding="@XAxisInnerPadding"
+                                   x-axis-outer-padding="@XAxisOuterPadding"
+                                   x-axis-tick-count="@XAxisTickCount"
+                                   y-axis-tick-count="@YAxisTickCount"
+                                   y-axis-tick-values="@YAxisTickValuesJson"
+                                   x-min-value="@XMinValue"
+                                   x-max-value="@XMaxValue"
+                                   y-min-value="@YMinValue"
+                                   y-max-value="@YMaxValue"
+                                   y-scale-type="@YAxisScaleType.ToAttributeValue()"
+                                   x-axis-title="@XAxisTitle"
+                                   y-axis-title="@YAxisTitle"
+                                   x-axis-tick-format="@XAxisTickFormat"
+                                   y-axis-tick-format="@YAxisTickFormat"
+                                   tick-padding="@TickPadding"
+                                   wrap-x-axis-labels="@(WrapXAxisLabels ? "true" : null)"
+                                   rotate-x-axis-labels="@(RotateXAxisLabels ? "true" : null)"
+                                   support-negative-data="@(SupportNegativeData ? "true" : null)"
+                                   rounded-ticks="@(RoundedTicks ? "true" : null)"
+                                   culture="@Culture?.Name"
+                                   stroke-width="@StrokeWidth"
+                                   no-of-chars-to-truncate="@NoOfCharsToTruncate"
+                                   show-x-axis-labels-tooltip="@(ShowXAxisLabelsTooltip ? "true" : null)"
+                                   hide-tick-overlap="@(HideTickOverlap ? "true" : null)"
+                                   date-localize-options="@DateLocalizeOptionsJson"
+                                   use-utc="@(UseUTC ? "true" : null)"
+                                   @attributes="@AdditionalAttributes">
+</fluent-vertical-stacked-bar-chart>
+
+@if (CartesianTooltipTemplate is not null)
+{
+    <div id="@_tooltipPortalId" style="display:none;position:absolute;">@CartesianTooltipTemplate((CartesianTooltipContext)_tooltipContext)</div>
+}
+else if (TooltipTemplate is not null)
+{
+    <div id="@_tooltipPortalId" style="display:none;position:absolute;">@TooltipTemplate(_tooltipContext)</div>
+}

--- a/src/Charts/Charts/VerticalStackedBarChart/FluentVerticalStackedBarChart.razor.cs
+++ b/src/Charts/Charts/VerticalStackedBarChart/FluentVerticalStackedBarChart.razor.cs
@@ -1,0 +1,80 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json;
+using Microsoft.AspNetCore.Components;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// FluentVerticalStackedBarChart displays data as a series of vertically stacked bars,
+/// where each bar is divided into segments representing a part-to-whole relationship.
+/// </summary>
+public partial class FluentVerticalStackedBarChart : FluentCartesianChartBase
+{
+    /// <summary />
+    public FluentVerticalStackedBarChart(LibraryConfiguration configuration) : base(configuration)
+    {
+    }
+
+    /// <summary />
+    internal string? ClassValue => DefaultClassBuilder
+        .AddClass("fluent-vertical-stacked-bar-chart")
+        .Build();
+
+    /// <summary>
+    /// Gets or sets the data for the vertical stacked bar chart.
+    /// </summary>
+    [Parameter, EditorRequired]
+    public IReadOnlyList<VerticalStackedBarChartSeries> ChartData { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the width of each bar. Use <see langword="null"/> to fill the available band automatically.
+    /// </summary>
+    [Parameter]
+    public string? BarWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum width of each bar when its width is calculated automatically.
+    /// </summary>
+    [Parameter]
+    public string? MaxBarWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the first resolved series color is used for every bar.
+    /// </summary>
+    [Parameter]
+    public bool UseSingleColor { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether a gradient fill is applied to the bars.
+    /// </summary>
+    [Parameter]
+    public bool EnableGradient { get; set; }
+
+    /// <summary>
+    /// Gets or sets the ordered color palette used when a data point does not provide a color.
+    /// </summary>
+    [Parameter]
+    public IReadOnlyList<string>? Colors { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum gap in pixels between bars when computed automatically.
+    /// </summary>
+    [Parameter]
+    public string? BarGapMax { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the tooltip aggregates all segment values in the stack
+    /// rather than showing only the hovered segment.
+    /// </summary>
+    [Parameter]
+    public bool IsCalloutForStack { get; set; }
+
+    /// <summary>
+    /// Serializes <see cref="Colors"/> to a JSON array string for the web component attribute.
+    /// </summary>
+    internal string? ColorsJson =>
+        Colors is not null ? JsonSerializer.Serialize(Colors, ChartJsonSerializerContext.Default.IEnumerableString) : null;
+}

--- a/src/Charts/Enums/ChartAxisScaleType.cs
+++ b/src/Charts/Enums/ChartAxisScaleType.cs
@@ -1,0 +1,25 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.ComponentModel;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Specifies the scale type used for a continuous numeric chart axis.
+/// </summary>
+public enum ChartAxisScaleType
+{
+    /// <summary>
+    /// Use a linear scale.
+    /// </summary>
+    [Description("default")]
+    Default,
+
+    /// <summary>
+    /// Use a logarithmic scale.
+    /// </summary>
+    [Description("log")]
+    Log,
+}

--- a/src/Charts/Enums/ChartStrokeLinecap.cs
+++ b/src/Charts/Enums/ChartStrokeLinecap.cs
@@ -1,0 +1,37 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.ComponentModel;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Specifies the SVG line cap style applied to an overlaid line stroke.
+/// </summary>
+public enum ChartStrokeLinecap
+{
+    /// <summary>
+    /// The stroke ends abruptly at the edge of the last point.
+    /// </summary>
+    [Description("butt")]
+    Butt,
+
+    /// <summary>
+    /// The stroke ends with a rounded cap centered on the last point.
+    /// </summary>
+    [Description("round")]
+    Round,
+
+    /// <summary>
+    /// The stroke ends with a square cap that extends beyond the last point.
+    /// </summary>
+    [Description("square")]
+    Square,
+
+    /// <summary>
+    /// The stroke cap is inherited from the parent element.
+    /// </summary>
+    [Description("inherit")]
+    Inherit,
+}

--- a/src/Charts/Enums/GaugeChartVariant.cs
+++ b/src/Charts/Enums/GaugeChartVariant.cs
@@ -1,0 +1,25 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.ComponentModel;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Specifies the visual variant used by the gauge chart.
+/// </summary>
+public enum GaugeChartVariant
+{
+    /// <summary>
+    /// Renders the gauge as a single tracked segment.
+    /// </summary>
+    [Description("single-segment")]
+    SingleSegment,
+
+    /// <summary>
+    /// Renders the gauge as multiple segments.
+    /// </summary>
+    [Description("multiple-segments")]
+    MultipleSegments,
+}

--- a/src/Charts/Enums/GaugeValueFormat.cs
+++ b/src/Charts/Enums/GaugeValueFormat.cs
@@ -1,0 +1,25 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.ComponentModel;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Specifies how the gauge center value is formatted.
+/// </summary>
+public enum GaugeValueFormat
+{
+    /// <summary>
+    /// Displays the current value as a percentage of the total range.
+    /// </summary>
+    [Description("percentage")]
+    Percentage,
+
+    /// <summary>
+    /// Displays the current value as a fraction of the total range.
+    /// </summary>
+    [Description("fraction")]
+    Fraction,
+}

--- a/src/Charts/Enums/HeatMapSortOrder.cs
+++ b/src/Charts/Enums/HeatMapSortOrder.cs
@@ -1,0 +1,25 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.ComponentModel;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Specifies how string axis labels are ordered in the heat map chart.
+/// </summary>
+public enum HeatMapSortOrder
+{
+    /// <summary>
+    /// Preserve the insertion order of string labels.
+    /// </summary>
+    [Description("none")]
+    None,
+
+    /// <summary>
+    /// Sort string labels alphabetically in ascending order.
+    /// </summary>
+    [Description("alphabetical")]
+    Alphabetical,
+}

--- a/src/Charts/Enums/PolarAxisUnit.cs
+++ b/src/Charts/Enums/PolarAxisUnit.cs
@@ -1,0 +1,25 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.ComponentModel;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Specifies the angular unit used by a polar axis.
+/// </summary>
+public enum PolarAxisUnit
+{
+    /// <summary>
+    /// Uses radians for angular values.
+    /// </summary>
+    [Description("radians")]
+    Radians,
+
+    /// <summary>
+    /// Uses degrees for angular values.
+    /// </summary>
+    [Description("degrees")]
+    Degrees,
+}

--- a/src/Charts/Enums/PolarChartDirection.cs
+++ b/src/Charts/Enums/PolarChartDirection.cs
@@ -1,0 +1,25 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.ComponentModel;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Specifies the angular rendering direction used by a polar chart.
+/// </summary>
+public enum PolarChartDirection
+{
+    /// <summary>
+    /// Angles increase in the clockwise direction.
+    /// </summary>
+    [Description("clockwise")]
+    Clockwise,
+
+    /// <summary>
+    /// Angles increase in the counterclockwise direction.
+    /// </summary>
+    [Description("counterclockwise")]
+    Counterclockwise,
+}

--- a/src/Charts/Enums/PolarChartShape.cs
+++ b/src/Charts/Enums/PolarChartShape.cs
@@ -1,0 +1,25 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.ComponentModel;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Specifies the grid outline shape used by a polar chart.
+/// </summary>
+public enum PolarChartShape
+{
+    /// <summary>
+    /// Renders the grid using concentric circles.
+    /// </summary>
+    [Description("circle")]
+    Circle,
+
+    /// <summary>
+    /// Renders the grid using concentric polygons.
+    /// </summary>
+    [Description("polygon")]
+    Polygon,
+}

--- a/src/Charts/Enums/PolarLineCurve.cs
+++ b/src/Charts/Enums/PolarLineCurve.cs
@@ -1,0 +1,43 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.ComponentModel;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Specifies the interpolation curve used for a polar line.
+/// </summary>
+public enum PolarLineCurve
+{
+    /// <summary>
+    /// Renders straight line segments.
+    /// </summary>
+    [Description("linear")]
+    Linear,
+
+    /// <summary>
+    /// Renders a smoothed natural spline.
+    /// </summary>
+    [Description("natural")]
+    Natural,
+
+    /// <summary>
+    /// Renders a step curve.
+    /// </summary>
+    [Description("step")]
+    Step,
+
+    /// <summary>
+    /// Renders a step-after curve.
+    /// </summary>
+    [Description("stepAfter")]
+    StepAfter,
+
+    /// <summary>
+    /// Renders a step-before curve.
+    /// </summary>
+    [Description("stepBefore")]
+    StepBefore,
+}

--- a/src/Charts/Enums/PolarSeriesType.cs
+++ b/src/Charts/Enums/PolarSeriesType.cs
@@ -1,0 +1,31 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.ComponentModel;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Specifies the rendered series type for a polar chart series.
+/// </summary>
+public enum PolarSeriesType
+{
+    /// <summary>
+    /// Renders the series as a filled polar area.
+    /// </summary>
+    [Description("areapolar")]
+    AreaPolar,
+
+    /// <summary>
+    /// Renders the series as a polar line.
+    /// </summary>
+    [Description("linepolar")]
+    LinePolar,
+
+    /// <summary>
+    /// Renders the series as polar scatter markers.
+    /// </summary>
+    [Description("scatterpolar")]
+    ScatterPolar,
+}

--- a/src/Charts/Enums/SparklineVariant.cs
+++ b/src/Charts/Enums/SparklineVariant.cs
@@ -1,0 +1,25 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.ComponentModel;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Specifies the sparkline rendering variant.
+/// </summary>
+public enum SparklineVariant
+{
+    /// <summary>
+    /// Renders the sparkline as a line.
+    /// </summary>
+    [Description("line")]
+    Line,
+
+    /// <summary>
+    /// Renders the sparkline as an area.
+    /// </summary>
+    [Description("area")]
+    Area,
+}

--- a/src/Charts/Infrastructure/ChartJson.cs
+++ b/src/Charts/Infrastructure/ChartJson.cs
@@ -78,6 +78,26 @@ public static class ChartJson
             GanttChartDataJsonSerializerContext.Default.IReadOnlyListGanttChartDataPoint);
 
     /// <summary>
+    /// Serializes gauge chart segments using the gauge chart serializer context.
+    /// </summary>
+    /// <param name="value">The gauge chart segments.</param>
+    /// <returns>A JSON string suitable for the <c>fluent-gauge-chart</c> component.</returns>
+    public static string Serialize(IReadOnlyList<GaugeChartSegment> value) =>
+        JsonSerializer.Serialize(
+            value,
+            GaugeChartDataJsonSerializerContext.Default.IReadOnlyListGaugeChartSegment);
+
+    /// <summary>
+    /// Serializes sparkline chart data using the sparkline chart serializer context.
+    /// </summary>
+    /// <param name="value">The sparkline chart data payload.</param>
+    /// <returns>A JSON string suitable for the <c>fluent-sparkline-chart</c> component.</returns>
+    public static string Serialize(SparklineChartData value) =>
+        JsonSerializer.Serialize(
+            value,
+            SparklineChartDataJsonSerializerContext.Default.SparklineChartData);
+
+    /// <summary>
     /// Serializes vertical bar chart data using the vertical bar chart serializer context.
     /// </summary>
     /// <param name="value">The vertical bar chart series collection.</param>
@@ -86,4 +106,74 @@ public static class ChartJson
         JsonSerializer.Serialize(
             value,
             VerticalBarChartDataJsonSerializerContext.Default.IReadOnlyListVerticalBarChartSeries);
+
+    /// <summary>
+    /// Serializes grouped vertical bar chart data using the grouped vertical bar chart serializer context.
+    /// </summary>
+    /// <param name="value">The grouped vertical bar chart series collection.</param>
+    /// <returns>A JSON string suitable for the <c>fluent-grouped-vertical-bar-chart</c> component.</returns>
+    public static string Serialize(IReadOnlyList<GroupedVerticalBarChartSeries> value) =>
+        JsonSerializer.Serialize(
+            value,
+            GroupedVerticalBarChartDataJsonSerializerContext.Default.IReadOnlyListGroupedVerticalBarChartSeries);
+
+    /// <summary>
+    /// Serializes vertical stacked bar chart data using the vertical stacked bar chart serializer context.
+    /// </summary>
+    /// <param name="value">The vertical stacked bar chart series collection.</param>
+    /// <returns>A JSON string suitable for the <c>fluent-vertical-stacked-bar-chart</c> component.</returns>
+    public static string Serialize(IReadOnlyList<VerticalStackedBarChartSeries> value) =>
+        JsonSerializer.Serialize(
+            value,
+            VerticalStackedBarChartDataJsonSerializerContext.Default.IReadOnlyListVerticalStackedBarChartSeries);
+
+    /// <summary>
+    /// Serializes polar chart data using the polar chart serializer context.
+    /// </summary>
+    /// <param name="value">The polar chart series collection.</param>
+    /// <returns>A JSON string suitable for the <c>fluent-polar-chart</c> component.</returns>
+    public static string Serialize(IReadOnlyList<PolarChartSeries> value) =>
+        JsonSerializer.Serialize(
+            value,
+            PolarChartDataJsonSerializerContext.Default.IReadOnlyListPolarChartSeries);
+
+    /// <summary>
+    /// Serializes sankey chart data using the sankey chart serializer context.
+    /// </summary>
+    /// <param name="value">The sankey chart payload.</param>
+    /// <returns>A JSON string suitable for the <c>fluent-sankey-chart</c> component.</returns>
+    public static string Serialize(SankeyChartData value) =>
+        JsonSerializer.Serialize(
+            value,
+            SankeyChartDataJsonSerializerContext.Default.SankeyChartData);
+
+    /// <summary>
+    /// Serializes line chart data using the line chart serializer context.
+    /// </summary>
+    /// <param name="value">The line chart series collection.</param>
+    /// <returns>A JSON string suitable for the <c>fluent-line-chart</c> component.</returns>
+    public static string Serialize(IReadOnlyList<LineChartSeries> value) =>
+        JsonSerializer.Serialize(
+            value,
+            LineChartDataJsonSerializerContext.Default.IReadOnlyListLineChartSeries);
+
+    /// <summary>
+    /// Serializes scatter chart data using the scatter chart serializer context.
+    /// </summary>
+    /// <param name="value">The scatter chart series collection.</param>
+    /// <returns>A JSON string suitable for the <c>fluent-scatter-chart</c> component.</returns>
+    public static string Serialize(IReadOnlyList<ScatterChartSeries> value) =>
+        JsonSerializer.Serialize(
+            value,
+            ScatterChartDataJsonSerializerContext.Default.IReadOnlyListScatterChartSeries);
+
+    /// <summary>
+    /// Serializes heat map chart data using the heat map chart serializer context.
+    /// </summary>
+    /// <param name="value">The heat map chart series collection.</param>
+    /// <returns>A JSON string suitable for the <c>fluent-heat-map-chart</c> component.</returns>
+    public static string Serialize(IReadOnlyList<HeatMapChartData> value) =>
+        JsonSerializer.Serialize(
+            value,
+            HeatMapChartDataJsonSerializerContext.Default.IReadOnlyListHeatMapChartData);
 }

--- a/src/Charts/Models/ChartAxisValue.cs
+++ b/src/Charts/Models/ChartAxisValue.cs
@@ -8,17 +8,17 @@ namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
 
 /// <summary>
 /// Represents a value that can be plotted on any axis of any chart type.
-/// Holds either a numeric value (e.g. a Unix timestamp in milliseconds or an
-/// arbitrary scalar) or a <see cref="DateTimeOffset"/> that is serialized as an
-/// ISO 8601 string so chart web components can consume it directly.
+/// Holds either a numeric value, a <see cref="DateTimeOffset"/>, or a string label,
+/// matching the value shapes accepted by the chart web components.
 /// </summary>
 /// <remarks>
 /// Use the implicit conversions from <see cref="double"/>, <see cref="DateTime"/>,
-/// or <see cref="DateTimeOffset"/> to create an instance:
+/// <see cref="DateTimeOffset"/>, or <see cref="string"/> to create an instance:
 /// <code>
 /// ChartAxisValue numeric = 42.0;
 /// ChartAxisValue date    = new DateTime(2024, 1, 1);
 /// ChartAxisValue offset  = DateTimeOffset.UtcNow;
+/// ChartAxisValue label   = "Monday";
 /// </code>
 /// </remarks>
 [JsonConverter(typeof(ChartAxisValueJsonConverter))]
@@ -27,22 +27,34 @@ public readonly struct ChartAxisValue : IEquatable<ChartAxisValue>
 {
     private readonly double? _number;
     private readonly DateTimeOffset? _date;
+    private readonly string? _text;
 
     private ChartAxisValue(double number)
     {
         _number = number;
         _date = null;
+        _text = null;
     }
 
     private ChartAxisValue(DateTimeOffset date)
     {
         _number = null;
         _date = date;
+        _text = null;
+    }
+
+    private ChartAxisValue(string text)
+    {
+        _number = null;
+        _date = null;
+        _text = text;
     }
 
     internal bool IsDate => _date.HasValue;
+    internal bool IsString => _text is not null;
     internal double NumberValue => _number ?? 0.0;
     internal DateTimeOffset DateValue => _date ?? default;
+    internal string StringValue => _text ?? string.Empty;
 
     /// <summary>Creates a <see cref="ChartAxisValue"/> from a numeric value.</summary>
     public static implicit operator ChartAxisValue(double value) => new(value);
@@ -59,14 +71,24 @@ public readonly struct ChartAxisValue : IEquatable<ChartAxisValue>
     /// <summary>Creates a <see cref="ChartAxisValue"/> from a <see cref="DateTimeOffset"/>.</summary>
     public static implicit operator ChartAxisValue(DateTimeOffset value) => new(value);
 
+    /// <summary>Creates a <see cref="ChartAxisValue"/> from a string label.</summary>
+    public static implicit operator ChartAxisValue(string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        return new(value);
+    }
+
     /// <summary>Determines whether this instance equals another <see cref="ChartAxisValue"/>.</summary>
-    public bool Equals(ChartAxisValue other) => _number == other._number && _date == other._date;
+    public bool Equals(ChartAxisValue other) =>
+        _number == other._number &&
+        _date == other._date &&
+        string.Equals(_text, other._text, StringComparison.Ordinal);
 
     /// <summary>Determines whether this instance equals another object.</summary>
     public override bool Equals(object? obj) => obj is ChartAxisValue other && Equals(other);
 
     /// <summary>Returns the hash code for this instance.</summary>
-    public override int GetHashCode() => HashCode.Combine(_number, _date);
+    public override int GetHashCode() => HashCode.Combine(_number, _date, _text);
 
     /// <summary>Returns <see langword="true"/> when both values are equal.</summary>
     public static bool operator ==(ChartAxisValue left, ChartAxisValue right) => left.Equals(right);

--- a/src/Charts/Models/ChartAxisValueJsonConverter.cs
+++ b/src/Charts/Models/ChartAxisValueJsonConverter.cs
@@ -9,8 +9,8 @@ using System.Text.Json.Serialization;
 namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
 
 /// <summary>
-/// Serializes and deserializes a <see cref="ChartAxisValue"/> as either a JSON
-/// number or an ISO 8601 string, matching the format expected by the chart web components.
+/// Serializes and deserializes a <see cref="ChartAxisValue"/> as either a JSON number
+/// or string, matching the format expected by the chart web components.
 /// </summary>
 internal sealed class ChartAxisValueJsonConverter : JsonConverter<ChartAxisValue>
 {
@@ -22,22 +22,33 @@ internal sealed class ChartAxisValueJsonConverter : JsonConverter<ChartAxisValue
             return (ChartAxisValue)reader.GetDouble();
         }
 
-        var str = reader.GetString();
-        return (ChartAxisValue)DateTimeOffset.Parse(str!, CultureInfo.InvariantCulture);
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            var value = reader.GetString() ?? string.Empty;
+
+            return DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var dateValue)
+                ? (ChartAxisValue)dateValue
+                : (ChartAxisValue)value;
+        }
+
+        throw new JsonException($"Unexpected token {reader.TokenType} when reading {nameof(ChartAxisValue)}.");
     }
 
     /// <inheritdoc/>
     public override void Write(Utf8JsonWriter writer, ChartAxisValue value, JsonSerializerOptions options)
     {
+        if (value.IsString)
+        {
+            writer.WriteStringValue(value.StringValue);
+            return;
+        }
+
         if (value.IsDate)
         {
             writer.WriteStringValue(value.DateValue.ToString("O", CultureInfo.InvariantCulture));
+            return;
         }
-        else
-        {
-            writer.WriteNumberValue(value.NumberValue);
-        }
+
+        writer.WriteNumberValue(value.NumberValue);
     }
 }
-
-#pragma warning restore MA0048 // File name must match type name

--- a/src/Charts/Models/GaugeChart/GaugeChartSegment.cs
+++ b/src/Charts/Models/GaugeChart/GaugeChartSegment.cs
@@ -1,0 +1,65 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+using Microsoft.FluentUI.AspNetCore.Components.Extensions;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Represents a single segment in a gauge chart.
+/// </summary>
+public sealed record GaugeChartSegment
+{
+    /// <summary>
+    /// Gets the legend text shown for the segment.
+    /// </summary>
+    [JsonPropertyName("legend")]
+    public string Legend { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the size of the segment within the gauge range.
+    /// </summary>
+    [JsonPropertyName("size")]
+    public double Size { get; init; }
+
+    /// <summary>
+    /// Gets the color used to render the segment.
+    /// Use <see cref="DataVizPalette.Custom"/> and set <see cref="CustomColor"/> to supply
+    /// an exact hex or CSS color string. If not provided, the web component falls back to
+    /// its default palette.
+    /// </summary>
+    [JsonIgnore]
+    public DataVizPalette? Color { get; init; }
+
+    /// <summary>
+    /// Custom color value used when <see cref="Color"/> is <see cref="DataVizPalette.Custom"/>.
+    /// Accepts an HTML hex color string (e.g. <c>#0099BC</c>) or a CSS variable.
+    /// </summary>
+    [JsonIgnore]
+    public string? CustomColor { get; init; }
+
+    /// <summary>
+    /// Gets the serialized color value sent to the web component.
+    /// Returns <see cref="CustomColor"/> when <see cref="Color"/> is <see cref="DataVizPalette.Custom"/>,
+    /// otherwise the palette token string, or <see langword="null"/> when no color is set.
+    /// </summary>
+    [JsonPropertyName("color")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SerializedColor => Color == DataVizPalette.Custom ? CustomColor : Color?.ToAttributeValue();
+
+    /// <summary>
+    /// Gets the optional two-stop gradient used when gradient rendering is enabled.
+    /// </summary>
+    [JsonPropertyName("gradient")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string[]? Gradient { get; init; }
+
+    /// <summary>
+    /// Gets the accessible label announced for the segment.
+    /// </summary>
+    [JsonPropertyName("ariaLabel")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? AriaLabel { get; init; }
+}

--- a/src/Charts/Models/HeatMapChart/HeatMapAccessibilityData.cs
+++ b/src/Charts/Models/HeatMapChart/HeatMapAccessibilityData.cs
@@ -1,0 +1,20 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Accessibility data attached to a heat map callout element.
+/// </summary>
+public sealed record HeatMapAccessibilityData
+{
+    /// <summary>
+    /// Gets the accessible label announced by screen readers for the callout element.
+    /// </summary>
+    [JsonPropertyName("ariaLabel")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? AriaLabel { get; init; }
+}

--- a/src/Charts/Models/HeatMapChart/HeatMapChartData.cs
+++ b/src/Charts/Models/HeatMapChart/HeatMapChartData.cs
@@ -1,0 +1,31 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Represents one heat map chart series in the data payload.
+/// </summary>
+public sealed record HeatMapChartData
+{
+    /// <summary>
+    /// Gets the legend text shown for the series.
+    /// </summary>
+    [JsonPropertyName("legend")]
+    public string Legend { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the representative numeric value used to derive the legend color.
+    /// </summary>
+    [JsonPropertyName("value")]
+    public double Value { get; init; }
+
+    /// <summary>
+    /// Gets the collection of heat map cells rendered within the series.
+    /// </summary>
+    [JsonPropertyName("data")]
+    public IReadOnlyList<HeatMapChartDataPoint> Data { get; init; } = [];
+}

--- a/src/Charts/Models/HeatMapChart/HeatMapChartDataPoint.cs
+++ b/src/Charts/Models/HeatMapChart/HeatMapChartDataPoint.cs
@@ -1,0 +1,61 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Represents a single cell in a heat map chart series.
+/// </summary>
+public sealed record HeatMapChartDataPoint
+{
+    /// <summary>
+    /// Gets the x-axis value rendered for this cell.
+    /// Accepts a numeric value, date/time value, or string category label.
+    /// </summary>
+    [JsonPropertyName("x")]
+    public ChartAxisValue X { get; init; }
+
+    /// <summary>
+    /// Gets the y-axis value rendered for this cell.
+    /// Accepts a numeric value, date/time value, or string category label.
+    /// </summary>
+    [JsonPropertyName("y")]
+    public ChartAxisValue Y { get; init; }
+
+    /// <summary>
+    /// Gets the numeric value used to determine the cell color.
+    /// </summary>
+    [JsonPropertyName("value")]
+    public double Value { get; init; }
+
+    /// <summary>
+    /// Gets the optional text rendered inside the cell.
+    /// </summary>
+    [JsonPropertyName("rectText")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? RectText { get; init; }
+
+    /// <summary>
+    /// Gets the optional ratio shown in the tooltip.
+    /// </summary>
+    [JsonPropertyName("ratio")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double[]? Ratio { get; init; }
+
+    /// <summary>
+    /// Gets the optional descriptive message shown in the tooltip.
+    /// </summary>
+    [JsonPropertyName("descriptionMessage")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DescriptionMessage { get; init; }
+
+    /// <summary>
+    /// Gets the optional accessibility data for the tooltip callout.
+    /// </summary>
+    [JsonPropertyName("callOutAccessibilityData")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public HeatMapAccessibilityData? CallOutAccessibilityData { get; init; }
+}

--- a/src/Charts/Models/LineChart/LineChartColorFillBar.cs
+++ b/src/Charts/Models/LineChart/LineChartColorFillBar.cs
@@ -1,0 +1,38 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Represents a color fill bar rendered behind matching line chart ranges.
+/// </summary>
+public sealed record LineChartColorFillBar
+{
+    /// <summary>
+    /// Gets the legend text associated with the fill bar.
+    /// </summary>
+    [JsonPropertyName("legend")]
+    public string Legend { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the CSS color value used to render the fill bar.
+    /// </summary>
+    [JsonPropertyName("color")]
+    public string Color { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the colored x-axis ranges rendered for this fill bar.
+    /// </summary>
+    [JsonPropertyName("data")]
+    public IReadOnlyList<LineChartColorFillBarData> Data { get; init; } = [];
+
+    /// <summary>
+    /// Gets whether the fill bar should use a patterned fill.
+    /// </summary>
+    [JsonPropertyName("applyPattern")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? ApplyPattern { get; init; }
+}

--- a/src/Charts/Models/LineChart/LineChartColorFillBarData.cs
+++ b/src/Charts/Models/LineChart/LineChartColorFillBarData.cs
@@ -1,0 +1,25 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Represents one colored x-axis range in a line chart fill bar.
+/// </summary>
+public sealed record LineChartColorFillBarData
+{
+    /// <summary>
+    /// Gets the start x-axis value of the colored range.
+    /// </summary>
+    [JsonPropertyName("startX")]
+    public ChartAxisValue StartX { get; init; }
+
+    /// <summary>
+    /// Gets the end x-axis value of the colored range.
+    /// </summary>
+    [JsonPropertyName("endX")]
+    public ChartAxisValue EndX { get; init; }
+}

--- a/src/Charts/Models/LineChart/LineChartDataPoint.cs
+++ b/src/Charts/Models/LineChart/LineChartDataPoint.cs
@@ -1,0 +1,47 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Represents a single data point in a line chart series.
+/// </summary>
+public sealed record LineChartDataPoint
+{
+    /// <summary>
+    /// Gets the x-axis value rendered for this point.
+    /// Accepts a numeric value, date/time value, or string category label.
+    /// </summary>
+    [JsonPropertyName("x")]
+    public ChartAxisValue X { get; init; }
+
+    /// <summary>
+    /// Gets the y-axis numeric value rendered for this point.
+    /// </summary>
+    [JsonPropertyName("y")]
+    public double Y { get; init; }
+
+    /// <summary>
+    /// Gets the optional x-axis callout text displayed in the tooltip.
+    /// </summary>
+    [JsonPropertyName("xAxisCalloutData")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? XAxisCalloutData { get; init; }
+
+    /// <summary>
+    /// Gets the optional y-axis callout text displayed in the tooltip.
+    /// </summary>
+    [JsonPropertyName("yAxisCalloutData")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? YAxisCalloutData { get; init; }
+
+    /// <summary>
+    /// Gets whether the tooltip callout should be hidden for this point.
+    /// </summary>
+    [JsonPropertyName("hideCallout")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? HideCallout { get; init; }
+}

--- a/src/Charts/Models/LineChart/LineChartGap.cs
+++ b/src/Charts/Models/LineChart/LineChartGap.cs
@@ -1,0 +1,25 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Represents a gap range between line chart data points.
+/// </summary>
+public sealed record LineChartGap
+{
+    /// <summary>
+    /// Gets the zero-based index of the first point in the gap.
+    /// </summary>
+    [JsonPropertyName("startIndex")]
+    public int StartIndex { get; init; }
+
+    /// <summary>
+    /// Gets the zero-based index of the last point in the gap.
+    /// </summary>
+    [JsonPropertyName("endIndex")]
+    public int EndIndex { get; init; }
+}

--- a/src/Charts/Models/LineChart/LineChartLineOptions.cs
+++ b/src/Charts/Models/LineChart/LineChartLineOptions.cs
@@ -1,0 +1,62 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+using Microsoft.FluentUI.AspNetCore.Components.Extensions;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Represents per-series stroke customization for a line chart.
+/// </summary>
+public sealed record LineChartLineOptions
+{
+    /// <summary>
+    /// Gets the stroke width in pixels for the line.
+    /// </summary>
+    [JsonPropertyName("strokeWidth")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? StrokeWidth { get; init; }
+
+    /// <summary>
+    /// Gets the SVG dash pattern applied to the line.
+    /// </summary>
+    [JsonPropertyName("strokeDasharray")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? StrokeDasharray { get; init; }
+
+    /// <summary>
+    /// Gets the SVG dash offset applied to the line.
+    /// </summary>
+    [JsonPropertyName("strokeDashoffset")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? StrokeDashoffset { get; init; }
+
+    /// <summary>
+    /// Gets the serialized SVG line cap style applied to the line.
+    /// </summary>
+    [JsonPropertyName("strokeLinecap")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SerializedStrokeLinecap => StrokeLinecap?.ToAttributeValue();
+
+    /// <summary>
+    /// Gets the typed SVG line cap style applied to the line.
+    /// </summary>
+    [JsonIgnore]
+    public ChartStrokeLinecap? StrokeLinecap { get; init; }
+
+    /// <summary>
+    /// Gets the border width in pixels applied around the line.
+    /// </summary>
+    [JsonPropertyName("lineBorderWidth")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? LineBorderWidth { get; init; }
+
+    /// <summary>
+    /// Gets the border color applied around the line.
+    /// </summary>
+    [JsonPropertyName("lineBorderColor")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? LineBorderColor { get; init; }
+}

--- a/src/Charts/Models/LineChart/LineChartSeries.cs
+++ b/src/Charts/Models/LineChart/LineChartSeries.cs
@@ -1,0 +1,72 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+using Microsoft.FluentUI.AspNetCore.Components.Extensions;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Represents one line chart series in the data payload.
+/// </summary>
+public sealed record LineChartSeries
+{
+    /// <summary>
+    /// Gets the legend text shown for the series.
+    /// </summary>
+    [JsonPropertyName("legend")]
+    public string Legend { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the collection of data points rendered within the series.
+    /// </summary>
+    [JsonPropertyName("data")]
+    public IReadOnlyList<LineChartDataPoint> Data { get; init; } = [];
+
+    /// <summary>
+    /// Gets the solid color used to render the series.
+    /// Use <see cref="DataVizPalette.Custom"/> and set <see cref="CustomColor"/> to supply
+    /// an exact hex or CSS color string. If not provided, the component falls back to its
+    /// default palette.
+    /// </summary>
+    [JsonIgnore]
+    public DataVizPalette? Color { get; init; }
+
+    /// <summary>
+    /// Custom color value used when <see cref="Color"/> is <see cref="DataVizPalette.Custom"/>.
+    /// Accepts an HTML hex color string (e.g. <c>#0099BC</c>) or a CSS variable.
+    /// </summary>
+    [JsonIgnore]
+    public string? CustomColor { get; init; }
+
+    /// <summary>
+    /// Gets the serialized color value sent to the web component.
+    /// Returns <see cref="CustomColor"/> when <see cref="Color"/> is <see cref="DataVizPalette.Custom"/>,
+    /// otherwise the palette token string, or <see langword="null"/> when no color is set.
+    /// </summary>
+    [JsonPropertyName("color")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SerializedColor => Color == DataVizPalette.Custom ? CustomColor : Color?.ToAttributeValue();
+
+    /// <summary>
+    /// Gets the optional explicit gap ranges rendered in the line.
+    /// </summary>
+    [JsonPropertyName("gaps")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<LineChartGap>? Gaps { get; init; }
+
+    /// <summary>
+    /// Gets whether this series uses the secondary (right) y-axis scale.
+    /// </summary>
+    [JsonPropertyName("useSecondaryYScale")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? UseSecondaryYScale { get; init; }
+
+    /// <summary>
+    /// Gets the optional per-series line styling.
+    /// </summary>
+    [JsonPropertyName("lineOptions")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public LineChartLineOptions? LineOptions { get; init; }
+}

--- a/src/Charts/Models/PolarChart/PolarAxisOptions.cs
+++ b/src/Charts/Models/PolarChart/PolarAxisOptions.cs
@@ -1,0 +1,109 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+using Microsoft.FluentUI.AspNetCore.Components.Extensions;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Represents axis options for a polar chart.
+/// </summary>
+public sealed record PolarAxisOptions
+{
+    /// <summary>
+    /// Gets the number of ticks to render.
+    /// </summary>
+    [JsonPropertyName("tickCount")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? TickCount { get; init; }
+
+    /// <summary>
+    /// Gets the explicit tick values to render.
+    /// </summary>
+    [JsonPropertyName("tickValues")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<ChartAxisValue>? TickValues { get; init; }
+
+    /// <summary>
+    /// Gets the explicit tick labels to render.
+    /// </summary>
+    [JsonPropertyName("tickText")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<string>? TickText { get; init; }
+
+    /// <summary>
+    /// Gets the tick format string.
+    /// </summary>
+    [JsonPropertyName("tickFormat")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? TickFormat { get; init; }
+
+    /// <summary>
+    /// Gets the tick step value.
+    /// </summary>
+    [JsonPropertyName("tickStep")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? TickStep { get; init; }
+
+    /// <summary>
+    /// Gets the axis origin tick value.
+    /// </summary>
+    [JsonPropertyName("tick0")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ChartAxisValue? Tick0 { get; init; }
+
+    /// <summary>
+    /// Gets the categorical ordering strategy.
+    /// </summary>
+    [JsonIgnore]
+    public ChartCategoryOrder? CategoryOrder { get; init; }
+
+    /// <summary>
+    /// Gets the serialized category order string sent to the web component.
+    /// </summary>
+    [JsonPropertyName("categoryOrder")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SerializedCategoryOrder => CategoryOrder?.ToAttributeValue();
+
+    /// <summary>
+    /// Gets the numeric scale type.
+    /// </summary>
+    [JsonIgnore]
+    public ChartAxisScaleType? ScaleType { get; init; }
+
+    /// <summary>
+    /// Gets the serialized scale type string sent to the web component.
+    /// </summary>
+    [JsonPropertyName("scaleType")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SerializedScaleType => ScaleType?.ToAttributeValue();
+
+    /// <summary>
+    /// Gets the minimum axis range value.
+    /// </summary>
+    [JsonPropertyName("rangeStart")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ChartAxisValue? RangeStart { get; init; }
+
+    /// <summary>
+    /// Gets the maximum axis range value.
+    /// </summary>
+    [JsonPropertyName("rangeEnd")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ChartAxisValue? RangeEnd { get; init; }
+
+    /// <summary>
+    /// Gets the angular unit.
+    /// </summary>
+    [JsonIgnore]
+    public PolarAxisUnit? Unit { get; init; }
+
+    /// <summary>
+    /// Gets the serialized angular unit string sent to the web component.
+    /// </summary>
+    [JsonPropertyName("unit")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SerializedUnit => Unit?.ToAttributeValue();
+}

--- a/src/Charts/Models/PolarChart/PolarChartDataPoint.cs
+++ b/src/Charts/Models/PolarChart/PolarChartDataPoint.cs
@@ -1,0 +1,89 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+using Microsoft.FluentUI.AspNetCore.Components.Extensions;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Represents a single data point in a polar chart series.
+/// </summary>
+public sealed record PolarChartDataPoint
+{
+    /// <summary>
+    /// Gets the angular value for the point.
+    /// </summary>
+    [JsonPropertyName("theta")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Theta { get; init; }
+
+    /// <summary>
+    /// Gets the radial value for the point.
+    /// </summary>
+    [JsonPropertyName("r")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ChartAxisValue? R { get; init; }
+
+    /// <summary>
+    /// Gets the legacy angular category value.
+    /// </summary>
+    [JsonPropertyName("x")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? X { get; init; }
+
+    /// <summary>
+    /// Gets the legacy radial numeric value.
+    /// </summary>
+    [JsonPropertyName("y")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? Y { get; init; }
+
+    /// <summary>
+    /// Gets the radial-axis callout text.
+    /// </summary>
+    [JsonPropertyName("radialAxisCalloutData")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? RadialAxisCalloutData { get; init; }
+
+    /// <summary>
+    /// Gets the angular-axis callout text.
+    /// </summary>
+    [JsonPropertyName("angularAxisCalloutData")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? AngularAxisCalloutData { get; init; }
+
+    /// <summary>
+    /// Gets the marker size for the point.
+    /// </summary>
+    [JsonPropertyName("markerSize")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? MarkerSize { get; init; }
+
+    /// <summary>
+    /// Gets the palette color used to render the point.
+    /// </summary>
+    [JsonIgnore]
+    public DataVizPalette? Color { get; init; }
+
+    /// <summary>
+    /// Gets the custom CSS color used when <see cref="Color"/> is <see cref="DataVizPalette.Custom"/>.
+    /// </summary>
+    [JsonIgnore]
+    public string? CustomColor { get; init; }
+
+    /// <summary>
+    /// Gets the serialized color value sent to the web component.
+    /// </summary>
+    [JsonPropertyName("color")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SerializedColor => Color == DataVizPalette.Custom ? CustomColor : Color?.ToAttributeValue();
+
+    /// <summary>
+    /// Gets the optional point label text.
+    /// </summary>
+    [JsonPropertyName("text")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Text { get; init; }
+}

--- a/src/Charts/Models/PolarChart/PolarChartMargins.cs
+++ b/src/Charts/Models/PolarChart/PolarChartMargins.cs
@@ -1,0 +1,37 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Represents explicit margins for a polar chart.
+/// </summary>
+public sealed record PolarChartMargins
+{
+    /// <summary>
+    /// Gets the top margin in pixels.
+    /// </summary>
+    [JsonPropertyName("top")]
+    public double Top { get; init; }
+
+    /// <summary>
+    /// Gets the right margin in pixels.
+    /// </summary>
+    [JsonPropertyName("right")]
+    public double Right { get; init; }
+
+    /// <summary>
+    /// Gets the bottom margin in pixels.
+    /// </summary>
+    [JsonPropertyName("bottom")]
+    public double Bottom { get; init; }
+
+    /// <summary>
+    /// Gets the left margin in pixels.
+    /// </summary>
+    [JsonPropertyName("left")]
+    public double Left { get; init; }
+}

--- a/src/Charts/Models/PolarChart/PolarChartSeries.cs
+++ b/src/Charts/Models/PolarChart/PolarChartSeries.cs
@@ -1,0 +1,65 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+using Microsoft.FluentUI.AspNetCore.Components.Extensions;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Represents one series in a polar chart payload.
+/// </summary>
+public sealed record PolarChartSeries
+{
+    /// <summary>
+    /// Gets the legend text shown for the series.
+    /// </summary>
+    [JsonPropertyName("legend")]
+    public string Legend { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the collection of data points rendered for the series.
+    /// </summary>
+    [JsonPropertyName("data")]
+    public IReadOnlyList<PolarChartDataPoint> Data { get; init; } = [];
+
+    /// <summary>
+    /// Gets the palette color used to render the series.
+    /// </summary>
+    [JsonIgnore]
+    public DataVizPalette? Color { get; init; }
+
+    /// <summary>
+    /// Gets the custom CSS color used when <see cref="Color"/> is <see cref="DataVizPalette.Custom"/>.
+    /// </summary>
+    [JsonIgnore]
+    public string? CustomColor { get; init; }
+
+    /// <summary>
+    /// Gets the serialized color value sent to the web component.
+    /// </summary>
+    [JsonPropertyName("color")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SerializedColor => Color == DataVizPalette.Custom ? CustomColor : Color?.ToAttributeValue();
+
+    /// <summary>
+    /// Gets the polar series rendering type.
+    /// </summary>
+    [JsonIgnore]
+    public PolarSeriesType? Type { get; init; }
+
+    /// <summary>
+    /// Gets the serialized polar series type string sent to the web component.
+    /// </summary>
+    [JsonPropertyName("type")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SerializedType => Type?.ToAttributeValue();
+
+    /// <summary>
+    /// Gets the optional line rendering options.
+    /// </summary>
+    [JsonPropertyName("lineOptions")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public PolarLineOptions? LineOptions { get; init; }
+}

--- a/src/Charts/Models/PolarChart/PolarLineOptions.cs
+++ b/src/Charts/Models/PolarChart/PolarLineOptions.cs
@@ -1,0 +1,61 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+using Microsoft.FluentUI.AspNetCore.Components.Extensions;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Represents line rendering options for a polar chart series.
+/// </summary>
+public sealed record PolarLineOptions
+{
+    /// <summary>
+    /// Gets the line stroke width.
+    /// </summary>
+    [JsonPropertyName("strokeWidth")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? StrokeWidth { get; init; }
+
+    /// <summary>
+    /// Gets the dash pattern applied to the line stroke.
+    /// </summary>
+    [JsonPropertyName("strokeDasharray")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? StrokeDasharray { get; init; }
+
+    /// <summary>
+    /// Gets the dash offset applied to the line stroke.
+    /// </summary>
+    [JsonPropertyName("strokeDashoffset")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? StrokeDashoffset { get; init; }
+
+    /// <summary>
+    /// Gets the SVG stroke line cap style.
+    /// </summary>
+    [JsonIgnore]
+    public ChartStrokeLinecap? StrokeLinecap { get; init; }
+
+    /// <summary>
+    /// Gets the serialized stroke line cap string sent to the web component.
+    /// </summary>
+    [JsonPropertyName("strokeLinecap")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SerializedStrokeLinecap => StrokeLinecap?.ToAttributeValue();
+
+    /// <summary>
+    /// Gets the curve interpolation mode.
+    /// </summary>
+    [JsonIgnore]
+    public PolarLineCurve? Curve { get; init; }
+
+    /// <summary>
+    /// Gets the serialized curve string sent to the web component.
+    /// </summary>
+    [JsonPropertyName("curve")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SerializedCurve => Curve?.ToAttributeValue();
+}

--- a/src/Charts/Models/SankeyChart/SankeyChartData.cs
+++ b/src/Charts/Models/SankeyChart/SankeyChartData.cs
@@ -1,0 +1,25 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Represents the top-level sankey chart payload.
+/// </summary>
+public sealed record SankeyChartData
+{
+    /// <summary>
+    /// Gets the chart nodes.
+    /// </summary>
+    [JsonPropertyName("nodes")]
+    public IReadOnlyList<SankeyChartNode> Nodes { get; init; } = [];
+
+    /// <summary>
+    /// Gets the chart links.
+    /// </summary>
+    [JsonPropertyName("links")]
+    public IReadOnlyList<SankeyChartLink> Links { get; init; } = [];
+}

--- a/src/Charts/Models/SankeyChart/SankeyChartLink.cs
+++ b/src/Charts/Models/SankeyChart/SankeyChartLink.cs
@@ -1,0 +1,31 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Represents a link between two nodes in a sankey chart payload.
+/// </summary>
+public sealed record SankeyChartLink
+{
+    /// <summary>
+    /// Gets the source node index.
+    /// </summary>
+    [JsonPropertyName("source")]
+    public int Source { get; init; }
+
+    /// <summary>
+    /// Gets the target node index.
+    /// </summary>
+    [JsonPropertyName("target")]
+    public int Target { get; init; }
+
+    /// <summary>
+    /// Gets the link value.
+    /// </summary>
+    [JsonPropertyName("value")]
+    public double Value { get; init; }
+}

--- a/src/Charts/Models/SankeyChart/SankeyChartNode.cs
+++ b/src/Charts/Models/SankeyChart/SankeyChartNode.cs
@@ -1,0 +1,39 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+using Microsoft.FluentUI.AspNetCore.Components.Extensions;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Represents a node in a sankey chart payload.
+/// </summary>
+public sealed record SankeyChartNode
+{
+    /// <summary>
+    /// Gets the node label.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the palette color used to render the node.
+    /// </summary>
+    [JsonIgnore]
+    public DataVizPalette? Color { get; init; }
+
+    /// <summary>
+    /// Gets the custom CSS color used when <see cref="Color"/> is <see cref="DataVizPalette.Custom"/>.
+    /// </summary>
+    [JsonIgnore]
+    public string? CustomColor { get; init; }
+
+    /// <summary>
+    /// Gets the serialized color value sent to the web component.
+    /// </summary>
+    [JsonPropertyName("color")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SerializedColor => Color == DataVizPalette.Custom ? CustomColor : Color?.ToAttributeValue();
+}

--- a/src/Charts/Models/ScatterChart/ScatterChartDataPoint.cs
+++ b/src/Charts/Models/ScatterChart/ScatterChartDataPoint.cs
@@ -1,0 +1,33 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Represents a single data point in a scatter chart series.
+/// </summary>
+public sealed record ScatterChartDataPoint
+{
+    /// <summary>
+    /// Gets the x-axis value rendered for this point.
+    /// Accepts a numeric value, date/time value, or string category label.
+    /// </summary>
+    [JsonPropertyName("x")]
+    public ChartAxisValue X { get; init; }
+
+    /// <summary>
+    /// Gets the y-axis numeric value rendered for this point.
+    /// </summary>
+    [JsonPropertyName("y")]
+    public double Y { get; init; }
+
+    /// <summary>
+    /// Gets the optional marker size in pixels.
+    /// </summary>
+    [JsonPropertyName("markerSize")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? MarkerSize { get; init; }
+}

--- a/src/Charts/Models/ScatterChart/ScatterChartSeries.cs
+++ b/src/Charts/Models/ScatterChart/ScatterChartSeries.cs
@@ -1,0 +1,51 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+using Microsoft.FluentUI.AspNetCore.Components.Extensions;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Represents one scatter chart series in the data payload.
+/// </summary>
+public sealed record ScatterChartSeries
+{
+    /// <summary>
+    /// Gets the legend text shown for the series.
+    /// </summary>
+    [JsonPropertyName("legend")]
+    public string Legend { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the collection of data points rendered within the series.
+    /// </summary>
+    [JsonPropertyName("data")]
+    public IReadOnlyList<ScatterChartDataPoint> Data { get; init; } = [];
+
+    /// <summary>
+    /// Gets the solid color used to render the series.
+    /// Use <see cref="DataVizPalette.Custom"/> and set <see cref="CustomColor"/> to supply
+    /// an exact hex or CSS color string. If not provided, the component falls back to its
+    /// default palette.
+    /// </summary>
+    [JsonIgnore]
+    public DataVizPalette? Color { get; init; }
+
+    /// <summary>
+    /// Custom color value used when <see cref="Color"/> is <see cref="DataVizPalette.Custom"/>.
+    /// Accepts an HTML hex color string (e.g. <c>#0099BC</c>) or a CSS variable.
+    /// </summary>
+    [JsonIgnore]
+    public string? CustomColor { get; init; }
+
+    /// <summary>
+    /// Gets the serialized color value sent to the web component.
+    /// Returns <see cref="CustomColor"/> when <see cref="Color"/> is <see cref="DataVizPalette.Custom"/>,
+    /// otherwise the palette token string, or <see langword="null"/> when no color is set.
+    /// </summary>
+    [JsonPropertyName("color")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SerializedColor => Color == DataVizPalette.Custom ? CustomColor : Color?.ToAttributeValue();
+}

--- a/src/Charts/Models/SparklineChart/SparklineChartData.cs
+++ b/src/Charts/Models/SparklineChart/SparklineChartData.cs
@@ -1,0 +1,26 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Represents the data payload for a sparkline chart.
+/// </summary>
+public sealed record SparklineChartData
+{
+    /// <summary>
+    /// Gets the optional title included in the chart data payload.
+    /// </summary>
+    [JsonPropertyName("chartTitle")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ChartTitle { get; init; }
+
+    /// <summary>
+    /// Gets the sparkline series rendered by the chart.
+    /// </summary>
+    [JsonPropertyName("lineChartData")]
+    public IReadOnlyList<SparklineChartSeries> LineChartData { get; init; } = [];
+}

--- a/src/Charts/Models/SparklineChart/SparklineChartSeries.cs
+++ b/src/Charts/Models/SparklineChart/SparklineChartSeries.cs
@@ -1,0 +1,52 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+using Microsoft.FluentUI.AspNetCore.Components.Extensions;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Represents one sparkline chart series in the data payload.
+/// </summary>
+public sealed record SparklineChartSeries
+{
+    /// <summary>
+    /// Gets the legend text shown for the series.
+    /// </summary>
+    [JsonPropertyName("legend")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Legend { get; init; }
+
+    /// <summary>
+    /// Gets the solid color used to render the series.
+    /// Use <see cref="DataVizPalette.Custom"/> and set <see cref="CustomColor"/> to supply
+    /// an exact hex or CSS color string. If not provided, the component falls back to its
+    /// default palette.
+    /// </summary>
+    [JsonIgnore]
+    public DataVizPalette? Color { get; init; }
+
+    /// <summary>
+    /// Custom color value used when <see cref="Color"/> is <see cref="DataVizPalette.Custom"/>.
+    /// Accepts an HTML hex color string (e.g. <c>#0099BC</c>) or a CSS variable.
+    /// </summary>
+    [JsonIgnore]
+    public string? CustomColor { get; init; }
+
+    /// <summary>
+    /// Gets the serialized color value sent to the web component.
+    /// Returns <see cref="CustomColor"/> when <see cref="Color"/> is <see cref="DataVizPalette.Custom"/>,
+    /// otherwise the palette token string, or <see langword="null"/> when no color is set.
+    /// </summary>
+    [JsonPropertyName("color")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SerializedColor => Color == DataVizPalette.Custom ? CustomColor : Color?.ToAttributeValue();
+
+    /// <summary>
+    /// Gets the collection of data points rendered within the series.
+    /// </summary>
+    [JsonPropertyName("data")]
+    public IReadOnlyList<SparklineDataPoint> Data { get; init; } = [];
+}

--- a/src/Charts/Models/SparklineChart/SparklineDataPoint.cs
+++ b/src/Charts/Models/SparklineChart/SparklineDataPoint.cs
@@ -1,0 +1,26 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Represents a single point in a sparkline series.
+/// </summary>
+public sealed record SparklineDataPoint
+{
+    /// <summary>
+    /// Gets the x-axis value rendered for this point.
+    /// Accepts either a numeric value or a date/time value.
+    /// </summary>
+    [JsonPropertyName("x")]
+    public ChartAxisValue X { get; init; }
+
+    /// <summary>
+    /// Gets the y-axis numeric value rendered for this point.
+    /// </summary>
+    [JsonPropertyName("y")]
+    public double Y { get; init; }
+}

--- a/src/Charts/Serialization/GaugeChartDataJsonSerializerContext.cs
+++ b/src/Charts/Serialization/GaugeChartDataJsonSerializerContext.cs
@@ -1,0 +1,18 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Provides source-generated JSON serialization metadata for gauge chart payloads.
+/// </summary>
+[JsonSerializable(typeof(GaugeChartSegment))]
+[JsonSerializable(typeof(IReadOnlyList<GaugeChartSegment>))]
+[ExcludeFromCodeCoverage(Justification = "This class is used for source-generated JSON serialization and does not contain any logic to be tested.")]
+internal sealed partial class GaugeChartDataJsonSerializerContext : JsonSerializerContext
+{
+}

--- a/src/Charts/Serialization/HeatMapChartDataJsonSerializerContext.cs
+++ b/src/Charts/Serialization/HeatMapChartDataJsonSerializerContext.cs
@@ -1,0 +1,22 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Provides source-generated JSON serialization metadata for heat map chart payloads.
+/// </summary>
+[JsonSerializable(typeof(ChartAxisValue))]
+[JsonSerializable(typeof(HeatMapAccessibilityData))]
+[JsonSerializable(typeof(HeatMapChartData))]
+[JsonSerializable(typeof(IReadOnlyList<HeatMapChartData>))]
+[JsonSerializable(typeof(HeatMapChartDataPoint))]
+[JsonSerializable(typeof(IReadOnlyList<HeatMapChartDataPoint>))]
+[ExcludeFromCodeCoverage(Justification = "This class is used for source-generated JSON serialization and does not contain any logic to be tested.")]
+internal sealed partial class HeatMapChartDataJsonSerializerContext : JsonSerializerContext
+{
+}

--- a/src/Charts/Serialization/LineChartDataJsonSerializerContext.cs
+++ b/src/Charts/Serialization/LineChartDataJsonSerializerContext.cs
@@ -1,0 +1,28 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Provides source-generated JSON serialization metadata for line chart payloads.
+/// </summary>
+[JsonSerializable(typeof(ChartAxisValue))]
+[JsonSerializable(typeof(LineChartSeries))]
+[JsonSerializable(typeof(IReadOnlyList<LineChartSeries>))]
+[JsonSerializable(typeof(LineChartDataPoint))]
+[JsonSerializable(typeof(IReadOnlyList<LineChartDataPoint>))]
+[JsonSerializable(typeof(LineChartGap))]
+[JsonSerializable(typeof(IReadOnlyList<LineChartGap>))]
+[JsonSerializable(typeof(LineChartLineOptions))]
+[JsonSerializable(typeof(LineChartColorFillBar))]
+[JsonSerializable(typeof(IReadOnlyList<LineChartColorFillBar>))]
+[JsonSerializable(typeof(LineChartColorFillBarData))]
+[JsonSerializable(typeof(IReadOnlyList<LineChartColorFillBarData>))]
+[ExcludeFromCodeCoverage(Justification = "This class is used for source-generated JSON serialization and does not contain any logic to be tested.")]
+internal sealed partial class LineChartDataJsonSerializerContext : JsonSerializerContext
+{
+}

--- a/src/Charts/Serialization/PolarChartDataJsonSerializerContext.cs
+++ b/src/Charts/Serialization/PolarChartDataJsonSerializerContext.cs
@@ -1,0 +1,27 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Provides source-generated JSON serialization metadata for polar chart payloads.
+/// </summary>
+[JsonSerializable(typeof(ChartAxisValue))]
+[JsonSerializable(typeof(IReadOnlyList<ChartAxisValue>))]
+[JsonSerializable(typeof(PolarChartSeries))]
+[JsonSerializable(typeof(IReadOnlyList<PolarChartSeries>))]
+[JsonSerializable(typeof(PolarChartDataPoint))]
+[JsonSerializable(typeof(IReadOnlyList<PolarChartDataPoint>))]
+[JsonSerializable(typeof(PolarLineOptions))]
+[JsonSerializable(typeof(PolarAxisOptions))]
+[JsonSerializable(typeof(PolarChartMargins))]
+[JsonSerializable(typeof(IDictionary<string, string>))]
+[JsonSerializable(typeof(Dictionary<string, string>))]
+[ExcludeFromCodeCoverage(Justification = "This class is used for source-generated JSON serialization and does not contain any logic to be tested.")]
+internal sealed partial class PolarChartDataJsonSerializerContext : JsonSerializerContext
+{
+}

--- a/src/Charts/Serialization/SankeyChartDataJsonSerializerContext.cs
+++ b/src/Charts/Serialization/SankeyChartDataJsonSerializerContext.cs
@@ -1,0 +1,21 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Provides source-generated JSON serialization metadata for sankey chart payloads.
+/// </summary>
+[JsonSerializable(typeof(SankeyChartData))]
+[JsonSerializable(typeof(SankeyChartNode))]
+[JsonSerializable(typeof(SankeyChartLink))]
+[JsonSerializable(typeof(IReadOnlyList<SankeyChartNode>))]
+[JsonSerializable(typeof(IReadOnlyList<SankeyChartLink>))]
+[ExcludeFromCodeCoverage(Justification = "This class is used for source-generated JSON serialization and does not contain any logic to be tested.")]
+internal sealed partial class SankeyChartDataJsonSerializerContext : JsonSerializerContext
+{
+}

--- a/src/Charts/Serialization/ScatterChartDataJsonSerializerContext.cs
+++ b/src/Charts/Serialization/ScatterChartDataJsonSerializerContext.cs
@@ -1,0 +1,21 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Provides source-generated JSON serialization metadata for scatter chart payloads.
+/// </summary>
+[JsonSerializable(typeof(ChartAxisValue))]
+[JsonSerializable(typeof(ScatterChartSeries))]
+[JsonSerializable(typeof(IReadOnlyList<ScatterChartSeries>))]
+[JsonSerializable(typeof(ScatterChartDataPoint))]
+[JsonSerializable(typeof(IReadOnlyList<ScatterChartDataPoint>))]
+[ExcludeFromCodeCoverage(Justification = "This class is used for source-generated JSON serialization and does not contain any logic to be tested.")]
+internal sealed partial class ScatterChartDataJsonSerializerContext : JsonSerializerContext
+{
+}

--- a/src/Charts/Serialization/SparklineChartDataJsonSerializerContext.cs
+++ b/src/Charts/Serialization/SparklineChartDataJsonSerializerContext.cs
@@ -1,0 +1,21 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.FluentUI.AspNetCore.Components.Charts;
+
+/// <summary>
+/// Provides source-generated JSON serialization metadata for sparkline chart payloads.
+/// </summary>
+[JsonSerializable(typeof(SparklineChartData))]
+[JsonSerializable(typeof(SparklineChartSeries))]
+[JsonSerializable(typeof(SparklineDataPoint))]
+[JsonSerializable(typeof(IReadOnlyList<SparklineChartSeries>))]
+[JsonSerializable(typeof(IReadOnlyList<SparklineDataPoint>))]
+[ExcludeFromCodeCoverage(Justification = "This class is used for source-generated JSON serialization and does not contain any logic to be tested.")]
+internal sealed partial class SparklineChartDataJsonSerializerContext : JsonSerializerContext
+{
+}


### PR DESCRIPTION
## Why

A recent commit added several new chart web components (and updated others) under `src/Charts.Scripts`, but the corresponding Blazor wrappers, data models, and serialization were never completed. Three chart wrappers (GroupedVerticalBarChart, VerticalBarChart, VerticalStackedBarChart) were left as empty stub `.razor` files with no code-behind, and seven chart types (LineChart, ScatterChart, HeatMapChart, GaugeChart, SparklineChart, PolarChart, SankeyChart) had no Blazor wrapper at all.

## What changed

Implemented the missing wrapper components end-to-end, following the existing patterns used by `FluentAreaChart` and `FluentDonutChart`:

**Cartesian charts** (extend `FluentCartesianChartBase`):
- `FluentLineChart`, `FluentScatterChart`, `FluentHeatMapChart` (new)
- `FluentGroupedVerticalBarChart`, `FluentVerticalBarChart`, `FluentVerticalStackedBarChart` (completed previously-empty stubs; their models/serialization already existed)

**Non-cartesian charts** (extend `FluentChartBase` directly):
- `FluentGaugeChart`, `FluentSparklineChart`, `FluentPolarChart`, `FluentSankeyChart` (new)

Each new chart got:
- Data model records under `Models/<ChartName>/`, following the `[JsonPropertyName]` + `DataVizPalette`/`CustomColor`/`SerializedColor` color pattern used elsewhere.
- A source-generated `JsonSerializerContext` under `Serialization/`.
- A `ChartJson.Serialize(...)` overload in `Infrastructure/ChartJson.cs`.
- New supporting enums where the TS component uses string-literal unions without an existing C# equivalent: `ChartAxisScaleType`, `ChartStrokeLinecap`, `GaugeChartVariant`, `GaugeValueFormat`, `HeatMapSortOrder`, `PolarChartShape`, `PolarChartDirection`, `PolarSeriesType`, `PolarAxisUnit`, `PolarLineCurve`, `SparklineVariant`.

`FluentCartesianChartBase` was also additively extended with shared attributes that the updated `cartesian-chart-base` TS component now exposes (x/y axis scale type, category order, axis padding, line stroke options, tick values, UTC handling), so the new Cartesian charts and any future ones can bind them without duplicating parameters per-chart. Existing chart wrappers' markup was left untouched to avoid disturbing their existing snapshot/bUnit tests.

## Notes for reviewers

- No unit tests or Demo/example pages were added, matching the current state of the repo (the pre-existing GroupedVerticalBarChart/VerticalBarChart/VerticalStackedBarChart wrappers also have no tests, and the new chart types have no demo pages either).
- `dotnet build src\Charts\Microsoft.FluentUI.AspNetCore.Components.Charts.csproj` succeeds with 0 warnings/errors (warnings are treated as errors in this repo).
- `ChartAxisValue` (the shared number/Date/string axis-value struct) was extended to also support plain string axis/category values, needed by LineChart/ScatterChart/HeatMapChart/PolarChart.