### PR TITLE
fix: synchronize popover state after native dismissal

### DIFF
--- a/src/Core.Scripts/src/Components/Popover/FluentPopover.ts
+++ b/src/Core.Scripts/src/Components/Popover/FluentPopover.ts
@@ -215,14 +215,17 @@ export namespace Microsoft.FluentUI.Blazor.Components.Popover {
 
     // Dispatch event when opened or closed
     private dispatchOpenedEvent(opened: boolean) {
-      this.dispatchEvent(new CustomEvent('toggle', {
+      const eventInit = {
         detail: {
           oldState: opened ? 'closed' : 'open',
           newState: opened ? 'open' : 'closed',
         },
         bubbles: true,
         composed: true
-      }));
+      };
+
+      this.dispatchEvent(new CustomEvent('toggle', eventInit));
+      this.dispatchEvent(new CustomEvent('fluentpopovertoggle', eventInit));
     }
 
     // Handles clicks outside the dialog to close it

--- a/src/Core.Scripts/src/FluentUICustomEvents.ts
+++ b/src/Core.Scripts/src/FluentUICustomEvents.ts
@@ -68,6 +68,20 @@ export namespace Microsoft.FluentUI.Blazor.FluentUICustomEvents {
     });
   }
 
+  export function PopoverToggle(blazor: Blazor) {
+    registerCustomEventType(blazor, 'popovertoggle', {
+      browserEventName: 'fluentpopovertoggle',
+      createEventArgs: (event: any) => {
+        return {
+          id: event.target.id,
+          type: event.type,
+          oldState: event.detail?.oldState,
+          newState: event.detail?.newState,
+        };
+      }
+    });
+  }
+
   export function MenuItem(blazor: Blazor) {
     registerCustomEventType(blazor, 'menuitemchange', {
       browserEventName: 'change',

--- a/src/Core.Scripts/src/Startup.ts
+++ b/src/Core.Scripts/src/Startup.ts
@@ -79,6 +79,7 @@ export namespace Microsoft.FluentUI.Blazor.Startup {
     // Register all custom events
     FluentUICustomEvents.Accordion(blazor);
     FluentUICustomEvents.DialogToggle(blazor);
+    FluentUICustomEvents.PopoverToggle(blazor);
     FluentUICustomEvents.MenuItem(blazor);
     FluentUICustomEvents.DropdownList(blazor);
     FluentUICustomEvents.Tabs(blazor);

--- a/src/Core/Components/Popover/FluentPopover.razor
+++ b/src/Core/Components/Popover/FluentPopover.razor
@@ -10,6 +10,6 @@
                   opened="@(Opened ? "true" : "false")"
                   nested="@(Nested ? "true" : null)"
                   @attributes="@AdditionalAttributes"
-                  @ondialogtoggle="@OnToggleAsync">
+                  @onpopovertoggle="@OnToggleAsync">
     @ChildContent
 </fluent-popover-b>

--- a/src/Core/Events/EventHandlers.cs
+++ b/src/Core/Events/EventHandlers.cs
@@ -30,6 +30,7 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 [EventHandler("onaccordionchange", typeof(AccordionItemEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
 [EventHandler("ondialogbeforetoggle", typeof(DialogToggleEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
 [EventHandler("ondialogtoggle", typeof(DialogToggleEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
+[EventHandler("onpopovertoggle", typeof(DialogToggleEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
 [EventHandler("onmenuitemchange", typeof(MenuItemEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
 [EventHandler("ontabchange", typeof(TabChangeEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
 [EventHandler("ondropdownchange", typeof(DropdownEventArgs), enableStopPropagation: true, enablePreventDefault: true)]

--- a/tests/Core/Components/Popover/FluentPopoverTests.razor
+++ b/tests/Core/Components/Popover/FluentPopoverTests.razor
@@ -105,4 +105,25 @@
         // Assert
         Assert.Equal(expectedOpened, Opened);
     }
+
+    [Fact]
+    public async Task FluentPopover_ToggleEvent_UpdatesBoundOpenedState()
+    {
+        bool Opened = true;
+
+        // Arrange
+        var cut = Render(@<FluentPopover Id="MyPopover" AnchorId="MyButton" @bind-Opened="@Opened">Popover Content</FluentPopover>);
+
+        // Act
+        await cut.Find("fluent-popover-b").TriggerEventAsync("onpopovertoggle", new DialogToggleEventArgs
+        {
+            Id = "MyPopover",
+            OldState = "open",
+            NewState = "closed"
+        });
+
+        // Assert
+        Assert.False(Opened);
+        Assert.Contains("opened=\"false\"", cut.Markup);
+    }
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

Synchronizes `FluentPopover.Opened` and `OpenedChanged` when the browser closes the native popover through Escape or light dismiss.

The popover now emits a dedicated internal `fluentpopovertoggle` browser event, mapped to the Blazor `popovertoggle` custom event. The existing public JavaScript `toggle` event remains unchanged for compatibility.

A regression test dispatches the event through the rendered `fluent-popover-b` host and verifies that the bound state and rendered `opened` attribute become `false`.

### 🎫 Issues

Fixes #5242

## 👩‍💻 Reviewer Notes

Please focus on the custom event mapping across `FluentPopover.ts`, `FluentUICustomEvents.ts`, and `FluentPopover.razor`.

Suggested smoke test:

1. Open a bound `FluentPopover`.
2. Dismiss it by clicking outside.
3. Confirm the bound `Opened` value becomes `false`.
4. Confirm one trigger click reopens it.

## 📑 Test Plan

- `dotnet test tests/Core/Components.Tests.csproj --configuration Debug --filter "FullyQualifiedName~FluentPopoverTests"` (10 passed)
- `npm run build` in `src/Core.Scripts`
- `npx tsc --noEmit` in `src/Core.Scripts`
- Playwright A/B verification in a .NET 10 standalone WebAssembly repro:
  - Confirmed `5.0.0-rc.6.26241.1` leaves the bound state stale after light dismiss and requires two trigger clicks.
  - Confirmed the fixed bundle updates the bound state and reopens on the first trigger click.
  - Confirmed direct native `hidePopover()` dismissal follows the corrected event path.

## ✅ Checklist

### General

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes. (Not required for this behavioral fix.)
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

None.