### PR TITLE
fix: restrict enum attribute reflection to fields

### DIFF
--- a/src/Core/Extensions/EnumExtensions.cs
+++ b/src/Core/Extensions/EnumExtensions.cs
@@ -68,14 +68,14 @@ public static class EnumExtensions
                      Justification = "In the context of the Enum, the 'Display' attribute will not be trimmed.")]
     public static string GetDescription(this Enum value)
     {
-        var memberInfo = value.GetType().GetMember(value.ToString());
+        var fieldInfo = value.GetType().GetField(value.ToString());
 
-        if (memberInfo.Length == 0)
+        if (fieldInfo is null)
         {
             return string.Empty;
         }
 
-        var attribute = memberInfo[0].GetCustomAttribute<DescriptionAttribute>();
+        var attribute = fieldInfo.GetCustomAttribute<DescriptionAttribute>();
         var result = attribute?.Description ?? value.ToString().ToLower(System.Globalization.CultureInfo.InvariantCulture);
 
         return result;
@@ -91,8 +91,8 @@ public static class EnumExtensions
                      Justification = "In the context of the Enum, the 'Display' attribute will not be trimmed.")]
     public static string GetDisplay(this Enum value)
     {
-        var memberInfo = value.GetType().GetMember(value.ToString());
-        var attribute = memberInfo[0].GetCustomAttribute<DisplayAttribute>();
+        var fieldInfo = value.GetType().GetField(value.ToString());
+        var attribute = fieldInfo?.GetCustomAttribute<DisplayAttribute>();
 
         var result = attribute?.GetName() ?? value.ToString().ToLower(System.Globalization.CultureInfo.InvariantCulture);
 
@@ -117,8 +117,8 @@ public static class EnumExtensions
     [RequiresUnreferencedCode("This method requires dynamic access to code. This code may be removed by the trimmer.")]
     public static bool IsObsolete(this Enum value)
     {
-        var memberInfo = value.GetType().GetMember(value.ToString());
-        var attribute = memberInfo[0].GetCustomAttribute<ObsoleteAttribute>();
+        var fieldInfo = value.GetType().GetField(value.ToString());
+        var attribute = fieldInfo?.GetCustomAttribute<ObsoleteAttribute>();
 
         return attribute != null;
     }

--- a/src/Core/Extensions/EnumExtensions.cs
+++ b/src/Core/Extensions/EnumExtensions.cs
@@ -65,7 +65,7 @@ public static class EnumExtensions
     /// <param name="value"></param>
     /// <returns></returns>
     [SuppressMessage("Trimming", "IL2075:'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.",
-                     Justification = "In the context of the Enum, the 'Display' attribute will not be trimmed.")]
+                     Justification = "In the context of the Enum, the 'Description' attribute will not be trimmed.")]
     public static string GetDescription(this Enum value)
     {
         var fieldInfo = value.GetType().GetField(value.ToString());


### PR DESCRIPTION
# Pull Request

## 📖 Description

Replace broad `Type.GetMember` calls in `EnumExtensions` with `Type.GetField` when reading `Description`, `Display`, and `Obsolete` attributes from enum constants.

Enum constants are fields. Restricting reflection to fields prevents Native AOT analysis from conservatively considering inherited `Enum` methods, including `Enum.GetValues(Type)`, which can produce IL3050. The change also handles enum values without a corresponding declared field without indexing an empty member array.

### 🎫 Issues

None.

## 👩‍💻 Reviewer Notes

The behavioral surface is limited to enum attribute lookup. Existing attributed and unattributed enum behavior is preserved; no component smoke test is required.

## 📑 Test Plan

- `dotnet test tests/Core/Components.Tests.csproj --configuration Debug --filter "FullyQualifiedName~EnumExtensionsTests"` (10 passed)
- `dotnet build src/Core/Microsoft.FluentUI.AspNetCore.Components.csproj --configuration Debug --no-restore`
- Published a Native AOT consumer exercising `Color.Primary.ToAttributeValue()` and `GetDisplay()`; no IL trimming or AOT warnings were emitted and both expected attribute values were returned.

## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

None.