### PR TITLE
[DataGrid] Retain empty content during virtualized refresh

### DIFF
--- a/src/Core/Components/DataGrid/FluentDataGrid.razor
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor
@@ -55,16 +55,20 @@
                 {
                     @if (Virtualize)
                     {
-                        if (_internalGridContext.TotalItemCount == 0 && _virtualizeItemsProvided)
+                        if (_internalGridContext.TotalItemCount == 0
+                            && (_virtualizeItemsProvided || _retainEmptyContentOnVirtualizedRefresh))
                         {
-                            @* The provider has reported zero items, so this render replaces the Virtualize
-                               component with the empty content, disposing the instance captured by the @ref.
-                               Clear the reference so refreshes don't delegate to the dead instance;
-                               RefreshDataCoreAsync re-mounts Virtualize by resetting the flag (#5151). *@
-                            _virtualizeComponent = null;
+                            @* After an empty result, this normally replaces Virtualize and disposes the
+                               instance captured by the @ref. During a refresh, it remains beside the newly
+                               mounted Virtualize until the provider responds, avoiding an empty-state flicker. *@
+                            if (_virtualizeItemsProvided)
+                            {
+                                _virtualizeComponent = null;
+                            }
                             @_renderEmptyContent
                         }
-                        else
+
+                        if (_internalGridContext.TotalItemCount != 0 || !_virtualizeItemsProvided)
                         {
                             @((RenderFragment)RenderVirtualize)
                         }

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -100,6 +100,7 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
     // empty content: "zero items" only means "no data" after the provider has actually answered,
     // not during the initial load window between the Virtualize mount and its first query (#5151).
     private bool _virtualizeItemsProvided;
+    private bool _retainEmptyContentOnVirtualizedRefresh;
     private Exception? _lastError;
     private GridItemsProviderRequest<TGridItem>? _lastRequest;
     private bool _forceRefreshData;
@@ -644,6 +645,7 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
         {
             _lastVirtualizationMode = Virtualize;
             _asyncQueryExecuted = false;
+            _retainEmptyContentOnVirtualizedRefresh = false;
         }
 
         if (Loading == true && _asyncQueryExecutor is not null && _asyncQueryExecuted)
@@ -1457,6 +1459,8 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
             // provider reported zero items. Clear the flag so the re-render below re-mounts Virtualize;
             // it will call us when it's ready, so we can just wait for that instead of trying to load
             // data now (#5151).
+            _retainEmptyContentOnVirtualizedRefresh |= _virtualizeItemsProvided
+                && _internalGridContext.TotalItemCount == 0;
             _virtualizeItemsProvided = false;
             _pendingDataLoadCancellationTokenSource = null;
             thisLoadCts.Dispose();
@@ -1565,6 +1569,7 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
             _internalGridContext.TotalItemCount = providerResult.TotalItemCount;
             _internalGridContext.TotalViewItemCount = Pagination?.ItemsPerPage ?? providerResult.TotalItemCount;
             _virtualizeItemsProvided = true;
+            _retainEmptyContentOnVirtualizedRefresh = false;
 
             if (RefreshItems is null)
             {

--- a/tests/Core/Components/DataGrid/FluentDataGridTests.razor
+++ b/tests/Core/Components/DataGrid/FluentDataGridTests.razor
@@ -594,18 +594,27 @@
         // Regression test for #5151: with Virtualize="true", once the ItemsProvider reports
         // TotalItemCount = 0 the empty content replaces (and disposes) the Virtualize component.
         // A later RefreshDataAsync, issued after the provider has data, must re-mount Virtualize
-        // and leave the empty state instead of delegating to the disposed instance forever.
+        // while retaining the empty content until the new data arrives, then leave the empty state
+        // instead of delegating to the disposed instance forever.
         // (bUnit cannot measure the viewport, so recovery is asserted through the empty content
         // disappearing and the Virtualize component re-appearing, not through visible data rows.)
 
         // Arrange
         FluentDataGrid<Customer>? grid = default!;
         var items = new List<Customer>(); // empty at first — data not loaded yet
+        TaskCompletionSource? providerHold = null;
 
-        GridItemsProvider<Customer> itemsProvider = req =>
-            ValueTask.FromResult(GridItemsProviderResult.From<Customer>(
+        GridItemsProvider<Customer> itemsProvider = async req =>
+        {
+            if (providerHold is not null)
+            {
+                await providerHold.Task;
+            }
+
+            return GridItemsProviderResult.From<Customer>(
                 items: items.Skip(req.StartIndex).Take(req.Count ?? items.Count).ToArray(),
-                totalItemCount: items.Count));
+                totalItemCount: items.Count);
+        };
 
         var cut = Render<FluentDataGrid<Customer>>(
             @<div style="height: 400px; max-width: 800px; overflow-y: scroll;">
@@ -625,9 +634,21 @@
 
         // Act: data becomes available and the host refreshes the grid
         items.AddRange(GetRandomCustomers(10));
-        await cut.InvokeAsync(() => grid!.RefreshDataAsync());
+        providerHold = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        var refreshTask = cut.InvokeAsync(() => grid!.RefreshDataAsync());
 
-        // Assert: the empty content is gone and Virtualize is mounted again. Queried as a
+        // Assert: Virtualize is mounted again to retrieve the new data, but the empty content
+        // remains visible while that request is pending.
+        cut.WaitForAssertion(() =>
+        {
+            Assert.NotEmpty(cut.FindAll("tr[row-state=empty-content]"));
+            Assert.NotEmpty(cut.FindComponents<Virtualize<(int, Customer)>>());
+        });
+
+        providerHold.SetResult();
+        await refreshTask;
+
+        // The empty content is gone after the provider returns. Queried as a
         // component (not through the spacer markup): the spacer rows only carry aria-hidden on
         // net10, so a DOM selector is not TFM-agnostic.
         cut.WaitForAssertion(() =>


### PR DESCRIPTION
# Pull Request

## 📖 Description

Keeps `EmptyContent` mounted while a virtualized DataGrid remounts `Virtualize` and waits for refreshed data.

Previously, refreshing after an empty provider result temporarily removed the empty row so `Virtualize` could be recreated. This caused the empty content to flicker. The grid now renders the retained empty content alongside the remounted `Virtualize` until the provider responds, while preserving recovery from the disposed virtualizer fixed by #5152.

### 🎫 Issues

Follow-up to #5152.

## 👩‍💻 Reviewer Notes

Focus on the transition from an empty virtualized result into `RefreshDataAsync`. Initial loading behavior remains unchanged: empty content is still gated until the provider has returned its first result.

No manual smoke test is required; the regression test blocks the provider to assert the intermediate render deterministically.

## 📑 Test Plan

- Updated `FluentDataGrid_Virtualize_RefreshDataAsync_RecoversFromEmpty` to hold the provider request open and verify that `EmptyContent` and `Virtualize` coexist during refresh.
- Verified empty content is removed after refreshed data arrives.
- Ran the full `FluentDataGridTests` class: 128 passed, 0 failed, 1 skipped.
- Ran `git diff --check` successfully.

## ✅ Checklist

### General

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

None.