### PR TITLE
[dev-v5][Nav] Add ActiveClass to NavCategory

### DIFF
--- a/src/Core/Components/Nav/FluentNavCategory.razor.cs
+++ b/src/Core/Components/Nav/FluentNavCategory.razor.cs
@@ -31,6 +31,7 @@ public partial class FluentNavCategory : FluentNavBase
     protected string? ClassValue => DefaultClassBuilder
         .AddClass("fluent-navcategoryitem")
         .AddClass("active", _isActive)
+        .AddClass(ActiveClass, !string.IsNullOrWhiteSpace(ActiveClass) && _isActive)
         .Build();
 
     /// <summary />
@@ -42,6 +43,13 @@ public partial class FluentNavCategory : FluentNavBase
     /// </summary>
     [Parameter]
     public string? Title { get; set; }
+
+    /// <summary>
+    /// Gets or sets additional class names to style the category item when it is active, separated by space. An active
+    /// category item always has the "active" class applied, so this property allows for additional styling.
+    /// </summary>
+    [Parameter]
+    public string? ActiveClass { get; set; }
 
     /// <summary>
     /// Gets or sets the icon displayed when the category is in its default (resting) state.

--- a/tests/Core/Components/Nav/FluentNavCategoryTests.razor
+++ b/tests/Core/Components/Nav/FluentNavCategoryTests.razor
@@ -845,4 +845,29 @@
         await category.Instance.ToggleExpandedAsync();
         Assert.False(category.Instance.Expanded, "Category should be collapsed");
     }
+
+    [Fact]
+    public async Task FluentNavCategory_Adds_ActiveClass_To_ClassValue_When_Active()
+    {
+        // Arrange
+        var navManager = Services.GetRequiredService<NavigationManager>();
+        navManager.NavigateTo("/test-page");
+
+        var cut = Render(@<FluentNav>
+            <FluentNavCategory Title="Test Category" Expanded="true" ActiveClass="my-active-class">
+                <FluentNavItem Href="/test-page">Active Sub Item</FluentNavItem>
+            </FluentNavCategory>
+        </FluentNav>);
+
+
+        var category = cut.FindComponent<FluentNavCategory>();
+
+        // Act - Collapse to make category active (active subitem + collapsed category)
+        await category.Instance.ToggleExpandedAsync();
+
+        // Assert
+        var button = cut.Find("button.fluent-navcategoryitem");
+        Assert.Contains("active", button.ClassList);
+        Assert.Contains("my-active-class", button.ClassList);
+    }
 }


### PR DESCRIPTION
Also add a unit test

Adds the `ActiveClass` parameter to the `FluentNavCategory`. 

>NOTE: Although this parameter is called `ActiveClass`, it DOES NOT influence the brand color indicator bar. This is taken care of internally by adding the `active` class to such an item. The `ActiveClass` can be used, for example, to set a distinct color:

```
<FluentNavCategory Class="inactive-category"
                                   ActiveClass="active-category"
                                   IconRest="@item.Icon"
                                   IconActive="@item.Icon">
    @ChildContent
</FluentNavCategory>
```

with CSS:
```
.inactive-category {
color: var(--colorNeutralForeground2);
}

.active-category {
color: var(--colorBrandForeground1);
}
```

Fix #5237 